### PR TITLE
Fix Claude CLI JSON parsing reliability with --output-format flag

### DIFF
--- a/src/utils/json-extractor.js
+++ b/src/utils/json-extractor.js
@@ -14,7 +14,7 @@ function extractJSON(response) {
   const strategies = [
     // Strategy 1: Look for markdown code blocks with 'json' label
     () => {
-      const codeBlockMatch = response.match(/```(?:json)?\s*([\s\S]*?)\s*```/);
+      const codeBlockMatch = response.match(/```(?:json)?\s*\n?([\s\S]*?)\n?```/);
       if (codeBlockMatch && codeBlockMatch[1]) {
         return JSON.parse(codeBlockMatch[1].trim());
       }


### PR DESCRIPTION
- Add --output-format json flag to claude CLI invocation
- Parse structured JSON envelope response format
- Extract actual result from envelope's result field
- Improve markdown code block regex to handle newline variations
- Add fallback for backward compatibility
- Enhance error handling for envelope error responses

This resolves issues where Level 1 analysis failed to parse JSON responses that started with ```json, ensuring more reliable AI suggestion extraction.

🤖 Generated with [Claude Code](https://claude.ai/code)