### PR TITLE
Add option to skip Level 3 codebase-wide analysis

### DIFF
--- a/.changeset/skip-level3-analysis.md
+++ b/.changeset/skip-level3-analysis.md
@@ -1,0 +1,11 @@
+---
+"@in-the-loop-labs/pair-review": minor
+---
+
+Add option to skip Level 3 codebase-wide analysis
+
+- Added "Analysis Scope" section to the AI Analysis config modal with a checkbox to skip Level 3 analysis
+- Fast-tier models automatically have Level 3 skipped with an informational banner explaining why
+- Switching between model tiers automatically updates the checkbox state to match
+- Backend properly handles skipped Level 3 by passing empty results to orchestration
+- Reduces analysis time for simple PRs or when using faster models

--- a/public/css/pr.css
+++ b/public/css/pr.css
@@ -7901,6 +7901,26 @@ body.resizing * {
   line-height: 1.4;
 }
 
+/* Skip Level 3 Info */
+.skip-level3-info {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  margin-bottom: 12px;
+  padding: 8px 12px;
+  background: var(--color-accent-light);
+  border-radius: 6px;
+  font-size: 12px;
+  color: var(--color-info);
+  line-height: 1.4;
+}
+
+.skip-level3-info svg {
+  flex-shrink: 0;
+  margin-top: 1px;
+  color: var(--color-info);
+}
+
 /* Preset Chips */
 .preset-chips {
   display: flex;

--- a/public/js/local.js
+++ b/public/js/local.js
@@ -1026,7 +1026,8 @@ class LocalManager {
           provider: config.provider || 'claude',
           model: config.model || 'sonnet',
           tier: config.tier || 'balanced',
-          customInstructions: config.customInstructions || null
+          customInstructions: config.customInstructions || null,
+          skipLevel3: config.skipLevel3 || false
         })
       });
 

--- a/public/js/pr.js
+++ b/public/js/pr.js
@@ -3375,7 +3375,8 @@ class PRManager {
           provider: config.provider || 'claude',
           model: config.model || 'sonnet',
           tier: config.tier || 'balanced',
-          customInstructions: config.customInstructions || null
+          customInstructions: config.customInstructions || null,
+          skipLevel3: config.skipLevel3 || false
         })
       });
 

--- a/src/routes/local.js
+++ b/src/routes/local.js
@@ -246,8 +246,8 @@ router.post('/api/local/:reviewId/analyze', async (req, res) => {
       });
     }
 
-    // Extract optional provider, model, tier and customInstructions from request body
-    const { provider: requestProvider, model: requestModel, tier: requestTier, customInstructions: rawInstructions } = req.body || {};
+    // Extract optional provider, model, tier, customInstructions and skipLevel3 from request body
+    const { provider: requestProvider, model: requestModel, tier: requestTier, customInstructions: rawInstructions, skipLevel3: requestSkipLevel3 } = req.body || {};
 
     // Trim and validate custom instructions
     const MAX_INSTRUCTIONS_LENGTH = 5000;
@@ -325,7 +325,7 @@ router.post('/api/local/:reviewId/analyze', async (req, res) => {
       levels: {
         1: { status: 'running', progress: 'Starting...' },
         2: { status: 'running', progress: 'Starting...' },
-        3: { status: 'running', progress: 'Starting...' },
+        3: requestSkipLevel3 ? { status: 'skipped', progress: 'Skipped' } : { status: 'running', progress: 'Starting...' },
         4: { status: 'pending', progress: 'Pending' }
       },
       filesAnalyzed: 0,
@@ -411,7 +411,8 @@ router.post('/api/local/:reviewId/analyze', async (req, res) => {
     // Pass analysisId for process tracking/cancellation
     // Pass separate instructions for storage, analyzer will merge them for prompts
     // Pass tier for prompt selection
-    analyzer.analyzeLevel1(reviewId, localPath, localMetadata, progressCallback, { repoInstructions, requestInstructions }, changedFiles, { analysisId, tier })
+    // Pass skipLevel3 flag to skip codebase-wide analysis when requested
+    analyzer.analyzeLevel1(reviewId, localPath, localMetadata, progressCallback, { repoInstructions, requestInstructions }, changedFiles, { analysisId, tier, skipLevel3: requestSkipLevel3 })
       .then(async result => {
         logger.section('Local Analysis Results');
         logger.success(`Analysis complete for local review #${reviewId}`);


### PR DESCRIPTION
## Summary
- Adds "Analysis Scope" section to the AI Analysis config modal with a checkbox to skip Level 3 codebase-wide analysis
- Fast-tier models automatically have Level 3 skipped, with an informational banner explaining why
- Reduces analysis time for simple PRs or when using faster models that don't benefit from codebase-wide context

## Test plan
- [ ] Open AI Analysis modal and verify "Analysis Scope" section appears
- [ ] Select a fast-tier model and verify checkbox is auto-checked and info banner appears
- [ ] Switch to a balanced/thorough model and verify checkbox unchecks and banner hides
- [ ] Run analysis with Level 3 skipped and verify it completes faster
- [ ] Run analysis with Level 3 enabled and verify all 3 levels run

🤖 Generated with [Claude Code](https://claude.com/claude-code)