### PR TITLE
Expand Claude Opus model definitions with granular variants

### DIFF
--- a/.changeset/expand-opus-models.md
+++ b/.changeset/expand-opus-models.md
@@ -1,0 +1,14 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Expand Claude Opus model definitions with granular variants and make Opus the default model
+
+- Replace single `opus` model with five variants: `opus-4.5`, `opus-4.6-low`, `opus-4.6-medium`, `opus` (high effort, default), and `opus-4.6-1m` (1M context)
+- Add `cli_model` field to decouple app-level model ID from CLI `--model` argument
+- Add `env` and `extra_args` support with three-way merge (built-in → provider config → per-model config)
+- Add alias support (`opus-4.6-high` resolves to `opus`)
+- Extract `_resolveModelConfig()` to consolidate model lookup logic
+- Extract `_quoteShellArgs()` for shell-safe argument quoting with POSIX escaping
+- Update default model from `sonnet` to `opus` across all code paths
+- Remove hardcoded fallback model list from repo-settings frontend

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Configuration is stored in `~/.pair-review/config.json`:
   "port": 7247,
   "theme": "light",
   "default_provider": "claude",
-  "default_model": "sonnet"
+  "default_model": "opus"
 }
 ```
 

--- a/config.example.json
+++ b/config.example.json
@@ -5,7 +5,7 @@
   "port": 7247,
   "theme": "light",
   "default_provider": "claude",
-  "default_model": "sonnet",
+  "default_model": "opus",
   "worktree_retention_days": 7,
   "dev_mode": false,
   "debug_stream": false,
@@ -70,41 +70,38 @@
     },
 
     "claude": {
-      "_comment": "Override Claude's built-in configuration. Useful for custom paths, wrapper scripts, or additional arguments.",
+      "_comment": "Override Claude's built-in configuration. Useful for custom paths, wrapper scripts, or additional arguments. Built-in models include haiku, sonnet, opus-4.5, opus-4.6-low, opus-4.6-medium, opus, and opus-4.6-1m. Use 'cli_model' to decouple the app-level model ID from the CLI --model argument. Use 'env' for model-specific environment variables.",
       "command": "claude",
       "extra_args": [],
       "env": {},
       "installInstructions": "Install Claude CLI: npm install -g @anthropic-ai/claude-code",
       "models": [
         {
-          "id": "haiku",
-          "tier": "fast",
-          "name": "Haiku",
-          "description": "Quick analysis for simple changes",
-          "tagline": "Lightning Fast",
-          "badge": "Fastest",
-          "badgeClass": "badge-speed"
-        },
-        {
+          "_comment": "Example: simple override — customize the display name and description of a built-in model. Note: 'tier' is required even for overrides (valid values: fast, balanced, thorough, premium).",
           "id": "sonnet",
           "tier": "balanced",
-          "default": true,
-          "name": "Sonnet",
-          "description": "Recommended for most reviews",
-          "tagline": "Best Balance",
-          "badge": "Recommended",
-          "badgeClass": "badge-recommended"
+          "name": "Sonnet (Team Default)",
+          "description": "Our team's standard model for reviews"
         },
         {
-          "id": "opus",
+          "_comment": "Example: override cli_model to use a specific version string for the CLI --model flag",
+          "id": "opus-4.5",
+          "cli_model": "claude-opus-4-5-20251101",
+          "tier": "thorough"
+        },
+        {
+          "_comment": "Example: cli_model set to null suppresses --model entirely (model set via env instead)",
+          "id": "custom-env-model",
+          "cli_model": null,
           "tier": "thorough",
-          "name": "Opus",
-          "description": "Deep analysis for complex code",
-          "tagline": "Most Capable",
-          "badge": "Most Thorough",
-          "badgeClass": "badge-power"
+          "name": "Custom Env Model",
+          "description": "Model specified entirely via environment variable",
+          "env": {
+            "ANTHROPIC_MODEL": "claude-opus-4-5-20251101"
+          }
         },
         {
+          "_comment": "Example: adding a custom model with extra arguments and env",
           "id": "custom-model",
           "tier": "premium",
           "name": "Custom Model",

--- a/public/js/components/AnalysisConfigModal.js
+++ b/public/js/components/AnalysisConfigModal.js
@@ -11,7 +11,7 @@ class AnalysisConfigModal {
     this.onCancel = null;
     this.escapeHandler = null;
     this.selectedProvider = 'claude';
-    this.selectedModel = 'sonnet';
+    this.selectedModel = 'opus';
     this.selectedPresets = new Set();
     this.rememberModel = false;
     this.repoInstructions = '';
@@ -92,9 +92,9 @@ class AnalysisConfigModal {
           id: 'claude',
           name: 'Claude',
           models: [
-            { id: 'sonnet', name: 'Sonnet', tier: 'balanced', default: true }
+            { id: 'opus', name: 'Opus 4.6 High', tier: 'thorough', default: true }
           ],
-          defaultModel: 'sonnet'
+          defaultModel: 'opus'
         }
       };
       this.models = this.providers.claude.models;

--- a/public/js/local.js
+++ b/public/js/local.js
@@ -363,7 +363,7 @@ class LocalManager {
         const providerStorageKey = `pair-review-provider:local-${reviewId}`;
         const rememberedModel = localStorage.getItem(modelStorageKey);
         const rememberedProvider = localStorage.getItem(providerStorageKey);
-        const currentModel = rememberedModel || repoSettings?.default_model || 'sonnet';
+        const currentModel = rememberedModel || repoSettings?.default_model || 'opus';
         const currentProvider = rememberedProvider || repoSettings?.default_provider || 'claude';
 
         // Show config modal
@@ -1027,7 +1027,7 @@ class LocalManager {
         },
         body: JSON.stringify({
           provider: config.provider || 'claude',
-          model: config.model || 'sonnet',
+          model: config.model || 'opus',
           tier: config.tier || 'balanced',
           customInstructions: config.customInstructions || null,
           skipLevel3: config.skipLevel3 || false

--- a/public/js/modules/analysis-history.js
+++ b/public/js/modules/analysis-history.js
@@ -734,6 +734,10 @@ class AnalysisHistoryManager {
       'haiku': 'fast',
       'sonnet': 'balanced',
       'opus': 'thorough',
+      'opus-4.5': 'balanced',
+      'opus-4.6-low': 'balanced',
+      'opus-4.6-medium': 'balanced',
+      'opus-4.6-1m': 'balanced',
       // Gemini models
       'flash': 'fast',
       'pro': 'balanced',

--- a/public/js/pr.js
+++ b/public/js/pr.js
@@ -3515,7 +3515,7 @@ class PRManager {
       const providerStorageKey = PRManager.getRepoStorageKey('pair-review-provider', owner, repo);
       const rememberedModel = localStorage.getItem(modelStorageKey);
       const rememberedProvider = localStorage.getItem(providerStorageKey);
-      const currentModel = rememberedModel || repoSettings?.default_model || 'sonnet';
+      const currentModel = rememberedModel || repoSettings?.default_model || 'opus';
       const currentProvider = rememberedProvider || repoSettings?.default_provider || 'claude';
 
       // Show the config modal
@@ -3593,7 +3593,7 @@ class PRManager {
         },
         body: JSON.stringify({
           provider: config.provider || 'claude',
-          model: config.model || 'sonnet',
+          model: config.model || 'opus',
           tier: config.tier || 'balanced',
           customInstructions: config.customInstructions || null,
           skipLevel3: config.skipLevel3 || false

--- a/public/js/repo-settings.js
+++ b/public/js/repo-settings.js
@@ -208,23 +208,11 @@ class RepoSettingsPage {
 
     } catch (error) {
       console.error('Error loading providers:', error);
-      // Last-resort degraded mode: hardcoded Claude fallback when the /api/providers
-      // endpoint is unavailable. This allows basic functionality even if the backend
-      // is partially broken. The canonical provider definitions live in
-      // src/ai/claude-provider.js - this fallback should mirror those values.
-      this.providers = {
-        claude: {
-          id: 'claude',
-          name: 'Claude',
-          models: [
-            { id: 'haiku', name: 'Haiku', tier: 'fast', badge: 'Fastest', badgeClass: 'badge-speed', tagline: 'Lightning Fast', description: 'Quick analysis for simple changes' },
-            { id: 'sonnet', name: 'Sonnet', tier: 'balanced', default: true, badge: 'Recommended', badgeClass: 'badge-recommended', tagline: 'Best Balance', description: 'Recommended for most reviews' },
-            { id: 'opus', name: 'Opus', tier: 'thorough', badge: 'Most Thorough', badgeClass: 'badge-power', tagline: 'Most Capable', description: 'Deep analysis for complex code' }
-          ],
-          defaultModel: 'sonnet'
-        }
-      };
+      // No hardcoded fallback — rely on the /api/providers endpoint as the single source of truth.
+      // If the endpoint is unavailable, show an empty state rather than stale data.
+      this.providers = {};
       this.renderProviderButtons();
+      this.showToast('error', 'Failed to load AI providers. Please refresh the page.');
     }
   }
 

--- a/src/ai/analyzer.js
+++ b/src/ai/analyzer.js
@@ -26,10 +26,10 @@ const { buildSparseCheckoutGuidance } = require('./prompts/sparse-checkout-guida
 class Analyzer {
   /**
    * @param {Object} database - Database instance
-   * @param {string} model - Model to use (e.g., 'sonnet', 'gemini-2.5-pro')
+   * @param {string} model - Model to use (e.g., 'opus', 'gemini-2.5-pro')
    * @param {string} provider - Provider ID (e.g., 'claude', 'gemini'). Defaults to 'claude'.
    */
-  constructor(database, model = 'sonnet', provider = 'claude') {
+  constructor(database, model = 'opus', provider = 'claude') {
     // Store model and provider for creating provider instances per level
     this.model = model;
     this.provider = provider;

--- a/src/ai/claude-cli.js
+++ b/src/ai/claude-cli.js
@@ -5,7 +5,7 @@ const logger = require('../utils/logger');
 const { extractJSON } = require('../utils/json-extractor');
 
 class ClaudeCLI {
-  constructor(model = 'sonnet') {
+  constructor(model = 'opus') {
     // Check for environment variable to override default command
     // Use PAIR_REVIEW_CLAUDE_CMD environment variable if set, otherwise default to 'claude'
     const claudeCmd = process.env.PAIR_REVIEW_CLAUDE_CMD || 'claude';

--- a/src/ai/provider.js
+++ b/src/ai/provider.js
@@ -192,7 +192,7 @@ class AIProvider {
       };
     }
 
-    const { command, args, useShell, promptViaStdin } = config;
+    const { command, args, useShell, promptViaStdin, env: configEnv } = config;
     const prompt = `Extract the JSON object from the following text. Return ONLY the valid JSON, nothing else. Do not include any explanation, markdown formatting, or code blocks - just the raw JSON.
 
 === BEGIN INPUT TEXT ===
