### PR TITLE
Add Cursor CLI as AI provider

### DIFF
--- a/.changeset/cursor-agent-provider.md
+++ b/.changeset/cursor-agent-provider.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": minor
+---
+
+Add Cursor Agent CLI as a new AI provider with streaming JSON output, sandbox mode, and built-in model definitions

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ pair-review is a local web application that transforms how you review code, espe
 - **Local-First**: All data and processing happens on your machine - no cloud dependencies
 - **GitHub-Familiar UI**: Interface feels instantly familiar to GitHub users
 - **Human-in-the-Loop**: AI suggests, you decide
-- **Multiple AI Providers**: Support for Claude, Gemini, Codex, Copilot, and OpenCode. Use your existing subscription!
+- **Multiple AI Providers**: Support for Claude, Gemini, Codex, Copilot, OpenCode, and Cursor. Use your existing subscription!
 - **Progressive**: Start simple with manual review, add AI analysis when you need it
 
 ## Quick Start
@@ -164,6 +164,7 @@ pair-review supports several environment variables for customizing behavior:
 | `PAIR_REVIEW_CODEX_CMD` | Custom command to invoke Codex CLI | `codex` |
 | `PAIR_REVIEW_COPILOT_CMD` | Custom command to invoke Copilot CLI | `copilot` |
 | `PAIR_REVIEW_OPENCODE_CMD` | Custom command to invoke OpenCode CLI | `opencode` |
+| `PAIR_REVIEW_CURSOR_AGENT_CMD` | Custom command to invoke Cursor Agent CLI | `agent` |
 | `PAIR_REVIEW_MODEL` | Override the AI model to use (same as `--model` flag) | Provider default |
 
 **Note:** `GITHUB_TOKEN` is the standard environment variable used by many GitHub tools (gh CLI, GitHub Actions, etc.). When set, it takes precedence over the `github_token` field in the config file.
@@ -216,6 +217,7 @@ pair-review integrates with AI providers via their CLI tools:
 - **Codex**: Uses Codex CLI
 - **GitHub Copilot**: Uses Copilot CLI
 - **OpenCode**: Uses OpenCode CLI (requires model configuration)
+- **Cursor**: Uses Cursor Agent CLI (streaming output with sandbox mode)
 
 You can select your preferred provider and model in the repository settings UI.
 

--- a/config.example.json
+++ b/config.example.json
@@ -142,6 +142,14 @@
       "extra_args": [],
       "env": {},
       "installInstructions": "Install Copilot CLI: npm install -g @github/copilot-cli"
+    },
+
+    "cursor-agent": {
+      "_comment": "Override Cursor Agent's built-in configuration. Uses streaming JSON output with sandbox mode enabled by default.",
+      "command": "agent",
+      "extra_args": [],
+      "env": {},
+      "installInstructions": "Install Cursor Agent CLI: https://cursor.com/docs/cli/using"
     }
   }
 }

