### PR TITLE
Disable hooks when invoking Claude CLI for AI analysis

### DIFF
--- a/.changeset/disable-hooks-claude-cli.md
+++ b/.changeset/disable-hooks-claude-cli.md
@@ -1,0 +1,7 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Disable hooks when invoking Claude CLI for AI analysis
+
+When pair-review invokes Claude CLI for AI analysis, it now passes `--settings '{"disableAllHooks":true}'` to prevent project-configured hooks from running during the analysis. This avoids slowdowns or interference from hooks configured in the repository being reviewed.

--- a/src/ai/claude-cli.js
+++ b/src/ai/claude-cli.js
@@ -18,12 +18,14 @@ class ClaudeCLI {
 
     if (this.useShell) {
       // Use the full command string with -p and --model appended
-      this.command = `${claudeCmd} -p --model ${model}`;
+      // Disable hooks to prevent project hooks from running during SDK mode invocation
+      this.command = `${claudeCmd} -p --model ${model} --settings '{"disableAllHooks":true}'`;
       this.args = [];
     } else {
       // Single command, use normal spawn mode
+      // Disable hooks to prevent project hooks from running during SDK mode invocation
       this.command = claudeCmd;
-      this.args = ['-p', '--model', model];
+      this.args = ['-p', '--model', model, '--settings', '{"disableAllHooks":true}'];
     }
   }
 


### PR DESCRIPTION
## Summary
- Pass `--settings '{"disableAllHooks":true}'` to Claude CLI when spawning for AI analysis
- Prevents project-configured hooks from running during SDK mode invocation
- Avoids slowdowns or interference from hooks in the repository being reviewed

## Test plan
- [x] All 1131 unit tests pass
- [ ] Manual test: Review a project that has Claude hooks configured and verify they don't run

🤖 Generated with [Claude Code](https://claude.com/claude-code)