### PR TITLE
Add multi-level analysis view with compact sidebar selector

### DIFF
--- a/public/css/pr.css
+++ b/public/css/pr.css
@@ -805,15 +805,13 @@
 }
 
 .diff-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
   margin-bottom: 16px;
 }
 
 .diff-header h2 {
   font-size: 18px;
   font-weight: 600;
+  margin-bottom: 12px;
 }
 
 .diff-stats {
@@ -1185,6 +1183,18 @@ tr.newly-expanded .d2h-code-line-ctn {
   border: 1px solid;
 }
 
+.level-badge.level-final {
+  background: #f6f8fa;
+  color: #24292f;
+  border-color: #d0d7de;
+}
+
+.level-badge.level-1 {
+  background: #dff7e8;
+  color: #116329;
+  border-color: #7ee7a3;
+}
+
 .level-badge.level-2 {
   background: #f0f9ff;
   color: #0284c7;
@@ -1196,6 +1206,31 @@ tr.newly-expanded .d2h-code-line-ctn {
   background: #fef7ed;
   color: #7c2d12;
   border-color: #fed7aa;
+}
+
+/* Dark theme level badge adjustments */
+[data-theme="dark"] .level-badge.level-final {
+  background: #161b22;
+  color: #c9d1d9;
+  border-color: #30363d;
+}
+
+[data-theme="dark"] .level-badge.level-1 {
+  background: #0d1c15;
+  color: #3fb950;
+  border-color: #2ea043;
+}
+
+[data-theme="dark"] .level-badge.level-2 {
+  background: #0c1b2b;
+  color: #58a6ff;
+  border-color: #1f6feb;
+}
+
+[data-theme="dark"] .level-badge.level-3 {
+  background: #221a14;
+  color: #f0883e;
+  border-color: #bd561d;
 }
 
 /* Type-specific colors */
@@ -1947,26 +1982,87 @@ tr.newly-expanded .d2h-code-line-ctn {
   background: var(--color-bg-secondary);
 }
 
+/* Level Selector */
+.level-selector {
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--color-border-primary);
+  background: var(--color-bg-primary);
+  display: flex;
+  flex-direction: row;
+  gap: 4px;
+  justify-content: space-between;
+}
+
+.level-option {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 8px;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background 0.15s ease;
+  user-select: none;
+  flex: 1;
+  justify-content: center;
+}
+
+.level-option:hover {
+  background: var(--color-bg-secondary);
+}
+
+.level-option input[type="radio"] {
+  margin: 0;
+  cursor: pointer;
+  width: 12px;
+  height: 12px;
+}
+
+.level-option span {
+  font-size: 12px;
+  color: var(--color-text-primary);
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+.level-option:has(input:checked) {
+  background: var(--color-accent-subtle);
+}
+
+.level-option:has(input:checked) span {
+  font-weight: 600;
+  color: var(--color-accent-fg);
+}
+
+/* Dark theme adjustments */
+[data-theme="dark"] .level-option:has(input:checked) {
+  background: rgba(56, 139, 253, 0.15);
+}
+
+[data-theme="dark"] .level-option:has(input:checked) span {
+  color: #58a6ff;
+}
+
 .navigator-controls {
-  padding: 12px 16px;
+  padding: 8px 12px;
   border-bottom: 1px solid var(--color-border-primary);
   position: sticky;
   top: 53px;
   background: var(--color-bg-primary);
   z-index: 1;
-}
-
-.suggestion-counter {
-  font-size: 13px;
-  color: var(--color-text-secondary);
-  text-align: center;
-  margin-bottom: 8px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
 }
 
 .navigation-buttons {
   display: flex;
-  gap: 8px;
-  justify-content: center;
+  gap: 4px;
+}
+
+.suggestion-counter {
+  font-size: 12px;
+  color: var(--color-text-secondary);
+  flex: 1;
 }
 
 .nav-btn {

--- a/public/js/components/SuggestionNavigator.js
+++ b/public/js/components/SuggestionNavigator.js
@@ -46,10 +46,25 @@ class SuggestionNavigator {
           </svg>
         </button>
       </div>
+      <div class="level-selector">
+        <label class="level-option" title="Orchestrated and curated suggestions (recommended)">
+          <input type="radio" name="analysis-level" value="final" checked>
+          <span>Overall</span>
+        </label>
+        <label class="level-option" title="Level 1: Diff analysis - issues found in changed lines only">
+          <input type="radio" name="analysis-level" value="1">
+          <span>L1</span>
+        </label>
+        <label class="level-option" title="Level 2: File context - consistency within modified files">
+          <input type="radio" name="analysis-level" value="2">
+          <span>L2</span>
+        </label>
+        <label class="level-option" title="Level 3: Codebase context - architectural patterns and cross-file dependencies">
+          <input type="radio" name="analysis-level" value="3">
+          <span>L3</span>
+        </label>
+      </div>
       <div class="navigator-controls">
-        <div class="suggestion-counter">
-          <span id="current-suggestion">0</span> of <span id="total-suggestions">0</span> suggestions
-        </div>
         <div class="navigation-buttons">
           <button class="nav-btn nav-prev" title="Previous suggestion (k)">
             <svg viewBox="0 0 16 16">
@@ -61,6 +76,9 @@ class SuggestionNavigator {
               <path d="M12.78 6.22a.75.75 0 010 1.06l-4.25 4.25a.75.75 0 01-1.06 0L3.22 7.28a.75.75 0 011.06-1.06L8 9.94l3.72-3.72a.75.75 0 011.06 0z"/>
             </svg>
           </button>
+        </div>
+        <div class="suggestion-counter">
+          <span id="current-suggestion">0</span> of <span id="total-suggestions">0</span> suggestions
         </div>
       </div>
       <div class="suggestions-list">
@@ -91,15 +109,29 @@ class SuggestionNavigator {
     // Toggle collapse/expand
     const toggleBtn = this.element.querySelector('.navigator-toggle');
     toggleBtn.addEventListener('click', () => this.toggleCollapse());
-    
+
     this.collapseToggle.addEventListener('click', () => this.toggleCollapse());
 
     // Navigation buttons
     const prevBtn = this.element.querySelector('.nav-prev');
     const nextBtn = this.element.querySelector('.nav-next');
-    
+
     prevBtn.addEventListener('click', () => this.goToPrevious());
     nextBtn.addEventListener('click', () => this.goToNext());
+
+    // Level selector radio buttons
+    const levelRadios = this.element.querySelectorAll('input[name="analysis-level"]');
+    levelRadios.forEach(radio => {
+      radio.addEventListener('change', (e) => {
+        if (e.target.checked) {
+          // Dispatch custom event that PRManager can listen for
+          const event = new CustomEvent('levelChanged', {
+            detail: { level: e.target.value }
+          });
+          document.dispatchEvent(event);
+        }
+      });
+    });
   }
 
   /**


### PR DESCRIPTION
Expose raw analysis results from Level 1 (diff), Level 2 (file context), and Level 3 (codebase) alongside the orchestrated "Overall" suggestions. Users can now choose which analysis granularity to view.

Backend:
- Modify suggestions API to accept levels query parameter
- Support filtering by 'final', '1', '2', '3' or combinations
- Order results by level, then file and line number

Frontend:
- Add compact radio button selector to AI suggestions sidebar
- Single-row layout with abbreviated labels (Overall, L1, L2, L3)
- Hover tooltips explain what each level analyzes
- Custom event communication between sidebar and PR manager
- Level badges on L1/L2/L3 suggestions (e.g., "L1: Diff Analysis")
- No badge for Overall suggestions (cleaner default view)
- Compact navigation: buttons left of "N of M suggestions" counter

Defaults to "Overall" (orchestrated) view, preserving existing behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)