### PR TITLE
Add multi-line range comment support with visual selection

### DIFF
--- a/public/css/pr.css
+++ b/public/css/pr.css
@@ -486,7 +486,13 @@
   
   --color-selection: #fff5b1;
   --color-selection-num: #ffeb3b;
-  
+
+  --color-range-selection: rgba(255, 223, 93, 0.3);
+  --color-range-selection-num: rgba(255, 223, 93, 0.4);
+  --color-range-indicator-bg: #ddf4ff;
+  --color-range-indicator-border: #54aeff;
+  --color-range-indicator-text: #0969da;
+
   --color-shadow: rgba(27, 31, 36, 0.04);
   --color-shadow-large: rgba(0, 0, 0, 0.3);
 }
@@ -523,7 +529,13 @@
   
   --color-selection: #3d3300;
   --color-selection-num: #4d4000;
-  
+
+  --color-range-selection: rgba(187, 128, 9, 0.25);
+  --color-range-selection-num: rgba(187, 128, 9, 0.3);
+  --color-range-indicator-bg: rgba(56, 139, 253, 0.15);
+  --color-range-indicator-border: #388bfd;
+  --color-range-indicator-text: #58a6ff;
+
   --color-shadow: rgba(0, 0, 0, 0.3);
   --color-shadow-large: rgba(0, 0, 0, 0.5);
 }
@@ -2328,7 +2340,7 @@ tr:hover .add-comment-btn {
 tr.line-range-selected,
 .line-range-start,
 tr.line-range-start {
-  background-color: rgba(255, 223, 93, 0.3) !important;
+  background-color: var(--color-range-selection) !important;
 }
 
 /* Ensure all cells in selected rows are highlighted */
@@ -2336,7 +2348,7 @@ tr.line-range-start {
 .line-range-start td,
 tr.line-range-selected td,
 tr.line-range-start td {
-  background-color: rgba(255, 223, 93, 0.3) !important;
+  background-color: var(--color-range-selection) !important;
 }
 
 /* Override diff-specific backgrounds for selected rows */
@@ -2346,7 +2358,7 @@ tr.line-range-selected.d2h-cntx,
 tr.line-range-start.d2h-ins,
 tr.line-range-start.d2h-del,
 tr.line-range-start.d2h-cntx {
-  background-color: rgba(255, 223, 93, 0.3) !important;
+  background-color: var(--color-range-selection) !important;
 }
 
 tr.line-range-selected.d2h-ins td,
@@ -2355,12 +2367,12 @@ tr.line-range-selected.d2h-cntx td,
 tr.line-range-start.d2h-ins td,
 tr.line-range-start.d2h-del td,
 tr.line-range-start.d2h-cntx td {
-  background-color: rgba(255, 223, 93, 0.3) !important;
+  background-color: var(--color-range-selection) !important;
 }
 
 .line-range-selected .d2h-code-linenumber,
 .line-range-start .d2h-code-linenumber {
-  background-color: rgba(255, 223, 93, 0.4) !important;
+  background-color: var(--color-range-selection-num) !important;
 }
 
 /* Override the code content cell background */
@@ -2374,69 +2386,12 @@ tr.line-range-start .d2h-code-line-ctn {
 .line-range-indicator {
   margin-left: auto;
   padding: 2px 8px;
-  background: #ddf4ff;
-  border: 1px solid #54aeff;
+  background: var(--color-range-indicator-bg);
+  border: 1px solid var(--color-range-indicator-border);
   border-radius: 4px;
   font-size: 12px;
   font-weight: 500;
-  color: #0969da;
-}
-
-/* Dark theme line range selection */
-.theme-dark .line-range-selected,
-.theme-dark tr.line-range-selected {
-  background-color: rgba(187, 128, 9, 0.25) !important;
-}
-
-.theme-dark .line-range-start,
-.theme-dark tr.line-range-start {
-  background-color: rgba(187, 128, 9, 0.35) !important;
-}
-
-/* Ensure all cells in selected rows are highlighted in dark theme */
-.theme-dark .line-range-selected td,
-.theme-dark .line-range-start td,
-.theme-dark tr.line-range-selected td,
-.theme-dark tr.line-range-start td {
-  background-color: rgba(187, 128, 9, 0.25) !important;
-}
-
-/* Override diff-specific backgrounds for selected rows in dark theme */
-.theme-dark tr.line-range-selected.d2h-ins,
-.theme-dark tr.line-range-selected.d2h-del,
-.theme-dark tr.line-range-selected.d2h-cntx,
-.theme-dark tr.line-range-start.d2h-ins,
-.theme-dark tr.line-range-start.d2h-del,
-.theme-dark tr.line-range-start.d2h-cntx {
-  background-color: rgba(187, 128, 9, 0.25) !important;
-}
-
-.theme-dark tr.line-range-selected.d2h-ins td,
-.theme-dark tr.line-range-selected.d2h-del td,
-.theme-dark tr.line-range-selected.d2h-cntx td,
-.theme-dark tr.line-range-start.d2h-ins td,
-.theme-dark tr.line-range-start.d2h-del td,
-.theme-dark tr.line-range-start.d2h-cntx td {
-  background-color: rgba(187, 128, 9, 0.25) !important;
-}
-
-.theme-dark .line-range-selected .d2h-code-linenumber,
-.theme-dark .line-range-start .d2h-code-linenumber {
-  background-color: rgba(187, 128, 9, 0.3) !important;
-}
-
-/* Override the code content cell background in dark theme */
-.theme-dark .line-range-selected .d2h-code-line-ctn,
-.theme-dark .line-range-start .d2h-code-line-ctn,
-.theme-dark tr.line-range-selected .d2h-code-line-ctn,
-.theme-dark tr.line-range-start .d2h-code-line-ctn {
-  background-color: transparent !important;
-}
-
-.theme-dark .line-range-indicator {
-  background: rgba(56, 139, 253, 0.15);
-  border-color: #388bfd;
-  color: #58a6ff;
+  color: var(--color-range-indicator-text);
 }
 
 /* Comment Form */


### PR DESCRIPTION
Implement GitHub-style line range selection for code review comments:
- Click line number to start selection (yellow highlight)
- Shift+click to complete range selection (all lines highlighted)
- Comment form displays selected range (e.g., "Lines 10-15")
- Database stores line_start and line_end for range comments
- Visual feedback with yellow highlighting during selection
- Dark theme support with adjusted color palette

🤖 Generated with [Claude Code](https://claude.com/claude-code)