### PR TITLE
Tighten data-side defaults and clean up suggestion fix

### DIFF
--- a/.changeset/fix-suggestion-side-default.md
+++ b/.changeset/fix-suggestion-side-default.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Fix suggestion on modified lines including both old and new line content by making getCodeFromLines always filter by side, defaulting to RIGHT when not provided

--- a/public/js/local.js
+++ b/public/js/local.js
@@ -620,7 +620,7 @@ class LocalManager {
                 data-file="${fileName}"
                 data-line="${lineStart}"
                 data-line-end="${lineEnd}"
-                ${side ? `data-side="${side}"` : ''}
+                data-side="${side || 'RIGHT'}"
               >${manager.escapeHtml(currentText)}</textarea>
               <div class="comment-edit-actions">
                 <button class="btn btn-sm btn-primary save-edit-btn">Save</button>

--- a/public/js/pr.js
+++ b/public/js/pr.js
@@ -1728,10 +1728,6 @@ class PRManager {
     this.commentManager.updateSuggestionButtonState(textarea, button);
   }
 
-  getCodeFromLines(fileName, startLine, endLine) {
-    return this.commentManager.getCodeFromLines(fileName, startLine, endLine);
-  }
-
   insertSuggestionBlock(textarea, button) {
     this.commentManager.insertSuggestionBlock(textarea, button);
   }
@@ -1793,7 +1789,7 @@ class PRManager {
             data-file="${fileName}"
             data-line="${lineStart}"
             data-line-end="${lineEnd}"
-            ${side ? `data-side="${side}"` : ''}
+            data-side="${side || 'RIGHT'}"
           >${this.escapeHtml(currentText)}</textarea>
           <div class="comment-edit-actions">
             <button class="btn btn-sm btn-primary save-edit-btn">Save</button>


### PR DESCRIPTION
## Summary
- Always emit `data-side` attribute (defaulting to `'RIGHT'`) in all three edit-mode textarea renderings (`comment-manager.js`, `pr.js`, `local.js`) so the `getCodeFromLines` default is a true last-resort fallback rather than a regularly exercised path
- Remove unused `getCodeFromLines` wrapper in `PRManager` (dead code — `insertSuggestionBlock` calls the `CommentManager` method directly)
- Clean up tests: delete impossible empty-side test case, fix misleading comment about mock vs real defaulting behavior

## Test plan
- [x] All 19 unit tests pass for `comment-manager-getcodefromlines.test.js`
- [ ] E2E tests pass for suggestion insertion in both PR and Local modes
- [ ] Verify suggestion button works correctly on modified lines (deletion+addition pair)

🤖 Generated with [Claude Code](https://claude.com/claude-code)