### PR TITLE
Fix cross-contamination between PR review sessions

### DIFF
--- a/public/js/components/AIPanel.js
+++ b/public/js/components/AIPanel.js
@@ -916,6 +916,39 @@ class AIPanel {
         document.querySelectorAll('.ai-suggestion-row').forEach(row => row.remove());
     }
 
+    /**
+     * Clear all state for session boundary.
+     * Called when switching PRs to prevent cross-contamination.
+     * This is more comprehensive than clearAllFindings() - it resets ALL session state.
+     */
+    clearAllState() {
+        console.log('[AIPanel] Clearing all state for session boundary');
+
+        // Clear data arrays
+        this.findings = [];
+        this.comments = [];
+
+        // Clear navigation state
+        this.currentIndex = -1;
+        this.selectedItemKey = null;
+
+        // Clear PR-specific state
+        this.currentPRKey = null;
+        this.fileOrder = new Map();
+
+        // Clear analysis state
+        this.summaryData = null;
+        this.analysisState = 'unknown';
+
+        // Reset level filter (resetLevelFilter only updates DOM, so explicitly reset property too)
+        this.selectedLevel = 'final';
+
+        // Reset UI
+        this.updateSegmentCounts();
+        this.renderFindings();
+        this.resetLevelFilter();
+    }
+
     // ========================================
     // Comment Management Methods
     // ========================================

--- a/public/js/local.js
+++ b/public/js/local.js
@@ -1181,6 +1181,12 @@ class LocalManager {
       return;
     }
 
+    // CRITICAL: Clear all state from previous session BEFORE loading new data
+    // This prevents cross-contamination between review sessions
+    if (manager.clearSession) {
+      manager.clearSession();
+    }
+
     manager.setLoading(true);
 
     try {

--- a/public/js/modules/file-comment-manager.js
+++ b/public/js/modules/file-comment-manager.js
@@ -1018,20 +1018,20 @@ class FileCommentManager {
       const fileName = zone.dataset.fileName;
       const container = zone.querySelector('.file-comments-container');
 
-      // Selectively clear existing cards based on what we're about to reload
-      // This prevents user comments from being cleared when only reloading AI suggestions
+      // CRITICAL: ALWAYS clear existing cards unconditionally.
+      // This prevents cross-contamination between sessions - old cards from
+      // a previous PR would persist if we only cleared when new data exists.
       if (container) {
-        // Only clear AI suggestions if we have suggestions to display
-        // (prevents stale suggestions from persisting when reloading or changing levels)
-        if (suggestions && suggestions.length > 0) {
+        // Always clear AI suggestions if suggestions array was provided (even if empty)
+        if (suggestions !== undefined) {
           const existingAISuggestions = container.querySelectorAll('.file-comment-card.ai-suggestion');
           for (const card of existingAISuggestions) {
             card.remove();
           }
         }
 
-        // Only clear user comments if we have comments to display
-        if (comments && comments.length > 0) {
+        // Always clear user comments if comments array was provided (even if empty)
+        if (comments !== undefined) {
           const existingUserComments = container.querySelectorAll('.file-comment-card.user-comment');
           for (const card of existingUserComments) {
             card.remove();


### PR DESCRIPTION
Add session boundary clearing to prevent AI suggestions and user comments from one PR session bleeding into another. The core fix establishes unconditional state clearing before loading new PR data.

Changes:
- Add clearSession() to PRManager that clears all state before loading
- Add clearAllState() to AIPanel for comprehensive state reset
- Fix FileCommentManager to clear cards unconditionally (not just when new data exists)
- Update refreshPR() to reload comments/suggestions and handle failures
- Add clearSession() call to LocalManager for local mode support
- Extract _clearReviewDOMElements() helper to avoid duplication