### PR TITLE
Improve GitHub token help in web UI to match CLI detail

### DIFF
--- a/.changeset/web-ui-token-help.md
+++ b/.changeset/web-ui-token-help.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Improve GitHub token help in web UI to match CLI quality: direct link to token creation page, required scopes, and GITHUB_TOKEN environment variable option

--- a/public/index.html
+++ b/public/index.html
@@ -1176,7 +1176,12 @@
   "port": 7247,
   "theme": "light"
 }</code></pre>
-                <p>Generate a token at <a href="https://github.com/settings/tokens" target="_blank" rel="noopener" style="color: var(--color-text-link);">GitHub Settings &rarr; Developer settings &rarr; Personal access tokens</a>.</p>
+                <p>Create a <a href="https://github.com/settings/tokens/new" target="_blank" rel="noopener" style="color: var(--color-text-link);">GitHub Personal Access Token</a> with the following scopes:</p>
+                <ul style="margin: 0.5em 0; padding-left: 1.5em;">
+                    <li><code>repo</code> &mdash; required for private repositories</li>
+                    <li><code>public_repo</code> &mdash; sufficient for public repositories only</li>
+                </ul>
+                <p style="margin-top: 0.5em;">You can also provide the token via the <code>GITHUB_TOKEN</code> environment variable, which takes precedence over the config file.</p>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- Updated the web UI help modal's GitHub token section to include the same detail as the CLI help
- Direct link to `github.com/settings/tokens/new` (was pointing to the vague settings page)
- Lists required scopes: `repo` for private repos, `public_repo` for public-only
- Mentions the `GITHUB_TOKEN` environment variable alternative

## Test plan
- [ ] Open the web UI and click the help/info modal
- [ ] Verify the Configuration section shows the token creation link, scopes, and env var info

🤖 Generated with [Claude Code](https://claude.com/claude-code)