### PR TITLE
Sharpen orchestration prompts to focus on synthesis over revalidation

### DIFF
--- a/.changeset/sharpen-orchestration-prompts.md
+++ b/.changeset/sharpen-orchestration-prompts.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Sharpen orchestration prompts to focus on synthesis over revalidation. Replace generic line number guidance with orchestration-specific guidance that preserves analysis results while retaining investigative capability. Remove file-line-counts section and dead code chain. Clean up unused fileLineCountMap parameter threading.

--- a/src/ai/analyzer.js
+++ b/src/ai/analyzer.js
@@ -218,7 +218,7 @@ class Analyzer {
           level3: levelResults.level3.suggestions
         };
 
-        const orchestrationResult = await this.orchestrateWithAI(allSuggestions, prMetadata, mergedInstructions, fileLineCountMap, worktreePath, { analysisId, tier, progressCallback });
+        const orchestrationResult = await this.orchestrateWithAI(allSuggestions, prMetadata, mergedInstructions, worktreePath, { analysisId, tier, progressCallback });
 
         // Validate and finalize suggestions
         const finalSuggestions = this.validateAndFinalizeSuggestions(
@@ -452,6 +452,54 @@ Your suggestions MUST reference the EXACT line where the issue exists:
   }
 
   /**
+   * Build lightweight line number guidance for the orchestration step.
+   *
+   * Unlike buildLineNumberGuidance() (used for levels 1-3), this does NOT
+   * instruct the AI to routinely run git-diff-lines or verify every line number.
+   * The orchestration step receives pre-computed suggestions whose line numbers
+   * were already determined by the analysis levels; its primary job is to
+   * intelligently combine them. However, it retains access to git-diff-lines
+   * for cases where it needs to investigate conflicting suggestions or verify
+   * a specific concern.
+   *
+   * @param {string|null} worktreePath - Path to the git worktree (for --cwd option)
+   * @returns {string} Orchestration-specific line number guidance
+   */
+  buildOrchestrationLineNumberGuidance(worktreePath = null) {
+    const scriptCommand = 'git-diff-lines';
+    const cwdOption = worktreePath ? ` --cwd "${worktreePath}"` : '';
+    const fullCommand = `${scriptCommand}${cwdOption}`;
+    return `
+## Line Number Handling
+
+You are receiving pre-computed suggestions from the analysis levels. Each suggestion
+already carries a \`line\` number and \`old_or_new\` value determined during analysis.
+Your primary focus is curation and synthesis, not line number verification.
+
+**Your responsibilities:**
+- **Preserve line numbers as-is** when passing suggestions through to the output.
+- **Preserve \`old_or_new\` values** from input suggestions.
+- **When merging duplicates or near-duplicates** that reference the same line,
+  keep the line number and \`old_or_new\` from the suggestion with the richest
+  context (prefer higher-level analysis when in doubt).
+- **When levels conflict** on the line number or \`old_or_new\` for what appears to
+  be the same issue, use your judgment based on the nature of the concern:
+  - For **architectural or cross-cutting issues**, prefer the suggestion from the
+    level with broader context (Level 3 > Level 2 > Level 1).
+  - For **precise line-level bugs or typos**, prefer the suggestion from the level
+    that targets the specific line most directly (often Level 1, which works
+    closest to the raw diff).
+
+**If you need to inspect a file diff** (e.g., to resolve conflicting suggestions or
+verify a specific concern), use the annotated diff tool instead of \`git diff\`:
+\`\`\`
+${fullCommand}
+\`\`\`
+All git diff arguments work: \`${fullCommand} HEAD~1\`, \`${fullCommand} -- src/\`
+`;
+  }
+
+  /**
    * Build the section of the prompt that includes custom review instructions
    * @param {string} customInstructions - Custom instructions text
    * @returns {string} Prompt section or empty string
@@ -485,31 +533,6 @@ ${changedFiles.map(f => `- ${f}`).join('\n')}
 
 Do NOT create suggestions for any files not in this list. If you cannot find issues in these files, that's okay - just return fewer suggestions.
 `;
-  }
-
-  /**
-   * Build the file line counts section for orchestration prompt
-   * @param {Map<string, number>} fileLineCountMap - Map of file paths to line counts
-   * @returns {string} Prompt section or empty string
-   */
-  buildFileLineCountsSection(fileLineCountMap) {
-    if (!fileLineCountMap || fileLineCountMap.size === 0) return '';
-
-    const lines = ['', '## File Line Counts for Validation'];
-    for (const [filePath, lineCount] of fileLineCountMap) {
-      if (lineCount === 0) {
-        // Empty files are valid text files - any line-specific suggestion would be invalid
-        lines.push(`- ${filePath}: 0 lines (empty file)`);
-      } else if (lineCount > 0) {
-        lines.push(`- ${filePath}: ${lineCount} lines`);
-      }
-      // Skip binary/missing files (lineCount === -1)
-    }
-    lines.push('');
-    lines.push('Verify that all suggestion line numbers are within these bounds.');
-    lines.push('If a suggestion has an invalid line number but valuable insight, convert it to a file-level suggestion.');
-    lines.push('');
-    return lines.join('\n');
   }
 
   /**
@@ -2326,13 +2349,12 @@ File-level suggestions should NOT have a line number. They apply to the entire f
    * @param {Object} allSuggestions - Object containing suggestions from all levels: {level1: [...], level2: [...], level3: [...]}
    * @param {Object} prMetadata - PR metadata for context
    * @param {string} customInstructions - Optional custom instructions to guide prioritization/filtering
-   * @param {Map<string, number>} fileLineCountMap - Optional map of file paths to line counts for validation
    * @param {string} worktreePath - Path to the git worktree
    * @param {Object} options - Additional options
    * @param {string} options.analysisId - Analysis ID for process tracking (enables cancellation)
    * @returns {Promise<Array>} Curated suggestions array
    */
