### PR TITLE
Fix repository location validation when reviewing PRs from different repos

### DIFF
--- a/.changeset/fix-repo-location-validation.md
+++ b/.changeset/fix-repo-location-validation.md
@@ -1,0 +1,9 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Fix repository location validation when reviewing PRs from different repositories
+
+Previously, when running `pair-review <PR-URL>` from a directory containing a different repository, the current working directory was incorrectly registered as the repository location. This caused git operations to fail with errors like "couldn't find remote ref" because the wrong repository was being used.
+
+Now the current directory is validated against the target PR's owner/repo before use. If there's a mismatch, pair-review falls back to finding an existing checkout or cloning the repository to `~/.pair-review/repos/`.


### PR DESCRIPTION
## Summary
- Fix bug where the current working directory was incorrectly used as the repository location even when reviewing a PR from a completely different repository
- Add `isMatchingRepository()` method to validate that a directory is a git checkout of the expected owner/repo before using it
- When cwd doesn't match the target PR's repo, fall back to `findRepositoryPath()` which locates an existing checkout or clones the repository

## Test plan
- [x] Unit tests added for `isMatchingRepository()` covering HTTPS/SSH URLs, case-insensitivity, mismatches, non-git directories, and error handling
- [ ] Manual testing: run `pair-review <PR-URL>` from a directory containing a different repository and verify it properly falls back instead of failing

🤖 Generated with [Claude Code](https://claude.com/claude-code)