### PR TITLE
Address Phase 1 feedback across all baseline prompts

### DIFF
--- a/src/ai/prompts/baseline/level1/balanced.js
+++ b/src/ai/prompts/baseline/level1/balanced.js
@@ -48,7 +48,7 @@ const taggedPrompt = `<section name="role" required="true">
 
 <section name="speed-expectations" required="true">
 ## Speed and Scope Expectations
-**This level should be fast** - focusing only on the diff itself without exploring file context or surrounding unchanged code. That analysis is reserved for Level 2.
+**This analysis should be fast** - focusing only on the diff itself without exploring file context or surrounding unchanged code.
 </section>
 
 <section name="generated-files" optional="true">
@@ -67,7 +67,7 @@ Do NOT create suggestions for any files not in this list. If you cannot find iss
 ## Initial Setup
 1. Run the annotated diff tool (shown above) to see the changes with line numbers
 2. Focus ONLY on the changed lines in the diff
-3. Do not analyze file context or surrounding unchanged code - that's for Level 2
+3. Do not analyze file context or surrounding unchanged code
 </section>
 
 <section name="focus-areas" required="true">
@@ -87,14 +87,14 @@ Identify the following in changed code:
 <section name="available-commands" required="true">
 ## Available Commands (READ-ONLY)
 You have READ-ONLY access to the codebase. You may run commands like:
-- The annotated diff tool shown above (preferred for viewing changes with line numbers)
+- The annotated diff tool shown above (required for viewing changes with line numbers)
 - \`cat -n <file>\` to view files with line numbers
 - ls, find, grep commands as needed
 
 IMPORTANT: Do NOT modify any files. Do NOT run write commands (rm, mv, git commit, etc.).
 Your role is strictly to analyze and report findings.
 
-Note: You may optionally use parallel read-only Tasks to analyze different parts of the changes if that would be helpful.
+Note: You may optionally use parallel read-only Tasks to analyze different files or different parts of the changes if that would be helpful.
 </section>
 
 <section name="output-schema" locked="true">
@@ -149,12 +149,20 @@ If you are unsure, use "NEW" - it is correct for the vast majority of suggestion
 <section name="guidelines" required="true">
 ## Important Guidelines
 - You may comment on any line in modified files. Prioritize changed lines, but include unchanged lines when they reveal issues (missing error handling, inconsistent patterns, etc.)
+- Prefer line-level comments over file-level comments when the suggestion applies to a specific line or range of lines
 - Focus on issues visible in the diff itself - do not analyze file context
-- Do not review unchanged code or missing tests (that's for Level 3)
-- Do not analyze file-level patterns or consistency (that's for Level 2)
+- Do not review unchanged code or missing tests
+- Do not analyze file-level patterns or consistency
 - For "praise" type suggestions: Omit the suggestion field entirely (no action needed)
-- For other types: Include specific, actionable suggestions
+- For other types, always include specific, actionable suggestions
 - This saves tokens and prevents empty suggestion sections
+
+Calibrate your confidence honestly:
+- High (0.8+): Clear issues you're certain about
+- Medium (0.5-0.79): Likely issues with some uncertainty
+- Lower: Observations you're less sure about
+
+When uncertain, prefer to omit rather than include marginal suggestions.
 </section>`;
 
 /**

--- a/src/ai/prompts/baseline/level1/fast.js
+++ b/src/ai/prompts/baseline/level1/fast.js
@@ -116,9 +116,11 @@ When unsure, use "NEW".
 
 <section name="guidelines" required="true" tier="fast">
 ## Guidelines
+- Only include suggestions you're confident about. If you're uncertain whether something is actually an issue, skip it.
+- Prefer line-level comments over file-level comments when the suggestion applies to a specific line or range of lines
 - Prioritize changed lines, include unchanged only if they reveal issues
 - For "praise" type: omit the suggestion field
-- For other types: include specific, actionable suggestions
+- For other types: always include specific, actionable suggestions
 </section>`;
 
 /**

--- a/src/ai/prompts/baseline/level1/thorough.js
+++ b/src/ai/prompts/baseline/level1/thorough.js
@@ -68,10 +68,8 @@ Quality matters more than speed for this review level. It's better to surface fe
 
 <section name="valid-files" locked="true">
 ## Valid Files for Suggestions
-You should ONLY create suggestions for files in this list:
+ONLY create suggestions for files in this list. If you cannot find issues in these files, that's okay - just return fewer suggestions.
 {{validFiles}}
-
-Do NOT create suggestions for any files not in this list. If you cannot find issues in these files, that's okay - just return fewer suggestions.
 </section>
 
 <section name="initial-setup" required="true" tier="thorough">
@@ -79,7 +77,7 @@ Do NOT create suggestions for any files not in this list. If you cannot find iss
 1. Run the annotated diff tool (shown above) to see the changes with line numbers
 2. Carefully read through all changes to understand the overall intent
 3. Focus on the changed lines in the diff, but note patterns across multiple changes
-4. Do not analyze file context or surrounding unchanged code - that's for Level 2
+4. Do not analyze file context or surrounding unchanged code
 5. Consider what could go wrong with each change
 </section>
 
@@ -181,32 +179,13 @@ If you are unsure, use "NEW" - it is correct for the vast majority of suggestion
 
 <section name="confidence-guidance" required="true" tier="thorough">
 ## Confidence Calibration
-Assign confidence scores carefully based on the certainty of your assessment:
+**Confidence** reflects your certainty that something IS an issue:
+- High (0.8-1.0): You're certain this is a real problem
+- Medium (0.5-0.79): Likely an issue, but context might justify it
+- Low (0.3-0.49): Possibly an issue, requires human judgment
+- Very low (<0.3): Observation only - flag for human awareness
 
-**High confidence (0.8-1.0):**
-- Clear bugs that will definitely cause runtime errors
-- Obvious security vulnerabilities with well-known exploit patterns
-- Definite typos or syntax errors
-- Violations of language rules or type system errors
-
-**Medium confidence (0.5-0.79):**
-- Likely bugs that depend on runtime conditions
-- Potential security issues that need context to confirm
-- Performance concerns that may or may not be significant
-- Code style issues that deviate from common conventions
-
-**Low confidence (0.3-0.49):**
-- Possible issues that require more context to evaluate
-- Stylistic suggestions that are subjective
-- Performance optimizations that may be premature
-- Design suggestions based on limited information
-
-**Very low confidence (0.0-0.29):**
-- Uncertain observations that may not be issues
-- Questions about intent rather than definite problems
-- Exploratory suggestions for consideration
-
-Be honest about uncertainty. A well-calibrated low confidence score is more useful than an overconfident high score.
+Note: Confidence is about certainty, not severity. A minor style issue can have high confidence. A potential security issue might have low confidence if you're unsure it's exploitable.
 </section>
 
 <section name="category-definitions" required="true" tier="thorough">
@@ -238,12 +217,13 @@ Be honest about uncertainty. A well-calibrated low confidence score is more usef
 - You may comment on any line in modified files
 - Prioritize changed lines, but include unchanged lines when they reveal issues (missing error handling, inconsistent patterns, etc.)
 - Focus on issues visible in the diff itself - do not analyze file context
-- Do not review unchanged code or missing tests (that's for Level 3)
-- Do not analyze file-level patterns or consistency (that's for Level 2)
+- Prefer line-level comments over file-level comments when the suggestion applies to a specific line or range of lines
+- Do not review unchanged code or missing tests
+- Do not analyze file-level patterns or consistency
 
 ### Output Quality
 - For "praise" type suggestions: Omit the suggestion field entirely (no action needed)
-- For other types: Include specific, actionable suggestions that the developer can implement
+- For other types always include specific, actionable suggestions that the developer can implement
 - Provide enough context in the description that a developer can understand the issue without seeing the code
 - Avoid vague suggestions like "consider improving this" - be specific about what and how
 

--- a/src/ai/prompts/baseline/level2/balanced.js
+++ b/src/ai/prompts/baseline/level2/balanced.js
@@ -143,8 +143,10 @@ If you are unsure, use "NEW" - it is correct for the vast majority of suggestion
 </section>
 
 <section name="file-level-guidance" optional="true" tier="balanced,thorough">
-## File-Level Suggestions
-In addition to line-specific suggestions, you may include file-level observations in the "fileLevelSuggestions" array. These are observations about an entire file that are not tied to specific lines, such as:
+## Line-Level vs File-Level Suggestions
+Prefer line-level comments (in the "suggestions" array) when the issue can be anchored to specific lines. Use file-level suggestions (in the "fileLevelSuggestions" array) only for observations that truly apply to the entire file and cannot be tied to specific lines.
+
+File-level suggestions are appropriate for:
 - Overall file architecture or organization issues
 - Naming convention concerns for the file/module
 - Missing tests for the file
@@ -157,11 +159,20 @@ File-level suggestions should NOT have a line number. They apply to the entire f
 
 <section name="guidelines" required="true">
 ## Important Guidelines
-- You may attach line-specific suggestions to any line within modified files, including context lines when they reveal file-level issues.
+- You may attach line-specific suggestions to any line within modified files, including context lines when they reveal file-level issues
+- Prefer line-level comments over file-level comments when the issue can be anchored to specific lines
+- Use fileLevelSuggestions only for observations that truly apply to the entire file
 - Focus on issues that require understanding the full file context
 - Focus on file-level patterns and consistency
 - For "praise" type: Omit the suggestion field entirely to save tokens
-- For other types: Include specific, actionable suggestions
+- For other types, always include specific, actionable suggestions
+
+Calibrate your confidence honestly:
+- High (0.8+): Clear issues you're certain about
+- Medium (0.5-0.79): Likely issues with some uncertainty
+- Lower: Observations you're less sure about
+
+When uncertain, prefer to omit rather than include marginal suggestions.
 </section>`;
 
 /**

--- a/src/ai/prompts/baseline/level2/fast.js
+++ b/src/ai/prompts/baseline/level2/fast.js
@@ -63,7 +63,7 @@ ONLY suggest for files in this list:
 ## Steps
 1. Run the annotated diff tool to see changes with line numbers
 2. Read full file content when needed for context
-3. Focus on file-level patterns and consistency
+3. Analyze in file context but anchor comments to specific lines
 4. Skip files without file-level issues
 </section>
 
@@ -126,9 +126,11 @@ When unsure, use "NEW".
 
 <section name="guidelines" required="true" tier="fast">
 ## Guidelines
-- Focus on issues requiring full file context
+- Focus on issues requiring full file context but locate comments on relevant lines within the file
+- Prefer line-level comments over file-level comments when the issue can be anchored to specific lines
 - For "praise" type: omit the suggestion field
-- For other types: include specific, actionable suggestions
+- For other types always include specific, actionable suggestions
+- Only include suggestions you're confident about. If you're uncertain whether something is actually an issue, skip it.
 </section>`;
 
 /**

--- a/src/ai/prompts/baseline/level2/thorough.js
+++ b/src/ai/prompts/baseline/level2/thorough.js
@@ -86,7 +86,8 @@ For each file with changes, follow this thorough analysis approach:
    5. **Evaluate consistency** - Naming, error handling, code style, documentation
    6. **Consider completeness** - Are there related changes within the file that should accompany these changes?
    7. **Assess file-level implications** - Does the change affect the file's overall coherence?
-   8. **Skip files where no file-level issues are found** - Efficiency focus, don't force findings
+   8. **Generate line-level suggestions** - After analyzing file context, create suggestions attached to specific lines where issues manifest
+   9. **Skip files where no file-level issues are found** - Efficiency focus, don't force findings
 </section>
 
 <section name="focus-areas" required="true" tier="thorough">
@@ -199,33 +200,13 @@ If you are unsure, use "NEW" - it is correct for the vast majority of suggestion
 
 <section name="confidence-guidance" required="true" tier="thorough">
 ## Confidence Calibration
-Assign confidence scores carefully based on the certainty of your assessment:
+**Confidence** reflects your certainty that something IS an issue:
+- High (0.8-1.0): You're certain this is a real problem
+- Medium (0.5-0.79): Likely an issue, but context might justify it
+- Low (0.3-0.49): Possibly an issue, requires human judgment
+- Very low (<0.3): Observation only - flag for human awareness
 
-**High confidence (0.8-1.0):**
-- Clear inconsistencies with well-established patterns in the file
-- Obvious integration issues that break file conventions
-- Definite missing related changes (e.g., import added but function not used)
-- Clear violations of the file's established security or error handling patterns
-
-**Medium confidence (0.5-0.79):**
-- Likely pattern violations that depend on file conventions being intentional
-- Potential consistency issues that may have valid reasons
-- Integration concerns that need more context to fully evaluate
-- Style issues that deviate from file norms but may be acceptable
-
-**Low confidence (0.3-0.49):**
-- Possible issues that require understanding file history
-- Stylistic suggestions based on inferred file conventions
-- Observations that may reflect intentional deviation from patterns
-- Suggestions for improvement based on limited file pattern evidence
-
-**Very low confidence (0.0-0.29):**
-- Uncertain observations about file patterns
-- Questions about intent rather than definite problems
-- Exploratory suggestions for file-level improvements
-- Observations where file context is unclear or ambiguous
-
-Be honest about uncertainty. A well-calibrated low confidence score is more useful than an overconfident high score.
+Note: Confidence is about certainty, not severity. A minor style issue can have high confidence. A potential security issue might have low confidence if you're unsure it's exploitable.
 </section>
 
 <section name="category-definitions" required="true" tier="thorough">
@@ -252,7 +233,7 @@ Be honest about uncertainty. A well-calibrated low confidence score is more usef
 
 <section name="file-level-guidance" required="true" tier="thorough">
 ## File-Level Suggestions
-In addition to line-specific suggestions, you SHOULD include file-level observations in the "fileLevelSuggestions" array. These are observations about an entire file that are not tied to specific lines, such as:
+In addition to line-specific suggestions, you MAY include file-level observations in the "fileLevelSuggestions" array. These are observations about an entire file that are not tied to specific lines, such as:
 - Overall file architecture or organization issues introduced by the changes
 - Naming convention concerns that affect the file/module as a whole
 - Missing tests for the file (if test patterns are visible in the codebase)
@@ -265,6 +246,7 @@ In addition to line-specific suggestions, you SHOULD include file-level observat
 File-level suggestions should NOT have a line number. They apply to the entire file.
 
 **When to use file-level suggestions:**
+- Line-level suggestions are preferred when they relate to a specific line or range of lines
 - The observation requires understanding the whole file, not just one line
 - The suggestion would improve overall file coherence
 - The issue cannot be addressed by changing a single line
@@ -282,7 +264,7 @@ File-level suggestions should NOT have a line number. They apply to the entire f
 
 ### Output Quality
 - For "praise" type suggestions: Omit the suggestion field entirely (no action needed)
-- For other types: Include specific, actionable suggestions grounded in file context
+- For other types always include specific, actionable suggestions grounded in file context
 - Explain WHY file context was needed to identify the issue
 - Provide enough context that a developer understands what file patterns they should follow
 - Avoid vague suggestions - be specific about what patterns exist and how to match them
@@ -293,13 +275,13 @@ File-level suggestions should NOT have a line number. They apply to the entire f
 - Distinguish between "must fix for consistency" and "nice to have improvements"
 - When in doubt about file conventions, lower your confidence score
 - Praise good integration with file patterns to reinforce positive practices
-- Remember: Level 2 is about file context. If an issue could be found from the diff alone, it belongs in Level 1.
+- Remember: This review is about changes in the context of the entire file. If an issue could be found from the diff alone, skip it.
 
 ### Prioritization
 - High priority: Breaking file conventions that could cause bugs or security issues
 - Medium priority: Consistency issues that affect maintainability
 - Low priority: Stylistic suggestions that would improve file coherence
-- Always include: Praise for excellent integration with file patterns
+- Maybe include praise for excellent integration with file patterns
 </section>`;
 
 /**

--- a/src/ai/prompts/baseline/level3/balanced.js
+++ b/src/ai/prompts/baseline/level3/balanced.js
@@ -70,7 +70,7 @@ Start from the changed files and explore outward to understand connections:
    - Whether these changes follow, improve, or violate patterns established elsewhere in the codebase
    - What impact these changes have on other parts of the system
 
-Explore as deeply as needed to understand the impact, but stay focused on relationships to the PR changes.
+Explore as deeply as needed to understand the impact, but stay focused on relationships to the changes.
 Avoid general codebase review - your goal is to evaluate these specific changes in their broader context.
 </section>
 
@@ -154,8 +154,10 @@ If you are unsure, use "NEW" - it is correct for the vast majority of suggestion
 </section>
 
 <section name="file-level-guidance" optional="true" tier="balanced,thorough">
-## File-Level Suggestions
-In addition to line-specific suggestions, you may include file-level observations in the "fileLevelSuggestions" array. These are observations about an entire file that are not tied to specific lines, such as:
+## Line-Level vs File-Level Suggestions
+Prefer line-level comments (in the "suggestions" array) when the issue can be anchored to specific lines. Use file-level suggestions (in the "fileLevelSuggestions" array) only for observations that truly apply to the entire file and cannot be tied to specific lines.
+
+File-level suggestions are appropriate for:
 - Architectural concerns about the file's role in the codebase
 - Missing tests for the file's functionality
 - Integration issues with other parts of the codebase
@@ -168,11 +170,18 @@ File-level suggestions should NOT have a line number. They apply to the entire f
 
 <section name="guidelines" required="true">
 ## Important Guidelines
-- You may attach line-specific suggestions to any line within files touched by this PR, including unchanged context lines when analysis reveals issues.
+- You may attach line-specific suggestions to any line within modified files, including context lines when they reveal codebase-level issues
+- Prefer line-level comments over file-level comments when the issue can be anchored to specific lines
+- Use fileLevelSuggestions only for observations that truly apply to the entire file
 - Focus on how these changes interact with the broader codebase
 - Look especially for missing tests, documentation, and integration issues
+- Calibrate your confidence honestly:
+  - High (0.8+): Clear issues you're certain about
+  - Medium (0.5-0.79): Likely issues with some uncertainty
+  - Lower: Observations you're less sure about
+- When uncertain, prefer to omit rather than include marginal suggestions.
 - For "praise" type: Omit the suggestion field entirely to save tokens
-- For other types: Include specific, actionable suggestions
+- For other types always include specific, actionable suggestions
 </section>`;
 
 /**

--- a/src/ai/prompts/baseline/level3/fast.js
+++ b/src/ai/prompts/baseline/level3/fast.js
@@ -134,8 +134,10 @@ When unsure, use "NEW".
 <section name="guidelines" required="true" tier="fast">
 ## Guidelines
 - Focus on codebase-level issues requiring broader context
+- Only include suggestions you're confident about. If you're uncertain whether something is actually an issue, skip it.
+- Prefer line-level comments over file-level comments when the suggestion applies to a specific line or range of lines
 - For "praise" type: omit the suggestion field
-- For other types: include specific, actionable suggestions
+- For other types always include specific, actionable suggestions
 </section>`;
 
 /**

--- a/src/ai/prompts/baseline/level3/thorough.js
+++ b/src/ai/prompts/baseline/level3/thorough.js
@@ -84,7 +84,7 @@ Key questions to answer:
 - How do these changes interact with the established architecture?
 - Are there patterns elsewhere in the codebase that these changes should follow?
 - What other parts of the system might be affected by these changes?
-- Are there missing changes (tests, documentation, configuration) that should accompany this PR?
+- Are there missing changes (tests, documentation, configuration) that should accompany these changes?
 </section>
 
 <section name="analysis-process" required="true" tier="thorough">
@@ -98,7 +98,7 @@ Start from the changed files and explore outward to understand connections:
    6. **Check completeness** - Are there tests, configurations, or documentation that should accompany these changes?
    7. **Consider evolution** - How do these changes affect the codebase's ability to evolve?
 
-Explore as deeply as needed to understand the impact, but stay focused on relationships to the PR changes.
+Explore as deeply as needed to understand the impact, but stay focused on relationships to the changes under review.
 Avoid general codebase review - your goal is to evaluate these specific changes in their broader context.
 </section>
 
@@ -249,37 +249,13 @@ If you are unsure, use "NEW" - it is correct for the vast majority of suggestion
 
 <section name="confidence-guidance" required="true" tier="thorough">
 ## Confidence Calibration
-Assign confidence scores carefully based on the certainty of your assessment:
+**Confidence** reflects your certainty that something IS an issue:
+- High (0.8-1.0): You're certain this is a real problem
+- Medium (0.5-0.79): Likely an issue, but context might justify it
+- Low (0.3-0.49): Possibly an issue, requires human judgment
+- Very low (<0.3): Observation only - flag for human awareness
 
-**High confidence (0.8-1.0):**
-- Clear violations of well-established architectural patterns
-- Obvious breaking changes to public APIs with documented contracts
-- Definite missing tests for code paths that existing tests cover elsewhere
-- Clear security vulnerabilities that bypass established security patterns
-- Obvious dependency issues that will cause runtime failures
-
-**Medium confidence (0.5-0.79):**
-- Likely pattern violations that depend on project conventions being intentional
-- Potential architectural concerns that may have valid reasons
-- Integration issues that could have been addressed elsewhere
-- Performance concerns that need profiling to confirm
-- Missing tests that might be covered by integration tests
-
-**Low confidence (0.3-0.49):**
-- Possible issues that require understanding project history
-- Stylistic suggestions based on inferred project conventions
-- Observations that may reflect intentional deviation from patterns
-- Suggestions for improvement based on limited codebase evidence
-- Questions about whether a pattern should be followed or improved
-
-**Very low confidence (0.0-0.29):**
-- Uncertain observations about codebase patterns
-- Questions about intent rather than definite problems
-- Exploratory suggestions for codebase-level improvements
-- Observations where codebase context is unclear or ambiguous
-- Speculation about how other parts of the system might be affected
-
-Be honest about uncertainty. A well-calibrated low confidence score is more useful than an overconfident high score.
+Note: Confidence is about certainty, not severity. A minor style issue can have high confidence. A potential architectural concern might have low confidence if you're unsure about the codebase conventions.
 </section>
 
 <section name="category-definitions" required="true" tier="thorough">
@@ -335,14 +311,15 @@ File-level suggestions should NOT have a line number. They apply to the entire f
 ## Important Guidelines
 
 ### What to Review
-- You may attach line-specific suggestions to any line within files touched by this PR, including unchanged context lines when analysis reveals issues
+- You may attach line-specific suggestions to any line within modified files, including unchanged context lines when analysis reveals issues
 - Focus on issues that REQUIRE understanding the codebase context - don't duplicate Level 1 or Level 2 findings
 - Look for patterns, conventions, and architectural issues that aren't visible from individual files alone
 - Include file-level suggestions for observations about overall codebase integration
+- Prefer line-level comments over file-level comments when the suggestion applies to a specific line or range of lines
 
 ### Output Quality
 - For "praise" type suggestions: Omit the suggestion field entirely (no action needed)
-- For other types: Include specific, actionable suggestions grounded in codebase context
+- For other types always include specific, actionable suggestions grounded in codebase context
 - Explain WHY codebase context was needed to identify the issue
 - Reference specific patterns or code elsewhere in the codebase when applicable
 - Provide enough context that a developer understands what codebase patterns they should follow
@@ -367,7 +344,7 @@ File-level suggestions should NOT have a line number. They apply to the entire f
 - Look for similar implementations to compare against
 - Check how dependents use the changed code
 - Verify test coverage matches patterns elsewhere
-- Don't spend time on general code review - stay focused on PR impact
+- Don't spend time on general code review - stay focused on the impact of these changes
 </section>`;
 
 /**

--- a/src/ai/prompts/baseline/orchestration/balanced.js
+++ b/src/ai/prompts/baseline/orchestration/balanced.js
@@ -48,7 +48,7 @@ Output ONLY valid JSON with no additional text, explanations, or markdown code b
 
 <section name="role-description" required="true">
 ## Your Role
-You are helping a human reviewer by intelligently curating and merging suggestions from a 3-level analysis system. Your goal is to provide the most valuable, non-redundant guidance to accelerate the human review process.
+You are helping a human reviewer by intelligently curating and merging suggestions from a multi-level analysis system. Your goal is to provide the most valuable, non-redundant guidance to accelerate the human review process.
 </section>
 
 <section name="custom-instructions" optional="true">
@@ -79,6 +79,7 @@ You are helping a human reviewer by intelligently curating and merging suggestio
 - **Combine related suggestions** across levels into comprehensive insights
 - **Merge overlapping concerns** (e.g., same security issue found in multiple levels)
 - **Preserve unique insights** that only one level discovered
+- **Prefer preserving line-level suggestions** over file-level suggestions when curating
 - **Do NOT mention which level found the issue** - focus on the insight itself
 </section>
 
@@ -124,7 +125,7 @@ Output JSON with this structure:
     "type": "bug|improvement|praise|suggestion|design|performance|security|code-style",
     "title": "Brief title describing the curated insight",
     "description": "Clear explanation of the issue and why this guidance matters to the human reviewer",
-    "suggestion": "Specific, actionable guidance for the reviewer (omit for praise items)",
+    "suggestion": "Specific, actionable guidance for the reviewer. For praise items this can be omitted. For other types always include specific, actionable suggestions.",
     "confidence": 0.0-1.0
   }],
   "fileLevelSuggestions": [{
@@ -135,7 +136,7 @@ Output JSON with this structure:
     "suggestion": "How to address the file-level concern (omit for praise items)",
     "confidence": 0.0-1.0
   }],
-  "summary": "Brief summary of orchestration results and key patterns found"
+  "summary": "Brief summary of the key findings and their significance to the reviewer. Focus on WHAT was found, not HOW it was found. Do NOT mention 'orchestration', 'levels', 'merged from Level 1/2/3' etc. Write as if a single reviewer produced this analysis."
 }
 </section>
 
@@ -166,6 +167,14 @@ Some input suggestions are marked as [FILE-LEVEL]. These are observations about 
 - **Suggestions may target any line in modified files** - Context lines can reveal issues too
 - **Only include modified files** - Discard any suggestions for files not modified in this PR
 - **Preserve file-level insights** - Don't discard valuable file-level observations
+
+**Confidence Calibration:**
+Calibrate your confidence honestly when curating:
+- High (0.8+): Clear issues you're certain should be included
+- Medium (0.5-0.79): Likely valuable suggestions
+- Lower: Consider omitting marginal suggestions
+
+When uncertain, prefer quality over quantity.
 </section>`;
 
 /**

--- a/src/ai/prompts/baseline/orchestration/fast.js
+++ b/src/ai/prompts/baseline/orchestration/fast.js
@@ -99,6 +99,8 @@ Curate and merge suggestions from 3-level analysis into high-value, non-redundan
 - Limit praise to 2-3 items
 - Focus on actionable items
 - Quality over quantity
+- Prefer preserving line-level suggestions over file-level suggestions
+- For other types always include specific, actionable suggestions
 </section>
 
 <section name="human-centric-framing" required="true" tier="fast">
@@ -135,7 +137,7 @@ Output JSON with this structure:
     "suggestion": "How to address the file-level concern (omit for praise items)",
     "confidence": 0.0-1.0
   }],
-  "summary": "Brief summary of orchestration results and key patterns found"
+  "summary": "Natural summary of key findings written as if from a single reviewer (do NOT mention orchestration, levels, merged analyses, or internal processes)"
 }
 </section>
 
@@ -153,6 +155,7 @@ Preserve old_or_new from input suggestions when merging.
 - Higher confidence for issues found in multiple levels
 - Only include modified files - discard suggestions for unmodified files
 - Preserve file-level insights in fileLevelSuggestions array
+- Only include suggestions you're confident about. If uncertain about a suggestion's validity, omit it.
 </section>`;
 
 /**

--- a/src/ai/prompts/baseline/orchestration/thorough.js
+++ b/src/ai/prompts/baseline/orchestration/thorough.js
@@ -204,37 +204,13 @@ Frame all suggestions as guidance for a human reviewer, not automated mandates:
 
 <section name="confidence-guidance" required="true" tier="thorough">
 ## Confidence Calibration
-Assign confidence scores carefully based on the evidence and cross-level agreement:
+**Confidence** when curating reflects certainty the suggestion is valuable:
+- High (0.8-1.0): Clearly valuable insight for the reviewer
+- Medium (0.5-0.79): Likely helpful, worth including
+- Low (0.3-0.49): Marginal value, consider context
+- Very low (<0.3): May not add value - consider omitting
 
-**High confidence (0.8-1.0):**
-- Issue identified at multiple analysis levels with consistent assessment
-- Clear evidence visible in the code or diff
-- Well-understood issue type with established patterns
-- Security or correctness issues with obvious exploitation paths
-
-**Medium confidence (0.5-0.79):**
-- Issue identified at one level with strong evidence
-- Cross-level support exists but with different emphasis
-- Likely issues that depend on runtime conditions or external context
-- Performance or design concerns that may have valid tradeoffs
-
-**Low confidence (0.3-0.49):**
-- Possible issues based on patterns or conventions
-- Single-level finding without corroboration
-- Stylistic suggestions that may reflect personal preference
-- Observations that require more context to fully evaluate
-
-**Very low confidence (0.0-0.29):**
-- Uncertain observations that warrant consideration but may not be issues
-- Questions about intent rather than definite problems
-- Exploratory suggestions based on limited information
-- Items where reviewer judgment is essential
-
-**Confidence Adjustment Factors:**
-- **Increase** when multiple levels agree on the same issue
-- **Increase** when the issue has clear, demonstrable impact
-- **Decrease** when levels disagree or provide conflicting assessments
-- **Decrease** when the issue depends heavily on context not visible in the PR
+Note: Confidence is about certainty of value, not severity. A minor improvement suggestion can have high confidence if you're sure it's helpful.
 </section>
 
 <section name="output-schema" locked="true">
@@ -264,7 +240,7 @@ Output JSON with this structure:
     "suggestion": "How to address the file-level concern (omit for praise items)",
     "confidence": 0.0-1.0
   }],
-  "summary": "Brief summary of orchestration results and key patterns found"
+  "summary": "Brief summary of the key findings and their significance to the reviewer. Focus on WHAT was found, not HOW it was found. Do NOT mention 'orchestration', 'levels', 'merged from Level 1/2/3' etc. Write as if a single reviewer produced this analysis."
 }
 </section>
 

--- a/tests/unit/prompts.test.js
+++ b/tests/unit/prompts.test.js
@@ -648,14 +648,16 @@ describe('Baseline Level 1 Thorough', () => {
     }
   });
 
-  it('should have detailed confidence guidance', async () => {
+  it('should have focused confidence guidance', async () => {
     const baseline = await import('../../src/ai/prompts/baseline/level1/thorough.js');
 
-    // Should have detailed confidence calibration
-    expect(baseline.taggedPrompt).toContain('High confidence (0.8-1.0)');
-    expect(baseline.taggedPrompt).toContain('Medium confidence (0.5-0.79)');
-    expect(baseline.taggedPrompt).toContain('Low confidence (0.3-0.49)');
-    expect(baseline.taggedPrompt).toContain('Very low confidence (0.0-0.29)');
+    // Should have confidence calibration that separates confidence from severity
+    expect(baseline.taggedPrompt).toContain('High (0.8-1.0)');
+    expect(baseline.taggedPrompt).toContain('Medium (0.5-0.79)');
+    expect(baseline.taggedPrompt).toContain('Low (0.3-0.49)');
+    expect(baseline.taggedPrompt).toContain('Very low (<0.3)');
+    // Key conceptual distinction
+    expect(baseline.taggedPrompt).toContain('Confidence is about certainty, not severity');
   });
 
   it('should have extended focus areas', async () => {
@@ -944,14 +946,16 @@ describe('Baseline Level 2 Thorough', () => {
     }
   });
 
-  it('should have detailed confidence guidance', async () => {
+  it('should have focused confidence guidance', async () => {
     const baseline = await import('../../src/ai/prompts/baseline/level2/thorough.js');
 
-    // Should have detailed confidence calibration
-    expect(baseline.taggedPrompt).toContain('High confidence (0.8-1.0)');
-    expect(baseline.taggedPrompt).toContain('Medium confidence (0.5-0.79)');
-    expect(baseline.taggedPrompt).toContain('Low confidence (0.3-0.49)');
-    expect(baseline.taggedPrompt).toContain('Very low confidence (0.0-0.29)');
+    // Should have confidence calibration that separates confidence from severity
+    expect(baseline.taggedPrompt).toContain('High (0.8-1.0)');
+    expect(baseline.taggedPrompt).toContain('Medium (0.5-0.79)');
+    expect(baseline.taggedPrompt).toContain('Low (0.3-0.49)');
+    expect(baseline.taggedPrompt).toContain('Very low (<0.3)');
+    // Key conceptual distinction
+    expect(baseline.taggedPrompt).toContain('Confidence is about certainty, not severity');
   });
 
   it('should have extended focus areas with file context emphasis', async () => {
@@ -1433,14 +1437,16 @@ describe('Baseline Level 3 Thorough', () => {
     }
   });
 
-  it('should have detailed confidence guidance', async () => {
+  it('should have focused confidence guidance', async () => {
     const baseline = await import('../../src/ai/prompts/baseline/level3/thorough.js');
 
-    // Should have detailed confidence calibration
-    expect(baseline.taggedPrompt).toContain('High confidence (0.8-1.0)');
-    expect(baseline.taggedPrompt).toContain('Medium confidence (0.5-0.79)');
-    expect(baseline.taggedPrompt).toContain('Low confidence (0.3-0.49)');
-    expect(baseline.taggedPrompt).toContain('Very low confidence (0.0-0.29)');
+    // Should have confidence calibration that separates confidence from severity
+    expect(baseline.taggedPrompt).toContain('High (0.8-1.0)');
+    expect(baseline.taggedPrompt).toContain('Medium (0.5-0.79)');
+    expect(baseline.taggedPrompt).toContain('Low (0.3-0.49)');
+    expect(baseline.taggedPrompt).toContain('Very low (<0.3)');
+    // Key conceptual distinction
+    expect(baseline.taggedPrompt).toContain('Confidence is about certainty, not severity');
   });
 
   it('should have extended focus areas with codebase context emphasis', async () => {
@@ -2037,14 +2043,14 @@ describe('Baseline Orchestration Thorough', () => {
     }
   });
 
-  it('should have detailed confidence guidance', async () => {
+  it('should have focused confidence guidance', async () => {
     const baseline = await import('../../src/ai/prompts/baseline/orchestration/thorough.js');
 
-    // Should have detailed confidence calibration
-    expect(baseline.taggedPrompt).toContain('High confidence (0.8-1.0)');
-    expect(baseline.taggedPrompt).toContain('Medium confidence (0.5-0.79)');
-    expect(baseline.taggedPrompt).toContain('Low confidence (0.3-0.49)');
-    expect(baseline.taggedPrompt).toContain('Very low confidence (0.0-0.29)');
+    // Should have confidence calibration focused on curation value
+    expect(baseline.taggedPrompt).toContain('High (0.8-1.0)');
+    expect(baseline.taggedPrompt).toContain('Medium (0.5-0.79)');
+    expect(baseline.taggedPrompt).toContain('Low (0.3-0.49)');
+    expect(baseline.taggedPrompt).toContain('Very low (<0.3)');
   });
 
   it('should have reasoning encouragement', async () => {
@@ -2114,13 +2120,16 @@ describe('Baseline Orchestration Thorough', () => {
     expect(baseline.taggedPrompt).toContain('pair programming partner');
   });
 
-  it('should have confidence adjustment factors', async () => {
+  it('should have focused confidence guidance for orchestration', async () => {
     const baseline = await import('../../src/ai/prompts/baseline/orchestration/thorough.js');
 
-    expect(baseline.taggedPrompt).toContain('Confidence Adjustment Factors');
-    expect(baseline.taggedPrompt).toContain('Increase');
-    expect(baseline.taggedPrompt).toContain('Decrease');
-    expect(baseline.taggedPrompt).toContain('cross-level agreement');
+    // Should have confidence calibration focused on curation value
+    expect(baseline.taggedPrompt).toContain('High (0.8-1.0)');
+    expect(baseline.taggedPrompt).toContain('Medium (0.5-0.79)');
+    expect(baseline.taggedPrompt).toContain('Low (0.3-0.49)');
+    expect(baseline.taggedPrompt).toContain('Very low (<0.3)');
+    // Key conceptual distinction
+    expect(baseline.taggedPrompt).toContain('Confidence is about certainty of value, not severity');
   });
 
   it('should have detailed file-level guidance', async () => {


### PR DESCRIPTION
Key improvements applied consistently across all 12 baseline prompts:

**Line-Level Comment Preference**
- All levels now emphasize preferring line-level comments over file-level
- Level 2/3 clarified: file-level ANALYSIS but line-level COMMENTS
- fileLevelSuggestions reserved for truly file-wide observations

**Cross-Level Reference Removal**
- Removed "that's for Level 2/3" phrases throughout
- Each prompt is now self-contained, saving tokens

**Consistent Phrasing**
- Standardized "For other types always include specific, actionable suggestions"
- Unified scope boundary language across tiers

**PR/Local Agnostic Language**
- Removed PR-specific assumptions in Level 3 prompts
- Works for both PR reviews and local mode

**Simplified Confidence Guidance** (major token savings)
- Fast: Simple directive "Only include suggestions you're confident about"
- Balanced: Light 4-line guidance without verbose tables
- Thorough: Focused guidance separating confidence from severity
- Key insight: "Confidence is about certainty, not severity"

**Orchestration Summary Guidance**
- Summary should focus on WHAT was found, not HOW
- No mention of orchestration, levels, or internal process
- Reads as if from a single reviewer

Net change: -31 lines (token savings from simplified confidence sections)