### PR TITLE
Fix AI analysis progress dialog to accurately track parallel level ex…

### DIFF
--- a/public/js/components/ProgressModal.js
+++ b/public/js/components/ProgressModal.js
@@ -317,13 +317,17 @@ class ProgressModal {
    * @param {Object} status - Status object from server
    */
   updateProgress(status) {
+    // Validate status structure before accessing properties
+    if (!status.levels || typeof status.levels !== 'object') {
+      console.warn('Invalid status structure - missing or malformed levels object:', status);
+      return;
+    }
+
     // Update each level's progress independently from the levels object
-    if (status.levels) {
-      for (let level = 1; level <= 3; level++) {
-        const levelStatus = status.levels[level];
-        if (levelStatus) {
-          this.updateLevelProgress(level, levelStatus);
-        }
+    for (let level = 1; level <= 3; level++) {
+      const levelStatus = status.levels[level];
+      if (levelStatus) {
+        this.updateLevelProgress(level, levelStatus);
       }
     }
 
@@ -409,6 +413,7 @@ class ProgressModal {
 
     } else {
       // For pending or other states
+      console.warn('Unexpected level status:', levelStatus.status, 'for level', level);
       icon.className = 'icon pending';
       icon.textContent = '⏸';
       statusText.textContent = levelStatus.progress || 'Pending';

--- a/src/ai/analyzer.js
+++ b/src/ai/analyzer.js
@@ -221,6 +221,15 @@ class Analyzer {
       await this.storeSuggestions(prId, runId, suggestions, 1);
       logger.success(`Level 1 complete: ${suggestions.length} suggestions`);
 
+      // Report completion to progress callback
+      if (progressCallback) {
+        progressCallback({
+          status: 'completed',
+          progress: `Level 1 complete: ${suggestions.length} suggestions`,
+          level: 1
+        });
+      }
+
       return {
         suggestions,
         summary: response.summary || `Level 1: Found ${suggestions.length} suggestions`
@@ -228,6 +237,16 @@ class Analyzer {
 
     } catch (error) {
       logger.error(`Level 1 analysis failed: ${error.message}`);
+
+      // Report failure to progress callback
+      if (progressCallback) {
+        progressCallback({
+          status: 'failed',
+          progress: `Level 1 failed: ${error.message}`,
+          level: 1
+        });
+      }
+
       throw error;
     }
   }
@@ -674,6 +693,15 @@ Output JSON with this structure:
       await this.storeSuggestions(prId, runId, suggestions, 2);
       logger.success(`Level 2 complete: ${suggestions.length} suggestions`);
 
+      // Report completion to progress callback
+      if (progressCallback) {
+        progressCallback({
+          status: 'completed',
+          progress: `Level 2 complete: ${suggestions.length} suggestions`,
+          level: 2
+        });
+      }
+
       return {
         suggestions,
         summary: response.summary || `Level 2: Found ${suggestions.length} file context suggestions`
@@ -681,6 +709,16 @@ Output JSON with this structure:
 
     } catch (error) {
       logger.error(`Level 2 analysis failed: ${error.message}`);
+
+      // Report failure to progress callback
+      if (progressCallback) {
+        progressCallback({
+          status: 'failed',
+          progress: `Level 2 failed: ${error.message}`,
+          level: 2
+        });
+      }
+
       throw error;
     }
   }
@@ -740,6 +778,15 @@ Output JSON with this structure:
       await this.storeSuggestions(prId, runId, suggestions, 3);
       logger.success(`Level 3 complete: ${suggestions.length} suggestions`);
 
+      // Report completion to progress callback
+      if (progressCallback) {
+        progressCallback({
+          status: 'completed',
+          progress: `Level 3 complete: ${suggestions.length} suggestions`,
+          level: 3
+        });
+      }
+
       return {
         suggestions,
         summary: response.summary || `Level 3: Found ${suggestions.length} codebase context suggestions`
@@ -747,6 +794,16 @@ Output JSON with this structure:
 
     } catch (error) {
       logger.error(`Level 3 analysis failed: ${error.message}`);
+
+      // Report failure to progress callback
+      if (progressCallback) {
+        progressCallback({
+          status: 'failed',
+          progress: `Level 3 failed: ${error.message}`,
+          level: 3
+        });
+      }
+
       throw error;
     }
   }

--- a/src/routes/pr.js
+++ b/src/routes/pr.js
@@ -527,6 +527,10 @@ router.post('/api/analyze/:owner/:repo/:pr', async (req, res) => {
         const completionInfo = determineCompletionInfo(result);
 
         const currentStatus = activeAnalyses.get(analysisId);
+        if (!currentStatus) {
+          console.warn('Analysis already completed or removed:', analysisId);
+          return;
+        }
 
         // Mark all completed levels as completed
         for (let i = 1; i <= completionInfo.completedLevel; i++) {
@@ -558,6 +562,10 @@ router.post('/api/analyze/:owner/:repo/:pr', async (req, res) => {
       .catch(error => {
         logger.error(`Analysis failed for PR #${prNumber}: ${error.message}`);
         const currentStatus = activeAnalyses.get(analysisId);
+        if (!currentStatus) {
+          console.warn('Analysis status not found during error handling:', analysisId);
+          return;
+        }
 
         // Mark all levels as failed
         for (let i = 1; i <= 3; i++) {


### PR DESCRIPTION
…ecution

The progress dialog was showing erratic state transitions (preparing → start → completed → progress bar) because all 3 analysis levels run in parallel, but progress updates were overwriting a single status object.

Changes:
- Backend now tracks each level's status separately in a `levels` object
- Frontend reads from the per-level status structure
- All three levels show progress bars immediately when analysis starts
- Removed confusing setTimeout that caused state jumping
- Each level updates independently without interfering with others

🤖 Generated with [Claude Code](https://claude.com/claude-code)