### PR TITLE
Add --yolo flag and test coverage for yolo mode

### DIFF
--- a/.changeset/yolo-flag.md
+++ b/.changeset/yolo-flag.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": minor
+---
+
+Add `--yolo` flag to skip fine-grained AI provider permission restrictions

--- a/config.example.json
+++ b/config.example.json
@@ -9,6 +9,7 @@
   "worktree_retention_days": 7,
   "dev_mode": false,
   "debug_stream": false,
+  "yolo": false,
 
   "providers": {
     "_comment": "Provider configurations override built-in defaults. Most providers have built-in models, but OpenCode requires manual configuration.",

--- a/src/ai/codex-provider.js
+++ b/src/ai/codex-provider.js
@@ -98,7 +98,12 @@ class CodexProvider extends AIProvider {
     // Note: The -a flag is for interactive mode only; exec subcommand uses --full-auto.
 
     // Build args: base args + provider extra_args + model extra_args
-    const baseArgs = ['exec', '-m', model, '--json', '--sandbox', 'workspace-write', '--full-auto', '-'];
+    // In yolo mode, bypass all sandbox restrictions and approval prompts
+    // (--dangerously-bypass-approvals-and-sandbox is the Codex CLI equivalent of Claude's --dangerously-skip-permissions)
+    const sandboxArgs = configOverrides.yolo
+      ? ['--dangerously-bypass-approvals-and-sandbox']
+      : ['--sandbox', 'workspace-write', '--full-auto'];
+    const baseArgs = ['exec', '-m', model, '--json', ...sandboxArgs, '-'];
     const providerArgs = configOverrides.extra_args || [];
     const modelConfig = configOverrides.models?.find(m => m.id === model);
     const modelArgs = modelConfig?.extra_args || [];

--- a/src/ai/copilot-provider.js
+++ b/src/ai/copilot-provider.js
@@ -101,49 +101,53 @@ class CopilotProvider extends AIProvider {
     // For shell commands, use shell(<prefix>) syntax to match command prefixes.
     // E.g., shell(git) allows "git status", "git diff", etc.
     // ============================================================================
-    const readOnlyArgs = [
-      // Allow specific read-only git commands (not blanket 'git' to block git commit, push, etc.)
-      '--allow-tool', 'shell(git diff)',
-      '--allow-tool', 'shell(git log)',
-      '--allow-tool', 'shell(git show)',
-      '--allow-tool', 'shell(git status)',
-      '--allow-tool', 'shell(git branch)',
-      '--allow-tool', 'shell(git rev-parse)',
-      // Custom tool for annotated diff line mapping (matches both direct and path invocations)
-      '--allow-tool', 'shell(git-diff-lines)',
-      '--allow-tool', 'shell(*/git-diff-lines)',  // Absolute path invocation
-      // Allow read-only shell commands
-      '--allow-tool', 'shell(ls)',            // Directory listing
-      '--allow-tool', 'shell(cat)',           // File content viewing
-      '--allow-tool', 'shell(pwd)',           // Current directory
-      '--allow-tool', 'shell(head)',          // File head viewing
-      '--allow-tool', 'shell(tail)',          // File tail viewing
-      '--allow-tool', 'shell(wc)',            // Word/line count
-      '--allow-tool', 'shell(find)',          // File finding
-      '--allow-tool', 'shell(grep)',          // Pattern searching
-      '--allow-tool', 'shell(rg)',            // Ripgrep (fast pattern searching)
-      // Deny dangerous shell commands (takes precedence over allow)
-      '--deny-tool', 'shell(rm)',
-      '--deny-tool', 'shell(mv)',
-      '--deny-tool', 'shell(chmod)',
-      '--deny-tool', 'shell(chown)',
-      '--deny-tool', 'shell(sudo)',
-      '--deny-tool', 'shell(git commit)',
-      '--deny-tool', 'shell(git push)',
-      '--deny-tool', 'shell(git checkout)',
-      '--deny-tool', 'shell(git reset)',
-      '--deny-tool', 'shell(git rebase)',
-      '--deny-tool', 'shell(git merge)',
-      // Block file write tools
-      '--deny-tool', 'write',
-      // Auto-approve remaining tools to avoid interactive prompts
-      '--allow-all-tools',
-      // Allow access to all paths (needed for analyzing files outside cwd)
-      '--allow-all-paths',
-    ];
+
+    // In yolo mode, skip all deny rules: everything is permitted (including writes, rm, git push)
+    const permissionArgs = configOverrides.yolo
+      ? ['--allow-all-tools', '--allow-all-paths']
+      : [
+          // Allow specific read-only git commands (not blanket 'git' to block git commit, push, etc.)
+          '--allow-tool', 'shell(git diff)',
+          '--allow-tool', 'shell(git log)',
+          '--allow-tool', 'shell(git show)',
+          '--allow-tool', 'shell(git status)',
+          '--allow-tool', 'shell(git branch)',
+          '--allow-tool', 'shell(git rev-parse)',
+          // Custom tool for annotated diff line mapping (matches both direct and path invocations)
+          '--allow-tool', 'shell(git-diff-lines)',
+          '--allow-tool', 'shell(*/git-diff-lines)',  // Absolute path invocation
+          // Allow read-only shell commands
+          '--allow-tool', 'shell(ls)',            // Directory listing
+          '--allow-tool', 'shell(cat)',           // File content viewing
+          '--allow-tool', 'shell(pwd)',           // Current directory
+          '--allow-tool', 'shell(head)',          // File head viewing
+          '--allow-tool', 'shell(tail)',          // File tail viewing
+          '--allow-tool', 'shell(wc)',            // Word/line count
+          '--allow-tool', 'shell(find)',          // File finding
+          '--allow-tool', 'shell(grep)',          // Pattern searching
+          '--allow-tool', 'shell(rg)',            // Ripgrep (fast pattern searching)
+          // Deny dangerous shell commands (takes precedence over allow)
+          '--deny-tool', 'shell(rm)',
+          '--deny-tool', 'shell(mv)',
+          '--deny-tool', 'shell(chmod)',
+          '--deny-tool', 'shell(chown)',
+          '--deny-tool', 'shell(sudo)',
+          '--deny-tool', 'shell(git commit)',
+          '--deny-tool', 'shell(git push)',
+          '--deny-tool', 'shell(git checkout)',
+          '--deny-tool', 'shell(git reset)',
+          '--deny-tool', 'shell(git rebase)',
+          '--deny-tool', 'shell(git merge)',
+          // Block file write tools
+          '--deny-tool', 'write',
+          // Auto-approve remaining tools to avoid interactive prompts
+          '--allow-all-tools',
+          // Allow access to all paths (needed for analyzing files outside cwd)
+          '--allow-all-paths',
+        ];
 
     // Build args: base args + provider extra_args + model extra_args
-    const baseArgs = ['--model', model, ...readOnlyArgs, '-s'];
+    const baseArgs = ['--model', model, ...permissionArgs, '-s'];
     const providerArgs = configOverrides.extra_args || [];
     const modelConfig = configOverrides.models?.find(m => m.id === model);
     const modelArgs = modelConfig?.extra_args || [];

--- a/src/ai/gemini-provider.js
+++ b/src/ai/gemini-provider.js
@@ -107,36 +107,42 @@ class GeminiProvider extends AIProvider {
     // E.g., run_shell_command(git) allows "git status", "git diff", etc.
     // Commands NOT matching any prefix will be denied in non-interactive mode.
     // ============================================================================
-    const readOnlyTools = [
-      // File system tools (read-only)
-      'list_directory',
-      'read_file',
-      'glob',
-      'search_file_content',
-      // Specific read-only git commands (not blanket 'git' to avoid git commit, push, etc.)
-      'run_shell_command(git diff)',
-      'run_shell_command(git log)',
-      'run_shell_command(git show)',
-      'run_shell_command(git status)',
-      'run_shell_command(git branch)',
-      'run_shell_command(git rev-parse)',
-      // Read-only shell commands
-      'run_shell_command(ls)',           // Directory listing
-      'run_shell_command(cat)',          // File content viewing
-      'run_shell_command(pwd)',          // Current directory
-      'run_shell_command(head)',         // File head viewing
-      'run_shell_command(tail)',         // File tail viewing
-      'run_shell_command(wc)',           // Word/line count
-      'run_shell_command(find)',         // File finding
-      'run_shell_command(grep)',         // Pattern searching
-      'run_shell_command(rg)',           // Ripgrep (fast pattern searching)
-      // git-diff-lines is added to PATH via BIN_DIR so bare command works
-      'run_shell_command(git-diff-lines)', // Custom annotated diff tool
-    ].join(',');
-
     // Build args: base args + provider extra_args + model extra_args
     // Use --output-format stream-json for JSONL streaming output (better debugging visibility)
-    const baseArgs = ['-m', model, '-o', 'stream-json', '--allowed-tools', readOnlyTools];
+    let baseArgs;
+    if (configOverrides.yolo) {
+      // In yolo mode, use Gemini's --yolo flag to auto-approve all tools
+      // (including write operations and destructive shell commands)
+      baseArgs = ['-m', model, '-o', 'stream-json', '--yolo'];
+    } else {
+      const readOnlyTools = [
+        // File system tools (read-only)
+        'list_directory',
+        'read_file',
+        'glob',
+        'search_file_content',
+        // Specific read-only git commands (not blanket 'git' to avoid git commit, push, etc.)
+        'run_shell_command(git diff)',
+        'run_shell_command(git log)',
+        'run_shell_command(git show)',
+        'run_shell_command(git status)',
+        'run_shell_command(git branch)',
+        'run_shell_command(git rev-parse)',
+        // Read-only shell commands
+        'run_shell_command(ls)',           // Directory listing
+        'run_shell_command(cat)',          // File content viewing
+        'run_shell_command(pwd)',          // Current directory
+        'run_shell_command(head)',         // File head viewing
+        'run_shell_command(tail)',         // File tail viewing
+        'run_shell_command(wc)',           // Word/line count
+        'run_shell_command(find)',         // File finding
+        'run_shell_command(grep)',         // Pattern searching
+        'run_shell_command(rg)',           // Ripgrep (fast pattern searching)
+        // git-diff-lines is added to PATH via BIN_DIR so bare command works
+        'run_shell_command(git-diff-lines)', // Custom annotated diff tool
+      ].join(',');
+      baseArgs = ['-m', model, '-o', 'stream-json', '--allowed-tools', readOnlyTools];
+    }
     const providerArgs = configOverrides.extra_args || [];
     const modelConfig = configOverrides.models?.find(m => m.id === model);
     const modelArgs = modelConfig?.extra_args || [];

--- a/src/config.js
+++ b/src/config.js
@@ -18,6 +18,7 @@ const DEFAULT_CONFIG = {
   worktree_retention_days: 7,
   dev_mode: false,  // When true, disables static file caching for development
   debug_stream: false,  // When true, logs AI provider streaming events (equivalent to --debug-stream CLI flag)
+  yolo: false,  // When true, skips fine-grained AI provider permission setup (equivalent to --yolo CLI flag)
   providers: {}  // Custom provider configurations (overrides built-in defaults)
 };
 

--- a/tests/unit/claude-provider.test.js
+++ b/tests/unit/claude-provider.test.js
@@ -177,6 +177,26 @@ describe('ClaudeProvider', () => {
       expect(provider.extraEnv.VAR1).toBe('model');
       expect(provider.extraEnv.VAR2).toBe('extra');
     });
+
+    describe('yolo mode', () => {
+      it('should use --allowedTools and not --dangerously-skip-permissions by default', () => {
+        const provider = new ClaudeProvider('sonnet');
+        expect(provider.args).toContain('--allowedTools');
+        expect(provider.args).not.toContain('--dangerously-skip-permissions');
+      });
+
+      it('should use --dangerously-skip-permissions and not --allowedTools when yolo is true', () => {
+        const provider = new ClaudeProvider('sonnet', { yolo: true });
+        expect(provider.args).toContain('--dangerously-skip-permissions');
+        expect(provider.args).not.toContain('--allowedTools');
+      });
+
+      it('should use --allowedTools and not --dangerously-skip-permissions when yolo is false', () => {
+        const provider = new ClaudeProvider('sonnet', { yolo: false });
+        expect(provider.args).toContain('--allowedTools');
+        expect(provider.args).not.toContain('--dangerously-skip-permissions');
+      });
+    });
   });
 
   describe('PAIR_REVIEW_MAX_BUDGET_USD validation', () => {

--- a/tests/unit/codex-provider.test.js
+++ b/tests/unit/codex-provider.test.js
@@ -177,6 +177,32 @@ describe('CodexProvider', () => {
       expect(provider.extraEnv.VAR1).toBe('model');
       expect(provider.extraEnv.VAR2).toBe('extra');
     });
+
+    describe('yolo mode', () => {
+      it('should include sandbox restrictions by default and no dangerously-bypass flag', () => {
+        const provider = new CodexProvider('gpt-5.1-codex-mini');
+        expect(provider.args).toContain('--sandbox');
+        expect(provider.args).toContain('workspace-write');
+        expect(provider.args).toContain('--full-auto');
+        expect(provider.args).not.toContain('--dangerously-bypass-approvals-and-sandbox');
+      });
+
+      it('should use --dangerously-bypass-approvals-and-sandbox when yolo is true', () => {
+        const provider = new CodexProvider('gpt-5.1-codex-mini', { yolo: true });
+        expect(provider.args).toContain('--dangerously-bypass-approvals-and-sandbox');
+        expect(provider.args).not.toContain('--sandbox');
+        expect(provider.args).not.toContain('workspace-write');
+        expect(provider.args).not.toContain('--full-auto');
+      });
+
+      it('should include sandbox restrictions when yolo is explicitly false', () => {
+        const provider = new CodexProvider('gpt-5.1-codex-mini', { yolo: false });
+        expect(provider.args).toContain('--sandbox');
+        expect(provider.args).toContain('workspace-write');
+        expect(provider.args).toContain('--full-auto');
+        expect(provider.args).not.toContain('--dangerously-bypass-approvals-and-sandbox');
+      });
+    });
   });
 
   describe('parseCodexResponse', () => {

--- a/tests/unit/copilot-provider.test.js
+++ b/tests/unit/copilot-provider.test.js
@@ -205,6 +205,48 @@ describe('CopilotProvider', () => {
       const provider = new CopilotProvider();
       expect(provider.baseArgs).not.toContain('-p');
     });
+
+    describe('yolo mode', () => {
+      it('should include deny rules and per-command allow rules by default', () => {
+        const provider = new CopilotProvider('gemini-3-pro-preview', {});
+        const args = provider.baseArgs;
+
+        // Default mode enforces read-only restrictions
+        expect(args).toContain('--deny-tool');
+        expect(args).toContain('--allow-tool');
+        expect(args).toContain('shell(git diff)');
+        expect(args).toContain('shell(rm)');
+        expect(args).toContain('write');
+      });
+
+      it('should skip deny rules and per-command allow rules when yolo is true', () => {
+        const provider = new CopilotProvider('gemini-3-pro-preview', { yolo: true });
+        const args = provider.baseArgs;
+
+        // Yolo mode: broad permissions only, no fine-grained rules
+        expect(args).toContain('--allow-all-tools');
+        expect(args).toContain('--allow-all-paths');
+
+        // Should NOT have any deny or per-command allow entries
+        expect(args).not.toContain('--deny-tool');
+        expect(args).not.toContain('--allow-tool');
+        expect(args).not.toContain('shell(git diff)');
+        expect(args).not.toContain('shell(rm)');
+        expect(args).not.toContain('write');
+      });
+
+      it('should use deny rules when yolo is explicitly false', () => {
+        const provider = new CopilotProvider('gemini-3-pro-preview', { yolo: false });
+        const args = provider.baseArgs;
+
+        // Explicit false behaves the same as default — restrictions apply
+        expect(args).toContain('--deny-tool');
+        expect(args).toContain('--allow-tool');
+        expect(args).toContain('shell(git diff)');
+        expect(args).toContain('shell(rm)');
+        expect(args).toContain('write');
+      });
+    });
   });
 
   describe('model metadata', () => {

--- a/tests/unit/gemini-provider.test.js
+++ b/tests/unit/gemini-provider.test.js
@@ -174,6 +174,26 @@ describe('GeminiProvider', () => {
       expect(provider.extraEnv.VAR1).toBe('model');
       expect(provider.extraEnv.VAR2).toBe('extra');
     });
+
+    describe('yolo mode', () => {
+      it('should include --allowed-tools and no --yolo flag by default', () => {
+        const provider = new GeminiProvider('gemini-2.5-pro');
+        expect(provider.args).toContain('--allowed-tools');
+        expect(provider.args).not.toContain('--yolo');
+      });
+
+      it('should use --yolo instead of --allowed-tools when yolo is true', () => {
+        const provider = new GeminiProvider('gemini-2.5-pro', { yolo: true });
+        expect(provider.args).toContain('--yolo');
+        expect(provider.args).not.toContain('--allowed-tools');
+      });
+
+      it('should use --allowed-tools when yolo is explicitly false', () => {
+        const provider = new GeminiProvider('gemini-2.5-pro', { yolo: false });
+        expect(provider.args).toContain('--allowed-tools');
+        expect(provider.args).not.toContain('--yolo');
+      });
+    });
   });
 
   describe('parseGeminiResponse', () => {

--- a/tests/unit/main.test.js
+++ b/tests/unit/main.test.js
@@ -225,6 +225,20 @@ describe('main.js parseArgs', () => {
       expect(result.flags.model).toBe('haiku');
       expect(result.prArgs).toEqual(['123']);
     });
+
+    it('should parse --yolo flag', () => {
+      const result = parseArgs(['123', '--yolo']);
+      expect(result.flags.yolo).toBe(true);
+      expect(result.prArgs).toEqual(['123']);
+    });
+
+    it('should parse --yolo with other flags', () => {
+      const result = parseArgs(['123', '--yolo', '--ai', '--model', 'opus']);
+      expect(result.flags.yolo).toBe(true);
+      expect(result.flags.ai).toBe(true);
+      expect(result.flags.model).toBe('opus');
+      expect(result.prArgs).toEqual(['123']);
+    });
   });
 });
 
@@ -246,6 +260,7 @@ describe('CLI help and version', () => {
     expect(output).toContain('--ai');
     expect(output).toContain('--ai-draft');
     expect(output).toContain('--debug');
+    expect(output).toContain('--yolo');
   });
 
   it('should show help text when -h is passed', () => {


### PR DESCRIPTION
Add test coverage for the yolo mode security feature across all four AI providers, the config propagation layer, and CLI argument parsing. 18 new tests verify that yolo mode correctly switches each provider from restrictive read-only permissions to unrestricted access.