### PR TITLE
Fix shell quoting for multi-word CLI commands

### DIFF
--- a/.changeset/fix-shell-quoting.md
+++ b/.changeset/fix-shell-quoting.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Fix shell quoting for --allowedTools when using multi-word CLI commands (e.g. `devx claude --`). The regex that detects shell metacharacters used `[]` which JavaScript treats as an empty character class matching nothing, unlike POSIX regex where `]` after `[` is literal. This caused parentheses in tool patterns like `Bash(git diff*)` to be interpreted as shell syntax, producing a syntax error.

--- a/src/ai/claude-provider.js
+++ b/src/ai/claude-provider.js
@@ -197,12 +197,9 @@ class ClaudeProvider extends AIProvider {
    * @private
    */
   _quoteShellArgs(args) {
-    return args.map((arg, i) => {
-      const prevArg = args[i - 1];
-      if (prevArg === '--allowedTools' || prevArg === '--model') {
-        if (/[][*?(){}$!&|;<>,\s']/.test(arg)) {
-          return `'${arg.replace(/'/g, "'\\''")}'`;
-        }
+    return args.map(arg => {
+      if (/[[\]*?(){}$!&|;<>,\s']/.test(arg)) {
+        return `'${arg.replace(/'/g, "'\\''")}'`;
       }
       return arg;
     });


### PR DESCRIPTION
## Summary
- Fix broken regex in `_quoteShellArgs()` that caused `--allowedTools` values like `Bash(git diff*)` to go unquoted in shell mode, producing `/bin/sh` syntax errors for multi-word CLI commands (e.g. `devx claude --`)
- Root cause: JavaScript treats `[]` as an empty character class (matches nothing), unlike POSIX regex where `]` after `[` is a literal — the regex never matched any string
- Also removed unnecessary `prevArg` guard so any argument with shell metacharacters gets quoted, not just values after specific flags

## Test plan
- [x] All 111 unit tests pass (103 existing + 8 new)
- [x] New `_quoteShellArgs` tests cover: parentheses, spaces, asterisks, brackets, semicolons, single-quote escaping, safe values unchanged
- [x] Integration test verifies shell mode produces properly quoted `--allowedTools` value
- [ ] Manual verification with `devx claude --` command

🤖 Generated with [Claude Code](https://claude.com/claude-code)