### PR TITLE
Fix comment location and mode-aware endpoints for review panel

### DIFF
--- a/public/js/modules/diff-renderer.js
+++ b/public/js/modules/diff-renderer.js
@@ -175,6 +175,12 @@ class DiffRenderer {
       if (diffPosition !== undefined) {
         row.dataset.diffPosition = diffPosition;
       }
+      // For context lines (unmodified), also store the old line number
+      // Context lines exist in BOTH coordinate systems: OLD (left) and NEW (right)
+      // This allows findLine() to locate context lines when searching by LEFT side
+      if (line.type === 'context' && line.oldNumber) {
+        row.dataset.oldLineNumber = line.oldNumber;
+      }
     }
 
     // Line numbers

--- a/tests/unit/file-comment-manager-endpoint.test.js
+++ b/tests/unit/file-comment-manager-endpoint.test.js
@@ -1,0 +1,905 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/**
+ * Unit tests for FileCommentManager._getFileCommentEndpoint()
+ *
+ * Tests the endpoint generation for file-level comment operations,
+ * ensuring the correct reviewId is used in local mode for all operations.
+ *
+ * This specifically tests the fix for a bug where 'prId' (undefined) was
+ * used instead of 'reviewId' for update and delete operations in local mode.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+// Setup global.window before importing production code that assigns to it
+global.window = global.window || {};
+
+// Import the actual FileCommentManager class from production code
+const { FileCommentManager } = require('../../public/js/modules/file-comment-manager.js');
+
+/**
+ * Create a minimal FileCommentManager instance for testing.
+ * @param {Object} prManagerConfig - Configuration for the mock prManager
+ */
+function createTestFileCommentManager(prManagerConfig = {}) {
+  const fileCommentManager = Object.create(FileCommentManager.prototype);
+  fileCommentManager.prManager = {
+    currentPR: {
+      id: prManagerConfig.reviewId || 'test-review-123',
+      reviewType: prManagerConfig.reviewType || 'local',
+      head_sha: prManagerConfig.headSha || 'abc123'
+    }
+  };
+  return fileCommentManager;
+}
+
+describe('FileCommentManager._getFileCommentEndpoint', () => {
+  describe('Local mode endpoints', () => {
+    let fileCommentManager;
+
+    beforeEach(() => {
+      fileCommentManager = createTestFileCommentManager({
+        reviewId: 'local-review-456',
+        reviewType: 'local',
+        headSha: 'def789'
+      });
+    });
+
+    it('should use reviewId for create endpoint in local mode', () => {
+      const result = fileCommentManager._getFileCommentEndpoint('create', {
+        file: 'src/test.js',
+        body: 'Test comment'
+      });
+
+      expect(result.endpoint).toBe('/api/local/local-review-456/file-comment');
+      expect(result.endpoint).not.toContain('undefined');
+    });
+
+    it('should use reviewId for update endpoint in local mode', () => {
+      const result = fileCommentManager._getFileCommentEndpoint('update', {
+        commentId: 'comment-789',
+        body: 'Updated comment'
+      });
+
+      expect(result.endpoint).toBe('/api/local/local-review-456/file-comment/comment-789');
+      expect(result.endpoint).not.toContain('undefined');
+    });
+
+    it('should use reviewId for delete endpoint in local mode', () => {
+      const result = fileCommentManager._getFileCommentEndpoint('delete', {
+        commentId: 'comment-789'
+      });
+
+      expect(result.endpoint).toBe('/api/local/local-review-456/file-comment/comment-789');
+      expect(result.endpoint).not.toContain('undefined');
+    });
+
+    it('should include correct request body for create operation', () => {
+      const result = fileCommentManager._getFileCommentEndpoint('create', {
+        file: 'src/test.js',
+        body: 'Test comment',
+        parent_id: 'parent-123',
+        type: 'suggestion',
+        title: 'Test Title'
+      });
+
+      expect(result.requestBody).toEqual({
+        file: 'src/test.js',
+        body: 'Test comment',
+        parent_id: 'parent-123',
+        type: 'suggestion',
+        title: 'Test Title'
+      });
+    });
+
+    it('should include correct request body for update operation', () => {
+      const result = fileCommentManager._getFileCommentEndpoint('update', {
+        commentId: 'comment-789',
+        body: 'Updated comment'
+      });
+
+      expect(result.requestBody).toEqual({
+        body: 'Updated comment'
+      });
+    });
+
+    it('should have null request body for delete operation', () => {
+      const result = fileCommentManager._getFileCommentEndpoint('delete', {
+        commentId: 'comment-789'
+      });
+
+      expect(result.requestBody).toBeNull();
+    });
+  });
+
+  describe('PR mode endpoints', () => {
+    let fileCommentManager;
+
+    beforeEach(() => {
+      fileCommentManager = createTestFileCommentManager({
+        reviewId: 'pr-review-123',
+        reviewType: 'pr',
+        headSha: 'abc123'
+      });
+    });
+
+    it('should use /api/file-comment for create endpoint in PR mode', () => {
+      const result = fileCommentManager._getFileCommentEndpoint('create', {
+        file: 'src/test.js',
+        body: 'Test comment'
+      });
+
+      expect(result.endpoint).toBe('/api/file-comment');
+    });
+
+    it('should use /api/user-comment/:id for update endpoint in PR mode', () => {
+      const result = fileCommentManager._getFileCommentEndpoint('update', {
+        commentId: 'comment-789',
+        body: 'Updated comment'
+      });
+
+      expect(result.endpoint).toBe('/api/user-comment/comment-789');
+    });
+
+    it('should use /api/user-comment/:id for delete endpoint in PR mode', () => {
+      const result = fileCommentManager._getFileCommentEndpoint('delete', {
+        commentId: 'comment-789'
+      });
+
+      expect(result.endpoint).toBe('/api/user-comment/comment-789');
+    });
+
+    it('should include review_id and commit_sha in create request body for PR mode', () => {
+      const result = fileCommentManager._getFileCommentEndpoint('create', {
+        file: 'src/test.js',
+        body: 'Test comment',
+        parent_id: 'parent-123',
+        type: 'suggestion',
+        title: 'Test Title'
+      });
+
+      expect(result.requestBody).toEqual({
+        review_id: 'pr-review-123',
+        file: 'src/test.js',
+        body: 'Test comment',
+        commit_sha: 'abc123',
+        parent_id: 'parent-123',
+        type: 'suggestion',
+        title: 'Test Title'
+      });
+    });
+  });
+
+  describe('Error handling', () => {
+    it('should throw for unknown operation', () => {
+      const fileCommentManager = createTestFileCommentManager();
+
+      expect(() => {
+        fileCommentManager._getFileCommentEndpoint('unknown', {});
+      }).toThrow('Unknown operation: unknown');
+    });
+  });
+});
+
+/**
+ * Tests for FileCommentManager._getSuggestionStatusEndpoint()
+ * Verifies that the helper method returns the correct endpoint URL
+ * for both local and PR modes.
+ */
+describe('FileCommentManager._getSuggestionStatusEndpoint', () => {
+  describe('Local mode', () => {
+    it('should return local API endpoint when reviewType is local', () => {
+      const fileCommentManager = createTestFileCommentManager({
+        reviewId: 'local-review-456',
+        reviewType: 'local'
+      });
+
+      const endpoint = fileCommentManager._getSuggestionStatusEndpoint(123);
+
+      expect(endpoint).toBe('/api/local/local-review-456/ai-suggestion/123/status');
+      expect(endpoint).not.toContain('undefined');
+    });
+
+    it('should include numeric reviewId correctly', () => {
+      const fileCommentManager = createTestFileCommentManager({
+        reviewId: 789,
+        reviewType: 'local'
+      });
+
+      const endpoint = fileCommentManager._getSuggestionStatusEndpoint(456);
+
+      expect(endpoint).toBe('/api/local/789/ai-suggestion/456/status');
+    });
+  });
+
+  describe('PR mode', () => {
+    it('should return PR API endpoint when reviewType is pr', () => {
+      const fileCommentManager = createTestFileCommentManager({
+        reviewId: 'pr-review-123',
+        reviewType: 'pr'
+      });
+
+      const endpoint = fileCommentManager._getSuggestionStatusEndpoint(456);
+
+      expect(endpoint).toBe('/api/ai-suggestion/456/status');
+    });
+
+    it('should not include reviewId in PR mode endpoint', () => {
+      const fileCommentManager = createTestFileCommentManager({
+        reviewId: 'pr-review-999',
+        reviewType: 'pr'
+      });
+
+      const endpoint = fileCommentManager._getSuggestionStatusEndpoint(111);
+
+      expect(endpoint).not.toContain('pr-review-999');
+      expect(endpoint).not.toContain('/local/');
+    });
+  });
+
+  describe('Edge cases', () => {
+    it('should default to PR mode when reviewType is undefined', () => {
+      // Bypass the test helper's default to test undefined reviewType
+      const fileCommentManager = Object.create(FileCommentManager.prototype);
+      fileCommentManager.prManager = {
+        currentPR: {
+          id: 'some-review',
+          reviewType: undefined  // Explicitly undefined, not defaulted
+        }
+      };
+
+      const endpoint = fileCommentManager._getSuggestionStatusEndpoint(123);
+
+      expect(endpoint).toBe('/api/ai-suggestion/123/status');
+    });
+
+    it('should handle missing prManager gracefully', () => {
+      const fileCommentManager = Object.create(FileCommentManager.prototype);
+      fileCommentManager.prManager = null;
+
+      const endpoint = fileCommentManager._getSuggestionStatusEndpoint(123);
+
+      // Should default to PR mode endpoint when prManager is null
+      expect(endpoint).toBe('/api/ai-suggestion/123/status');
+    });
+  });
+});
+
+/**
+ * Tests for FileCommentManager.restoreAISuggestion()
+ * Verifies that restoring a file-level AI suggestion:
+ * 1. Calls the API to update suggestion status to 'active'
+ * 2. Updates the AIPanel to reflect the active status
+ */
+describe('FileCommentManager.restoreAISuggestion', () => {
+  let mockFetch;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mockFetch = vi.fn();
+    global.fetch = mockFetch;
+
+    // Setup window with aiPanel mock
+    global.window = {
+      aiPanel: {
+        updateFindingStatus: vi.fn()
+      },
+      toast: {
+        showError: vi.fn()
+      }
+    };
+
+    // Mock console.error
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should call PR mode API endpoint when reviewType is pr', async () => {
+    const fileCommentManager = createTestFileCommentManager({
+      reviewId: 'pr-review-123',
+      reviewType: 'pr'
+    });
+    const suggestionId = 123;
+
+    // Mock successful API response
+    mockFetch.mockResolvedValueOnce({ ok: true });
+
+    // Create mock zone with suggestion card
+    const mockCard = {
+      classList: {
+        remove: vi.fn()
+      }
+    };
+    const mockZone = {
+      querySelector: vi.fn().mockReturnValue(mockCard)
+    };
+
+    await fileCommentManager.restoreAISuggestion(mockZone, suggestionId);
+
+    // Verify PR mode endpoint was called
+    expect(mockFetch).toHaveBeenCalledWith(
+      `/api/ai-suggestion/${suggestionId}/status`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status: 'active' })
+      }
+    );
+  });
+
+  it('should call local mode API endpoint when reviewType is local', async () => {
+    const fileCommentManager = createTestFileCommentManager({
+      reviewId: 'local-review-456',
+      reviewType: 'local'
+    });
+    const suggestionId = 789;
+
+    // Mock successful API response
+    mockFetch.mockResolvedValueOnce({ ok: true });
+
+    const mockCard = { classList: { remove: vi.fn() } };
+    const mockZone = { querySelector: vi.fn().mockReturnValue(mockCard) };
+
+    await fileCommentManager.restoreAISuggestion(mockZone, suggestionId);
+
+    // Verify local mode endpoint was called with reviewId
+    expect(mockFetch).toHaveBeenCalledWith(
+      `/api/local/local-review-456/ai-suggestion/${suggestionId}/status`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status: 'active' })
+      }
+    );
+  });
+
+  it('should update AIPanel with active status after successful API call', async () => {
+    const fileCommentManager = createTestFileCommentManager();
+    const suggestionId = 456;
+
+    mockFetch.mockResolvedValueOnce({ ok: true });
+
+    const mockCard = { classList: { remove: vi.fn() } };
+    const mockZone = { querySelector: vi.fn().mockReturnValue(mockCard) };
+
+    await fileCommentManager.restoreAISuggestion(mockZone, suggestionId);
+
+    // Verify AIPanel was notified
+    expect(window.aiPanel.updateFindingStatus).toHaveBeenCalledTimes(1);
+    expect(window.aiPanel.updateFindingStatus).toHaveBeenCalledWith(suggestionId, 'active');
+  });
+
+  it('should remove collapsed class from suggestion card', async () => {
+    const fileCommentManager = createTestFileCommentManager();
+    const suggestionId = 789;
+
+    mockFetch.mockResolvedValueOnce({ ok: true });
+
+    const mockRemove = vi.fn();
+    const mockCard = { classList: { remove: mockRemove } };
+    const mockZone = { querySelector: vi.fn().mockReturnValue(mockCard) };
+
+    await fileCommentManager.restoreAISuggestion(mockZone, suggestionId);
+
+    // Verify collapsed class was removed
+    expect(mockRemove).toHaveBeenCalledWith('collapsed');
+  });
+
+  it('should not update AIPanel when API call fails', async () => {
+    const fileCommentManager = createTestFileCommentManager();
+    const suggestionId = 111;
+
+    // Mock failed API response
+    mockFetch.mockResolvedValueOnce({ ok: false });
+
+    const mockCard = { classList: { remove: vi.fn() } };
+    const mockZone = { querySelector: vi.fn().mockReturnValue(mockCard) };
+
+    await fileCommentManager.restoreAISuggestion(mockZone, suggestionId);
+
+    // AIPanel should NOT be updated on failure
+    expect(window.aiPanel.updateFindingStatus).not.toHaveBeenCalled();
+
+    // Toast error should be shown
+    expect(window.toast.showError).toHaveBeenCalledWith('Failed to restore suggestion');
+  });
+
+  it('should handle missing AIPanel gracefully', async () => {
+    window.aiPanel = null;
+
+    const fileCommentManager = createTestFileCommentManager();
+    const suggestionId = 222;
+
+    mockFetch.mockResolvedValueOnce({ ok: true });
+
+    const mockCard = { classList: { remove: vi.fn() } };
+    const mockZone = { querySelector: vi.fn().mockReturnValue(mockCard) };
+
+    // Should not throw even without aiPanel
+    await expect(
+      fileCommentManager.restoreAISuggestion(mockZone, suggestionId)
+    ).resolves.not.toThrow();
+  });
+
+  it('should handle missing suggestion card gracefully', async () => {
+    const fileCommentManager = createTestFileCommentManager();
+    const suggestionId = 333;
+
+    mockFetch.mockResolvedValueOnce({ ok: true });
+
+    // Zone returns null for querySelector (card not found)
+    const mockZone = { querySelector: vi.fn().mockReturnValue(null) };
+
+    // Should not throw
+    await expect(
+      fileCommentManager.restoreAISuggestion(mockZone, suggestionId)
+    ).resolves.not.toThrow();
+
+    // API should still be called
+    expect(mockFetch).toHaveBeenCalled();
+
+    // AIPanel should still be updated
+    expect(window.aiPanel.updateFindingStatus).toHaveBeenCalledWith(suggestionId, 'active');
+  });
+
+  it('should query for suggestion card with correct selector', async () => {
+    const fileCommentManager = createTestFileCommentManager();
+    const suggestionId = 444;
+
+    mockFetch.mockResolvedValueOnce({ ok: true });
+
+    const mockQuerySelector = vi.fn().mockReturnValue({ classList: { remove: vi.fn() } });
+    const mockZone = { querySelector: mockQuerySelector };
+
+    await fileCommentManager.restoreAISuggestion(mockZone, suggestionId);
+
+    // Verify querySelector was called with correct selector
+    expect(mockQuerySelector).toHaveBeenCalledWith(`[data-suggestion-id="${suggestionId}"]`);
+  });
+
+  it('should call updateCommentCount after restoring suggestion', async () => {
+    const fileCommentManager = createTestFileCommentManager();
+    const suggestionId = 555;
+
+    mockFetch.mockResolvedValueOnce({ ok: true });
+
+    const mockCard = { classList: { remove: vi.fn() } };
+    const mockZone = { querySelector: vi.fn().mockReturnValue(mockCard) };
+
+    // Spy on updateCommentCount
+    fileCommentManager.updateCommentCount = vi.fn();
+
+    await fileCommentManager.restoreAISuggestion(mockZone, suggestionId);
+
+    // Verify updateCommentCount was called with the zone
+    expect(fileCommentManager.updateCommentCount).toHaveBeenCalledTimes(1);
+    expect(fileCommentManager.updateCommentCount).toHaveBeenCalledWith(mockZone);
+  });
+
+  it('should not call updateCommentCount when API call fails', async () => {
+    const fileCommentManager = createTestFileCommentManager();
+    const suggestionId = 666;
+
+    // Mock failed API response
+    mockFetch.mockResolvedValueOnce({ ok: false });
+
+    const mockZone = { querySelector: vi.fn().mockReturnValue({ classList: { remove: vi.fn() } }) };
+    fileCommentManager.updateCommentCount = vi.fn();
+
+    await fileCommentManager.restoreAISuggestion(mockZone, suggestionId);
+
+    // updateCommentCount should NOT be called on failure
+    expect(fileCommentManager.updateCommentCount).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * Tests for FileCommentManager.deleteFileComment()
+ * Verifies that deleting a file-level comment:
+ * 1. Calls the correct API endpoint
+ * 2. Updates AIPanel when the comment had a parent suggestion (dismissedSuggestionId)
+ */
+describe('FileCommentManager.deleteFileComment', () => {
+  let mockFetch;
+  let mockConfirmDialog;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mockFetch = vi.fn();
+    global.fetch = mockFetch;
+
+    mockConfirmDialog = {
+      show: vi.fn().mockResolvedValue('confirm')
+    };
+
+    // Setup window with mocks
+    global.window = {
+      aiPanel: {
+        updateFindingStatus: vi.fn(),
+        removeComment: vi.fn()
+      },
+      confirmDialog: mockConfirmDialog,
+      toast: {
+        showError: vi.fn()
+      }
+    };
+
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should call API to delete comment', async () => {
+    const fileCommentManager = createTestFileCommentManager({
+      reviewId: 'local-review-456',
+      reviewType: 'local'
+    });
+    const commentId = 123;
+
+    // Mock successful API response
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: vi.fn().mockResolvedValue({ success: true })
+    });
+
+    const mockCard = { remove: vi.fn() };
+    const mockZone = { querySelector: vi.fn().mockReturnValue(mockCard) };
+    fileCommentManager.updateCommentCount = vi.fn();
+
+    await fileCommentManager.deleteFileComment(mockZone, commentId);
+
+    // Verify API was called
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/api/local/local-review-456/file-comment/123',
+      { method: 'DELETE' }
+    );
+  });
+
+  it('should update AIPanel with active status when dismissedSuggestionId is returned', async () => {
+    const fileCommentManager = createTestFileCommentManager();
+    const commentId = 456;
+    const parentSuggestionId = 789;
+
+    // Mock successful API response with dismissedSuggestionId
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: vi.fn().mockResolvedValue({
+        success: true,
+        dismissedSuggestionId: parentSuggestionId
+      })
+    });
+
+    const mockCard = { remove: vi.fn() };
+    const mockZone = { querySelector: vi.fn().mockReturnValue(mockCard) };
+    fileCommentManager.updateCommentCount = vi.fn();
+
+    await fileCommentManager.deleteFileComment(mockZone, commentId);
+
+    // Verify AIPanel removeComment was called
+    expect(window.aiPanel.removeComment).toHaveBeenCalledWith(commentId);
+
+    // Verify AIPanel updateFindingStatus was called with 'dismissed' status
+    // (suggestion card is still collapsed in diff view; user can click "Show" to restore to active)
+    expect(window.aiPanel.updateFindingStatus).toHaveBeenCalledWith(parentSuggestionId, 'dismissed');
+  });
+
+  it('should not update AIPanel findingStatus when no dismissedSuggestionId', async () => {
+    const fileCommentManager = createTestFileCommentManager();
+    const commentId = 111;
+
+    // Mock successful API response WITHOUT dismissedSuggestionId
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: vi.fn().mockResolvedValue({ success: true })
+    });
+
+    const mockCard = { remove: vi.fn() };
+    const mockZone = { querySelector: vi.fn().mockReturnValue(mockCard) };
+    fileCommentManager.updateCommentCount = vi.fn();
+
+    await fileCommentManager.deleteFileComment(mockZone, commentId);
+
+    // AIPanel removeComment should still be called
+    expect(window.aiPanel.removeComment).toHaveBeenCalledWith(commentId);
+
+    // But updateFindingStatus should NOT be called
+    expect(window.aiPanel.updateFindingStatus).not.toHaveBeenCalled();
+  });
+
+  it('should handle missing AIPanel gracefully', async () => {
+    window.aiPanel = null;
+
+    const fileCommentManager = createTestFileCommentManager();
+    const commentId = 222;
+    const parentSuggestionId = 333;
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: vi.fn().mockResolvedValue({
+        success: true,
+        dismissedSuggestionId: parentSuggestionId
+      })
+    });
+
+    const mockCard = { remove: vi.fn() };
+    const mockZone = { querySelector: vi.fn().mockReturnValue(mockCard) };
+    fileCommentManager.updateCommentCount = vi.fn();
+
+    // Should not throw even without aiPanel
+    await expect(
+      fileCommentManager.deleteFileComment(mockZone, commentId)
+    ).resolves.not.toThrow();
+  });
+
+  it('should not proceed when user cancels confirmation dialog', async () => {
+    mockConfirmDialog.show.mockResolvedValue('cancel');
+
+    const fileCommentManager = createTestFileCommentManager();
+
+    await fileCommentManager.deleteFileComment({}, 123);
+
+    // API should NOT be called
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('should show error toast when API call fails', async () => {
+    const fileCommentManager = createTestFileCommentManager();
+    const commentId = 444;
+
+    // Mock failed API response
+    mockFetch.mockResolvedValueOnce({ ok: false });
+
+    const mockZone = { querySelector: vi.fn().mockReturnValue({ remove: vi.fn() }) };
+    fileCommentManager.updateCommentCount = vi.fn();
+
+    await fileCommentManager.deleteFileComment(mockZone, commentId);
+
+    // Toast error should be shown
+    expect(window.toast.showError).toHaveBeenCalledWith('Failed to delete comment');
+
+    // AIPanel should NOT be updated on failure
+    expect(window.aiPanel.removeComment).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * Tests for FileCommentManager.adoptAISuggestion()
+ * Verifies that adopting a file-level AI suggestion uses mode-aware endpoints.
+ */
+describe('FileCommentManager.adoptAISuggestion', () => {
+  let mockFetch;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mockFetch = vi.fn();
+    global.fetch = mockFetch;
+
+    // Setup window with mocks
+    global.window = {
+      aiPanel: {
+        updateFindingStatus: vi.fn(),
+        addComment: vi.fn()
+      },
+      toast: {
+        showError: vi.fn()
+      }
+    };
+
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should call local mode API endpoint for status update when reviewType is local', async () => {
+    const fileCommentManager = createTestFileCommentManager({
+      reviewId: 'local-review-456',
+      reviewType: 'local'
+    });
+
+    // Mock all required methods
+    fileCommentManager.formatAdoptedComment = vi.fn().mockReturnValue('formatted comment');
+    fileCommentManager._getFileCommentEndpoint = vi.fn().mockReturnValue({
+      endpoint: '/api/local/local-review-456/file-comment',
+      requestBody: { file: 'test.js', body: 'formatted comment' }
+    });
+    fileCommentManager.displayUserComment = vi.fn();
+    fileCommentManager.updateCommentCount = vi.fn();
+
+    const suggestion = {
+      id: 123,
+      file: 'test.js',
+      body: 'Original suggestion',
+      type: 'bug'
+    };
+
+    // Mock successful API responses
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: vi.fn().mockResolvedValue({ commentId: 999 })
+      })
+      .mockResolvedValueOnce({ ok: true }); // status update
+
+    const mockCard = {
+      classList: { add: vi.fn() },
+      querySelector: vi.fn().mockReturnValue({ textContent: '' })
+    };
+    const mockZone = { querySelector: vi.fn().mockReturnValue(mockCard) };
+
+    await fileCommentManager.adoptAISuggestion(mockZone, suggestion);
+
+    // Verify status update call uses local mode endpoint
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(mockFetch).toHaveBeenNthCalledWith(
+      2,
+      '/api/local/local-review-456/ai-suggestion/123/status',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status: 'adopted' })
+      }
+    );
+  });
+
+  it('should call PR mode API endpoint for status update when reviewType is pr', async () => {
+    const fileCommentManager = createTestFileCommentManager({
+      reviewId: 'pr-review-123',
+      reviewType: 'pr',
+      headSha: 'abc123'
+    });
+
+    fileCommentManager.formatAdoptedComment = vi.fn().mockReturnValue('formatted comment');
+    fileCommentManager._getFileCommentEndpoint = vi.fn().mockReturnValue({
+      endpoint: '/api/file-comment',
+      requestBody: { review_id: 'pr-review-123', file: 'test.js', body: 'formatted comment', commit_sha: 'abc123' }
+    });
+    fileCommentManager.displayUserComment = vi.fn();
+    fileCommentManager.updateCommentCount = vi.fn();
+
+    const suggestion = {
+      id: 456,
+      file: 'test.js',
+      body: 'Original suggestion',
+      type: 'suggestion'
+    };
+
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: vi.fn().mockResolvedValue({ commentId: 888 })
+      })
+      .mockResolvedValueOnce({ ok: true });
+
+    const mockCard = {
+      classList: { add: vi.fn() },
+      querySelector: vi.fn().mockReturnValue({ textContent: '' })
+    };
+    const mockZone = { querySelector: vi.fn().mockReturnValue(mockCard) };
+
+    await fileCommentManager.adoptAISuggestion(mockZone, suggestion);
+
+    // Verify status update call uses PR mode endpoint
+    expect(mockFetch).toHaveBeenNthCalledWith(
+      2,
+      '/api/ai-suggestion/456/status',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status: 'adopted' })
+      }
+    );
+  });
+});
+
+/**
+ * Tests for FileCommentManager.dismissAISuggestion()
+ * Verifies that dismissing a file-level AI suggestion uses mode-aware endpoints.
+ */
+describe('FileCommentManager.dismissAISuggestion', () => {
+  let mockFetch;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mockFetch = vi.fn();
+    global.fetch = mockFetch;
+
+    global.window = {
+      aiPanel: {
+        updateFindingStatus: vi.fn()
+      },
+      toast: {
+        showError: vi.fn()
+      }
+    };
+
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should call local mode API endpoint when reviewType is local', async () => {
+    const fileCommentManager = createTestFileCommentManager({
+      reviewId: 'local-review-789',
+      reviewType: 'local'
+    });
+    fileCommentManager.updateCommentCount = vi.fn();
+
+    const suggestionId = 555;
+
+    mockFetch.mockResolvedValueOnce({ ok: true });
+
+    const mockCard = {
+      classList: { add: vi.fn() },
+      querySelector: vi.fn().mockReturnValue({ textContent: '' })
+    };
+    const mockZone = { querySelector: vi.fn().mockReturnValue(mockCard) };
+
+    await fileCommentManager.dismissAISuggestion(mockZone, suggestionId);
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/api/local/local-review-789/ai-suggestion/555/status',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status: 'dismissed' })
+      }
+    );
+  });
+
+  it('should call PR mode API endpoint when reviewType is pr', async () => {
+    const fileCommentManager = createTestFileCommentManager({
+      reviewId: 'pr-review-456',
+      reviewType: 'pr'
+    });
+    fileCommentManager.updateCommentCount = vi.fn();
+
+    const suggestionId = 777;
+
+    mockFetch.mockResolvedValueOnce({ ok: true });
+
+    const mockCard = {
+      classList: { add: vi.fn() },
+      querySelector: vi.fn().mockReturnValue({ textContent: '' })
+    };
+    const mockZone = { querySelector: vi.fn().mockReturnValue(mockCard) };
+
+    await fileCommentManager.dismissAISuggestion(mockZone, suggestionId);
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/api/ai-suggestion/777/status',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status: 'dismissed' })
+      }
+    );
+  });
+
+  it('should update AIPanel with dismissed status after successful API call', async () => {
+    const fileCommentManager = createTestFileCommentManager();
+    fileCommentManager.updateCommentCount = vi.fn();
+
+    const suggestionId = 888;
+
+    mockFetch.mockResolvedValueOnce({ ok: true });
+
+    const mockCard = {
+      classList: { add: vi.fn() },
+      querySelector: vi.fn().mockReturnValue({ textContent: '' })
+    };
+    const mockZone = { querySelector: vi.fn().mockReturnValue(mockCard) };
+
+    await fileCommentManager.dismissAISuggestion(mockZone, suggestionId);
+
+    expect(window.aiPanel.updateFindingStatus).toHaveBeenCalledWith(suggestionId, 'dismissed');
+  });
+});

