### PR TITLE
Fix EPIPE crash from missing stdin error handlers

### DIFF
--- a/.changeset/fix-stdin-epipe-crash.md
+++ b/.changeset/fix-stdin-epipe-crash.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Fix server crash from unhandled EPIPE error when AI provider process exits before stdin write completes

--- a/src/ai/claude-cli.js
+++ b/src/ai/claude-cli.js
@@ -123,6 +123,11 @@ class ClaudeCLI {
         }
       });
 
+      // Handle stdin errors (e.g., EPIPE if process exits before write completes)
+      claude.stdin.on('error', (err) => {
+        logger.error(`${levelPrefix} stdin error: ${err.message}`);
+      });
+
       // Send the prompt to stdin with backpressure handling
       claude.stdin.write(prompt, (err) => {
         if (err) {

--- a/src/ai/claude-provider.js
+++ b/src/ai/claude-provider.js
@@ -430,6 +430,11 @@ class ClaudeProvider extends AIProvider {
         }
       });
 
+      // Handle stdin errors (e.g., EPIPE if process exits before write completes)
+      claude.stdin.on('error', (err) => {
+        logger.error(`${levelPrefix} stdin error: ${err.message}`);
+      });
+
       // Send the prompt to stdin
       claude.stdin.write(prompt, (err) => {
         if (err) {

--- a/src/ai/codex-provider.js
+++ b/src/ai/codex-provider.js
@@ -305,6 +305,11 @@ class CodexProvider extends AIProvider {
         }
       });
 
+      // Handle stdin errors (e.g., EPIPE if process exits before write completes)
+      codex.stdin.on('error', (err) => {
+        logger.error(`${levelPrefix} stdin error: ${err.message}`);
+      });
+
       // Send the prompt to stdin
       codex.stdin.write(prompt, (err) => {
         if (err) {

--- a/src/ai/cursor-agent-provider.js
+++ b/src/ai/cursor-agent-provider.js
@@ -352,6 +352,11 @@ class CursorAgentProvider extends AIProvider {
         }
       });
 
+      // Handle stdin errors (e.g., EPIPE if process exits before write completes)
+      agent.stdin.on('error', (err) => {
+        logger.error(`${levelPrefix} stdin error: ${err.message}`);
+      });
+
       // Send the prompt to stdin
       agent.stdin.write(prompt, (err) => {
         if (err) {

--- a/src/ai/gemini-provider.js
+++ b/src/ai/gemini-provider.js
@@ -354,6 +354,11 @@ class GeminiProvider extends AIProvider {
         }
       });
 
+      // Handle stdin errors (e.g., EPIPE if process exits before write completes)
+      gemini.stdin.on('error', (err) => {
+        logger.error(`${levelPrefix} stdin error: ${err.message}`);
+      });
+
       // Send the prompt to stdin
       gemini.stdin.write(prompt, (err) => {
         if (err) {

--- a/src/ai/opencode-provider.js
+++ b/src/ai/opencode-provider.js
@@ -289,6 +289,11 @@ class OpenCodeProvider extends AIProvider {
         }
       });
 
+      // Handle stdin errors (e.g., EPIPE if process exits before write completes)
+      opencode.stdin.on('error', (err) => {
+        logger.error(`${levelPrefix} stdin error: ${err.message}`);
+      });
+
       // Send the prompt to stdin (OpenCode reads from stdin when no positional args)
       // Note on error handling: When stdin.write fails, we kill the process which
       // triggers the 'close' event handler. The `settled` guard (line 142) prevents

--- a/src/ai/provider.js
+++ b/src/ai/provider.js
@@ -280,6 +280,11 @@ ${rawResponse}
 
       // Send prompt via stdin if configured
       if (promptViaStdin) {
+        // Handle stdin errors (e.g., EPIPE if process exits before write completes)
+        proc.stdin.on('error', (err) => {
+          logger.warn(`${levelPrefix} extraction stdin error: ${err.message}`);
+        });
+
         proc.stdin.write(prompt, (err) => {
           if (err) {
             logger.warn(`${levelPrefix} Failed to write extraction prompt: ${err}`);


### PR DESCRIPTION
## Summary

- When a child process (e.g., Claude CLI) exits before the parent finishes writing to its `stdin`, Node.js emits an `'error'` event on the stdin writable stream with `code: 'EPIPE'`. Without a listener, this crashes the server as an uncaught exception.
- Added `stdin.on('error', ...)` handlers in all 7 AI provider files, placed before each `stdin.write()` call. The handlers log the error; existing `write` callbacks and `close`/`exit` handlers already manage promise rejection and cleanup.
- Files modified: `claude-provider.js`, `gemini-provider.js`, `codex-provider.js`, `cursor-agent-provider.js`, `opencode-provider.js`, `provider.js`, `claude-cli.js`

## Test plan

- [x] All 2699 unit tests pass (`npm test`)
- [x] E2E tests pass (207/209, 1 skipped, 1 pre-existing flaky test unrelated to this change)
- [ ] Manual verification: trigger an EPIPE scenario (kill child process mid-write) and confirm it logs gracefully instead of crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)