--- a/public/js/utils/tier-icons.js
+++ b/public/js/utils/tier-icons.js
@@ -13,6 +13,7 @@
   function getTierIcon(tier) {
     switch (tier) {
       case 'fast': return '\u26A1';        // Lightning bolt
+      case 'free': return '\u26A1';        // Lightning bolt (alias for fast)
       case 'balanced': return '\u2696\uFE0F'; // Balance scale
       case 'thorough': return '\uD83C\uDFAF'; // Direct hit (target)
       case 'premium': return '\uD83D\uDC8E';  // Gem stone

--- a/scripts/verify-ai-permissions.js
+++ b/scripts/verify-ai-permissions.js
@@ -105,6 +105,7 @@ function loadProviders() {
     require('../src/ai/copilot-provider');
     require('../src/ai/codex-provider');
     require('../src/ai/gemini-provider');
+    require('../src/ai/cursor-agent-provider');
 
     // Get the provider registry
     const { getProviderClass, getRegisteredProviderIds } = require('../src/ai/provider');
@@ -200,6 +201,26 @@ const providerTestConfigs = {
     writeBlockKnownLimitation: 'Gemini CLI cannot restrict tool availability (only auto-approval). Write operations rely on prompt engineering.',
     buildTestCommands: (provider, testPrompt) => {
       // Gemini uses stdin for prompts
+      return {
+        command: provider.command,
+        args: provider.args,
+        stdin: testPrompt,
+        useShell: provider.useShell,
+      };
+    },
+  },
+
+  'cursor-agent': {
+    name: 'Cursor',
+    envVar: 'PAIR_REVIEW_CURSOR_AGENT_CMD',
+    defaultCmd: 'agent',
+    checkArgs: ['--version'],
+    // Known limitation: Cursor Agent CLI does not support fine-grained tool permission
+    // controls. Sandbox mode is enabled but its exact restrictions are undocumented.
+    // Write operations rely on prompt engineering and worktree isolation.
+    writeBlockKnownLimitation: 'Cursor Agent CLI has no fine-grained tool permissions. Write blocking relies on sandbox mode, prompt engineering, and worktree isolation.',
+    buildTestCommands: (provider, testPrompt) => {
+      // Cursor Agent uses stdin for prompts
       return {
         command: provider.command,
         args: provider.args,

--- a/src/ai/cursor-agent-provider.js
+++ b/src/ai/cursor-agent-provider.js
@@ -1,0 +1,739 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/**
+ * Cursor Agent AI Provider
+ *
+ * Implements the AI provider interface for Cursor's Agent CLI.
+ * Uses the `agent -p` command for non-interactive execution with
+ * `--output-format stream-json` for JSONL streaming output.
+ *
+ * Agent stream-json event types:
+ * - system (subtype: init): Session initialization with model info
+ * - user: User message echo
+ * - assistant: Assistant text responses (content blocks with type/text)
+ * - tool_call (subtype: started|completed): Tool invocations with call_id
+ * - result (subtype: success|error): Final result with duration_ms and result text
+ */
+
+const path = require('path');
+const { spawn } = require('child_process');
+const { AIProvider, registerProvider } = require('./provider');
+const logger = require('../utils/logger');
+const { extractJSON } = require('../utils/json-extractor');
+const { CancellationError, isAnalysisCancelled } = require('../routes/shared');
+const { StreamParser, parseCursorAgentLine } = require('./stream-parser');
+
+// Directory containing bin scripts (git-diff-lines, etc.)
+const BIN_DIR = path.join(__dirname, '..', '..', 'bin');
+
+/**
+ * Cursor Agent model definitions with tier mappings
+ *
+ * Based on PR #83 recommendations:
+ * - free (auto): Cursor's default auto-routing model
+ * - fast (gemini-3-flash): Quick analysis for simple changes
+ * - balanced (sonnet-4.5): Recommended for most reviews
+ * - thorough (opus-4.5-thinking): Deep analysis with thinking for complex code
+ */
+const CURSOR_AGENT_MODELS = [
+  {
+    id: 'auto',
+    name: 'Auto',
+    tier: 'free',
+    tagline: 'Cursor Auto-Routed',
+    description: 'Cursor picks the best model automatically',
+    badge: 'Free Tier',
+    badgeClass: 'badge-speed'
+  },
+  {
+    id: 'gemini-3-flash',
+    name: 'Gemini 3 Flash',
+    tier: 'fast',
+    tagline: 'Lightning Fast',
+    description: 'Quick analysis for simple changes',
+    badge: 'Fastest',
+    badgeClass: 'badge-speed'
+  },
+  {
+    id: 'sonnet-4.5',
+    name: 'Claude 4.5 Sonnet',
+    tier: 'balanced',
+    tagline: 'Best Balance',
+    description: 'Recommended for most reviews',
+    badge: 'Recommended',
+    badgeClass: 'badge-recommended',
+    default: true
+  },
+  {
+    id: 'opus-4.5-thinking',
+    name: 'Claude 4.5 Opus (Thinking)',
+    tier: 'thorough',
+    tagline: 'Most Capable',
+    description: 'Deep analysis with extended thinking for complex code',
+    badge: 'Most Thorough',
+    badgeClass: 'badge-power'
+  }
+];
+
+class CursorAgentProvider extends AIProvider {
+  /**
+   * @param {string} model - Model identifier
+   * @param {Object} configOverrides - Config overrides from providers config
+   * @param {string} configOverrides.command - Custom CLI command
+   * @param {string[]} configOverrides.extra_args - Additional CLI arguments
+   * @param {Object} configOverrides.env - Additional environment variables
+   * @param {Object[]} configOverrides.models - Custom model definitions
+   */
+  constructor(model = 'sonnet-4.5', configOverrides = {}) {
+    super(model);
+
+    // Command precedence: ENV > config > default
+    const envCmd = process.env.PAIR_REVIEW_CURSOR_AGENT_CMD;
+    const configCmd = configOverrides.command;
+    const agentCmd = envCmd || configCmd || 'agent';
+
+    // Store for use in getExtractionConfig and testAvailability
+    this.agentCmd = agentCmd;
+    this.configOverrides = configOverrides;
+
+    // For multi-word commands, use shell mode (same pattern as other providers)
+    this.useShell = agentCmd.includes(' ');
+
+    // ============================================================================
+    // SECURITY LIMITATION - READ CAREFULLY
+    // ============================================================================
+    //
+    // IMPORTANT: Cursor Agent CLI does NOT currently support fine-grained tool
+    // permission controls (no --allowedTools, --allow-tool, or --deny-tool flags).
+    //
+    // The --sandbox flag controls sandbox mode but its exact behavior with tool
+    // restrictions is undocumented. We enable sandbox mode as a precaution.
+    //
+    // MITIGATION STRATEGY:
+    // 1. Prompt engineering: The analysis prompts explicitly instruct the AI to
+    //    only use read-only operations and never modify files
+    // 2. Worktree isolation: Analysis runs in a git worktree, limiting blast radius
+    // 3. Sandbox mode: Enabled as an additional safety layer
+    //
+    // If a mechanism to restrict tool permissions becomes available in the Agent CLI,
+    // it should be added here similar to Claude's --allowedTools or Copilot's
+    // --allow-tool/--deny-tool flags.
+    // ============================================================================
+
+    // Build args: base args + provider extra_args + model extra_args
+    // Use --output-format stream-json for JSONL streaming output
+    // Use --stream-partial-output for real-time text deltas (better for progress display)
+    //   NOTE: --stream-partial-output is tightly coupled to the delta-filtering logic
+    //   in parseCursorAgentResponse (isStreamingDelta / timestamp_ms check). If this
+    //   flag is removed, the parser will treat all assistant events as complete messages,
+    //   which is fine but will change accumulation behavior. Keep these in sync.
+    // Use --sandbox enabled for security (when not in yolo mode)
+    const sandboxArgs = configOverrides.yolo ? ['--sandbox', 'disabled'] : ['--sandbox', 'enabled'];
+    const baseArgs = ['-p', '--output-format', 'stream-json', '--stream-partial-output', '--model', model, ...sandboxArgs];
+    const providerArgs = configOverrides.extra_args || [];
+    const modelConfig = configOverrides.models?.find(m => m.id === model);
+    const modelArgs = modelConfig?.extra_args || [];
+
+    // Merge env: provider env + model env
+    this.extraEnv = {
+      ...(configOverrides.env || {}),
+      ...(modelConfig?.env || {})
+    };
+
+    if (this.useShell) {
+      // In shell mode, build full command string with args
+      this.command = `${agentCmd} ${[...baseArgs, ...providerArgs, ...modelArgs].join(' ')}`;
+      this.args = [];
+    } else {
+      this.command = agentCmd;
+      this.args = [...baseArgs, ...providerArgs, ...modelArgs];
+    }
+  }
+
+  /**
+   * Execute Cursor Agent CLI with a prompt
+   * @param {string} prompt - The prompt to send to Cursor Agent
+   * @param {Object} options - Optional configuration
+   * @returns {Promise<Object>} Parsed response or error
+   */
+  async execute(prompt, options = {}) {
+    return new Promise((resolve, reject) => {
+      const { cwd = process.cwd(), timeout = 300000, level = 'unknown', analysisId, registerProcess, onStreamEvent } = options;
+
+      const levelPrefix = `[Level ${level}]`;
+      logger.info(`${levelPrefix} Executing Cursor Agent CLI...`);
+      logger.info(`${levelPrefix} Writing prompt: ${prompt.length} chars`);
+
+      const agent = spawn(this.command, this.args, {
+        cwd,
+        env: {
+          ...process.env,
+          ...this.extraEnv,
+          PATH: `${BIN_DIR}:${process.env.PATH}`
+        },
+        shell: this.useShell
+      });
+
+      const pid = agent.pid;
+      logger.info(`${levelPrefix} Spawned Cursor Agent CLI process: PID ${pid}`);
+
+      // Register process for cancellation tracking if analysisId provided
+      if (analysisId && registerProcess) {
+        registerProcess(analysisId, agent);
+        logger.info(`${levelPrefix} Registered process ${pid} for analysis ${analysisId}`);
+      }
+
+      let stdout = '';
+      let stderr = '';
+      let timeoutId = null;
+      let settled = false;  // Guard against multiple resolve/reject calls
+      let lineBuffer = '';  // Buffer for incomplete JSONL lines
+      let lineCount = 0;    // Count of JSONL events for progress tracking
+
+      const settle = (fn, value) => {
+        if (settled) return;
+        settled = true;
+        if (timeoutId) clearTimeout(timeoutId);
+        fn(value);
+      };
+
+      // Set up side-channel stream parser for live progress events
+      const streamParser = onStreamEvent
+        ? new StreamParser(parseCursorAgentLine, onStreamEvent, { cwd })
+        : null;
+
+      // Set timeout
+      if (timeout) {
+        timeoutId = setTimeout(() => {
+          logger.error(`${levelPrefix} Process ${pid} timed out after ${timeout}ms`);
+          agent.kill('SIGTERM');
+          settle(reject, new Error(`${levelPrefix} Cursor Agent CLI timed out after ${timeout}ms`));
+        }, timeout);
+      }
+
+      // Collect stdout with streaming JSONL parsing for debug visibility
+      agent.stdout.on('data', (data) => {
+        const chunk = data.toString();
+        stdout += chunk;
+
+        // Feed side-channel stream parser for live progress events
+        if (streamParser) {
+          streamParser.feed(chunk);
+        }
+
+        // Parse JSONL lines as they arrive for streaming debug output
+        lineBuffer += chunk;
+        const lines = lineBuffer.split('\n');
+        // Keep the last incomplete line in buffer
+        lineBuffer = lines.pop() || '';
+
+        for (const line of lines) {
+          if (line.trim()) {
+            lineCount++;
+            this.logStreamLine(line, lineCount, levelPrefix);
+          }
+        }
+      });
+
+      // Collect stderr
+      agent.stderr.on('data', (data) => {
+        stderr += data.toString();
+      });
+
+      // Handle completion
+      agent.on('close', (code) => {
+        if (settled) return;  // Already settled by timeout or error
+
+        // Flush any remaining stream parser buffer
+        if (streamParser) {
+          streamParser.flush();
+        }
+
+        // Check for cancellation signals (SIGTERM=143, SIGKILL=137)
+        const isCancellationCode = code === 143 || code === 137;
+        if (isCancellationCode && analysisId && isAnalysisCancelled(analysisId)) {
+          logger.info(`${levelPrefix} Cursor Agent CLI terminated due to analysis cancellation (exit code ${code})`);
+          settle(reject, new CancellationError(`${levelPrefix} Analysis cancelled by user`));
+          return;
+        }
+
+        // Always log stderr if present
+        if (stderr.trim()) {
+          if (code !== 0) {
+            logger.error(`${levelPrefix} Cursor Agent CLI stderr (exit code ${code}): ${stderr}`);
+          } else {
+            logger.warn(`${levelPrefix} Cursor Agent CLI stderr (success): ${stderr}`);
+          }
+        }
+
+        if (code !== 0) {
+          logger.error(`${levelPrefix} Cursor Agent CLI exited with code ${code}`);
+          settle(reject, new Error(`${levelPrefix} Cursor Agent CLI exited with code ${code}: ${stderr}`));
+          return;
+        }
+
+        // Process any remaining buffered line
+        if (lineBuffer.trim()) {
+          lineCount++;
+          this.logStreamLine(lineBuffer, lineCount, levelPrefix);
+        }
+
+        // Log completion with event count (after lineBuffer flush for accurate count)
+        logger.info(`${levelPrefix} Cursor Agent CLI completed: ${lineCount} JSONL events received`);
+
+        // Parse the Cursor Agent JSONL stream response
+        const parsed = this.parseCursorAgentResponse(stdout, level);
+        if (parsed.success) {
+          logger.success(`${levelPrefix} Successfully parsed JSON response`);
+          // Dump the parsed data for debugging
+          const dataPreview = JSON.stringify(parsed.data, null, 2);
+          logger.debug(`${levelPrefix} [parsed_data] ${dataPreview.substring(0, 3000)}${dataPreview.length > 3000 ? '...' : ''}`);
+          // Log suggestion count if present
+          if (parsed.data?.suggestions) {
+            const count = Array.isArray(parsed.data.suggestions) ? parsed.data.suggestions.length : 0;
+            logger.info(`${levelPrefix} [response] ${count} suggestions in parsed response`);
+          }
+          settle(resolve, parsed.data);
+        } else {
+          // Regex extraction failed, try LLM-based extraction as fallback
+          logger.warn(`${levelPrefix} Regex extraction failed: ${parsed.error}`);
+          logger.info(`${levelPrefix} Raw response length: ${stdout.length} characters`);
+          logger.info(`${levelPrefix} Attempting LLM-based JSON extraction fallback...`);
+
+          // Use async IIFE to handle the async LLM extraction
+          (async () => {
+            try {
+              // Re-check settled before spawning LLM extraction to avoid
+              // orphan processes if timeout fired between close-handler entry
+              // and reaching this point.
+              if (settled) return;
+              const llmExtracted = await this.extractJSONWithLLM(stdout, { level, analysisId, registerProcess });
+              if (llmExtracted.success) {
+                logger.success(`${levelPrefix} LLM extraction fallback succeeded`);
+                settle(resolve, llmExtracted.data);
+              } else {
+                logger.warn(`${levelPrefix} LLM extraction fallback also failed: ${llmExtracted.error}`);
+                logger.info(`${levelPrefix} Raw response preview: ${stdout.substring(0, 500)}...`);
+                settle(resolve, { raw: stdout, parsed: false });
+              }
+            } catch (llmError) {
+              logger.warn(`${levelPrefix} LLM extraction fallback error: ${llmError.message}`);
+              settle(resolve, { raw: stdout, parsed: false });
+            }
+          })();
+        }
+      });
+
+      // Handle errors
+      agent.on('error', (error) => {
+        if (error.code === 'ENOENT') {
+          logger.error(`${levelPrefix} Cursor Agent CLI not found. Please ensure Cursor Agent CLI is installed.`);
+          settle(reject, new Error(`${levelPrefix} Cursor Agent CLI not found. ${CursorAgentProvider.getInstallInstructions()}`));
+        } else {
+          logger.error(`${levelPrefix} Cursor Agent process error: ${error}`);
+          settle(reject, error);
+        }
+      });
+
+      // Send the prompt to stdin
+      agent.stdin.write(prompt, (err) => {
+        if (err) {
+          logger.error(`${levelPrefix} Failed to write prompt to stdin: ${err}`);
+          agent.kill('SIGTERM');
+          settle(reject, new Error(`${levelPrefix} Failed to write prompt to stdin: ${err}`));
+        }
+      });
+      agent.stdin.end();
+    });
+  }
+
+  /**
+   * Parse Cursor Agent CLI JSONL stream response
+   *
+   * Agent with --output-format stream-json outputs JSONL with:
+   * - system (subtype: init): Session initialization with model info
+   * - user: User message echo
+   * - assistant: Text responses in content blocks [{type: "text", text: "..."}]
+   *   With --stream-partial-output, multiple assistant events arrive as deltas.
+   *   The last assistant event (no timestamp_ms) contains the complete accumulated text.
+   * - tool_call (subtype: started|completed): Tool invocations
+   * - result (subtype: success): Final result with 'result' text field
+   *
+   * We accumulate text from assistant messages and extract JSON from them.
+   * The result event's 'result' field is used as fallback.
+   *
+   * @param {string} stdout - Raw stdout from Cursor Agent CLI (JSONL format)
+   * @param {string|number} level - Analysis level for logging
+   * @returns {{success: boolean, data?: Object, error?: string}}
+   */
+  parseCursorAgentResponse(stdout, level) {
+    const levelPrefix = `[Level ${level}]`;
+
+    try {
+      // Split by newlines and parse each JSON line
+      const lines = stdout.trim().split('\n').filter(line => line.trim());
+      // Accumulate text from assistant messages.
+      // With --stream-partial-output, the last assistant event (without timestamp_ms)
+      // contains the complete accumulated text for that turn.
+      // Without --stream-partial-output, each assistant event has complete content.
+      let assistantText = '';
+      let resultText = '';
+
+      for (const line of lines) {
+        try {
+          const event = JSON.parse(line);
+
+          // Collect text from assistant messages
+          // With streaming, we get incremental deltas (with timestamp_ms)
+          // followed by a final complete message (without timestamp_ms).
+          // We only take the final complete message per turn to avoid duplication.
+          if (event.type === 'assistant') {
+            const content = event.message?.content || [];
+            const isStreamingDelta = typeof event.timestamp_ms === 'number';
+
+            if (!isStreamingDelta) {
+              // This is a complete assistant message (final accumulation)
+              // Replace any previous accumulated text from this turn
+              let turnText = '';
+              for (const block of content) {
+                if (block.type === 'text' && block.text) {
+                  turnText += block.text;
+                }
+              }
+              if (turnText) {
+                assistantText += turnText;
+              }
+            }
+          }
+
+          // Also capture the result event's text as fallback
+          if (event.type === 'result' && event.result) {
+            resultText = event.result;
+          }
+        } catch (lineError) {
+          // Skip malformed lines
+          logger.debug(`${levelPrefix} Skipping malformed JSONL line: ${line.substring(0, 100)}`);
+        }
+      }
+
+      // Primary: try to extract JSON from accumulated assistant text
+      if (assistantText) {
+        logger.debug(`${levelPrefix} Extracted ${assistantText.length} chars of assistant text from JSONL`);
+        const extracted = extractJSON(assistantText, level);
+        if (extracted.success) {
+          return extracted;
+        }
+
+        logger.warn(`${levelPrefix} Assistant text is not JSON, trying result text fallback`);
+      }
+
+      // Fallback: try extracting JSON from the result event's text
+      if (resultText) {
+        logger.debug(`${levelPrefix} Trying result text: ${resultText.length} chars`);
+        const extracted = extractJSON(resultText, level);
+        if (extracted.success) {
+          return extracted;
+        }
+
+        logger.warn(`${levelPrefix} Result text is not JSON either`);
+      }
+
+      // Last resort: try extracting JSON directly from raw stdout
+      if (!assistantText && !resultText) {
+        const extracted = extractJSON(stdout, level);
+        return extracted;
+      }
+
+      return { success: false, error: 'No valid JSON found in assistant or result text' };
+
+    } catch (parseError) {
+      // stdout might not be valid JSONL at all, try extracting JSON from it
+      const extracted = extractJSON(stdout, level);
+      if (extracted.success) {
+        return extracted;
+      }
+
+      return { success: false, error: `JSONL parse error: ${parseError.message}` };
+    }
+  }
+
+  /**
+   * Log a streaming JSONL line for debugging visibility
+   *
+   * Cursor Agent stream-json format event types:
+   * - system (subtype: init): Session initialization
+   * - user: User message echo
+   * - assistant: Text responses (may be streaming deltas with timestamp_ms)
+   * - tool_call (subtype: started|completed): Tool invocations
+   * - result (subtype: success): Final result with stats
+   *
+   * Uses logger.streamDebug() which only logs when --debug-stream flag is enabled.
+   *
+   * @param {string} line - A single JSONL line
+   * @param {number} lineNum - Line number for reference
+   * @param {string} levelPrefix - Logging prefix
+   */
+  logStreamLine(line, lineNum, levelPrefix) {
+    // Check stream debug status - branches exit early if disabled
+    const streamEnabled = logger.isStreamDebugEnabled();
+
+    try {
+      const event = JSON.parse(line);
+      const eventType = event.type;
+
+      if (eventType === 'system') {
+        if (!streamEnabled) return;
+        const sessionId = event.session_id || '';
+        const model = event.model || '';
+        const subtype = event.subtype || '';
+        const sessionPart = sessionId ? ` session=${sessionId.substring(0, 12)}` : '';
+        const modelPart = model ? ` model=${model}` : '';
+        const subtypePart = subtype ? ` (${subtype})` : '';
+        logger.streamDebug(`${levelPrefix} [#${lineNum}] system${subtypePart}${sessionPart}${modelPart}`);
+
+      } else if (eventType === 'user') {
+        if (!streamEnabled) return;
+        const content = event.message?.content || [];
+        let textPreview = '';
+        for (const block of content) {
+          if (block.type === 'text' && block.text) {
+            textPreview += block.text;
+          }
+        }
+        if (textPreview) {
+          const preview = textPreview.replace(/\n/g, '\\n').substring(0, 40);
+          logger.streamDebug(`${levelPrefix} [#${lineNum}] user: ${preview}${textPreview.length > 40 ? '...' : ''}`);
+        } else {
+          logger.streamDebug(`${levelPrefix} [#${lineNum}] user`);
+        }
+
+      } else if (eventType === 'assistant') {
+        if (!streamEnabled) return;
+        const content = event.message?.content || [];
+        const isStreamingDelta = typeof event.timestamp_ms === 'number';
+        const deltaPart = isStreamingDelta ? ' (delta)' : '';
+
+        for (const block of content) {
+          if (block.type === 'text' && block.text) {
+            const preview = block.text.replace(/\n/g, '\\n').substring(0, 60);
+            logger.streamDebug(`${levelPrefix} [#${lineNum}] assistant${deltaPart}: ${preview}${block.text.length > 60 ? '...' : ''}`);
+          }
+        }
+
+      } else if (eventType === 'tool_call') {
+        if (!streamEnabled) return;
+        const subtype = event.subtype || '';
+        const callId = event.call_id || '';
+        const toolCall = event.tool_call || {};
+
+        // Extract tool name and details from the tool_call object
+        // Agent format: { shellToolCall: { args: { command: "..." } } }
+        // or similar structures for other tool types
+        let toolName = 'unknown';
+        let toolDetail = '';
+
+        if (toolCall.shellToolCall) {
+          toolName = 'shell';
+          const cmd = toolCall.shellToolCall.args?.command || toolCall.shellToolCall.result?.rejected?.command || '';
+          if (cmd) {
+            toolDetail = `cmd="${cmd.substring(0, 50)}${cmd.length > 50 ? '...' : ''}"`;
+          }
+        } else if (toolCall.readToolCall) {
+          toolName = 'read';
+          const filePath = toolCall.readToolCall.args?.path || '';
+          if (filePath) {
+            toolDetail = `path="${filePath}"`;
+          }
+        } else if (toolCall.editToolCall) {
+          toolName = 'edit';
+          const filePath = toolCall.editToolCall.args?.path || '';
+          if (filePath) {
+            toolDetail = `path="${filePath}"`;
+          }
+        } else {
+          // Try to identify the tool type from the keys
+          const toolKeys = Object.keys(toolCall);
+          if (toolKeys.length > 0) {
+            toolName = toolKeys[0].replace('ToolCall', '');
+          }
+        }
+
+        const idPart = callId ? ` [${callId.substring(0, 12)}]` : '';
+        const subtypePart = subtype ? ` ${subtype}` : '';
+        const detailPart = toolDetail ? ` ${toolDetail}` : '';
+        logger.streamDebug(`${levelPrefix} [#${lineNum}] tool_call${subtypePart}: ${toolName}${idPart}${detailPart}`);
+
+      } else if (eventType === 'result') {
+        // Final result - always log this at info level (not stream debug)
+        const subtype = event.subtype || '';
+        const durationMs = event.duration_ms || 0;
+        const durationApiMs = event.duration_api_ms || 0;
+        const isError = event.is_error || false;
+        const resultText = event.result || '';
+
+        const statusPart = isError ? ' ERROR' : ' OK';
+        const durationPart = durationMs ? ` duration=${durationMs}ms` : '';
+        const apiDurationPart = durationApiMs ? ` api=${durationApiMs}ms` : '';
+
+        logger.info(`${levelPrefix} [result] ${subtype}${statusPart}${durationPart}${apiDurationPart}`);
+
+        // Show a preview of the actual response content
+        if (resultText) {
+          const charCount = resultText.length;
+          const preview = resultText.replace(/\s+/g, ' ').substring(0, 100);
+          logger.info(`${levelPrefix} [response] ${charCount} chars: ${preview}${charCount > 100 ? '...' : ''}`);
+        }
+
+      } else if (eventType && streamEnabled) {
+        // Unknown event type - only log if we have an actual type and stream debug is on
+        logger.streamDebug(`${levelPrefix} [#${lineNum}] ${eventType}`);
+      }
+      // Silently ignore events with no type
+
+    } catch (parseError) {
+      if (streamEnabled) {
+        // Skip malformed lines
+        logger.streamDebug(`${levelPrefix} [#${lineNum}] (malformed: ${line.substring(0, 50)}${line.length > 50 ? '...' : ''})`);
+      }
+    }
+  }
+
+  /**
+   * Build args for Cursor Agent CLI extraction, applying provider and model extra_args.
+   * This ensures consistent arg construction for getExtractionConfig().
+   *
+   * Note: For extraction, we use text output (--output-format text) for simpler
+   * JSON parsing. No sandbox needed since extraction doesn't use tools.
+   *
+   * @param {string} model - The model identifier to use
+   * @returns {string[]} Complete args array for the CLI
+   */
+  buildArgsForModel(model) {
+    // Base args for extraction (text output, no tools needed)
+    const baseArgs = ['-p', '--output-format', 'text', '--model', model];
+    // Provider-level extra_args (from configOverrides)
+    const providerArgs = this.configOverrides?.extra_args || [];
+    // Model-specific extra_args (from the model config for the given model)
+    const modelConfig = this.configOverrides?.models?.find(m => m.id === model);
+    const modelArgs = modelConfig?.extra_args || [];
+
+    return [...baseArgs, ...providerArgs, ...modelArgs];
+  }
+
+  /**
+   * Get CLI configuration for LLM extraction
+   * @param {string} model - The model to use for extraction
+   * @returns {Object} Configuration for spawning extraction process
+   */
+  getExtractionConfig(model) {
+    // Use the already-resolved command from the constructor (this.agentCmd)
+    // which respects: ENV > config > default precedence
+    const agentCmd = this.agentCmd;
+    const useShell = this.useShell;
+
+    // Build args consistently using the shared method, applying provider and model extra_args
+    const args = this.buildArgsForModel(model);
+
+    // For extraction, we pass the prompt via stdin
+    if (useShell) {
+      return {
+        command: `${agentCmd} ${args.join(' ')}`,
+        args: [],
+        useShell: true,
+        promptViaStdin: true
+      };
+    }
+    return {
+      command: agentCmd,
+      args,
+      useShell: false,
+      promptViaStdin: true
+    };
+  }
+
+  /**
+   * Test if Cursor Agent CLI is available
+   * Uses the command configured in the instance (respects ENV > config > default precedence)
+   * @returns {Promise<boolean>}
+   */
+  async testAvailability() {
+    return new Promise((resolve) => {
+      // For availability test, we just need to check --version
+      // Use the already-resolved command from the constructor (this.agentCmd)
+      // which respects: ENV > config > default precedence
+      const useShell = this.useShell;
+      const command = useShell ? `${this.agentCmd} --version` : this.agentCmd;
+      const args = useShell ? [] : ['--version'];
+
+      const agent = spawn(command, args, {
+        env: {
+          ...process.env,
+          PATH: `${BIN_DIR}:${process.env.PATH}`
+        },
+        shell: useShell
+      });
+
+      let stdout = '';
+      let settled = false;
+
+      // Timeout guard: if the CLI hangs (e.g., waiting for auth), resolve false
+      const availabilityTimeout = setTimeout(() => {
+        if (settled) return;
+        settled = true;
+        logger.warn('Cursor Agent CLI availability check timed out after 10s');
+        try { agent.kill(); } catch { /* ignore */ }
+        resolve(false);
+      }, 10000);
+
+      agent.stdout.on('data', (data) => {
+        stdout += data.toString();
+      });
+
+      agent.on('close', (code) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(availabilityTimeout);
+        if (code === 0) {
+          logger.info(`Cursor Agent CLI available: ${stdout.trim()}`);
+          resolve(true);
+        } else {
+          logger.warn('Cursor Agent CLI not available or returned unexpected output');
+          resolve(false);
+        }
+      });
+
+      agent.on('error', (error) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(availabilityTimeout);
+        logger.warn(`Cursor Agent CLI not available: ${error.message}`);
+        resolve(false);
+      });
+    });
+  }
+
+  static getProviderName() {
+    return 'Cursor';
+  }
+
+  static getProviderId() {
+    return 'cursor-agent';
+  }
+
+  static getModels() {
+    return CURSOR_AGENT_MODELS;
+  }
+
+  static getDefaultModel() {
+    return 'sonnet-4.5';
+  }
+
+  static getInstallInstructions() {
+    return 'Install Cursor Agent CLI: https://cursor.com/docs/cli/using\n' +
+           'Run "agent login" to authenticate after installation.';
+  }
+}
+
+// Register this provider
+registerProvider('cursor-agent', CursorAgentProvider);
+
+module.exports = CursorAgentProvider;

--- a/src/ai/index.js
+++ b/src/ai/index.js
@@ -30,6 +30,7 @@ require('./gemini-provider');
 require('./codex-provider');
 require('./copilot-provider');
 require('./opencode-provider');
+require('./cursor-agent-provider');
 
 // Export the unified API
 module.exports = {

--- a/src/ai/provider.js
+++ b/src/ai/provider.js
@@ -373,6 +373,7 @@ function inferModelDefaults(model) {
 
   return {
     ...model,
+    tier: canonicalTier, // Normalize tier alias to canonical form
     name: model.name || prettifyModelId(model.id),
     tagline: model.tagline || '',
     description: model.description || '',

--- a/tests/unit/cursor-agent-provider.test.js
+++ b/tests/unit/cursor-agent-provider.test.js
@@ -1,0 +1,687 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+
+/**
+ * Unit tests for CursorAgentProvider
+ *
+ * These tests focus on static methods, constructor behavior, response parsing,
+ * and stream logging without requiring actual CLI processes.
+ *
+ * Note: execute() tests that require child_process.spawn mocking are not yet
+ * implemented (would need a separate file for module isolation).
+ */
+
+// Mock logger to suppress output during tests
+// Use actual implementation for state tracking, but mock output methods
+// Note: Logger exports directly via CommonJS (module.exports = new AILogger()),
+// so mock must export methods at top level, not under 'default'
+vi.mock('../../src/utils/logger', () => {
+  let streamDebugEnabled = false;
+  return {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    success: vi.fn(),
+    debug: vi.fn(),
+    streamDebug: vi.fn(),
+    section: vi.fn(),
+    isStreamDebugEnabled: () => streamDebugEnabled,
+    setStreamDebugEnabled: (enabled) => { streamDebugEnabled = enabled; }
+  };
+});
+
+// Import after mocks are set up
+const CursorAgentProvider = require('../../src/ai/cursor-agent-provider');
+
+describe('CursorAgentProvider', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Reset environment for each test
+    delete process.env.PAIR_REVIEW_CURSOR_AGENT_CMD;
+  });
+
+  afterEach(() => {
+    // Restore original environment
+    process.env = { ...originalEnv };
+  });
+
+  describe('static methods', () => {
+    it('should return correct provider name', () => {
+      expect(CursorAgentProvider.getProviderName()).toBe('Cursor');
+    });
+
+    it('should return correct provider ID', () => {
+      expect(CursorAgentProvider.getProviderId()).toBe('cursor-agent');
+    });
+
+    it('should return sonnet-4.5 as default model', () => {
+      expect(CursorAgentProvider.getDefaultModel()).toBe('sonnet-4.5');
+    });
+
+    it('should return array of models with expected structure', () => {
+      const models = CursorAgentProvider.getModels();
+      expect(Array.isArray(models)).toBe(true);
+      expect(models.length).toBe(4);
+
+      // Check that we have the expected model IDs
+      const modelIds = models.map(m => m.id);
+      expect(modelIds).toContain('auto');
+      expect(modelIds).toContain('gemini-3-flash');
+      expect(modelIds).toContain('sonnet-4.5');
+      expect(modelIds).toContain('opus-4.5-thinking');
+
+      // Check model structure for the default model
+      const defaultModel = models.find(m => m.id === 'sonnet-4.5');
+      expect(defaultModel).toMatchObject({
+        id: 'sonnet-4.5',
+        name: 'Claude 4.5 Sonnet',
+        tier: 'balanced',
+        default: true
+      });
+    });
+
+    it('should have correct tier assignments', () => {
+      const models = CursorAgentProvider.getModels();
+      const tierMap = Object.fromEntries(models.map(m => [m.id, m.tier]));
+      expect(tierMap['auto']).toBe('free');
+      expect(tierMap['gemini-3-flash']).toBe('fast');
+      expect(tierMap['sonnet-4.5']).toBe('balanced');
+      expect(tierMap['opus-4.5-thinking']).toBe('thorough');
+    });
+
+    it('should return install instructions', () => {
+      const instructions = CursorAgentProvider.getInstallInstructions();
+      expect(instructions).toContain('Cursor');
+      expect(instructions).toContain('agent');
+    });
+  });
+
+  describe('constructor', () => {
+    it('should create instance with default model', () => {
+      const provider = new CursorAgentProvider();
+      expect(provider.model).toBe('sonnet-4.5');
+    });
+
+    it('should create instance with specified model', () => {
+      const provider = new CursorAgentProvider('opus-4.5-thinking');
+      expect(provider.model).toBe('opus-4.5-thinking');
+    });
+
+    it('should use default agent command', () => {
+      const provider = new CursorAgentProvider('sonnet-4.5');
+      expect(provider.command).toBe('agent');
+      expect(provider.useShell).toBe(false);
+    });
+
+    it('should respect PAIR_REVIEW_CURSOR_AGENT_CMD environment variable', () => {
+      process.env.PAIR_REVIEW_CURSOR_AGENT_CMD = '/custom/agent';
+      const provider = new CursorAgentProvider('sonnet-4.5');
+      expect(provider.command).toBe('/custom/agent');
+    });
+
+    it('should use shell mode for multi-word commands', () => {
+      process.env.PAIR_REVIEW_CURSOR_AGENT_CMD = 'devx agent';
+      const provider = new CursorAgentProvider('sonnet-4.5');
+      expect(provider.useShell).toBe(true);
+      expect(provider.command).toContain('devx agent');
+    });
+
+    it('should configure base args correctly', () => {
+      const provider = new CursorAgentProvider('gemini-3-flash');
+      expect(provider.args).toContain('-p');
+      expect(provider.args).toContain('--output-format');
+      expect(provider.args).toContain('stream-json');
+      expect(provider.args).toContain('--stream-partial-output');
+      expect(provider.args).toContain('--model');
+      expect(provider.args).toContain('gemini-3-flash');
+      expect(provider.args).toContain('--sandbox');
+      expect(provider.args).toContain('enabled');
+    });
+
+    it('should merge provider extra_args from config', () => {
+      const provider = new CursorAgentProvider('sonnet-4.5', {
+        extra_args: ['--custom-flag', '--timeout', '60']
+      });
+      expect(provider.args).toContain('--custom-flag');
+      expect(provider.args).toContain('--timeout');
+      expect(provider.args).toContain('60');
+    });
+
+    it('should merge model-specific extra_args from config', () => {
+      const provider = new CursorAgentProvider('opus-4.5-thinking', {
+        models: [
+          { id: 'opus-4.5-thinking', extra_args: ['--special-flag'] }
+        ]
+      });
+      expect(provider.args).toContain('--special-flag');
+    });
+
+    it('should use config command over default', () => {
+      const provider = new CursorAgentProvider('sonnet-4.5', {
+        command: '/path/to/agent'
+      });
+      expect(provider.command).toBe('/path/to/agent');
+    });
+
+    it('should prefer ENV command over config command', () => {
+      process.env.PAIR_REVIEW_CURSOR_AGENT_CMD = '/env/agent';
+      const provider = new CursorAgentProvider('sonnet-4.5', {
+        command: '/config/agent'
+      });
+      expect(provider.command).toBe('/env/agent');
+    });
+
+    it('should merge env from provider config', () => {
+      const provider = new CursorAgentProvider('sonnet-4.5', {
+        env: { CUSTOM_VAR: 'value' }
+      });
+      expect(provider.extraEnv).toEqual({ CUSTOM_VAR: 'value' });
+    });
+
+    it('should merge model-specific env over provider env', () => {
+      const provider = new CursorAgentProvider('opus-4.5-thinking', {
+        env: { VAR1: 'provider' },
+        models: [
+          { id: 'opus-4.5-thinking', env: { VAR1: 'model', VAR2: 'extra' } }
+        ]
+      });
+      expect(provider.extraEnv.VAR1).toBe('model');
+      expect(provider.extraEnv.VAR2).toBe('extra');
+    });
+
+    describe('yolo mode', () => {
+      it('should include sandbox enabled by default', () => {
+        const provider = new CursorAgentProvider('gemini-3-flash');
+        expect(provider.args).toContain('--sandbox');
+        expect(provider.args).toContain('enabled');
+      });
+
+      it('should disable sandbox when yolo is true', () => {
+        const provider = new CursorAgentProvider('gemini-3-flash', { yolo: true });
+        expect(provider.args).toContain('--sandbox');
+        expect(provider.args).toContain('disabled');
+        expect(provider.args).not.toContain('enabled');
+      });
+
+      it('should include sandbox enabled when yolo is explicitly false', () => {
+        const provider = new CursorAgentProvider('gemini-3-flash', { yolo: false });
+        expect(provider.args).toContain('--sandbox');
+        expect(provider.args).toContain('enabled');
+      });
+    });
+  });
+
+  describe('parseCursorAgentResponse', () => {
+    let provider;
+
+    beforeEach(() => {
+      provider = new CursorAgentProvider('sonnet-4.5');
+    });
+
+    describe('assistant text extraction', () => {
+      it('should extract JSON from assistant message content', () => {
+        const stdout = [
+          '{"type": "system", "subtype": "init", "session_id": "abc", "model": "Claude 4.5 Sonnet"}',
+          '{"type": "user", "message": {"role": "user", "content": [{"type": "text", "text": "test"}]}}',
+          '{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "{\\"findings\\": []}"}]}}',
+          '{"type": "result", "subtype": "success", "duration_ms": 1000, "result": "{\\"findings\\": []}"}'
+        ].join('\n');
+
+        const result = provider.parseCursorAgentResponse(stdout, 1);
+        expect(result.success).toBe(true);
+        expect(result.data).toEqual({ findings: [] });
+      });
+
+      it('should handle assistant message with embedded JSON in text', () => {
+        const stdout = JSON.stringify({
+          type: 'assistant',
+          message: {
+            role: 'assistant',
+            content: [{ type: 'text', text: 'Here is the analysis: {"suggestions": [{"id": 1}]}' }]
+          }
+        });
+
+        const result = provider.parseCursorAgentResponse(stdout, 1);
+        expect(result.success).toBe(true);
+        expect(result.data).toEqual({ suggestions: [{ id: 1 }] });
+      });
+
+      it('should skip streaming delta events and use final complete message', () => {
+        // With --stream-partial-output, deltas have timestamp_ms,
+        // while the final complete message does not
+        const stdout = [
+          '{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "{\\"partial\\":"}]}, "timestamp_ms": 1000}',
+          '{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "{\\"partial\\": \\"val"}]}, "timestamp_ms": 1001}',
+          '{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "{\\"complete\\": true}"}]}}',
+          '{"type": "result", "subtype": "success", "result": "{\\"complete\\": true}"}'
+        ].join('\n');
+
+        const result = provider.parseCursorAgentResponse(stdout, 1);
+        expect(result.success).toBe(true);
+        expect(result.data).toEqual({ complete: true });
+      });
+    });
+
+    describe('multiple assistant messages (multi-turn with tools)', () => {
+      it('should accumulate text from multiple complete assistant messages', () => {
+        const stdout = [
+          '{"type": "system", "subtype": "init", "session_id": "abc"}',
+          '{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "Let me analyze..."}]}}',
+          '{"type": "tool_call", "subtype": "started", "call_id": "tool1"}',
+          '{"type": "tool_call", "subtype": "completed", "call_id": "tool1"}',
+          '{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "Based on the file: {\\"issues\\": [\\"bug1\\"]}"}]}}',
+          '{"type": "result", "subtype": "success", "result": "accumulated text"}'
+        ].join('\n');
+
+        const result = provider.parseCursorAgentResponse(stdout, 1);
+        expect(result.success).toBe(true);
+        expect(result.data).toEqual({ issues: ['bug1'] });
+      });
+    });
+
+    describe('result text fallback', () => {
+      it('should fall back to result text when assistant text has no JSON', () => {
+        const stdout = [
+          '{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "Just plain text without JSON."}]}}',
+          '{"type": "result", "subtype": "success", "result": "{\\"fallback\\": true}"}'
+        ].join('\n');
+
+        const result = provider.parseCursorAgentResponse(stdout, 1);
+        expect(result.success).toBe(true);
+        expect(result.data).toEqual({ fallback: true });
+      });
+
+      it('should use result text when no assistant messages exist', () => {
+        const stdout = [
+          '{"type": "system", "subtype": "init"}',
+          '{"type": "result", "subtype": "success", "result": "{\\"data\\": 42}"}'
+        ].join('\n');
+
+        const result = provider.parseCursorAgentResponse(stdout, 1);
+        expect(result.success).toBe(true);
+        expect(result.data).toEqual({ data: 42 });
+      });
+    });
+
+    describe('no JSON found', () => {
+      it('should return error when no JSON found anywhere', () => {
+        const stdout = [
+          'plain text line 1',
+          'plain text line 2',
+          'no json here'
+        ].join('\n');
+
+        const result = provider.parseCursorAgentResponse(stdout, 1);
+        expect(result.success).toBe(false);
+      });
+
+      it('should return error when assistant text is not JSON and no result', () => {
+        const stdout = JSON.stringify({
+          type: 'assistant',
+          message: {
+            role: 'assistant',
+            content: [{ type: 'text', text: 'Just plain text without any JSON structure.' }]
+          }
+        });
+
+        const result = provider.parseCursorAgentResponse(stdout, 1);
+        expect(result.success).toBe(false);
+      });
+    });
+
+    describe('malformed JSONL handling', () => {
+      it('should skip invalid JSON lines gracefully', () => {
+        const stdout = [
+          '{"type": "system", "subtype": "init"}',
+          'not valid json at all',
+          '{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "{\\"valid\\": true}"}]}}',
+          '{ broken'
+        ].join('\n');
+
+        const result = provider.parseCursorAgentResponse(stdout, 1);
+        expect(result.success).toBe(true);
+        expect(result.data).toEqual({ valid: true });
+      });
+
+      it('should handle empty lines', () => {
+        const stdout = [
+          '',
+          '{"type": "system", "subtype": "init"}',
+          '',
+          '{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "{\\"data\\": 123}"}]}}',
+          ''
+        ].join('\n');
+
+        const result = provider.parseCursorAgentResponse(stdout, 1);
+        expect(result.success).toBe(true);
+        expect(result.data).toEqual({ data: 123 });
+      });
+
+      it('should handle completely malformed input by trying extractJSON', () => {
+        const stdout = '{"broken json';
+
+        const result = provider.parseCursorAgentResponse(stdout, 1);
+        expect(result.success).toBe(false);
+      });
+    });
+
+    describe('markdown-wrapped JSON', () => {
+      it('should handle assistant text with markdown-wrapped JSON', () => {
+        const stdout = JSON.stringify({
+          type: 'assistant',
+          message: {
+            role: 'assistant',
+            content: [{ type: 'text', text: '```json\n{"wrapped": true}\n```' }]
+          }
+        });
+
+        const result = provider.parseCursorAgentResponse(stdout, 1);
+        expect(result.success).toBe(true);
+        expect(result.data).toEqual({ wrapped: true });
+      });
+    });
+
+    describe('edge cases', () => {
+      it('should handle empty response string', () => {
+        const result = provider.parseCursorAgentResponse('', 1);
+        expect(result.success).toBe(false);
+      });
+
+      it('should handle whitespace-only response', () => {
+        const result = provider.parseCursorAgentResponse('   \n\t\n  ', 1);
+        expect(result.success).toBe(false);
+      });
+
+      it('should handle assistant message without content', () => {
+        const stdout = [
+          '{"type": "assistant", "message": {"role": "assistant"}}',
+          '{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "{\\"ok\\": true}"}]}}'
+        ].join('\n');
+
+        const result = provider.parseCursorAgentResponse(stdout, 1);
+        expect(result.success).toBe(true);
+        expect(result.data).toEqual({ ok: true });
+      });
+
+      it('should handle assistant content with non-text blocks', () => {
+        const stdout = [
+          '{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "image", "data": "..."}]}}',
+          '{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "{\\"found\\": true}"}]}}'
+        ].join('\n');
+
+        const result = provider.parseCursorAgentResponse(stdout, 1);
+        expect(result.success).toBe(true);
+        expect(result.data).toEqual({ found: true });
+      });
+
+      it('should handle result event with is_error', () => {
+        const stdout = [
+          '{"type": "result", "subtype": "error", "is_error": true, "result": "Something went wrong"}'
+        ].join('\n');
+
+        // Result text is not JSON, so extraction should fail
+        const result = provider.parseCursorAgentResponse(stdout, 1);
+        expect(result.success).toBe(false);
+      });
+
+      it('should prefer assistant text JSON over result text JSON', () => {
+        const stdout = [
+          '{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "{\\"source\\": \\"assistant\\"}"}]}}',
+          '{"type": "result", "subtype": "success", "result": "{\\"source\\": \\"result\\"}"}'
+        ].join('\n');
+
+        const result = provider.parseCursorAgentResponse(stdout, 1);
+        expect(result.success).toBe(true);
+        expect(result.data).toEqual({ source: 'assistant' });
+      });
+    });
+  });
+
+  describe('getExtractionConfig', () => {
+    it('should return correct config for default command', () => {
+      const provider = new CursorAgentProvider();
+      const config = provider.getExtractionConfig('gemini-3-flash');
+
+      expect(config.command).toBe('agent');
+      expect(config.args).toContain('-p');
+      expect(config.args).toContain('--output-format');
+      expect(config.args).toContain('text');
+      expect(config.args).toContain('--model');
+      expect(config.args).toContain('gemini-3-flash');
+      expect(config.useShell).toBe(false);
+      expect(config.promptViaStdin).toBe(true);
+    });
+
+    it('should not include stream-json for extraction (uses text)', () => {
+      const provider = new CursorAgentProvider();
+      const config = provider.getExtractionConfig('auto');
+
+      // Extraction should use text format, not stream-json
+      const formatIdx = config.args.indexOf('--output-format');
+      expect(formatIdx).toBeGreaterThanOrEqual(0);
+      expect(config.args[formatIdx + 1]).toBe('text');
+    });
+
+    it('should use shell mode for multi-word command', () => {
+      process.env.PAIR_REVIEW_CURSOR_AGENT_CMD = 'docker run agent';
+      const provider = new CursorAgentProvider();
+      const config = provider.getExtractionConfig('auto');
+
+      expect(config.useShell).toBe(true);
+      expect(config.command).toContain('docker run agent');
+      expect(config.args).toEqual([]);
+    });
+
+    it('should include provider extra_args in extraction config', () => {
+      const provider = new CursorAgentProvider('sonnet-4.5', {
+        extra_args: ['--custom']
+      });
+      const config = provider.getExtractionConfig('auto');
+
+      expect(config.args).toContain('--custom');
+    });
+  });
+
+  describe('logStreamLine', () => {
+    let provider;
+    const logger = require('../../src/utils/logger');
+
+    beforeEach(() => {
+      provider = new CursorAgentProvider('sonnet-4.5');
+      vi.clearAllMocks();
+    });
+
+    afterEach(() => {
+      // Ensure stream debug is disabled after tests
+      logger.setStreamDebugEnabled(false);
+    });
+
+    it('should not throw when stream debug is disabled', () => {
+      logger.setStreamDebugEnabled(false);
+      const line = '{"type": "system", "subtype": "init", "session_id": "abc123"}';
+      expect(() => provider.logStreamLine(line, 1, '[Level 1]')).not.toThrow();
+    });
+
+    it('should not throw when stream debug is enabled', () => {
+      logger.setStreamDebugEnabled(true);
+      const line = '{"type": "system", "subtype": "init", "session_id": "abc123"}';
+      expect(() => provider.logStreamLine(line, 1, '[Level 1]')).not.toThrow();
+    });
+
+    it('should handle system init events without throwing', () => {
+      logger.setStreamDebugEnabled(true);
+      const line = '{"type": "system", "subtype": "init", "session_id": "abc123456789", "model": "Claude 4.5 Sonnet"}';
+      expect(() => provider.logStreamLine(line, 1, '[Level 1]')).not.toThrow();
+    });
+
+    it('should handle user events without throwing', () => {
+      logger.setStreamDebugEnabled(true);
+      const line = '{"type": "user", "message": {"role": "user", "content": [{"type": "text", "text": "test prompt"}]}}';
+      expect(() => provider.logStreamLine(line, 2, '[Level 1]')).not.toThrow();
+    });
+
+    it('should handle assistant events without throwing', () => {
+      logger.setStreamDebugEnabled(true);
+      const line = '{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "analysis result"}]}}';
+      expect(() => provider.logStreamLine(line, 3, '[Level 1]')).not.toThrow();
+    });
+
+    it('should handle assistant streaming delta events without throwing', () => {
+      logger.setStreamDebugEnabled(true);
+      const line = '{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "partial"}]}, "timestamp_ms": 1234}';
+      expect(() => provider.logStreamLine(line, 3, '[Level 1]')).not.toThrow();
+    });
+
+    it('should handle long assistant text without throwing', () => {
+      logger.setStreamDebugEnabled(true);
+      const longText = 'A'.repeat(100);
+      const line = `{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "${longText}"}]}}`;
+      expect(() => provider.logStreamLine(line, 3, '[Level 1]')).not.toThrow();
+    });
+
+    it('should handle tool_call started events without throwing', () => {
+      logger.setStreamDebugEnabled(true);
+      const event = {
+        type: 'tool_call',
+        subtype: 'started',
+        call_id: 'tool_12345678',
+        tool_call: {
+          shellToolCall: {
+            args: { command: 'git diff HEAD~1' }
+          }
+        }
+      };
+      expect(() => provider.logStreamLine(JSON.stringify(event), 4, '[Level 1]')).not.toThrow();
+    });
+
+    it('should handle tool_call completed events without throwing', () => {
+      logger.setStreamDebugEnabled(true);
+      const event = {
+        type: 'tool_call',
+        subtype: 'completed',
+        call_id: 'tool_12345678',
+        tool_call: {
+          shellToolCall: {
+            result: { rejected: { command: 'echo hello', reason: '' } }
+          }
+        }
+      };
+      expect(() => provider.logStreamLine(JSON.stringify(event), 5, '[Level 1]')).not.toThrow();
+    });
+
+    it('should handle readToolCall events without throwing', () => {
+      logger.setStreamDebugEnabled(true);
+      const event = {
+        type: 'tool_call',
+        subtype: 'started',
+        call_id: 'tool_read123',
+        tool_call: {
+          readToolCall: {
+            args: { path: '/path/to/file.js' }
+          }
+        }
+      };
+      expect(() => provider.logStreamLine(JSON.stringify(event), 6, '[Level 1]')).not.toThrow();
+    });
+
+    it('should handle editToolCall events without throwing', () => {
+      logger.setStreamDebugEnabled(true);
+      const event = {
+        type: 'tool_call',
+        subtype: 'started',
+        call_id: 'tool_edit123',
+        tool_call: {
+          editToolCall: {
+            args: { path: '/path/to/file.js' }
+          }
+        }
+      };
+      expect(() => provider.logStreamLine(JSON.stringify(event), 7, '[Level 1]')).not.toThrow();
+    });
+
+    it('should handle unknown tool call types without throwing', () => {
+      logger.setStreamDebugEnabled(true);
+      const event = {
+        type: 'tool_call',
+        subtype: 'started',
+        call_id: 'tool_unknown',
+        tool_call: {
+          customToolCall: {
+            args: {}
+          }
+        }
+      };
+      expect(() => provider.logStreamLine(JSON.stringify(event), 8, '[Level 1]')).not.toThrow();
+    });
+
+    it('should handle result events without throwing', () => {
+      logger.setStreamDebugEnabled(true);
+      const line = '{"type": "result", "subtype": "success", "duration_ms": 5000, "duration_api_ms": 4500, "is_error": false, "result": "analysis complete"}';
+      expect(() => provider.logStreamLine(line, 10, '[Level 1]')).not.toThrow();
+    });
+
+    it('should handle result events with is_error without throwing', () => {
+      logger.setStreamDebugEnabled(true);
+      const line = '{"type": "result", "subtype": "error", "duration_ms": 1000, "is_error": true, "result": "error message"}';
+      expect(() => provider.logStreamLine(line, 10, '[Level 1]')).not.toThrow();
+    });
+
+    it('should process result events even when stream debug is disabled', () => {
+      // Result events are always logged at info level, not gated by stream debug
+      logger.setStreamDebugEnabled(false);
+      const line = '{"type": "result", "subtype": "success", "duration_ms": 5000, "result": "some result"}';
+      // Should not throw - verifies result events are handled even with stream debug off
+      expect(() => provider.logStreamLine(line, 10, '[Level 1]')).not.toThrow();
+    });
+
+    it('should handle unknown event types without throwing', () => {
+      logger.setStreamDebugEnabled(true);
+      const line = '{"type": "some_new_event_type"}';
+      expect(() => provider.logStreamLine(line, 8, '[Level 1]')).not.toThrow();
+    });
+
+    it('should handle malformed JSON gracefully without throwing', () => {
+      logger.setStreamDebugEnabled(true);
+      expect(() => provider.logStreamLine('not valid json {', 9, '[Level 1]')).not.toThrow();
+    });
+
+    it('should handle empty line without throwing', () => {
+      logger.setStreamDebugEnabled(true);
+      expect(() => provider.logStreamLine('', 1, '[Level 1]')).not.toThrow();
+    });
+
+    it('should handle empty tool_call without throwing', () => {
+      logger.setStreamDebugEnabled(true);
+      const line = '{"type": "tool_call", "subtype": "started", "tool_call": {}}';
+      expect(() => provider.logStreamLine(line, 1, '[Level 1]')).not.toThrow();
+    });
+
+    it('should handle user event without content without throwing', () => {
+      logger.setStreamDebugEnabled(true);
+      const line = '{"type": "user", "message": {"role": "user"}}';
+      expect(() => provider.logStreamLine(line, 1, '[Level 1]')).not.toThrow();
+    });
+
+    it('should handle assistant event without content without throwing', () => {
+      logger.setStreamDebugEnabled(true);
+      const line = '{"type": "assistant", "message": {"role": "assistant"}}';
+      expect(() => provider.logStreamLine(line, 1, '[Level 1]')).not.toThrow();
+    });
+  });
+
+  describe('provider registration', () => {
+    it('should be registered with the correct ID', () => {
+      const { getProviderClass } = require('../../src/ai/provider');
+      const RegisteredProvider = getProviderClass('cursor-agent');
+      expect(RegisteredProvider).toBe(CursorAgentProvider);
+    });
+
+    it('should be listed in registered providers', () => {
+      const { getRegisteredProviderIds } = require('../../src/ai/provider');
+      const ids = getRegisteredProviderIds();
+      expect(ids).toContain('cursor-agent');
+    });
+  });
+});


### PR DESCRIPTION
Implement full Cursor Agent CLI support with JSONL streaming, multi-fallback JSON extraction, and comprehensive test coverage.

- Add cursor-agent-provider.js with streaming output parsing
- Add parseCursorAgentLine to stream-parser for progress events
- Register provider in index.js and verify-ai-permissions.js
- Add 'free' tier support and normalize to 'fast' in provider.js
- Update README and config.example.json with Cursor documentation
- Add 66 provider tests and 173 stream-parser tests