### PR TITLE
Fix stale-check fetch blocking dialog with AbortController

### DIFF
--- a/.changeset/abort-controller-stale-check.md
+++ b/.changeset/abort-controller-stale-check.md
@@ -1,0 +1,15 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Fix stale-check fetch blocking dialog by using AbortController
+
+The stale-check fetch used a simple sequential `await fetch()` with no timeout. If the
+underlying HTTP connection hung (e.g., slow git commands on some machines), it could
+exhaust the browser's per-origin connection limit (~6), blocking subsequent fetches and
+delaying or preventing the analysis config dialog from appearing.
+
+Switch to AbortController with a 2-second timeout so the fetch is truly cancelled,
+immediately freeing the connection. Additionally, run the stale check in parallel with
+the settings fetches via Promise.all to minimize dialog delay. Applied to both local
+and PR mode.


### PR DESCRIPTION
## Summary
- **Stale-check fetch now uses `AbortController`** with a 2-second timeout so the connection is truly cancelled on timeout, freeing the browser's per-origin connection pool
- **Stale check runs in parallel** with `fetchRepoSettings()` and `fetchLastCustomInstructions()` via `Promise.all`, minimizing dialog delay
- **Applied consistently to both local and PR mode** with matching `_fetchError` handling, error logging, and timer cleanup on early returns

## Test plan
- [ ] Verify analysis config dialog appears promptly when stale-check endpoint is slow/unresponsive
- [ ] Verify stale PR dialog still appears correctly when PR has new commits
- [ ] Verify stale local dialog still appears correctly when working directory has changed
- [ ] Verify timeout fires after 2s and fetch is aborted (check console for debug log)
- [ ] Verify non-OK HTTP responses show status code in warning toast
- [ ] Run E2E tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)