### PR TITLE
Fix Markdown syntax highlighting treating mid-word underscores as italic

### DIFF
--- a/.changeset/fix-markdown-underscore-highlighting.md
+++ b/.changeset/fix-markdown-underscore-highlighting.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Fix Markdown syntax highlighting so underscores within words (e.g. `update_policy`) are no longer incorrectly treated as italic/bold markers. Added `fixMarkdownHighlighting()` post-processing that strips mid-word emphasis/strong spans from highlight.js output.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@in-the-loop-labs/pair-review",
-  "version": "1.0.5",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@in-the-loop-labs/pair-review",
-      "version": "1.0.5",
+      "version": "1.1.0",
       "license": "GPL-3.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.25.3",


### PR DESCRIPTION
highlight.js does not enforce CommonMark word-boundary rules for underscore emphasis in Markdown, causing identifiers like update_policy to render with _policy styled as italic. Add fixMarkdownHighlighting() post-processing to strip hljs-emphasis/hljs-strong spans preceded by word characters, mirroring the existing fixRubyHighlighting() approach. Uses [^<]* in regex to safely handle nested spans.