### PR TITLE
Route index page starts through setup page for step-by-step progress

### DIFF
--- a/.changeset/puny-roses-shine.md
+++ b/.changeset/puny-roses-shine.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Route index page review starts through the setup page to show step-by-step progress matching the MCP/CLI flow, and fix bfcache form state bug


### PR DESCRIPTION
## Summary
- The index page was bypassing the setup page infrastructure, calling APIs directly and showing a flat spinner when starting reviews
- Both PR and local review starts now navigate to the setup routes (`/pr/{owner}/{repo}/{number}` and `/local?path=...`), showing the same step-by-step progress as the MCP/CLI flow
- Fixes a bfcache bug where the PR form remained stuck in loading state when using browser back navigation

## Test plan
- [ ] Start a PR review from the index page — verify setup page with steps is shown
- [ ] Start a local review from the index page — verify setup page with steps is shown
- [ ] After navigating to setup, hit browser back button — verify form is not stuck in loading state
- [ ] Run E2E tests: `npm run test:e2e`

🤖 Generated with [Claude Code](https://claude.com/claude-code)