### PR TITLE
Improve PR header UI layout and add GitHub link

### DIFF
--- a/public/css/pr.css
+++ b/public/css/pr.css
@@ -89,6 +89,21 @@
   color: #1f2328;
   margin: 0 0 8px 0;
   line-height: 1.2;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.pr-title .pr-number {
+  font-size: 20px;
+  font-weight: 400;
+  color: #656d76;
+}
+
+.pr-title .github-link {
+  display: inline-flex;
+  align-items: center;
+  margin-left: 4px;
 }
 
 .pr-meta {
@@ -2881,6 +2896,15 @@ body {
 
 [data-theme="dark"] .github-link:hover {
   color: #58a6ff;
+}
+
+/* Dark theme support for pr-title elements */
+[data-theme="dark"] .pr-title {
+  color: #c9d1d9;
+}
+
+[data-theme="dark"] .pr-title .pr-number {
+  color: #8b949e;
 }
 
 /* Review button styles */

--- a/public/js/pr.js
+++ b/public/js/pr.js
@@ -200,10 +200,9 @@ class PRManager {
       headerContainer.innerHTML = `
         <div class="pr-header">
           <div class="pr-title-section">
-            <h1 class="pr-title">${this.escapeHtml(pr.title)}</h1>
-            <div class="pr-meta">
+            <h1 class="pr-title">
+              ${this.escapeHtml(pr.title)}
               <span class="pr-number">#${pr.number}</span>
-              ${stateBadge}
               ${pr.html_url ? `
                 <a href="${pr.html_url}" target="_blank" class="github-link" title="View on GitHub">
                   <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
@@ -211,6 +210,9 @@ class PRManager {
                   </svg>
                 </a>
               ` : ''}
+            </h1>
+            <div class="pr-meta">
+              ${stateBadge}
               <span class="pr-author">opened by <strong>${this.escapeHtml(pr.author)}</strong></span>
               <span class="pr-dates">on ${createdDate}</span>
               ${updatedDate !== createdDate ? `<span class="pr-updated">• updated ${updatedDate}</span>` : ''}

--- a/src/routes/pr.js
+++ b/src/routes/pr.js
@@ -133,7 +133,8 @@ router.get('/api/pr/:owner/:repo/:number', async (req, res) => {
         file_changes: extendedData.changed_files ? extendedData.changed_files.length : 0,
         additions: extendedData.additions || 0,
         deletions: extendedData.deletions || 0,
-        diff_content: extendedData.diff || ''
+        diff_content: extendedData.diff || '',
+        html_url: extendedData.html_url || `https://github.com/${repoOwner}/${repoName}/pull/${prMetadata.pr_number}`
       }
     };
 


### PR DESCRIPTION
- Move PR number inline with title for better visual hierarchy
- Add GitHub icon link next to PR number for quick access to GitHub
- Include html_url in API response to enable GitHub link
- Update CSS for proper alignment and dark theme support

🤖 Generated with [Claude Code](https://claude.ai/code)