### PR TITLE
Add workaround for highlight.js Ruby variable truncation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,11 +24,12 @@
       "devDependencies": {
         "@playwright/test": "^1.57.0",
         "@vitest/coverage-v8": "^4.0.16",
+        "highlight.js": "^11.11.1",
         "supertest": "^7.1.4",
         "vitest": "^4.0.16"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -2286,6 +2287,16 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/highlight.js": {
+      "version": "11.11.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
+      "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/html-escaper": {

--- a/package.json
+++ b/package.json
@@ -53,16 +53,17 @@
   "homepage": "https://github.com/in-the-loop-labs/pair-review#readme",
   "dependencies": {
     "@octokit/rest": "^19.0.11",
+    "better-sqlite3": "^11.8.1",
     "express": "^4.18.2",
     "markdown-it": "^13.0.2",
     "open": "^9.1.0",
     "simple-git": "^3.19.1",
-    "better-sqlite3": "^11.8.1",
     "uuid": "^11.1.0"
   },
   "devDependencies": {
     "@playwright/test": "^1.57.0",
     "@vitest/coverage-v8": "^4.0.16",
+    "highlight.js": "^11.11.1",
     "supertest": "^7.1.4",
     "vitest": "^4.0.16"
   }


### PR DESCRIPTION
The highlight.js Ruby grammar uses lookaheads that cause variables at end-of-line to truncate at the last underscore (e.g., @foo_bar_baz renders as @foo_bar with _baz unhighlighted). This is due to the positive lookahead requiring a character after the match combined with a negative lookahead rejecting letters.

Add fixRubyHighlighting() to merge orphaned underscore-segments back into the variable span. Applies to Ruby and ERB files, covering instance (@), class (@@), and global ($) variables.

Also adds highlight.js as dev dependency for testing syntax highlighting.