@@ -209,6 +209,7 @@ ${rawResponse}
         cwd: process.cwd(),
         env: {
           ...process.env,
+          ...(configEnv || {}),
           PATH: `${BIN_DIR}:${process.env.PATH}`
         },
         shell: useShell

--- a/src/config.js
+++ b/src/config.js
@@ -14,7 +14,7 @@ const DEFAULT_CONFIG = {
   port: 7247,
   theme: "light",
   default_provider: "claude",  // AI provider: 'claude', 'gemini', 'codex', 'copilot', 'opencode'
-  default_model: "sonnet",     // Model within the provider (e.g., 'sonnet' for Claude, 'gemini-2.5-pro' for Gemini)
+  default_model: "opus",       // Model within the provider (e.g., 'opus' for Claude, 'gemini-2.5-pro' for Gemini)
   worktree_retention_days: 7,
   dev_mode: false,  // When true, disables static file caching for development
   debug_stream: false,  // When true, logs AI provider streaming events (equivalent to --debug-stream CLI flag)

--- a/src/main.js
+++ b/src/main.js
@@ -110,6 +110,7 @@ OPTIONS:
                             The web UI also starts for the human reviewer.
     --model <name>          Override the AI model. Claude Code is the default provider.
                             Available models: opus, sonnet, haiku (Claude Code);
+                            also: opus-4.5, opus-4.6-low, opus-4.6-medium, opus-4.6-1m
                             or use provider-specific models with Gemini/Codex
     --use-checkout          Use current directory instead of creating worktree
                             (automatic in GitHub Actions)
@@ -129,7 +130,7 @@ ENVIRONMENT VARIABLES:
     PAIR_REVIEW_CLAUDE_CMD  Custom command to invoke Claude CLI (default: claude)
     PAIR_REVIEW_GEMINI_CMD  Custom command to invoke Gemini CLI (default: gemini)
     PAIR_REVIEW_CODEX_CMD   Custom command to invoke Codex CLI (default: codex)
-    PAIR_REVIEW_MODEL       Override the AI model (same as --model flag)
+    PAIR_REVIEW_MODEL       Override the AI model (same as --model flag, default: opus)
 
 CONFIGURATION:
     Config file: ~/.pair-review/config.json
@@ -852,7 +853,7 @@ async function performHeadlessReview(args, config, db, flags, options) {
 
     // Run AI analysis
     console.log('Running AI analysis (all 3 levels)...');
-    const model = flags.model || process.env.PAIR_REVIEW_MODEL || 'sonnet';
+    const model = flags.model || process.env.PAIR_REVIEW_MODEL || 'opus';
     const analyzer = new Analyzer(db, model);
 
     let analysisSummary = null;

--- a/src/routes/mcp.js
+++ b/src/routes/mcp.js
@@ -527,7 +527,7 @@ function createMCPServer(db, options = {}) {
           // Resolve provider and model
           const repoSettings = repository ? await repoSettingsRepo.getRepoSettings(repository) : null;
           const provider = process.env.PAIR_REVIEW_PROVIDER || repoSettings?.default_provider || config.default_provider || config.provider || 'claude';
-          const model = process.env.PAIR_REVIEW_MODEL || repoSettings?.default_model || config.default_model || config.model || 'sonnet';
+          const model = process.env.PAIR_REVIEW_MODEL || repoSettings?.default_model || config.default_model || config.model || 'opus';
 
           // Create unified run/analysis ID and DB record immediately
           const runId = uuidv4();
@@ -676,7 +676,7 @@ function createMCPServer(db, options = {}) {
           // Resolve provider and model
           const repoSettings = await repoSettingsRepo.getRepoSettings(repository);
           const provider = process.env.PAIR_REVIEW_PROVIDER || repoSettings?.default_provider || config.default_provider || config.provider || 'claude';
-          const model = process.env.PAIR_REVIEW_MODEL || repoSettings?.default_model || config.default_model || config.model || 'sonnet';
+          const model = process.env.PAIR_REVIEW_MODEL || repoSettings?.default_model || config.default_model || config.model || 'opus';
 
           // Create unified run/analysis ID and DB record immediately
           const runId = uuidv4();

--- a/src/routes/shared.js
+++ b/src/routes/shared.js
@@ -70,7 +70,7 @@ function getLocalReviewKey(reviewId) {
 
 /**
  * Get the model to use for AI analysis
- * Priority: CLI flag (PAIR_REVIEW_MODEL env var) > config.default_model > 'sonnet' default
+ * Priority: CLI flag (PAIR_REVIEW_MODEL env var) > config.default_model > 'opus' default
  * @param {Object} req - Express request object
  * @returns {string} Model name to use
  */
@@ -93,7 +93,7 @@ function getModel(req) {
   }
 
   // Default fallback
-  return 'sonnet';
+  return 'opus';
 }
 
 /**


### PR DESCRIPTION
## Summary
- Replace single `opus` model with five granular variants: `opus-4.5`, `opus-4.6-low`, `opus-4.6-medium`, `opus` (high effort, default), and `opus-4.6-1m` (1M context window)
- Add `cli_model` field to decouple app-level model ID from CLI `--model` argument, with `env` and `extra_args` three-way merge (built-in → provider config → per-model config)
- Make Opus the default model across all code paths (was Sonnet), with `opus-4.6-high` supported as an alias
- Extract `_resolveModelConfig()` and `_quoteShellArgs()` helpers to consolidate duplicated logic
- Remove hardcoded fallback model list from repo-settings frontend in favor of relying on the API endpoint

## Test plan
- [x] All 2,672 tests pass (103 in claude-provider.test.js)
- [ ] Manual: start app, open analysis config modal, verify new model cards appear with correct badges
- [ ] Manual: verify `opus-4.6-high` alias resolves correctly
- [ ] Manual: verify shell mode with `opus[1m]` model doesn't trigger glob expansion

🤖 Generated with [Claude Code](https://claude.com/claude-code)