### PR TITLE
Add keyboard shortcuts for common operations

### DIFF
--- a/.changeset/keyboard-shortcuts.md
+++ b/.changeset/keyboard-shortcuts.md
@@ -1,0 +1,13 @@
+---
+"@in-the-loop-labs/pair-review": minor
+---
+
+Add keyboard shortcuts for common operations
+
+- Press `?` to show keyboard shortcuts help overlay
+- Press `c c` to copy all comments to clipboard as markdown
+- Press `c x` to clear all comments (with confirmation)
+- Press `j`/`k` to navigate between AI suggestions
+- Press `Enter` to confirm dialogs, `Escape` to cancel
+
+Shortcuts use chord detection (e.g., press `c` then `c` within 500ms) and are disabled when typing in input fields or when modals are open.

--- a/public/js/components/ConfirmDialog.js
+++ b/public/js/components/ConfirmDialog.js
@@ -79,13 +79,28 @@ class ConfirmDialog {
       }
     });
 
-    // Handle escape key with a stored reference for cleanup
-    this.escapeHandler = (e) => {
-      if (e.key === 'Escape' && this.isVisible) {
+    // Handle keyboard shortcuts with a stored reference for cleanup
+    this.keyHandler = (e) => {
+      if (!this.isVisible) return;
+
+      if (e.key === 'Escape') {
         this.handleCancel();
+      } else if (e.key === 'Enter') {
+        // Only trigger if confirm button exists and is enabled, and not in a textarea
+        const confirmBtn = this.dialogElement?.querySelector('.confirm-btn') ||
+                           this.modal?.querySelector('#confirm-dialog-btn');
+        if (confirmBtn && !confirmBtn.disabled && window.getComputedStyle(confirmBtn).display !== 'none') {
+          // Don't intercept Enter in textareas or input fields
+          if (e.target.tagName === 'TEXTAREA' || e.target.tagName === 'INPUT') return;
+          e.preventDefault();
+          this.handleConfirm();
+        }
       }
     };
-    document.addEventListener('keydown', this.escapeHandler);
+    document.addEventListener('keydown', this.keyHandler);
+
+    // Keep escapeHandler reference for backward compatibility
+    this.escapeHandler = this.keyHandler;
   }
 
   /**

--- a/public/js/components/KeyboardShortcuts.js
+++ b/public/js/components/KeyboardShortcuts.js
@@ -1,0 +1,701 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/**
+ * Keyboard Shortcuts Manager
+ * Provides chord detection (key sequences like 'c c' or 'c x') and a help overlay
+ */
+class KeyboardShortcuts {
+  /**
+   * @param {Object} options - Configuration options
+   * @param {Function} options.onCopyComments - Callback for 'c c' (copy comments)
+   * @param {Function} options.onClearComments - Callback for 'c x' (clear comments)
+   */
+  constructor(options = {}) {
+    this.options = options;
+    this.shortcuts = new Map();
+    this.pendingKeys = [];
+    this.chordTimeout = null;
+    this.chordTimeoutMs = 500;
+    this.helpOverlay = null;
+    this.isHelpVisible = false;
+
+    this.registerDefaultShortcuts();
+    this.createHelpOverlay();
+    this.setupEventListeners();
+  }
+
+  /**
+   * Register the default shortcuts
+   */
+  registerDefaultShortcuts() {
+    // Help overlay
+    this.registerShortcut(['?'], 'Show keyboard shortcuts', () => {
+      this.showHelp();
+    });
+
+    // Comment actions (chords)
+    this.registerShortcut(['c', 'c'], 'Copy comments to clipboard', () => {
+      if (this.options.onCopyComments) {
+        this.options.onCopyComments();
+      }
+    });
+
+    this.registerShortcut(['c', 'x'], 'Clear all comments', () => {
+      if (this.options.onClearComments) {
+        this.options.onClearComments();
+      }
+    });
+
+    // Suggestion navigation
+    this.registerShortcut(['j'], 'Next suggestion', () => {
+      if (this.options.onNextSuggestion) {
+        this.options.onNextSuggestion();
+      }
+    });
+
+    this.registerShortcut(['k'], 'Previous suggestion', () => {
+      if (this.options.onPrevSuggestion) {
+        this.options.onPrevSuggestion();
+      }
+    });
+  }
+
+  /**
+   * Register a keyboard shortcut
+   * @param {string[]} keys - Array of keys in sequence (e.g., ['c', 'c'] or ['?'])
+   * @param {string} description - Human-readable description for help overlay
+   * @param {Function} callback - Function to execute when shortcut is triggered
+   */
+  registerShortcut(keys, description, callback) {
+    if (!Array.isArray(keys) || keys.length === 0) {
+      console.warn('KeyboardShortcuts: keys must be a non-empty array');
+      return;
+    }
+
+    const keyString = keys.join(' ');
+    this.shortcuts.set(keyString, {
+      keys,
+      description,
+      callback
+    });
+  }
+
+  /**
+   * Unregister a keyboard shortcut
+   * @param {string[]} keys - Array of keys in sequence
+   */
+  unregisterShortcut(keys) {
+    const keyString = keys.join(' ');
+    this.shortcuts.delete(keyString);
+  }
+
+  /**
+   * Create the help overlay DOM structure
+   */
+  createHelpOverlay() {
+    // Remove existing overlay if present
+    const existing = document.getElementById('keyboard-shortcuts-help');
+    if (existing) {
+      existing.remove();
+    }
+
+    const overlay = document.createElement('div');
+    overlay.id = 'keyboard-shortcuts-help';
+    overlay.className = 'keyboard-shortcuts-overlay';
+    overlay.style.display = 'none';
+
+    overlay.innerHTML = `
+      <div class="keyboard-shortcuts-backdrop" data-action="close"></div>
+      <div class="keyboard-shortcuts-panel">
+        <div class="keyboard-shortcuts-header">
+          <h2>Keyboard Shortcuts</h2>
+          <button class="keyboard-shortcuts-close" data-action="close" title="Close (Escape)">
+            <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+              <path d="M3.72 3.72a.75.75 0 011.06 0L8 6.94l3.22-3.22a.75.75 0 111.06 1.06L9.06 8l3.22 3.22a.75.75 0 11-1.06 1.06L8 9.06l-3.22 3.22a.75.75 0 01-1.06-1.06L6.94 8 3.72 4.78a.75.75 0 010-1.06z"/>
+            </svg>
+          </button>
+        </div>
+        <div class="keyboard-shortcuts-body">
+          <div class="keyboard-shortcuts-list">
+            ${this.renderShortcutsList()}
+          </div>
+        </div>
+      </div>
+    `;
+
+    document.body.appendChild(overlay);
+    this.helpOverlay = overlay;
+
+    // Bind click handlers
+    overlay.addEventListener('click', (e) => {
+      const action = e.target.closest('[data-action]')?.dataset.action;
+      if (action === 'close') {
+        this.hideHelp();
+      }
+    });
+  }
+
+  /**
+   * Render the shortcuts list HTML
+   * @returns {string} HTML string for shortcuts list
+   */
+  renderShortcutsList() {
+    const groups = {
+      navigation: { title: 'Navigation', shortcuts: [] },
+      comments: { title: 'Comments', shortcuts: [] },
+      general: { title: 'General', shortcuts: [] }
+    };
+
+    // Categorize shortcuts
+    for (const [keyString, shortcut] of this.shortcuts) {
+      const { keys, description } = shortcut;
+      const item = { keys, description };
+
+      if (keys.includes('j') || keys.includes('k')) {
+        groups.navigation.shortcuts.push(item);
+      } else if (keys[0] === 'c') {
+        groups.comments.shortcuts.push(item);
+      } else {
+        groups.general.shortcuts.push(item);
+      }
+    }
+
+    let html = '';
+
+    for (const [groupKey, group] of Object.entries(groups)) {
+      if (group.shortcuts.length === 0) continue;
+
+      html += `
+        <div class="keyboard-shortcuts-group">
+          <h3 class="keyboard-shortcuts-group-title">${group.title}</h3>
+          <div class="keyboard-shortcuts-items">
+            ${group.shortcuts.map(shortcut => this.renderShortcutItem(shortcut)).join('')}
+          </div>
+        </div>
+      `;
+    }
+
+    return html;
+  }
+
+  /**
+   * Render a single shortcut item
+   * @param {Object} shortcut - Shortcut object with keys and description
+   * @returns {string} HTML string for shortcut item
+   */
+  renderShortcutItem(shortcut) {
+    const keysHtml = shortcut.keys
+      .map(key => `<kbd class="keyboard-shortcut-key">${this.escapeHtml(this.formatKey(key))}</kbd>`)
+      .join('<span class="keyboard-shortcut-then">then</span>');
+
+    return `
+      <div class="keyboard-shortcut-item">
+        <span class="keyboard-shortcut-keys">${keysHtml}</span>
+        <span class="keyboard-shortcut-description">${this.escapeHtml(shortcut.description)}</span>
+      </div>
+    `;
+  }
+
+  /**
+   * Format a key for display
+   * @param {string} key - The key to format
+   * @returns {string} Formatted key string
+   */
+  formatKey(key) {
+    const keyMap = {
+      '?': '?',
+      'Escape': 'Esc',
+      'ArrowUp': '\u2191',
+      'ArrowDown': '\u2193',
+      'ArrowLeft': '\u2190',
+      'ArrowRight': '\u2192',
+      'Enter': '\u21B5',
+      ' ': 'Space'
+    };
+    return keyMap[key] || key.toUpperCase();
+  }
+
+  /**
+   * Setup keyboard event listeners
+   */
+  setupEventListeners() {
+    this.boundKeyHandler = (e) => this.handleKeyDown(e);
+    document.addEventListener('keydown', this.boundKeyHandler);
+  }
+
+  /**
+   * Handle keydown events
+   * @param {KeyboardEvent} e - The keyboard event
+   */
+  handleKeyDown(e) {
+    // Close help overlay on Escape
+    if (e.key === 'Escape' && this.isHelpVisible) {
+      e.preventDefault();
+      this.hideHelp();
+      return;
+    }
+
+    // Ignore shortcuts when in input fields
+    if (this.isInInputField(e.target)) {
+      this.resetChord();
+      return;
+    }
+
+    // Ignore shortcuts when a modal is open (except our help overlay)
+    if (this.isModalOpen()) {
+      this.resetChord();
+      return;
+    }
+
+    // Ignore shortcuts with modifier keys (except Shift for special chars like ?)
+    if (e.ctrlKey || e.metaKey || e.altKey) {
+      return;
+    }
+
+    // Get the key, accounting for Shift
+    const key = e.key;
+
+    // Clear timeout and add key to pending sequence
+    this.clearChordTimeout();
+    this.pendingKeys.push(key);
+
+    // Try to match shortcuts
+    const matched = this.tryMatchShortcut();
+
+    if (matched) {
+      e.preventDefault();
+      this.resetChord();
+    } else if (this.hasPotentialMatch()) {
+      // There's a potential match, wait for more keys
+      e.preventDefault();
+      this.startChordTimeout();
+    } else {
+      // No match possible, reset
+      this.resetChord();
+    }
+  }
+
+  /**
+   * Check if the event target is an input field
+   * @param {HTMLElement} target - The event target
+   * @returns {boolean} True if target is an input field
+   */
+  isInInputField(target) {
+    if (!target) return false;
+
+    const tagName = target.tagName.toUpperCase();
+    if (tagName === 'INPUT' || tagName === 'TEXTAREA' || tagName === 'SELECT') {
+      return true;
+    }
+
+    // Check for contenteditable
+    if (target.isContentEditable || target.contentEditable === 'true') {
+      return true;
+    }
+
+    return false;
+  }
+
+  /**
+   * Check if a modal is currently open (excluding our help overlay)
+   * @returns {boolean} True if a modal is open
+   */
+  isModalOpen() {
+    // Check for common modal patterns in the codebase
+    const modalSelectors = [
+      '.modal-overlay:not(#keyboard-shortcuts-help)',
+      '.review-modal-overlay',
+      '.preview-modal-overlay',
+      '.confirm-dialog-overlay',
+      '.analysis-config-overlay',
+      '.ai-summary-modal-overlay',
+      '[role="dialog"]:not(#keyboard-shortcuts-help)'
+    ];
+
+    for (const selector of modalSelectors) {
+      const modal = document.querySelector(selector);
+      if (modal && this.isElementVisible(modal)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  /**
+   * Check if an element is visible
+   * @param {HTMLElement} element - The element to check
+   * @returns {boolean} True if element is visible
+   */
+  isElementVisible(element) {
+    if (!element) return false;
+
+    const style = window.getComputedStyle(element);
+    if (style.display === 'none' || style.visibility === 'hidden' || style.opacity === '0') {
+      return false;
+    }
+
+    return true;
+  }
+
+  /**
+   * Try to match the current key sequence against registered shortcuts
+   * @returns {boolean} True if a shortcut was matched and executed
+   */
+  tryMatchShortcut() {
+    const keyString = this.pendingKeys.join(' ');
+
+    const shortcut = this.shortcuts.get(keyString);
+    if (shortcut) {
+      shortcut.callback();
+      return true;
+    }
+
+    return false;
+  }
+
+  /**
+   * Check if there's a potential match with more keys
+   * @returns {boolean} True if a shortcut could match with more keys
+   */
+  hasPotentialMatch() {
+    const prefix = this.pendingKeys.join(' ');
+
+    for (const keyString of this.shortcuts.keys()) {
+      if (keyString.startsWith(prefix + ' ')) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  /**
+   * Start the chord timeout
+   */
+  startChordTimeout() {
+    this.chordTimeout = setTimeout(() => {
+      this.resetChord();
+    }, this.chordTimeoutMs);
+  }
+
+  /**
+   * Clear the chord timeout
+   */
+  clearChordTimeout() {
+    if (this.chordTimeout) {
+      clearTimeout(this.chordTimeout);
+      this.chordTimeout = null;
+    }
+  }
+
+  /**
+   * Reset the chord state
+   */
+  resetChord() {
+    this.clearChordTimeout();
+    this.pendingKeys = [];
+  }
+
+  /**
+   * Show the help overlay
+   */
+  showHelp() {
+    if (!this.helpOverlay || this.isHelpVisible) return;
+
+    // Update the shortcuts list in case new shortcuts were registered
+    const listContainer = this.helpOverlay.querySelector('.keyboard-shortcuts-list');
+    if (listContainer) {
+      listContainer.innerHTML = this.renderShortcutsList();
+    }
+
+    this.helpOverlay.style.display = 'flex';
+    this.isHelpVisible = true;
+
+    // Add animation class
+    requestAnimationFrame(() => {
+      this.helpOverlay.classList.add('keyboard-shortcuts-visible');
+    });
+  }
+
+  /**
+   * Hide the help overlay
+   */
+  hideHelp() {
+    if (!this.helpOverlay || !this.isHelpVisible) return;
+
+    this.helpOverlay.classList.remove('keyboard-shortcuts-visible');
+
+    // Wait for animation to complete
+    setTimeout(() => {
+      this.helpOverlay.style.display = 'none';
+      this.isHelpVisible = false;
+    }, 150);
+  }
+
+  /**
+   * Toggle the help overlay
+   */
+  toggleHelp() {
+    if (this.isHelpVisible) {
+      this.hideHelp();
+    } else {
+      this.showHelp();
+    }
+  }
+
+  /**
+   * Escape HTML special characters
+   * @param {string} text - Text to escape
+   * @returns {string} Escaped text
+   */
+  escapeHtml(text) {
+    const div = document.createElement('div');
+    div.textContent = text;
+    return div.innerHTML;
+  }
+
+  /**
+   * Destroy the keyboard shortcuts manager
+   * Removes event listeners and DOM elements
+   */
+  destroy() {
+    this.resetChord();
+
+    // Remove the keydown event listener to prevent memory leaks
+    if (this.boundKeyHandler) {
+      document.removeEventListener('keydown', this.boundKeyHandler);
+      this.boundKeyHandler = null;
+    }
+
+    if (this.helpOverlay) {
+      this.helpOverlay.remove();
+      this.helpOverlay = null;
+    }
+
+    this.shortcuts.clear();
+  }
+}
+
+// Inject styles for the help overlay
+(function injectKeyboardShortcutsStyles() {
+  if (document.getElementById('keyboard-shortcuts-styles')) {
+    return;
+  }
+
+  const style = document.createElement('style');
+  style.id = 'keyboard-shortcuts-styles';
+  style.textContent = `
+    /* Keyboard Shortcuts Help Overlay */
+    .keyboard-shortcuts-overlay {
+      position: fixed;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      z-index: 9999;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      opacity: 0;
+      transition: opacity 150ms ease-out;
+    }
+
+    .keyboard-shortcuts-overlay.keyboard-shortcuts-visible {
+      opacity: 1;
+    }
+
+    .keyboard-shortcuts-backdrop {
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background: rgba(0, 0, 0, 0.5);
+      cursor: pointer;
+    }
+
+    .keyboard-shortcuts-panel {
+      position: relative;
+      width: 90%;
+      max-width: 500px;
+      max-height: 80vh;
+      background: var(--color-bg-primary, #ffffff);
+      border-radius: 12px;
+      box-shadow: 0 16px 32px rgba(0, 0, 0, 0.15), 0 0 0 1px rgba(0, 0, 0, 0.05);
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+      transform: scale(0.95) translateY(10px);
+      transition: transform 150ms ease-out;
+    }
+
+    .keyboard-shortcuts-overlay.keyboard-shortcuts-visible .keyboard-shortcuts-panel {
+      transform: scale(1) translateY(0);
+    }
+
+    .keyboard-shortcuts-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 16px 20px;
+      border-bottom: 1px solid var(--color-border-muted, #d0d7de);
+    }
+
+    .keyboard-shortcuts-header h2 {
+      margin: 0;
+      font-size: 16px;
+      font-weight: 600;
+      color: var(--color-fg-default, #1f2328);
+    }
+
+    .keyboard-shortcuts-close {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 32px;
+      height: 32px;
+      padding: 0;
+      background: transparent;
+      border: none;
+      border-radius: 6px;
+      color: var(--color-fg-muted, #656d76);
+      cursor: pointer;
+      transition: background-color 150ms ease, color 150ms ease;
+    }
+
+    .keyboard-shortcuts-close:hover {
+      background: var(--color-bg-subtle, #f6f8fa);
+      color: var(--color-fg-default, #1f2328);
+    }
+
+    .keyboard-shortcuts-body {
+      padding: 16px 20px;
+      overflow-y: auto;
+    }
+
+    .keyboard-shortcuts-list {
+      display: flex;
+      flex-direction: column;
+      gap: 20px;
+    }
+
+    .keyboard-shortcuts-group {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+    }
+
+    .keyboard-shortcuts-group-title {
+      margin: 0;
+      font-size: 12px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+      color: var(--color-fg-muted, #656d76);
+    }
+
+    .keyboard-shortcuts-items {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+    }
+
+    .keyboard-shortcut-item {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 8px 12px;
+      background: var(--color-bg-subtle, #f6f8fa);
+      border-radius: 6px;
+    }
+
+    .keyboard-shortcut-keys {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+    }
+
+    .keyboard-shortcut-key {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-width: 24px;
+      height: 24px;
+      padding: 0 8px;
+      background: var(--color-bg-primary, #ffffff);
+      border: 1px solid var(--color-border-default, #d0d7de);
+      border-radius: 4px;
+      font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
+      font-size: 12px;
+      font-weight: 500;
+      color: var(--color-fg-default, #1f2328);
+      box-shadow: 0 1px 0 rgba(0, 0, 0, 0.05);
+    }
+
+    .keyboard-shortcut-then {
+      font-size: 11px;
+      color: var(--color-fg-muted, #656d76);
+      font-style: italic;
+    }
+
+    .keyboard-shortcut-description {
+      font-size: 13px;
+      color: var(--color-fg-default, #1f2328);
+    }
+
+    /* Dark theme support */
+    [data-theme="dark"] .keyboard-shortcuts-backdrop {
+      background: rgba(0, 0, 0, 0.7);
+    }
+
+    [data-theme="dark"] .keyboard-shortcuts-panel {
+      background: #0d1117;
+      box-shadow: 0 16px 32px rgba(0, 0, 0, 0.4), 0 0 0 1px rgba(255, 255, 255, 0.1);
+    }
+
+    [data-theme="dark"] .keyboard-shortcuts-header {
+      border-bottom-color: #30363d;
+    }
+
+    [data-theme="dark"] .keyboard-shortcuts-header h2 {
+      color: #e6edf3;
+    }
+
+    [data-theme="dark"] .keyboard-shortcuts-close {
+      color: #8b949e;
+    }
+
+    [data-theme="dark"] .keyboard-shortcuts-close:hover {
+      background: #21262d;
+      color: #e6edf3;
+    }
+
+    [data-theme="dark"] .keyboard-shortcuts-group-title {
+      color: #8b949e;
+    }
+
+    [data-theme="dark"] .keyboard-shortcut-item {
+      background: #161b22;
+    }
+
+    [data-theme="dark"] .keyboard-shortcut-key {
+      background: #0d1117;
+      border-color: #30363d;
+      color: #e6edf3;
+      box-shadow: 0 1px 0 rgba(0, 0, 0, 0.3);
+    }
+
+    [data-theme="dark"] .keyboard-shortcut-then {
+      color: #8b949e;
+    }
+
+    [data-theme="dark"] .keyboard-shortcut-description {
+      color: #e6edf3;
+    }
+  `;
+
+  document.head.appendChild(style);
+})();
+
+// Export for use
+window.KeyboardShortcuts = KeyboardShortcuts;

--- a/public/js/components/PreviewModal.js
+++ b/public/js/components/PreviewModal.js
@@ -327,6 +327,11 @@ class PreviewModal {
   }
 }
 
+// Export class to window for static method access
+if (typeof window !== 'undefined') {
+  window.PreviewModal = PreviewModal;
+}
+
 // Initialize when DOM is ready if not already initialized
 if (typeof window !== 'undefined' && !window.previewModal) {
   if (document.readyState === 'loading') {

--- a/public/js/components/SuggestionNavigator.js
+++ b/public/js/components/SuggestionNavigator.js
@@ -20,8 +20,7 @@ class SuggestionNavigator {
    */
   init() {
     this.createElement();
-    this.setupKeyboardShortcuts();
-    
+
     // Set initial main content classes based on collapsed state
     const mainContent = document.querySelector('.main-content');
     if (mainContent && this.isCollapsed) {
@@ -132,26 +131,6 @@ class SuggestionNavigator {
           document.dispatchEvent(event);
         }
       });
-    });
-  }
-
-  /**
-   * Setup keyboard shortcuts
-   */
-  setupKeyboardShortcuts() {
-    document.addEventListener('keydown', (e) => {
-      // Only handle shortcuts when not in input fields
-      if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA') {
-        return;
-      }
-
-      if (e.key === 'j' && !e.metaKey && !e.ctrlKey) {
-        e.preventDefault();
-        this.goToNext();
-      } else if (e.key === 'k' && !e.metaKey && !e.ctrlKey) {
-        e.preventDefault();
-        this.goToPrevious();
-      }
     });
   }
 

--- a/public/local.html
+++ b/public/local.html
@@ -434,6 +434,7 @@
     <script src="/js/components/AISummaryModal.js"></script>
     <script src="/js/components/AIPanel.js"></script>
     <script src="/js/components/EmojiPicker.js"></script>
+    <script src="/js/components/KeyboardShortcuts.js"></script>
 
     <!-- PR Modules (must load before pr.js) -->
     <script src="/js/modules/storage-cleanup.js"></script>

--- a/public/pr.html
+++ b/public/pr.html
@@ -312,6 +312,7 @@
     <script src="/js/components/AISummaryModal.js"></script>
     <script src="/js/components/AIPanel.js"></script>
     <script src="/js/components/EmojiPicker.js"></script>
+    <script src="/js/components/KeyboardShortcuts.js"></script>
 
     <!-- PR Modules (must load before pr.js) -->
     <script src="/js/modules/storage-cleanup.js"></script>

--- a/tests/unit/keyboard-shortcuts.test.js
+++ b/tests/unit/keyboard-shortcuts.test.js
@@ -1,0 +1,520 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+// Mock window object
+global.window = {};
+
+// Minimal DOM mocks for Node environment
+const createMockElement = (tag = 'div', options = {}) => {
+  let _textContent = '';
+  return {
+    tagName: tag.toUpperCase(),
+    style: { display: '' },
+    className: '',
+    id: options.id || '',
+    classList: {
+      add: vi.fn(),
+      remove: vi.fn(),
+      toggle: vi.fn()
+    },
+    innerHTML: '',
+    get textContent() { return _textContent; },
+    set textContent(val) {
+      _textContent = val;
+      // Simulate escapeHtml behavior - innerHTML gets escaped version
+      this.innerHTML = val
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;');
+    },
+    appendChild: vi.fn(),
+    remove: vi.fn(),
+    querySelector: vi.fn(() => null),
+    querySelectorAll: vi.fn(() => []),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    getBoundingClientRect: vi.fn(() => ({ top: 0, left: 0, width: 100, height: 20 })),
+    closest: vi.fn((selector) => {
+      if (options.dataAction && selector === '[data-action]') {
+        return { dataset: { action: options.dataAction } };
+      }
+      return null;
+    }),
+    isContentEditable: false,
+    contentEditable: 'false'
+  };
+};
+
+let documentListeners = {};
+let createdElements = [];
+let headAppendedChildren = [];
+
+global.document = {
+  body: {
+    innerHTML: '',
+    appendChild: vi.fn((el) => createdElements.push(el)),
+    removeChild: vi.fn()
+  },
+  head: {
+    appendChild: vi.fn((el) => headAppendedChildren.push(el))
+  },
+  createElement: vi.fn((tag) => createMockElement(tag)),
+  getElementById: vi.fn((id) => {
+    if (id === 'keyboard-shortcuts-help') {
+      return null; // No existing element
+    }
+    if (id === 'keyboard-shortcuts-styles') {
+      // Return existing style element to prevent re-injection
+      return headAppendedChildren.find(el => el.id === 'keyboard-shortcuts-styles');
+    }
+    return null;
+  }),
+  querySelector: vi.fn((selector) => {
+    // Check for modal visibility
+    if (selector.includes('modal-overlay')) {
+      return null; // No modal open by default
+    }
+    return null;
+  }),
+  addEventListener: vi.fn((event, handler) => {
+    if (!documentListeners[event]) {
+      documentListeners[event] = [];
+    }
+    documentListeners[event].push(handler);
+  }),
+  removeEventListener: vi.fn()
+};
+
+global.requestAnimationFrame = vi.fn((cb) => setTimeout(cb, 0));
+global.setTimeout = vi.fn((cb, delay) => {
+  cb();
+  return 1;
+});
+global.clearTimeout = vi.fn();
+
+// Mock window.getComputedStyle
+global.window.getComputedStyle = vi.fn(() => ({
+  display: 'flex',
+  visibility: 'visible',
+  opacity: '1'
+}));
+
+// Import the KeyboardShortcuts module
+require('../../public/js/components/KeyboardShortcuts.js');
+
+const { KeyboardShortcuts } = global.window;
+
+describe('KeyboardShortcuts', () => {
+  let shortcuts;
+  let mockCallbacks;
+
+  beforeEach(() => {
+    // Reset state
+    documentListeners = {};
+    createdElements = [];
+
+    mockCallbacks = {
+      onCopyComments: vi.fn(),
+      onClearComments: vi.fn(),
+      onNextSuggestion: vi.fn(),
+      onPrevSuggestion: vi.fn()
+    };
+
+    shortcuts = new KeyboardShortcuts(mockCallbacks);
+  });
+
+  afterEach(() => {
+    if (shortcuts) {
+      shortcuts.destroy();
+      shortcuts = null;
+    }
+  });
+
+  describe('constructor', () => {
+    it('should initialize with default shortcuts', () => {
+      expect(shortcuts.shortcuts.size).toBeGreaterThan(0);
+      expect(shortcuts.shortcuts.has('?')).toBe(true);
+      expect(shortcuts.shortcuts.has('c c')).toBe(true);
+      expect(shortcuts.shortcuts.has('c x')).toBe(true);
+      expect(shortcuts.shortcuts.has('j')).toBe(true);
+      expect(shortcuts.shortcuts.has('k')).toBe(true);
+    });
+
+    it('should initialize with empty pending keys', () => {
+      expect(shortcuts.pendingKeys).toEqual([]);
+    });
+
+    it('should initialize with help overlay hidden', () => {
+      expect(shortcuts.isHelpVisible).toBe(false);
+    });
+
+    it('should set chord timeout to 500ms', () => {
+      expect(shortcuts.chordTimeoutMs).toBe(500);
+    });
+
+    it('should store options', () => {
+      expect(shortcuts.options).toBe(mockCallbacks);
+    });
+  });
+
+  describe('registerShortcut', () => {
+    it('should register a new shortcut', () => {
+      const callback = vi.fn();
+      shortcuts.registerShortcut(['g', 'i'], 'Go to issues', callback);
+
+      expect(shortcuts.shortcuts.has('g i')).toBe(true);
+      const shortcut = shortcuts.shortcuts.get('g i');
+      expect(shortcut.keys).toEqual(['g', 'i']);
+      expect(shortcut.description).toBe('Go to issues');
+      expect(shortcut.callback).toBe(callback);
+    });
+
+    it('should warn and not register if keys is not an array', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      shortcuts.registerShortcut('?', 'Invalid', vi.fn());
+
+      expect(warnSpy).toHaveBeenCalledWith('KeyboardShortcuts: keys must be a non-empty array');
+      warnSpy.mockRestore();
+    });
+
+    it('should warn and not register if keys is empty', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      shortcuts.registerShortcut([], 'Invalid', vi.fn());
+
+      expect(warnSpy).toHaveBeenCalledWith('KeyboardShortcuts: keys must be a non-empty array');
+      warnSpy.mockRestore();
+    });
+
+    it('should allow overwriting existing shortcut', () => {
+      const callback1 = vi.fn();
+      const callback2 = vi.fn();
+
+      shortcuts.registerShortcut(['x'], 'First', callback1);
+      shortcuts.registerShortcut(['x'], 'Second', callback2);
+
+      const shortcut = shortcuts.shortcuts.get('x');
+      expect(shortcut.description).toBe('Second');
+      expect(shortcut.callback).toBe(callback2);
+    });
+  });
+
+  describe('unregisterShortcut', () => {
+    it('should remove a registered shortcut', () => {
+      shortcuts.registerShortcut(['x', 'y'], 'Test', vi.fn());
+      expect(shortcuts.shortcuts.has('x y')).toBe(true);
+
+      shortcuts.unregisterShortcut(['x', 'y']);
+      expect(shortcuts.shortcuts.has('x y')).toBe(false);
+    });
+
+    it('should not throw when unregistering non-existent shortcut', () => {
+      expect(() => shortcuts.unregisterShortcut(['z', 'z', 'z'])).not.toThrow();
+    });
+  });
+
+  describe('isInInputField', () => {
+    it('should return true for INPUT element', () => {
+      const input = createMockElement('input');
+      expect(shortcuts.isInInputField(input)).toBe(true);
+    });
+
+    it('should return true for TEXTAREA element', () => {
+      const textarea = createMockElement('textarea');
+      expect(shortcuts.isInInputField(textarea)).toBe(true);
+    });
+
+    it('should return true for SELECT element', () => {
+      const select = createMockElement('select');
+      expect(shortcuts.isInInputField(select)).toBe(true);
+    });
+
+    it('should return true for contenteditable element', () => {
+      const div = createMockElement('div');
+      div.isContentEditable = true;
+      expect(shortcuts.isInInputField(div)).toBe(true);
+    });
+
+    it('should return true for contentEditable="true" attribute', () => {
+      const div = createMockElement('div');
+      div.contentEditable = 'true';
+      expect(shortcuts.isInInputField(div)).toBe(true);
+    });
+
+    it('should return false for regular div', () => {
+      const div = createMockElement('div');
+      expect(shortcuts.isInInputField(div)).toBe(false);
+    });
+
+    it('should return false for null', () => {
+      expect(shortcuts.isInInputField(null)).toBe(false);
+    });
+  });
+
+  describe('isElementVisible', () => {
+    it('should return false for null element', () => {
+      expect(shortcuts.isElementVisible(null)).toBe(false);
+    });
+
+    it('should return false for display:none element', () => {
+      const element = createMockElement('div');
+      global.window.getComputedStyle = vi.fn(() => ({ display: 'none', visibility: 'visible', opacity: '1' }));
+      expect(shortcuts.isElementVisible(element)).toBe(false);
+    });
+
+    it('should return false for visibility:hidden element', () => {
+      const element = createMockElement('div');
+      global.window.getComputedStyle = vi.fn(() => ({ display: 'flex', visibility: 'hidden', opacity: '1' }));
+      expect(shortcuts.isElementVisible(element)).toBe(false);
+    });
+
+    it('should return false for opacity:0 element', () => {
+      const element = createMockElement('div');
+      global.window.getComputedStyle = vi.fn(() => ({ display: 'flex', visibility: 'visible', opacity: '0' }));
+      expect(shortcuts.isElementVisible(element)).toBe(false);
+    });
+
+    it('should return true for visible element', () => {
+      const element = createMockElement('div');
+      global.window.getComputedStyle = vi.fn(() => ({ display: 'flex', visibility: 'visible', opacity: '1' }));
+      expect(shortcuts.isElementVisible(element)).toBe(true);
+    });
+  });
+
+  describe('chord detection', () => {
+    it('should match single-key shortcuts immediately', () => {
+      // Simulate pressing '?'
+      shortcuts.pendingKeys = ['?'];
+      const matched = shortcuts.tryMatchShortcut();
+
+      expect(matched).toBe(true);
+    });
+
+    it('should match two-key chords', () => {
+      // Simulate 'c' then 'c'
+      shortcuts.pendingKeys = ['c', 'c'];
+      const matched = shortcuts.tryMatchShortcut();
+
+      expect(matched).toBe(true);
+    });
+
+    it('should detect potential match for chord prefix', () => {
+      // After pressing 'c', there are potential matches like 'c c' and 'c x'
+      shortcuts.pendingKeys = ['c'];
+      const hasPotential = shortcuts.hasPotentialMatch();
+
+      expect(hasPotential).toBe(true);
+    });
+
+    it('should not detect potential match for non-prefix', () => {
+      shortcuts.pendingKeys = ['z'];
+      const hasPotential = shortcuts.hasPotentialMatch();
+
+      expect(hasPotential).toBe(false);
+    });
+  });
+
+  describe('resetChord', () => {
+    it('should clear pending keys', () => {
+      shortcuts.pendingKeys = ['c', 'x'];
+      shortcuts.resetChord();
+
+      expect(shortcuts.pendingKeys).toEqual([]);
+    });
+
+    it('should clear chord timeout', () => {
+      shortcuts.chordTimeout = 123;
+      shortcuts.resetChord();
+
+      expect(global.clearTimeout).toHaveBeenCalledWith(123);
+      expect(shortcuts.chordTimeout).toBe(null);
+    });
+  });
+
+  describe('callback invocation', () => {
+    it('should invoke onCopyComments for c c chord', () => {
+      const shortcut = shortcuts.shortcuts.get('c c');
+      shortcut.callback();
+
+      expect(mockCallbacks.onCopyComments).toHaveBeenCalled();
+    });
+
+    it('should invoke onClearComments for c x chord', () => {
+      const shortcut = shortcuts.shortcuts.get('c x');
+      shortcut.callback();
+
+      expect(mockCallbacks.onClearComments).toHaveBeenCalled();
+    });
+
+    it('should invoke onNextSuggestion for j shortcut', () => {
+      const shortcut = shortcuts.shortcuts.get('j');
+      shortcut.callback();
+
+      expect(mockCallbacks.onNextSuggestion).toHaveBeenCalled();
+    });
+
+    it('should invoke onPrevSuggestion for k shortcut', () => {
+      const shortcut = shortcuts.shortcuts.get('k');
+      shortcut.callback();
+
+      expect(mockCallbacks.onPrevSuggestion).toHaveBeenCalled();
+    });
+
+    it('should not throw if callback is undefined', () => {
+      const noCallbacks = new KeyboardShortcuts({});
+      const shortcut = noCallbacks.shortcuts.get('c c');
+
+      expect(() => shortcut.callback()).not.toThrow();
+      noCallbacks.destroy();
+    });
+  });
+
+  describe('help overlay', () => {
+    it('should show help overlay', () => {
+      shortcuts.helpOverlay = createMockElement('div');
+      shortcuts.helpOverlay.querySelector = vi.fn(() => createMockElement('div'));
+
+      shortcuts.showHelp();
+
+      expect(shortcuts.helpOverlay.style.display).toBe('flex');
+      expect(shortcuts.isHelpVisible).toBe(true);
+    });
+
+    it('should not show help if already visible', () => {
+      shortcuts.helpOverlay = createMockElement('div');
+      shortcuts.isHelpVisible = true;
+      shortcuts.helpOverlay.style.display = 'flex';
+
+      const originalDisplay = shortcuts.helpOverlay.style.display;
+      shortcuts.showHelp();
+
+      expect(shortcuts.helpOverlay.style.display).toBe(originalDisplay);
+    });
+
+    it('should hide help overlay', () => {
+      shortcuts.helpOverlay = createMockElement('div');
+      shortcuts.helpOverlay.style.display = 'flex';
+      shortcuts.isHelpVisible = true;
+
+      shortcuts.hideHelp();
+
+      // After setTimeout (mocked to run immediately)
+      expect(shortcuts.helpOverlay.style.display).toBe('none');
+      expect(shortcuts.isHelpVisible).toBe(false);
+    });
+
+    it('should not hide help if not visible', () => {
+      shortcuts.helpOverlay = createMockElement('div');
+      shortcuts.isHelpVisible = false;
+
+      // This should be a no-op
+      shortcuts.hideHelp();
+
+      expect(shortcuts.isHelpVisible).toBe(false);
+    });
+
+    it('should toggle help overlay', () => {
+      shortcuts.helpOverlay = createMockElement('div');
+      shortcuts.helpOverlay.querySelector = vi.fn(() => createMockElement('div'));
+      shortcuts.isHelpVisible = false;
+
+      shortcuts.toggleHelp();
+      expect(shortcuts.isHelpVisible).toBe(true);
+
+      shortcuts.toggleHelp();
+      expect(shortcuts.isHelpVisible).toBe(false);
+    });
+  });
+
+  describe('formatKey', () => {
+    it('should format special keys', () => {
+      expect(shortcuts.formatKey('Escape')).toBe('Esc');
+      expect(shortcuts.formatKey('ArrowUp')).toBe('\u2191');
+      expect(shortcuts.formatKey('ArrowDown')).toBe('\u2193');
+      expect(shortcuts.formatKey('Enter')).toBe('\u21B5');
+      expect(shortcuts.formatKey(' ')).toBe('Space');
+    });
+
+    it('should uppercase regular keys', () => {
+      expect(shortcuts.formatKey('a')).toBe('A');
+      expect(shortcuts.formatKey('c')).toBe('C');
+      expect(shortcuts.formatKey('j')).toBe('J');
+    });
+
+    it('should preserve ? key', () => {
+      expect(shortcuts.formatKey('?')).toBe('?');
+    });
+  });
+
+  describe('escapeHtml', () => {
+    it('should escape HTML special characters', () => {
+      // The escapeHtml method uses DOM to escape - our mock simulates this behavior
+      expect(shortcuts.escapeHtml('<script>')).toBe('&lt;script&gt;');
+      expect(shortcuts.escapeHtml('a & b')).toBe('a &amp; b');
+      expect(shortcuts.escapeHtml('"quoted"')).toBe('&quot;quoted&quot;');
+    });
+
+    it('should handle plain text unchanged', () => {
+      expect(shortcuts.escapeHtml('Hello World')).toBe('Hello World');
+    });
+  });
+
+  describe('renderShortcutsList', () => {
+    it('should group shortcuts by category', () => {
+      const html = shortcuts.renderShortcutsList();
+
+      // Should contain group titles
+      expect(html).toContain('Navigation');
+      expect(html).toContain('Comments');
+      expect(html).toContain('General');
+    });
+
+    it('should generate proper structure for shortcut items', () => {
+      const html = shortcuts.renderShortcutsList();
+
+      // Should contain proper structure
+      expect(html).toContain('keyboard-shortcuts-group');
+      expect(html).toContain('keyboard-shortcuts-group-title');
+      expect(html).toContain('keyboard-shortcut-item');
+      expect(html).toContain('keyboard-shortcut-key');
+      expect(html).toContain('keyboard-shortcut-description');
+    });
+
+    it('should include "then" separator for multi-key shortcuts', () => {
+      const html = shortcuts.renderShortcutsList();
+
+      // Multi-key shortcuts like 'c c' should have "then" separator
+      expect(html).toContain('keyboard-shortcut-then');
+    });
+  });
+
+  describe('destroy', () => {
+    it('should reset chord state', () => {
+      shortcuts.pendingKeys = ['c'];
+      shortcuts.chordTimeout = 123;
+
+      shortcuts.destroy();
+
+      expect(shortcuts.pendingKeys).toEqual([]);
+      expect(shortcuts.chordTimeout).toBe(null);
+    });
+
+    it('should remove help overlay', () => {
+      const mockOverlay = createMockElement('div');
+      shortcuts.helpOverlay = mockOverlay;
+
+      shortcuts.destroy();
+
+      expect(mockOverlay.remove).toHaveBeenCalled();
+      expect(shortcuts.helpOverlay).toBe(null);
+    });
+
+    it('should clear shortcuts map', () => {
+      expect(shortcuts.shortcuts.size).toBeGreaterThan(0);
+
+      shortcuts.destroy();
+
+      expect(shortcuts.shortcuts.size).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `?` to show keyboard shortcuts help overlay
- Add `c c` to copy all comments to clipboard as markdown
- Add `c x` to clear all comments (with confirmation)
- Add `j`/`k` to navigate between AI suggestions (consolidated from SuggestionNavigator)
- Add `Enter` to confirm dialogs, `Escape` to cancel

Shortcuts use chord detection (press keys in sequence within 500ms) and are automatically disabled when typing in input fields or when modals are open.

## Test plan
- [ ] Press `?` - help overlay appears with all shortcuts listed
- [ ] Press `?` again or `Escape` - help overlay closes
- [ ] Add some comments, press `c c` - comments copied to clipboard as markdown, toast shown
- [ ] Press `c x` - confirmation dialog appears
- [ ] Press `Enter` in confirmation - comments cleared
- [ ] Run AI analysis, press `j`/`k` - navigates through suggestions
- [ ] Type in a comment textarea - shortcuts don't fire
- [ ] Open any modal - shortcuts don't fire

🤖 Generated with [Claude Code](https://claude.com/claude-code)