### PR TITLE
Add pagination to index page worktree list

### DIFF
--- a/.changeset/index-pagination.md
+++ b/.changeset/index-pagination.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Add pagination to the index page worktree list with "Show more" button. Uses cursor-based pagination for stability during background stale cleanup.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,6 +161,9 @@ Test structure:
 - When modifying prompt templates or line number guidance in `src/ai/prompts/`, run `node scripts/generate-skill-prompts.js` to regenerate the static reference files in `plugin-code-critic/skills/analyze/references/`
 - These reference files are used by the `code-critic:analyze` skill when no MCP connection is available, so they must stay in sync with the source prompts
 
+### Logging Convention
+- Always use `logger` (from `src/utils/logger.js`) instead of `console.log/error/warn` in server-side code. The logger provides consistent formatting and can be configured for different output levels. This applies to all route handlers, middleware, and utility code.
+
 ### Research Before Implementation
 - **Look for official documentation before guessing at technical specs**. When integrating with external tools or APIs (Claude CLI, Gemini CLI, etc.), search for and consult official documentation rather than inferring behavior from trial and error. This prevents bugs from incorrect assumptions about data formats, message types, or API contracts.
 - Key documentation sources for AI provider CLIs:

--- a/public/index.html
+++ b/public/index.html
@@ -746,6 +746,57 @@
             font-size: 14px;
         }
 
+        /* Show More button for pagination */
+        .show-more-container {
+            display: flex;
+            justify-content: center;
+            padding: 16px 0 0;
+        }
+
+        .btn-show-more {
+            display: inline-flex;
+            align-items: center;
+            gap: 8px;
+            padding: 8px 24px;
+            font-family: var(--font-sans);
+            font-size: 13px;
+            font-weight: 500;
+            color: var(--color-text-secondary);
+            background: var(--color-bg-primary);
+            border: 1px solid var(--color-border-primary);
+            border-radius: var(--radius-md);
+            cursor: pointer;
+            transition: all var(--transition-fast);
+        }
+
+        .btn-show-more:hover:not(:disabled) {
+            background: var(--color-bg-secondary);
+            color: var(--color-text-primary);
+        }
+
+        .btn-show-more:disabled {
+            opacity: 0.6;
+            cursor: not-allowed;
+        }
+
+        .btn-show-more .spinner {
+            width: 14px;
+            height: 14px;
+            border: 2px solid var(--color-border-primary);
+            border-top-color: var(--color-accent-primary);
+            border-radius: 50%;
+            animation: spin 0.8s linear infinite;
+            display: none;
+        }
+
+        .btn-show-more.loading .spinner {
+            display: block;
+        }
+
+        .btn-show-more.loading .btn-show-more-text {
+            display: none;
+        }
+
         /* Initial loading state - hide content until JS determines what to show */
         .loading-hidden {
             display: none !important;
@@ -1081,18 +1132,36 @@
             }
         }
 
-        // Event delegation for delete buttons
+        // Event delegation for delete buttons and show-more button
         document.addEventListener('click', function(event) {
             const deleteBtn = event.target.closest('.btn-delete-worktree');
             if (deleteBtn) {
                 event.preventDefault();
                 event.stopPropagation();
                 deleteWorktree(deleteBtn);
+                return;
+            }
+
+            const showMoreBtn = event.target.closest('#btn-show-more');
+            if (showMoreBtn) {
+                event.preventDefault();
+                loadMoreReviews();
             }
         });
 
