### PR TITLE
Add --ai command line option for auto-triggering AI analysis

### DIFF
--- a/public/js/pr.js
+++ b/public/js/pr.js
@@ -83,6 +83,9 @@ class PRManager {
         this.displayPR(data);
       }
       
+      // Check for auto-ai parameter after successful PR display
+      this.checkAutoAITrigger();
+      
     } catch (error) {
       console.error('Error loading PR:', error);
       this.showError(error.message);
@@ -1142,6 +1145,30 @@ class PRManager {
     }
   }
 
+  /**
+   * Check for auto-ai parameter and trigger analysis automatically
+   */
+  checkAutoAITrigger() {
+    const urlParams = new URLSearchParams(window.location.search);
+    const autoAI = urlParams.get('auto-ai');
+    
+    if (autoAI === 'true') {
+      console.log('Auto-triggering AI analysis...');
+      
+      // Clean up URL parameter using history.replaceState()
+      const url = new URL(window.location);
+      url.searchParams.delete('auto-ai');
+      window.history.replaceState({}, document.title, url.toString());
+      
+      // Trigger AI analysis with a small delay to ensure UI is ready
+      setTimeout(() => {
+        this.triggerAIAnalysis().catch(error => {
+          console.error('Auto-triggered AI analysis failed:', error);
+          this.showError('Auto-triggered AI analysis failed: ' + error.message);
+        });
+      }, 500);
+    }
+  }
 
   /**
    * Load and display user comments


### PR DESCRIPTION
Implements a new --ai flag that automatically starts AI analysis when opening a PR, eliminating the need for manual clicking. The flag can be used with both PR number and URL formats in flexible positions.

Features:
- Parse --ai flag in main.js with flexible positioning support
- Validate that --ai requires a PR identifier
- Pass auto-AI flag to frontend via URL parameter
- Auto-trigger AI analysis after PR loads successfully
- Clean up URL parameter after triggering
- Provide console feedback for auto-triggered analysis
- Maintain full compatibility with existing functionality

Usage: npx pair-review <PR-number-or-URL> --ai

🤖 Generated with [Claude Code](https://claude.ai/code)