### PR TITLE
Add provider availability checking at server startup

### DIFF
--- a/.changeset/provider-availability.md
+++ b/.changeset/provider-availability.md
@@ -1,0 +1,14 @@
+---
+"@in-the-loop-labs/pair-review": minor
+---
+
+Add provider availability checking at server startup
+
+- Check all AI providers in the background when server starts, caching availability status
+- Default provider is checked first for faster initial availability
+- Claude provider now uses fast `claude --version` check instead of running a prompt
+- Analysis config modal only shows available providers (unavailable ones are hidden)
+- Added refresh button to manually re-check provider availability
+- Provider buttons now wrap to multiple lines when there are many providers
+- Shows helpful message when no providers are available
+- Auto-selects first available provider if currently selected one becomes unavailable

--- a/public/css/pr.css
+++ b/public/css/pr.css
@@ -7847,15 +7847,20 @@ body.resizing * {
 /* Provider Toggle */
 .provider-toggle {
   display: flex;
+  flex-wrap: wrap;
   gap: 8px;
   padding: 4px;
   background: var(--color-bg-tertiary);
   border-radius: 8px;
-  width: fit-content;
+  width: 100%;
+  max-width: 100%;
 }
 
 .provider-btn {
-  padding: 8px 20px;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 16px;
   border: none;
   background: transparent;
   color: var(--color-text-secondary);
@@ -7864,6 +7869,7 @@ body.resizing * {
   border-radius: 6px;
   cursor: pointer;
   transition: all 0.2s ease;
+  white-space: nowrap;
 }
 
 .provider-btn:hover {
@@ -7879,6 +7885,54 @@ body.resizing * {
 
 [data-theme="dark"] .provider-btn.selected {
   background: var(--color-bg-secondary);
+}
+
+/* No providers available message */
+.no-providers-message {
+  font-size: 13px;
+  font-style: italic;
+  color: var(--color-text-muted);
+  padding: 8px 12px;
+}
+
+/* Provider refresh button */
+.provider-refresh-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  margin-left: 4px;
+  border: none;
+  background: transparent;
+  color: var(--color-text-tertiary);
+  border-radius: 4px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.provider-refresh-btn:hover {
+  background: var(--color-bg-tertiary);
+  color: var(--color-text-secondary);
+}
+
+.provider-refresh-btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.provider-refresh-btn.refreshing svg {
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 /* Model Cards */

--- a/public/css/repo-settings.css
+++ b/public/css/repo-settings.css
@@ -268,48 +268,15 @@ html, body {
 }
 
 /* ============================================
-   Provider Toggle (matching AnalysisConfigModal)
-   ============================================ */
-
-.provider-toggle {
-  display: flex;
-  gap: 8px;
-  padding: 4px;
-  background: var(--color-bg-tertiary);
-  border-radius: 8px;
-  width: fit-content;
-}
-
-.provider-btn {
-  padding: 8px 20px;
-  border: none;
-  background: transparent;
-  color: var(--color-text-secondary);
-  font-size: 14px;
-  font-weight: 500;
-  border-radius: 6px;
-  cursor: pointer;
-  transition: all 0.2s ease;
-}
-
-.provider-btn:hover {
-  background: var(--color-bg-secondary);
-  color: var(--color-text-primary);
-}
-
-.provider-btn.selected {
-  background: var(--color-bg-primary);
-  color: var(--color-text-primary);
-  box-shadow: 0 1px 3px var(--color-shadow);
-}
-
-[data-theme="dark"] .provider-btn.selected {
-  background: var(--color-bg-secondary);
-}
-
-/* ============================================
    Model Cards (matching AnalysisConfigModal)
+   Note: Provider toggle styles are inherited from pr.css
    ============================================ */
+
+/* Override provider toggle width for settings page layout */
+.settings-section .provider-toggle {
+  width: auto;
+  max-width: 100%;
+}
 
 .model-cards {
   display: grid;

--- a/src/ai/index.js
+++ b/src/ai/index.js
@@ -23,6 +23,16 @@ const {
   prettifyModelId
 } = require('./provider');
 
+// Load the availability checking module
+const {
+  getCachedAvailability,
+  getAllCachedAvailability,
+  checkProviderAvailability: checkSingleProviderAvailability,
+  checkAllProviders,
+  isCheckInProgress,
+  clearCache: clearAvailabilityCache
+} = require('./provider-availability');
+
 // Load and register all providers
 // Each provider self-registers when loaded
 require('./claude-provider');
@@ -57,5 +67,13 @@ module.exports = {
   getProviderConfigOverrides,
   inferModelDefaults,
   resolveDefaultModel,
-  prettifyModelId
+  prettifyModelId,
+
+  // Provider availability checking
+  getCachedAvailability,
+  getAllCachedAvailability,
+  checkSingleProviderAvailability,
+  checkAllProviders,
+  isCheckInProgress,
+  clearAvailabilityCache
 };

--- a/src/ai/provider-availability.js
+++ b/src/ai/provider-availability.js
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/**
+ * Provider Availability Module
+ *
+ * Manages background checking of AI provider availability at server startup.
+ * Caches results and exposes them for the /api/providers endpoint.
+ */
+
+const logger = require('../utils/logger');
+const { getRegisteredProviderIds, testProviderAvailability, getProviderClass } = require('./provider');
+
+/**
+ * Cache of provider availability status
+ * Map<providerId, { available: boolean, error?: string, checkedAt: number }>
+ */
+const availabilityCache = new Map();
+
+/**
+ * Whether a check is currently in progress
+ */
+let checkInProgress = false;
+
+/**
+ * Get cached availability status for a provider
+ * @param {string} providerId - Provider ID
+ * @returns {{available: boolean, error?: string, checkedAt: number} | null}
+ */
+function getCachedAvailability(providerId) {
+  return availabilityCache.get(providerId) || null;
+}
+
+/**
+ * Get all cached availability statuses
+ * @returns {Object} Map of providerId to availability status
+ */
+function getAllCachedAvailability() {
+  const result = {};
+  for (const [providerId, status] of availabilityCache) {
+    result[providerId] = status;
+  }
+  return result;
+}
+
+/**
+ * Check availability of a single provider and cache the result
+ * Uses testProviderAvailability from provider.js which handles timeout and error capture
+ * @param {string} providerId - Provider ID
+ * @returns {Promise<{available: boolean, error?: string}>}
+ */
+async function checkProviderAvailability(providerId) {
+  // Use the centralized testProviderAvailability which handles timeout and error capture
+  const result = await testProviderAvailability(providerId);
+
+  const status = {
+    available: result.available,
+    checkedAt: Date.now()
+  };
+
+  if (!result.available) {
+    // Preserve specific error message if available, otherwise use generic message
+    status.error = result.error || 'CLI not available or not authenticated';
+    status.installInstructions = result.installInstructions ||
+      (getProviderClass(providerId)?.getInstallInstructions() || 'Check provider documentation');
+  }
+
+  availabilityCache.set(providerId, status);
+  return status;
+}
+
+/**
+ * Check availability of all registered providers
+ * Optionally prioritizes a specific provider (e.g., the configured default)
+ * @param {string} [priorityProviderId] - Provider to check first
+ * @returns {Promise<void>}
+ */
+async function checkAllProviders(priorityProviderId = null) {
+  if (checkInProgress) {
+    logger.debug('Provider availability check already in progress, skipping');
+    return;
+  }
+
+  checkInProgress = true;
+
+  try {
+    const providerIds = getRegisteredProviderIds();
+
+    logger.info(`Checking availability of ${providerIds.length} AI providers...`);
+
+    // If a priority provider is specified and exists, check it first
+    if (priorityProviderId && providerIds.includes(priorityProviderId)) {
+      logger.debug(`Checking priority provider first: ${priorityProviderId}`);
+      const status = await checkProviderAvailability(priorityProviderId);
+      logger.info(`  ${priorityProviderId}: ${status.available ? 'available' : 'unavailable'}`);
+    }
+
+    // Check remaining providers in parallel
+    const remainingProviders = providerIds.filter(id => id !== priorityProviderId);
+    const results = await Promise.all(
+      remainingProviders.map(async (providerId) => {
+        const status = await checkProviderAvailability(providerId);
+        return { providerId, status };
+      })
+    );
+
+    // Log results
+    for (const { providerId, status } of results) {
+      logger.info(`  ${providerId}: ${status.available ? 'available' : 'unavailable'}`);
+    }
+
+    // Summary
+    const availableCount = Array.from(availabilityCache.values()).filter(s => s.available).length;
+    logger.info(`Provider check complete: ${availableCount}/${providerIds.length} available`);
+  } finally {
+    checkInProgress = false;
+  }
+}
+
+/**
+ * Check if a provider availability check is in progress
+ * @returns {boolean}
+ */
+function isCheckInProgress() {
+  return checkInProgress;
+}
+
+/**
+ * Clear the availability cache
+ * Useful for forcing a fresh check
+ */
+function clearCache() {
+  availabilityCache.clear();
+}
+
+/**
+ * Reset all module state (cache and checkInProgress flag)
+ * Primarily useful for testing to ensure clean state between tests
+ */
+function resetState() {
+  availabilityCache.clear();
+  checkInProgress = false;
+}
+
+module.exports = {
+  getCachedAvailability,
+  getAllCachedAvailability,
+  checkProviderAvailability,
+  checkAllProviders,
+  isCheckInProgress,
+  clearCache,
+  resetState
+};

--- a/tests/unit/provider-availability.test.js
+++ b/tests/unit/provider-availability.test.js
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+/**
+ * Unit tests for provider-availability.js
+ *
+ * Tests the cache management and state tracking functionality.
+ * Note: Tests for checkProviderAvailability and checkAllProviders are limited
+ * because they require mocking the provider module which is challenging with
+ * CommonJS modules. The actual provider availability checking is covered by
+ * integration tests.
+ */
+
+const {
+  getCachedAvailability,
+  getAllCachedAvailability,
+  isCheckInProgress,
+  clearCache,
+  resetState
+} = require('../../src/ai/provider-availability');
+
+describe('provider-availability', () => {
+  beforeEach(() => {
+    resetState();
+  });
+
+  afterEach(() => {
+    resetState();
+  });
+
+  describe('getCachedAvailability', () => {
+    it('should return null for uncached provider', () => {
+      const result = getCachedAvailability('claude');
+      expect(result).toBeNull();
+    });
+
+    it('should return null for non-existent provider', () => {
+      const result = getCachedAvailability('nonexistent-provider');
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('getAllCachedAvailability', () => {
+    it('should return empty object when no providers checked', () => {
+      const result = getAllCachedAvailability();
+      expect(result).toEqual({});
+    });
+
+    it('should return an object not a Map', () => {
+      const result = getAllCachedAvailability();
+      expect(result).toBeInstanceOf(Object);
+      expect(result).not.toBeInstanceOf(Map);
+    });
+  });
+
+  describe('isCheckInProgress', () => {
+    it('should return false initially', () => {
+      expect(isCheckInProgress()).toBe(false);
+    });
+
+    it('should return a boolean', () => {
+      expect(typeof isCheckInProgress()).toBe('boolean');
+    });
+  });
+
+  describe('clearCache', () => {
+    it('should be callable without error', () => {
+      expect(() => clearCache()).not.toThrow();
+    });
+
+    it('should result in empty cache after call', () => {
+      clearCache();
+      expect(getAllCachedAvailability()).toEqual({});
+    });
+
+    it('should allow multiple calls without error', () => {
+      clearCache();
+      clearCache();
+      clearCache();
+      expect(getAllCachedAvailability()).toEqual({});
+    });
+  });
+
+  describe('resetState', () => {
+    it('should be callable without error', () => {
+      expect(() => resetState()).not.toThrow();
+    });
+
+    it('should clear cache and reset checkInProgress flag', () => {
+      resetState();
+      expect(getAllCachedAvailability()).toEqual({});
+      expect(isCheckInProgress()).toBe(false);
+    });
+
+    it('should allow multiple calls without error', () => {
+      resetState();
+      resetState();
+      resetState();
+      expect(getAllCachedAvailability()).toEqual({});
+      expect(isCheckInProgress()).toBe(false);
+    });
+  });
+
+  describe('module exports', () => {
+    it('should export checkProviderAvailability function', () => {
+      const { checkProviderAvailability } = require('../../src/ai/provider-availability');
+      expect(typeof checkProviderAvailability).toBe('function');
+    });
+
+    it('should export checkAllProviders function', () => {
+      const { checkAllProviders } = require('../../src/ai/provider-availability');
+      expect(typeof checkAllProviders).toBe('function');
+    });
+
+    it('should export getCachedAvailability function', () => {
+      expect(typeof getCachedAvailability).toBe('function');
+    });
+
+    it('should export getAllCachedAvailability function', () => {
+      expect(typeof getAllCachedAvailability).toBe('function');
+    });
+
+    it('should export isCheckInProgress function', () => {
+      expect(typeof isCheckInProgress).toBe('function');
+    });
+
+    it('should export clearCache function', () => {
+      expect(typeof clearCache).toBe('function');
+    });
+
+    it('should export resetState function', () => {
+      expect(typeof resetState).toBe('function');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Check all AI providers in background when server starts, caching availability status
- Default provider is checked first for faster initial availability
- Claude provider now uses fast `claude --version` check instead of running a prompt
- Analysis config modal only shows available providers (unavailable ones are hidden)
- Added refresh button to manually re-check provider availability
- Provider buttons now wrap to multiple lines when there are many providers
- Shows helpful message when no providers are available
- Auto-selects first available provider if currently selected one becomes unavailable

## Test plan

- [ ] Start server and verify providers are checked in background (check logs)
- [ ] Open analysis config modal and verify only available providers are shown
- [ ] Click refresh button and verify it re-checks availability
- [ ] Verify provider buttons wrap correctly when window is narrow
- [ ] Run `npm test` to verify all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)