### PR TITLE
Fix text wrapping in diff panel suggestions and comments

### DIFF
--- a/.changeset/fix-suggestion-wrapping.md
+++ b/.changeset/fix-suggestion-wrapping.md
@@ -1,0 +1,7 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Fix text wrapping in diff panel suggestions and comments
+
+AI suggestions and user comments now wrap long text properly instead of overflowing the diff panel.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,6 +115,7 @@ Test structure:
 ## Development workflow
 - **Git workflow**: Ask before committing to main or pushing to remote
 - **Releases**: Never run `npm run release` unless explicitly instructed—it publishes to npm and pushes tags
+- **Changesets**: Create a changeset (`.changeset/*.md`) for user-facing changes that warrant a version bump. Use `patch` for bug fixes, `minor` for new features, `major` for breaking changes. Not needed for docs-only or internal refactoring changes.
 - Add a 'SPDX-License-Identifier: GPL-3.0-or-later' notice at the start of all source code files.
 - Package name: `pair-review`
 - No specific Node version requirement (use modern/recent)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@in-the-loop-labs/pair-review",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@in-the-loop-labs/pair-review",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "GPL-3.0",
       "dependencies": {
         "@octokit/rest": "^19.0.11",

--- a/public/css/pr.css
+++ b/public/css/pr.css
@@ -1543,8 +1543,7 @@
 
 .d2h-code-line-ctn {
   padding: 0 8px;
-  white-space: pre-wrap; /* Wrap long lines instead of scrolling */
-  word-break: break-all; /* Break anywhere if needed */
+  white-space: pre-wrap; /* Preserve whitespace but allow wrapping */
   font-family: inherit;
   vertical-align: top;
 }
@@ -1710,6 +1709,11 @@ tr.newly-expanded .d2h-code-line-ctn {
   box-shadow: 0 0 20px var(--ai-glow, rgba(245, 158, 11, 0.2)); /* Amber glow shadow */
   transition: all 0.2s ease;
   animation: slideUp 0.3s ease;
+  overflow: hidden;
+  word-break: break-word;
+  /* Viewport-based max-width: total viewport minus sidebar, AI panel, and padding/margins */
+  max-width: calc(100vw - var(--sidebar-width) - var(--ai-panel-width) - 100px);
+  box-sizing: border-box;
 }
 
 /* Dark theme suggestion background */
@@ -2006,6 +2010,9 @@ tr.newly-expanded .d2h-code-line-ctn {
   font-family: 'JetBrains Mono', 'SF Mono', 'SFMono-Regular', 'Consolas', 'Liberation Mono', 'Menlo', monospace;
   font-size: 0.8125rem;
   color: var(--ai-secondary, #fbbf24);
+  /* Allow long inline code (file paths, etc.) to break when needed */
+  overflow-wrap: break-word;
+  word-break: break-word;
 }
 
 .ai-suggestion-body pre,
@@ -2016,6 +2023,8 @@ tr.newly-expanded .d2h-code-line-ctn {
   padding: 12px;
   margin: 12px 0;
   overflow-x: auto;
+  white-space: pre-wrap;  /* Allow wrapping while preserving whitespace */
+  word-break: break-word;
 }
 
 .ai-suggestion-body pre code,
@@ -2025,6 +2034,8 @@ tr.newly-expanded .d2h-code-line-ctn {
   font-size: 0.8125rem;
   line-height: 1.6;
   color: var(--color-text-primary);
+  white-space: pre-wrap;  /* Inherit wrapping behavior */
+  word-break: break-word;
 }
 
 .ai-suggestion-body ul,
@@ -3506,6 +3517,11 @@ tr.line-range-start .d2h-code-line-ctn {
   margin: 6px 16px;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
   position: relative;
+  overflow: hidden;
+  word-break: break-word;
+  /* Viewport-based max-width: total viewport minus sidebar, AI panel, and padding/margins */
+  max-width: calc(100vw - var(--sidebar-width) - var(--ai-panel-width) - 100px);
+  box-sizing: border-box;
 }
 
 .user-comment-header {
@@ -5499,7 +5515,7 @@ body:not([data-theme="dark"]) .theme-icon-light {
 .main-layout .diff-view {
   flex: 1 1 0; /* Grow, shrink, start from 0 basis to ensure proper flex calculation */
   min-width: 0; /* Prevent flex item from expanding beyond container */
-  overflow-x: hidden; /* No horizontal scroll on diff view */
+  overflow-x: hidden; /* No horizontal scroll - content wraps instead */
   overflow-y: auto;
   background: var(--color-bg-secondary);
   display: flex;
@@ -5841,7 +5857,7 @@ body:not([data-theme="dark"]) .theme-icon-light {
   min-width: 0; /* Prevent flex item from expanding beyond container */
   padding: 16px;
   overflow-y: auto;
-  overflow-x: auto; /* Allow horizontal scroll for long code lines */
+  overflow-x: auto; /* Allow scroll as fallback for unbreakable content */
 }
 
 /* --------------------------------------------------------------------------

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -227,9 +227,7 @@ mark.d2h-code-line-ctn {
 .d2h-code-line-ctn {
     padding-left: 10px !important;  /* Small buffer between line numbers and code */
     padding-right: 10px !important;
-    white-space: pre-wrap !important;  /* Preserve whitespace but allow wrapping for long lines */
-    word-wrap: anywhere !important;
-    overflow-wrap: anywhere !important;
+    white-space: pre-wrap !important;  /* Preserve whitespace but allow wrapping */
     font-family: 'SF Mono', Monaco, 'Cascadia Code', monospace !important;
     font-size: 12px !important;
     tab-size: 4 !important;  /* Ensure tabs display correctly */
@@ -248,20 +246,16 @@ mark.d2h-code-line-ctn {
     display: none !important;
 }
 
-/* Collapse borders and spacing */
-.d2h-diff-table {
-    border-collapse: collapse !important;
-    border-spacing: 0 !important;
-}
-
-/* Clean unified diff table structure */
+/* Unified diff table structure */
 .d2h-diff-table {
     width: 100% !important;
     border-collapse: collapse !important;
+    border-spacing: 0 !important;
     font-family: 'SF Mono', Monaco, 'Cascadia Code', monospace !important;
     font-size: 12px !important;
-    table-layout: fixed !important;
-    text-align: left !important;  /* Ensure table content is left-aligned */
+    table-layout: auto !important;  /* auto allows content-based column sizing */
+    text-align: left !important;
+    overflow: visible !important;
 }
 
 .d2h-diff-tbody td.d2h-code-linenumber,
@@ -337,12 +331,6 @@ mark.d2h-code-line-ctn {
 .d2h-code-line-ctn::before {
     content: none !important;
     display: none !important;
-}
-
-/* Ensure proper table layout */
-.d2h-diff-table {
-    table-layout: auto !important;
-    overflow: visible !important;
 }
 
 .d2h-diff-tbody {


### PR DESCRIPTION
Add overflow constraints to suggestion and comment elements so long lines wrap instead of expanding the diff table horizontally.

- Add overflow:hidden to .ai-suggestion-cell and .user-comment-cell
- Add overflow:hidden and word-break:break-word to .ai-suggestion
- Add overflow:hidden and word-break:break-word to .user-comment
- Remove conflicting table-layout:auto rule from d2h-diff-table

Closes pair_review-wa9z