-  async orchestrateWithAI(allSuggestions, prMetadata, customInstructions = null, fileLineCountMap = null, worktreePath = null, options = {}) {
+  async orchestrateWithAI(allSuggestions, prMetadata, customInstructions = null, worktreePath = null, options = {}) {
     const { analysisId, tier = 'balanced', progressCallback } = options;
     logger.section('[Orchestration] AI Orchestration Starting');
 
@@ -2352,7 +2374,7 @@ File-level suggestions should NOT have a line number. They apply to the entire f
       const aiProvider = createProvider(this.provider, this.model);
 
       // Build the orchestration prompt
-      const prompt = this.buildOrchestrationPrompt(allSuggestions, prMetadata, customInstructions, fileLineCountMap, worktreePath, tier);
+      const prompt = this.buildOrchestrationPrompt(allSuggestions, prMetadata, customInstructions, worktreePath, tier);
 
       // Execute Claude CLI for orchestration
       logger.info('[Orchestration] Running AI orchestration to curate and merge suggestions...');
@@ -2458,12 +2480,11 @@ File-level suggestions should NOT have a line number. They apply to the entire f
    * @param {Object} allSuggestions - Suggestions from all levels
    * @param {Object} prMetadata - PR metadata for context
    * @param {string} customInstructions - Optional custom instructions to guide prioritization/filtering
-   * @param {Map<string, number>} fileLineCountMap - Optional map of file paths to line counts for validation
    * @param {string} worktreePath - Path to the git worktree
    * @param {string} tier - Capability tier: 'fast', 'balanced', or 'thorough' (default: 'balanced')
    * @returns {string} Orchestration prompt
    */
-  buildOrchestrationPrompt(allSuggestions, prMetadata, customInstructions = null, fileLineCountMap = null, worktreePath = null, tier = 'balanced') {
+  buildOrchestrationPrompt(allSuggestions, prMetadata, customInstructions = null, worktreePath = null, tier = 'balanced') {
     logger.debug(`[Orchestration] Building prompt with tier: ${tier}`);
     const promptBuilder = getPromptBuilder('orchestration', tier, this.provider);
 
@@ -2476,14 +2497,13 @@ File-level suggestions should NOT have a line number. They apply to the entire f
     const context = {
       reviewIntro: `You are orchestrating AI-powered code review suggestions for ${reviewDescription}.`,
       customInstructions: customInstructions ? this.buildCustomInstructionsSection(customInstructions) : '',
-      lineNumberGuidance: this.buildLineNumberGuidance(worktreePath),
+      lineNumberGuidance: this.buildOrchestrationLineNumberGuidance(worktreePath),
       level1Count: allSuggestions.level1?.length || 0,
       level2Count: allSuggestions.level2?.length || 0,
       level3Count: allSuggestions.level3?.length || 0,
       level1Suggestions: this._formatSuggestionsForOrchestration(allSuggestions.level1),
       level2Suggestions: this._formatSuggestionsForOrchestration(allSuggestions.level2),
-      level3Suggestions: this._formatSuggestionsForOrchestration(allSuggestions.level3),
-      fileLineCounts: this.buildFileLineCountsSection(fileLineCountMap)
+      level3Suggestions: this._formatSuggestionsForOrchestration(allSuggestions.level3)
     };
 
     return promptBuilder.build(context);

--- a/src/ai/prompts/baseline/orchestration/balanced.js
+++ b/src/ai/prompts/baseline/orchestration/balanced.js
@@ -32,7 +32,6 @@ const { ORCHESTRATION_INPUT_SCHEMA_DOCS } = require('../../shared/output-schema'
  * - {{level1Suggestions}} - Level 1 suggestions as JSON array
  * - {{level2Suggestions}} - Level 2 suggestions as JSON array
  * - {{level3Suggestions}} - Level 3 suggestions as JSON array
- * - {{fileLineCounts}} - File line count validation data (optional)
  */
 const taggedPrompt = `<section name="role" required="true">
 {{reviewIntro}}
@@ -72,10 +71,6 @@ ${ORCHESTRATION_INPUT_SCHEMA_DOCS}
 
 **Level 3 - Codebase Context ({{level3Count}} suggestions):**
 {{level3Suggestions}}
-</section>
-
-<section name="file-line-counts" optional="true">
-{{fileLineCounts}}
 </section>
 
 <section name="intelligent-merging" required="true">
@@ -194,7 +189,6 @@ const sections = [
   { name: 'role-description', required: true },
   { name: 'custom-instructions', optional: true },
   { name: 'input-suggestions', locked: true },
-  { name: 'file-line-counts', optional: true },
   { name: 'intelligent-merging', required: true },
   { name: 'priority-curation', required: true },
   { name: 'balanced-output', required: true },
@@ -216,7 +210,6 @@ const defaultOrder = [
   'role-description',
   'custom-instructions',
   'input-suggestions',
-  'file-line-counts',
   'intelligent-merging',
   'priority-curation',
   'balanced-output',

--- a/src/ai/prompts/baseline/orchestration/fast.js
+++ b/src/ai/prompts/baseline/orchestration/fast.js
@@ -35,7 +35,6 @@ const { ORCHESTRATION_INPUT_SCHEMA_DOCS } = require('../../shared/output-schema'
  * - {{level1Suggestions}} - Level 1 suggestions as JSON array
  * - {{level2Suggestions}} - Level 2 suggestions as JSON array
  * - {{level3Suggestions}} - Level 3 suggestions as JSON array
- * - {{fileLineCounts}} - File line count validation data (optional)
  */
 const taggedPrompt = `<section name="role" required="true" tier="fast">
 {{reviewIntro}}
@@ -75,10 +74,6 @@ ${ORCHESTRATION_INPUT_SCHEMA_DOCS}
 
 **Level 3 - Codebase Context ({{level3Count}} suggestions):**
 {{level3Suggestions}}
-</section>
-
-<section name="file-line-counts" optional="true" tier="fast,balanced,thorough">
-{{fileLineCounts}}
 </section>
 
 <section name="intelligent-merging" required="true" tier="fast">
@@ -149,7 +144,6 @@ const sections = [
   { name: 'role-description', required: true, tier: ['fast'] },
   { name: 'custom-instructions', optional: true, tier: ['fast', 'balanced', 'thorough'] },
   { name: 'input-suggestions', locked: true },
-  { name: 'file-line-counts', optional: true, tier: ['fast', 'balanced', 'thorough'] },
   { name: 'intelligent-merging', required: true, tier: ['fast'] },
   { name: 'priority-curation', required: true, tier: ['fast'] },
   { name: 'balanced-output', required: true, tier: ['fast'] },
@@ -171,7 +165,6 @@ const defaultOrder = [
   'role-description',
   'custom-instructions',
   'input-suggestions',
-  'file-line-counts',
   'intelligent-merging',
   'priority-curation',
   'balanced-output',

--- a/src/ai/prompts/baseline/orchestration/thorough.js
+++ b/src/ai/prompts/baseline/orchestration/thorough.js
@@ -39,7 +39,6 @@ const { ORCHESTRATION_INPUT_SCHEMA_DOCS } = require('../../shared/output-schema'
  * - {{level1Suggestions}} - Level 1 suggestions as JSON array
  * - {{level2Suggestions}} - Level 2 suggestions as JSON array
  * - {{level3Suggestions}} - Level 3 suggestions as JSON array
- * - {{fileLineCounts}} - File line count validation data (optional)
  */
 const taggedPrompt = `<section name="role" required="true" tier="thorough">
 {{reviewIntro}}
@@ -99,10 +98,6 @@ ${ORCHESTRATION_INPUT_SCHEMA_DOCS}
 
 **Level 3 - Codebase Context ({{level3Count}} suggestions):**
 {{level3Suggestions}}
-</section>
-
-<section name="file-line-counts" optional="true" tier="balanced,thorough">
-{{fileLineCounts}}
 </section>
 
 <section name="intelligent-merging" required="true" tier="thorough">
@@ -375,7 +370,6 @@ const sections = [
   { name: 'reasoning-encouragement', required: true, tier: ['thorough'] },
   { name: 'custom-instructions', optional: true, tier: ['balanced', 'thorough'] },
   { name: 'input-suggestions', locked: true },
-  { name: 'file-line-counts', optional: true, tier: ['balanced', 'thorough'] },
   { name: 'intelligent-merging', required: true, tier: ['thorough'] },
   { name: 'priority-curation', required: true, tier: ['thorough'] },
   { name: 'balanced-output', required: true, tier: ['thorough'] },
@@ -401,7 +395,6 @@ const defaultOrder = [
   'reasoning-encouragement',
   'custom-instructions',
   'input-suggestions',
-  'file-line-counts',
   'intelligent-merging',
   'priority-curation',
   'balanced-output',


### PR DESCRIPTION
Replace generic line number guidance with orchestration-specific guidance that preserves analysis results while retaining investigative capability. Remove file-line-counts section from orchestration prompts and clean up unused fileLineCountMap parameter threading. Update tests to reflect the simplified interface.