+        /** Pagination state for the recent reviews list */
+        const recentReviewsPagination = {
+            /** ISO timestamp of the last loaded item (cursor for next fetch) */
+            lastTimestamp: null,
+            /** Number of worktrees to fetch per page */
+            pageSize: 10,
+            /** Whether the server has indicated more results exist */
+            hasMore: false
+        };
+
         /**
-         * Fetch and display recent reviews
+         * Fetch and display recent reviews (initial load).
+         * Resets pagination state and renders the full table from scratch.
          */
         async function loadRecentReviews() {
             const container = document.getElementById('recent-reviews-container');
@@ -1100,8 +1169,12 @@
             const sectionHeader = document.getElementById('recent-reviews-header');
             const usageInfo = document.getElementById('usage-info');
 
+            // Reset pagination state
+            recentReviewsPagination.lastTimestamp = null;
+            recentReviewsPagination.hasMore = false;
+
             try {
-                const response = await fetch('/api/worktrees/recent?limit=10');
+                const response = await fetch(`/api/worktrees/recent?limit=${recentReviewsPagination.pageSize}`);
 
                 if (!response.ok) {
                     throw new Error('Failed to fetch recent reviews');
@@ -1123,6 +1196,10 @@
                     return;
                 }
 
+                // Update pagination state — track the cursor for the next page
+                recentReviewsPagination.lastTimestamp = data.worktrees[data.worktrees.length - 1].last_accessed_at;
+                recentReviewsPagination.hasMore = !!data.hasMore;
+
                 // Hide usage info when there are reviews (keep loading-hidden class)
                 // Show the section header
                 if (sectionHeader) sectionHeader.classList.remove('loading-hidden');
@@ -1140,10 +1217,11 @@
                                 <th>Actions</th>
                             </tr>
                         </thead>
-                        <tbody>
+                        <tbody id="recent-reviews-tbody">
                             ${data.worktrees.map(renderRecentReviewRow).join('')}
                         </tbody>
                     </table>
+                    ${renderShowMoreButton(data.hasMore)}
                 `;
                 container.innerHTML = html;
                 container.classList.remove('recent-reviews-loading');
@@ -1153,6 +1231,90 @@
                 // Hide the section on error, show usage info as fallback
                 section.style.display = 'none';
                 if (usageInfo) usageInfo.classList.remove('loading-hidden');
+            }
+        }
+
+        /**
+         * Render the "Show more" button HTML.
+         * @param {boolean} hasMore - Whether more results are available
+         * @returns {string} HTML string for the show-more container
+         */
+        function renderShowMoreButton(hasMore) {
+            if (!hasMore) return '';
+            return `
+                <div class="show-more-container" id="show-more-container">
+                    <button class="btn-show-more" id="btn-show-more" type="button">
+                        <span class="btn-show-more-text">Show more</span>
+                        <span class="spinner"></span>
+                    </button>
+                </div>
+            `;
+        }
+
+        /**
+         * Load the next page of worktrees and append them to the existing table.
+         * Called when the "Show more" button is clicked.
+         */
+        async function loadMoreReviews() {
+            const btn = document.getElementById('btn-show-more');
+            const tbody = document.getElementById('recent-reviews-tbody');
+            if (!btn || !tbody) return;
+
+            // Show loading state on the button
+            btn.classList.add('loading');
+            btn.disabled = true;
+
+            try {
+                const { lastTimestamp, pageSize } = recentReviewsPagination;
+                const params = new URLSearchParams({ limit: pageSize });
+                if (lastTimestamp) params.set('before', lastTimestamp);
+                const response = await fetch(`/api/worktrees/recent?${params}`);
+
+                if (!response.ok) {
+                    throw new Error('Failed to fetch more reviews');
+                }
+
+                const data = await response.json();
+
+                // Guard against stale response if the table was refreshed (e.g. by a delete) while loading
+                if (!document.contains(btn)) return;
+
+                if (!data.success || !data.worktrees || data.worktrees.length === 0) {
+                    // No more results - remove the button
+                    const showMoreContainer = document.getElementById('show-more-container');
+                    if (showMoreContainer) showMoreContainer.remove();
+                    recentReviewsPagination.hasMore = false;
+                    return;
+                }
+
+                // Append new rows to the existing table body
+                tbody.insertAdjacentHTML('beforeend', data.worktrees.map(renderRecentReviewRow).join(''));
+
+                // Update pagination state — advance the cursor
+                recentReviewsPagination.lastTimestamp = data.worktrees[data.worktrees.length - 1].last_accessed_at;
+                recentReviewsPagination.hasMore = !!data.hasMore;
+
+                // Update or remove the "Show more" button
+                if (!data.hasMore) {
+                    const showMoreContainer = document.getElementById('show-more-container');
+                    if (showMoreContainer) showMoreContainer.remove();
+                } else {
+                    // Reset button state
+                    btn.classList.remove('loading');
+                    btn.disabled = false;
+                }
+
+            } catch (error) {
+                console.error('Error loading more reviews:', error);
+                // Reset button state and show error so the user knows what happened
+                btn.classList.remove('loading');
+                btn.disabled = false;
+                const textEl = btn.querySelector('.btn-show-more-text');
+                if (textEl) {
+                    textEl.textContent = 'Failed to load — click to retry';
+                    // Restore original text after a brief delay so the user sees the error
+                    setTimeout(() => { textEl.textContent = 'Show more'; }, 4000);
+                }
             }
         }
 

--- a/tests/integration/worktree-pagination.test.js
+++ b/tests/integration/worktree-pagination.test.js
@@ -1,0 +1,320 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import { createTestDatabase, closeTestDatabase } from '../utils/schema';
+
+// CommonJS require() is used here (instead of ESM import) because:
+// 1. vi.spyOn(fs, 'access') must be set up BEFORE the route module is loaded,
+//    and ESM static imports are hoisted above any runtime statements.
+// 2. require() is evaluated in order, giving us control over mock timing.
+const { run } = require('../../src/database.js');
+
+// Mock fs.access to simulate worktree path existence checks
+const fs = require('fs').promises;
+vi.spyOn(fs, 'access').mockResolvedValue(undefined);
+
+// Load the worktrees route module (after fs mock is in place)
+const worktreesRoutes = require('../../src/routes/worktrees');
+
+/**
+ * Create a minimal test Express app with just worktree routes
+ */
+function createTestApp(db) {
+  const app = express();
+  app.use(express.json());
+  app.set('db', db);
+  app.set('config', { github_token: 'test-token' });
+  app.use('/', worktreesRoutes);
+  return app;
+}
+
+/**
+ * Insert a worktree with associated pr_metadata into the test database.
+ *
+ * @param {object} db - Database instance
+ * @param {object} opts
+ * @param {string} opts.id          - Worktree ID (unique)
+ * @param {number} opts.prNumber    - PR number
+ * @param {string} opts.repository  - owner/repo
+ * @param {string} opts.title       - PR title
+ * @param {string} opts.author      - PR author
+ * @param {string} opts.accessedAt  - ISO date for last_accessed_at
+ * @param {string} [opts.branch]    - Branch name (default: 'feature')
+ * @param {string} [opts.path]      - Worktree filesystem path
+ */
+async function insertWorktree(db, { id, prNumber, repository, title, author, accessedAt, branch = 'feature', path = '/tmp/wt' }) {
+  const createdAt = accessedAt; // simplify: same as accessed
+
+  await run(db, `
+    INSERT OR IGNORE INTO pr_metadata (pr_number, repository, title, author, base_branch, head_branch)
+    VALUES (?, ?, ?, ?, 'main', ?)
+  `, [prNumber, repository, title, author, branch]);
+
+  await run(db, `
+    INSERT INTO worktrees (id, pr_number, repository, branch, path, created_at, last_accessed_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?)
+  `, [id, prNumber, repository, branch, path, createdAt, accessedAt]);
+}
+
+// ============================================================================
+// GET /api/worktrees/recent — Pagination Tests
+// ============================================================================
+
+describe('GET /api/worktrees/recent — pagination', () => {
+  let db;
+  let app;
+
+  beforeEach(async () => {
+    db = createTestDatabase();
+    app = createTestApp(db);
+  });
+
+  afterEach(async () => {
+    closeTestDatabase(db);
+    vi.restoreAllMocks();
+    // Re-apply the fs.access mock for the next test (restoreAllMocks clears it)
+    vi.spyOn(fs, 'access').mockResolvedValue(undefined);
+  });
+
+  it('should return hasMore=false when total worktrees fit in one page', async () => {
+    // Insert 3 worktrees, request with limit=10 (default)
+    for (let i = 1; i <= 3; i++) {
+      await insertWorktree(db, {
+        id: `wt-${i}`,
+        prNumber: i,
+        repository: 'owner/repo',
+        title: `PR ${i}`,
+        author: 'user',
+        accessedAt: new Date(Date.now() - i * 60000).toISOString()
+      });
+    }
+
+    const res = await request(app).get('/api/worktrees/recent?limit=10');
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.worktrees).toHaveLength(3);
+    expect(res.body.hasMore).toBe(false);
+  });
+
+  it('should return hasMore=true when more worktrees exist beyond the limit', async () => {
+    // Insert 5 worktrees, request limit=3
+    for (let i = 1; i <= 5; i++) {
+      await insertWorktree(db, {
+        id: `wt-${i}`,
+        prNumber: i,
+        repository: 'owner/repo',
+        title: `PR ${i}`,
+        author: 'user',
+        accessedAt: new Date(Date.now() - i * 60000).toISOString()
+      });
+    }
+
+    const res = await request(app).get('/api/worktrees/recent?limit=3');
+
+    expect(res.status).toBe(200);
+    expect(res.body.worktrees).toHaveLength(3);
+    expect(res.body.hasMore).toBe(true);
+  });
+
+  it('should paginate correctly using cursor-based before parameter', async () => {
+    // Insert 5 worktrees with descending access times
+    for (let i = 1; i <= 5; i++) {
+      await insertWorktree(db, {
+        id: `wt-${i}`,
+        prNumber: i,
+        repository: 'owner/repo',
+        title: `PR ${i}`,
+        author: 'user',
+        // Most recent first: wt-1 is newest
+        accessedAt: new Date(Date.now() - i * 60000).toISOString()
+      });
+    }
+
+    // Page 1: no cursor (initial load), limit=2
+    const page1 = await request(app).get('/api/worktrees/recent?limit=2');
+    expect(page1.body.worktrees).toHaveLength(2);
+    expect(page1.body.worktrees[0].pr_number).toBe(1); // Most recent
+    expect(page1.body.worktrees[1].pr_number).toBe(2);
+    expect(page1.body.hasMore).toBe(true);
+
+    // Page 2: use last item's timestamp as cursor
+    const cursor1 = page1.body.worktrees[1].last_accessed_at;
+    const page2 = await request(app).get(`/api/worktrees/recent?limit=2&before=${encodeURIComponent(cursor1)}`);
+    expect(page2.body.worktrees).toHaveLength(2);
+    expect(page2.body.worktrees[0].pr_number).toBe(3);
+    expect(page2.body.worktrees[1].pr_number).toBe(4);
+    expect(page2.body.hasMore).toBe(true);
+
+    // Page 3: use last item's timestamp as cursor
+    const cursor2 = page2.body.worktrees[1].last_accessed_at;
+    const page3 = await request(app).get(`/api/worktrees/recent?limit=2&before=${encodeURIComponent(cursor2)}`);
+    expect(page3.body.worktrees).toHaveLength(1);
+    expect(page3.body.worktrees[0].pr_number).toBe(5);
+    expect(page3.body.hasMore).toBe(false);
+  });
+
+  it('should return empty array when cursor is older than all entries', async () => {
+    await insertWorktree(db, {
+      id: 'wt-1',
+      prNumber: 1,
+      repository: 'owner/repo',
+      title: 'PR 1',
+      author: 'user',
+      accessedAt: new Date().toISOString()
+    });
+
+    // Use a very old cursor that predates all entries
+    const oldCursor = new Date('2000-01-01T00:00:00.000Z').toISOString();
+    const res = await request(app).get(`/api/worktrees/recent?limit=10&before=${encodeURIComponent(oldCursor)}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.worktrees).toHaveLength(0);
+    expect(res.body.hasMore).toBe(false);
+  });
+
+  it('should return results from the top when no cursor is provided', async () => {
+    for (let i = 1; i <= 3; i++) {
+      await insertWorktree(db, {
+        id: `wt-${i}`,
+        prNumber: i,
+        repository: 'owner/repo',
+        title: `PR ${i}`,
+        author: 'user',
+        accessedAt: new Date(Date.now() - i * 60000).toISOString()
+      });
+    }
+
+    const res = await request(app).get('/api/worktrees/recent?limit=2');
+
+    expect(res.body.worktrees).toHaveLength(2);
+    expect(res.body.worktrees[0].pr_number).toBe(1); // Most recent
+    expect(res.body.hasMore).toBe(true);
+  });
+
+  it('should filter stale worktrees and still paginate correctly', async () => {
+    // Insert 4 worktrees: 2 valid, 2 with corrupted data (unknown branch)
+    for (let i = 1; i <= 4; i++) {
+      await insertWorktree(db, {
+        id: `wt-${i}`,
+        prNumber: i,
+        repository: 'owner/repo',
+        title: `PR ${i}`,
+        author: 'user',
+        accessedAt: new Date(Date.now() - i * 60000).toISOString(),
+        // Make wt-2 and wt-4 stale by giving them 'unknown' branch
+        branch: (i % 2 === 0) ? 'unknown' : 'feature'
+      });
+    }
+
+    // Request limit=1 — should get wt-1 (wt-2 is stale)
+    const page1 = await request(app).get('/api/worktrees/recent?limit=1');
+    expect(page1.body.worktrees).toHaveLength(1);
+    expect(page1.body.worktrees[0].pr_number).toBe(1);
+    expect(page1.body.hasMore).toBe(true);
+
+    // Page 2: cursor from page 1 — should get wt-3 (wt-4 is stale)
+    const cursor = page1.body.worktrees[0].last_accessed_at;
+    const page2 = await request(app).get(`/api/worktrees/recent?limit=1&before=${encodeURIComponent(cursor)}`);
+    expect(page2.body.worktrees).toHaveLength(1);
+    expect(page2.body.worktrees[0].pr_number).toBe(3);
+    expect(page2.body.hasMore).toBe(false);
+  });
+
+  it('should return hasMore in response even for empty results', async () => {
+    const res = await request(app).get('/api/worktrees/recent?limit=10');
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.worktrees).toHaveLength(0);
+    expect(res.body.hasMore).toBe(false);
+  });
+
+  it('should respect the limit cap of 50', async () => {
+    // Insert 5 worktrees
+    for (let i = 1; i <= 5; i++) {
+      await insertWorktree(db, {
+        id: `wt-${i}`,
+        prNumber: i,
+        repository: 'owner/repo',
+        title: `PR ${i}`,
+        author: 'user',
+        accessedAt: new Date(Date.now() - i * 60000).toISOString()
+      });
+    }
+
+    // Request with limit=100 (should be capped at 50, but only 5 exist)
+    const res = await request(app).get('/api/worktrees/recent?limit=100');
+    expect(res.body.worktrees).toHaveLength(5);
+    expect(res.body.hasMore).toBe(false);
+  });
+
+  it('should filter out worktrees whose paths no longer exist on the filesystem', async () => {
+    // Insert 4 worktrees: 2 with accessible paths, 2 with stale paths
+    for (let i = 1; i <= 4; i++) {
+      await insertWorktree(db, {
+        id: `wt-${i}`,
+        prNumber: i,
+        repository: 'owner/repo',
+        title: `PR ${i}`,
+        author: 'user',
+        accessedAt: new Date(Date.now() - i * 60000).toISOString(),
+        // Mark wt-2 and wt-4 as stale via their path
+        path: (i % 2 === 0) ? `/tmp/stale-wt-${i}` : `/tmp/wt-${i}`
+      });
+    }
+
+    // Override fs.access to reject paths containing 'stale'
+    vi.restoreAllMocks();
+    vi.spyOn(fs, 'access').mockImplementation(path =>
+      path.includes('stale') ? Promise.reject(new Error('ENOENT')) : Promise.resolve()
+    );
+
+    const res = await request(app).get('/api/worktrees/recent?limit=10');
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    // Only wt-1 and wt-3 should survive (wt-2 and wt-4 have stale paths)
+    expect(res.body.worktrees).toHaveLength(2);
+    expect(res.body.worktrees[0].pr_number).toBe(1);
+    expect(res.body.worktrees[1].pr_number).toBe(3);
+    expect(res.body.hasMore).toBe(false);
+  });
+
+  it('should correctly paginate when fs.access filters out stale filesystem entries', async () => {
+    // Insert 5 worktrees: wt-2 and wt-4 have stale filesystem paths
+    for (let i = 1; i <= 5; i++) {
+      await insertWorktree(db, {
+        id: `wt-${i}`,
+        prNumber: i,
+        repository: 'owner/repo',
+        title: `PR ${i}`,
+        author: 'user',
+        accessedAt: new Date(Date.now() - i * 60000).toISOString(),
+        path: (i % 2 === 0) ? `/tmp/stale-wt-${i}` : `/tmp/wt-${i}`
+      });
+    }
+
+    // Override fs.access to reject paths containing 'stale'
+    vi.restoreAllMocks();
+    vi.spyOn(fs, 'access').mockImplementation(path =>
+      path.includes('stale') ? Promise.reject(new Error('ENOENT')) : Promise.resolve()
+    );
+
+    // Page 1: limit=2 — should get wt-1 and wt-3 (wt-2 filtered out by fs.access)
+    const page1 = await request(app).get('/api/worktrees/recent?limit=2');
+    expect(page1.body.worktrees).toHaveLength(2);
+    expect(page1.body.worktrees[0].pr_number).toBe(1);
+    expect(page1.body.worktrees[1].pr_number).toBe(3);
+    expect(page1.body.hasMore).toBe(true);
+
+    // Page 2: cursor from page 1 — should get wt-5 (wt-4 filtered out by fs.access)
+    const cursor = page1.body.worktrees[1].last_accessed_at;
+    const page2 = await request(app).get(`/api/worktrees/recent?limit=2&before=${encodeURIComponent(cursor)}`);
+    expect(page2.body.worktrees).toHaveLength(1);
+    expect(page2.body.worktrees[0].pr_number).toBe(5);
+    expect(page2.body.hasMore).toBe(false);
+  });
+});


### PR DESCRIPTION
- Add "Show more" button with cursor-based pagination
- Use timestamp cursor instead of offset for stable pagination
- Skip stale cleanup during paginated requests
- Add race condition guard for concurrent delete/pagination
- Add fs.access stale detection test coverage
- Add logging convention note to CLAUDE.md