--- a/tests/unit/suggestion-manager-getfileandlineinfo.test.js
+++ b/tests/unit/suggestion-manager-getfileandlineinfo.test.js
@@ -1,0 +1,603 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/**
+ * Unit tests for SuggestionManager.getFileAndLineInfo()
+ *
+ * Tests the extraction of file and line information from AI suggestion elements,
+ * including:
+ * - Line-level suggestions with stored data attributes
+ * - File-level suggestions (isFileLevel: true)
+ * - Fallback DOM traversal for legacy suggestions
+ *
+ * IMPORTANT: These tests import the actual SuggestionManager class from production code
+ * to ensure tests verify real behavior, not a reimplementation.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Setup global.window before importing production code that assigns to it
+global.window = global.window || {};
+
+// Import the actual SuggestionManager class from production code
+const { SuggestionManager } = require('../../public/js/modules/suggestion-manager.js');
+
+/**
+ * Create a minimal SuggestionManager instance for testing.
+ */
+function createTestSuggestionManager() {
+  const suggestionManager = Object.create(SuggestionManager.prototype);
+  suggestionManager.prManager = null;
+  return suggestionManager;
+}
+
+/**
+ * Create a mock suggestion div element with data attributes
+ */
+function createMockSuggestionDiv(options = {}) {
+  const {
+    fileName = '',
+    lineNumber = '',
+    side = '',
+    diffPosition = '',
+    isFileLevel = 'false',
+    parentRow = null,
+    previousRow = null
+  } = options;
+
+  const dataset = {
+    fileName,
+    lineNumber,
+    side,
+    diffPosition,
+    isFileLevel
+  };
+
+  // Create a mock element with closest() and dataset
+  const mockDiv = {
+    dataset,
+    closest: vi.fn().mockReturnValue(parentRow)
+  };
+
+  return mockDiv;
+}
+
+/**
+ * Create a mock table row with previousElementSibling chain
+ */
+function createMockRow(options = {}) {
+  const {
+    className = '',
+    previousSibling = null,
+    dataset = {},
+    lineNum1 = null,
+    lineNum2 = null
+  } = options;
+
+  const mockRow = {
+    classList: {
+      contains: vi.fn((cls) => className.split(' ').includes(cls))
+    },
+    previousElementSibling: previousSibling,
+    dataset: { ...dataset },
+    closest: vi.fn().mockReturnValue(null),
+    querySelector: vi.fn((selector) => {
+      if (selector === '.line-num1' && lineNum1 !== null) {
+        return { textContent: String(lineNum1) };
+      }
+      if (selector === '.line-num2' && lineNum2 !== null) {
+        return { textContent: String(lineNum2) };
+      }
+      return null;
+    })
+  };
+
+  return mockRow;
+}
+
+describe('SuggestionManager.getFileAndLineInfo()', () => {
+  describe('Line-level suggestions with stored data', () => {
+    it('should return correct values from stored data attributes', () => {
+      const suggestionManager = createTestSuggestionManager();
+
+      // Create a diff row (the target) and suggestion row
+      const targetRow = createMockRow({
+        className: 'd2h-code-linenumber',
+        dataset: { diffPosition: '15', side: 'RIGHT' }
+      });
+
+      const suggestionRow = createMockRow({
+        className: 'ai-suggestion-row',
+        previousSibling: targetRow
+      });
+
+      const suggestionDiv = createMockSuggestionDiv({
+        fileName: 'src/components/Button.js',
+        lineNumber: '42',
+        side: 'RIGHT',
+        diffPosition: '15',
+        isFileLevel: 'false',
+        parentRow: suggestionRow
+      });
+
+      const result = suggestionManager.getFileAndLineInfo(suggestionDiv);
+
+      expect(result.fileName).toBe('src/components/Button.js');
+      expect(result.lineNumber).toBe(42); // Should be parsed as integer
+      expect(result.side).toBe('RIGHT');
+      expect(result.diffPosition).toBe('15');
+      expect(result.isFileLevel).toBe(false);
+      expect(result.suggestionRow).toBe(suggestionRow);
+      expect(result.targetRow).toBe(targetRow);
+    });
+
+    it('should parse lineNumber as integer for type consistency', () => {
+      const suggestionManager = createTestSuggestionManager();
+
+      const targetRow = createMockRow({ className: '' });
+      const suggestionRow = createMockRow({
+        className: 'ai-suggestion-row',
+        previousSibling: targetRow
+      });
+
+      const suggestionDiv = createMockSuggestionDiv({
+        fileName: 'test.js',
+        lineNumber: '123',
+        side: 'LEFT',
+        diffPosition: '50',
+        isFileLevel: 'false',
+        parentRow: suggestionRow
+      });
+
+      const result = suggestionManager.getFileAndLineInfo(suggestionDiv);
+
+      expect(typeof result.lineNumber).toBe('number');
+      expect(result.lineNumber).toBe(123);
+    });
+
+    it('should default side to RIGHT when not specified in stored data', () => {
+      const suggestionManager = createTestSuggestionManager();
+
+      const targetRow = createMockRow({ className: '' });
+      const suggestionRow = createMockRow({
+        className: 'ai-suggestion-row',
+        previousSibling: targetRow
+      });
+
+      const suggestionDiv = createMockSuggestionDiv({
+        fileName: 'test.js',
+        lineNumber: '10',
+        side: '', // Empty side
+        diffPosition: '5',
+        isFileLevel: 'false',
+        parentRow: suggestionRow
+      });
+
+      const result = suggestionManager.getFileAndLineInfo(suggestionDiv);
+
+      expect(result.side).toBe('RIGHT');
+    });
+
+    it('should return null diffPosition when not stored', () => {
+      const suggestionManager = createTestSuggestionManager();
+
+      const targetRow = createMockRow({ className: '' });
+      const suggestionRow = createMockRow({
+        className: 'ai-suggestion-row',
+        previousSibling: targetRow
+      });
+
+      const suggestionDiv = createMockSuggestionDiv({
+        fileName: 'test.js',
+        lineNumber: '10',
+        side: 'RIGHT',
+        diffPosition: '', // Empty diffPosition
+        isFileLevel: 'false',
+        parentRow: suggestionRow
+      });
+
+      const result = suggestionManager.getFileAndLineInfo(suggestionDiv);
+
+      expect(result.diffPosition).toBeNull();
+    });
+  });
+
+  describe('File-level suggestions', () => {
+    it('should return isFileLevel: true with null line/position values', () => {
+      const suggestionManager = createTestSuggestionManager();
+
+      const suggestionRow = createMockRow({
+        className: 'ai-suggestion-row'
+      });
+
+      // File-level suggestions have empty lineNumber, side, diffPosition
+      const suggestionDiv = createMockSuggestionDiv({
+        fileName: 'src/utils/helpers.js',
+        lineNumber: '',
+        side: '',
+        diffPosition: '',
+        isFileLevel: 'true',
+        parentRow: suggestionRow
+      });
+
+      const result = suggestionManager.getFileAndLineInfo(suggestionDiv);
+
+      expect(result.isFileLevel).toBe(true);
+      expect(result.fileName).toBe('src/utils/helpers.js');
+      expect(result.lineNumber).toBeNull();
+      expect(result.diffPosition).toBeNull();
+      expect(result.side).toBeNull();
+      expect(result.targetRow).toBeNull();
+      expect(result.suggestionRow).toBe(suggestionRow);
+    });
+
+    it('should handle file-level suggestion even with fileName containing colons', () => {
+      const suggestionManager = createTestSuggestionManager();
+
+      const suggestionRow = createMockRow({
+        className: 'ai-suggestion-row'
+      });
+
+      // Windows-style path with drive letter
+      const suggestionDiv = createMockSuggestionDiv({
+        fileName: 'C:\\Users\\dev\\project\\file.js',
+        lineNumber: '',
+        side: '',
+        diffPosition: '',
+        isFileLevel: 'true',
+        parentRow: suggestionRow
+      });
+
+      const result = suggestionManager.getFileAndLineInfo(suggestionDiv);
+
+      expect(result.isFileLevel).toBe(true);
+      expect(result.fileName).toBe('C:\\Users\\dev\\project\\file.js');
+    });
+  });
+
+  describe('Fallback DOM traversal', () => {
+    it('should skip ai-suggestion-row when traversing', () => {
+      const suggestionManager = createTestSuggestionManager();
+
+      // Create chain: targetRow -> anotherSuggestionRow -> suggestionRow
+      const targetRow = createMockRow({
+        className: '',
+        dataset: { diffPosition: '20', side: 'RIGHT' },
+        lineNum2: '50'
+      });
+
+      // Set up closest() to return a file wrapper
+      targetRow.closest = vi.fn().mockReturnValue({
+        dataset: { fileName: 'fallback-file.js' }
+      });
+
+      const anotherSuggestionRow = createMockRow({
+        className: 'ai-suggestion-row',
+        previousSibling: targetRow
+      });
+
+      const suggestionRow = createMockRow({
+        className: 'ai-suggestion-row',
+        previousSibling: anotherSuggestionRow
+      });
+
+      // No stored data - forces fallback path
+      const suggestionDiv = createMockSuggestionDiv({
+        fileName: '',  // Empty triggers fallback
+        lineNumber: '',
+        side: '',
+        diffPosition: '',
+        isFileLevel: '',
+        parentRow: suggestionRow
+      });
+
+      const result = suggestionManager.getFileAndLineInfo(suggestionDiv);
+
+      expect(result.targetRow).toBe(targetRow);
+      expect(result.fileName).toBe('fallback-file.js');
+      expect(result.lineNumber).toBe(50);
+    });
+
+    it('should skip user-comment-row when traversing', () => {
+      const suggestionManager = createTestSuggestionManager();
+
+      const targetRow = createMockRow({
+        className: '',
+        dataset: { diffPosition: '25', side: 'LEFT' },
+        lineNum1: '30'
+      });
+
+      targetRow.closest = vi.fn().mockReturnValue({
+        dataset: { fileName: 'user-comment-file.js' }
+      });
+
+      const userCommentRow = createMockRow({
+        className: 'user-comment-row',
+        previousSibling: targetRow
+      });
+
+      const suggestionRow = createMockRow({
+        className: 'ai-suggestion-row',
+        previousSibling: userCommentRow
+      });
+
+      const suggestionDiv = createMockSuggestionDiv({
+        fileName: '',
+        parentRow: suggestionRow
+      });
+
+      const result = suggestionManager.getFileAndLineInfo(suggestionDiv);
+
+      expect(result.targetRow).toBe(targetRow);
+    });
+
+    it('should skip context-expand-row when traversing', () => {
+      const suggestionManager = createTestSuggestionManager();
+
+      const targetRow = createMockRow({
+        className: '',
+        dataset: { diffPosition: '30', side: 'RIGHT' },
+        lineNum2: '75'
+      });
+
+      targetRow.closest = vi.fn().mockReturnValue({
+        dataset: { fileName: 'expand-file.js' }
+      });
+
+      const expandRow = createMockRow({
+        className: 'context-expand-row',
+        previousSibling: targetRow
+      });
+
+      const suggestionRow = createMockRow({
+        className: 'ai-suggestion-row',
+        previousSibling: expandRow
+      });
+
+      const suggestionDiv = createMockSuggestionDiv({
+        fileName: '',
+        parentRow: suggestionRow
+      });
+
+      const result = suggestionManager.getFileAndLineInfo(suggestionDiv);
+
+      expect(result.targetRow).toBe(targetRow);
+      expect(result.fileName).toBe('expand-file.js');
+    });
+
+    it('should throw error when no target row found', () => {
+      const suggestionManager = createTestSuggestionManager();
+
+      // Suggestion row with no previous sibling
+      const suggestionRow = createMockRow({
+        className: 'ai-suggestion-row',
+        previousSibling: null
+      });
+
+      const suggestionDiv = createMockSuggestionDiv({
+        fileName: '',
+        parentRow: suggestionRow
+      });
+
+      expect(() => {
+        suggestionManager.getFileAndLineInfo(suggestionDiv);
+      }).toThrow('Could not find target line for comment');
+    });
+
+    it('should use line-num1 for LEFT side in fallback path', () => {
+      const suggestionManager = createTestSuggestionManager();
+
+      const targetRow = createMockRow({
+        className: '',
+        dataset: { diffPosition: '35', side: 'LEFT' },
+        lineNum1: '100',
+        lineNum2: '105'
+      });
+
+      targetRow.closest = vi.fn().mockReturnValue({
+        dataset: { fileName: 'left-side.js' }
+      });
+
+      const suggestionRow = createMockRow({
+        className: 'ai-suggestion-row',
+        previousSibling: targetRow
+      });
+
+      const suggestionDiv = createMockSuggestionDiv({
+        fileName: '',
+        parentRow: suggestionRow
+      });
+
+      const result = suggestionManager.getFileAndLineInfo(suggestionDiv);
+
+      // LEFT side should use line-num1
+      expect(result.lineNumber).toBe(100);
+      expect(result.side).toBe('LEFT');
+    });
+
+    it('should use line-num2 for RIGHT side in fallback path', () => {
+      const suggestionManager = createTestSuggestionManager();
+
+      const targetRow = createMockRow({
+        className: '',
+        dataset: { diffPosition: '40', side: 'RIGHT' },
+        lineNum1: '100',
+        lineNum2: '110'
+      });
+
+      targetRow.closest = vi.fn().mockReturnValue({
+        dataset: { fileName: 'right-side.js' }
+      });
+
+      const suggestionRow = createMockRow({
+        className: 'ai-suggestion-row',
+        previousSibling: targetRow
+      });
+
+      const suggestionDiv = createMockSuggestionDiv({
+        fileName: '',
+        parentRow: suggestionRow
+      });
+
+      const result = suggestionManager.getFileAndLineInfo(suggestionDiv);
+
+      // RIGHT side should use line-num2
+      expect(result.lineNumber).toBe(110);
+      expect(result.side).toBe('RIGHT');
+    });
+
+    it('should default to RIGHT side when side not in dataset', () => {
+      const suggestionManager = createTestSuggestionManager();
+
+      const targetRow = createMockRow({
+        className: '',
+        dataset: { diffPosition: '45' }, // No side specified
+        lineNum2: '200'
+      });
+
+      targetRow.closest = vi.fn().mockReturnValue({
+        dataset: { fileName: 'no-side.js' }
+      });
+
+      const suggestionRow = createMockRow({
+        className: 'ai-suggestion-row',
+        previousSibling: targetRow
+      });
+
+      const suggestionDiv = createMockSuggestionDiv({
+        fileName: '',
+        parentRow: suggestionRow
+      });
+
+      const result = suggestionManager.getFileAndLineInfo(suggestionDiv);
+
+      expect(result.side).toBe('RIGHT');
+      expect(result.lineNumber).toBe(200);
+    });
+
+    it('should throw error when lineNumber cannot be determined', () => {
+      const suggestionManager = createTestSuggestionManager();
+
+      const targetRow = createMockRow({
+        className: '',
+        dataset: { diffPosition: '50', side: 'RIGHT' },
+        lineNum1: null,
+        lineNum2: null // No line numbers
+      });
+
+      targetRow.closest = vi.fn().mockReturnValue({
+        dataset: { fileName: 'no-line.js' }
+      });
+
+      const suggestionRow = createMockRow({
+        className: 'ai-suggestion-row',
+        previousSibling: targetRow
+      });
+
+      const suggestionDiv = createMockSuggestionDiv({
+        fileName: '',
+        parentRow: suggestionRow
+      });
+
+      expect(() => {
+        suggestionManager.getFileAndLineInfo(suggestionDiv);
+      }).toThrow('Could not determine file and line information');
+    });
+
+    it('should throw error when fileName cannot be determined', () => {
+      const suggestionManager = createTestSuggestionManager();
+
+      const targetRow = createMockRow({
+        className: '',
+        dataset: { diffPosition: '55', side: 'RIGHT' },
+        lineNum2: '300'
+      });
+
+      // closest returns null or element without fileName
+      targetRow.closest = vi.fn().mockReturnValue(null);
+
+      const suggestionRow = createMockRow({
+        className: 'ai-suggestion-row',
+        previousSibling: targetRow
+      });
+
+      const suggestionDiv = createMockSuggestionDiv({
+        fileName: '',
+        parentRow: suggestionRow
+      });
+
+      expect(() => {
+        suggestionManager.getFileAndLineInfo(suggestionDiv);
+      }).toThrow('Could not determine file and line information');
+    });
+  });
+
+  describe('Edge cases', () => {
+    it('should handle stored fileName without lineNumber (file-level check comes first)', () => {
+      const suggestionManager = createTestSuggestionManager();
+
+      const suggestionRow = createMockRow({
+        className: 'ai-suggestion-row'
+      });
+
+      // Has fileName but no lineNumber and isFileLevel is true
+      const suggestionDiv = createMockSuggestionDiv({
+        fileName: 'edge-case.js',
+        lineNumber: '',
+        side: '',
+        diffPosition: '',
+        isFileLevel: 'true',
+        parentRow: suggestionRow
+      });
+
+      const result = suggestionManager.getFileAndLineInfo(suggestionDiv);
+
+      // Should be treated as file-level
+      expect(result.isFileLevel).toBe(true);
+      expect(result.lineNumber).toBeNull();
+    });
+
+    it('should handle multiple intermediate rows correctly', () => {
+      const suggestionManager = createTestSuggestionManager();
+
+      const targetRow = createMockRow({
+        className: '',
+        dataset: { diffPosition: '60', side: 'RIGHT' },
+        lineNum2: '400'
+      });
+
+      targetRow.closest = vi.fn().mockReturnValue({
+        dataset: { fileName: 'multiple-rows.js' }
+      });
+
+      const expandRow = createMockRow({
+        className: 'context-expand-row',
+        previousSibling: targetRow
+      });
+
+      const userCommentRow = createMockRow({
+        className: 'user-comment-row',
+        previousSibling: expandRow
+      });
+
+      const anotherSuggestionRow = createMockRow({
+        className: 'ai-suggestion-row',
+        previousSibling: userCommentRow
+      });
+
+      const suggestionRow = createMockRow({
+        className: 'ai-suggestion-row',
+        previousSibling: anotherSuggestionRow
+      });
+
+      const suggestionDiv = createMockSuggestionDiv({
+        fileName: '',
+        parentRow: suggestionRow
+      });
+
+      const result = suggestionManager.getFileAndLineInfo(suggestionDiv);
+
+      expect(result.targetRow).toBe(targetRow);
+      expect(result.fileName).toBe('multiple-rows.js');
+      expect(result.lineNumber).toBe(400);
+    });
+  });
+});


### PR DESCRIPTION
- Fix LEFT side line location: pass side parameter when loading user comments so context lines can be found in either OLD or NEW coordinate system (pr.js, local.js, line-tracker.js)
- Add mode-aware endpoints: extract _getSuggestionStatusEndpoint helper and update adoptAISuggestion, dismissAISuggestion, adoptWithEdit to use correct local/PR endpoints (file-comment-manager.js)
- Fix async event handler: await restoreAISuggestion to prevent race conditions and ensure error propagation (file-comment-manager.js)
- Add comprehensive test coverage for endpoint selection, suggestion status updates, and line/file info extraction