### PR TITLE
Forbid o3-pro from review model selection

### DIFF
--- a/.changeset/ban-o3-pro-from-review.md
+++ b/.changeset/ban-o3-pro-from-review.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Forbid openai/o3-pro from review model selection due to extreme cost

--- a/.pi/skills/review-model-guidance/SKILL.md
+++ b/.pi/skills/review-model-guidance/SKILL.md
@@ -15,6 +15,17 @@ Before switching models, check which models are actually available by running
 configured in `provider   model` columns. Specify models as
 `provider/model`. Only switch to models that appear in that list.
 
+## Forbidden Models
+
+The following models are **never** permitted due to extreme cost:
+
+- **openai/o3-pro** — Prohibitively expensive. Use `openai/o3` instead, which
+  provides strong reasoning at a fraction of the cost.
+
+Do not select these models for your own work, subtasks, or any model parameter.
+If a forbidden model is the only reasoning model available, fall back to a
+balanced model with extended thinking enabled instead.
+
 ## When to Switch Models
 
 Not every task benefits from model switching. Use these heuristics:
@@ -58,11 +69,8 @@ Here are the higher-end models and their strengths for code review:
 - **anthropic/claude-sonnet-4-5 with extended thinking**: Enable thinking for complex analysis
   without switching models. Good balance of capability and responsiveness.
 
-**OpenAI**
-- **openai/o3-pro**: OpenAI's most powerful reasoning model. Excels at exhaustive
-  multi-step analysis and finding subtle logical flaws. Strongest at tracing
-  complex execution paths and catching concurrency bugs.
-- **openai/o3**: Strong reasoning model. Good for state management analysis, algorithmic
+**OpenAI** (note: o3-pro is forbidden — see Forbidden Models above)
+- **openai/o3**: OpenAI's best reasoning model for code review. Good for state management analysis, algorithmic
   correctness, and methodical bug-hunting through code paths.
 - **openai/gpt-5-pro / openai/gpt-5.2-pro**: OpenAI's flagship non-o-series models with
   reasoning. Good general-purpose deep analysis.
@@ -93,7 +101,7 @@ Here are the higher-end models and their strengths for code review:
 When the goal is specifically to track down bugs or logical flaws in changes,
 these models excel:
 
-- **openai/o3 / openai/o3-pro**: The o-series models are particularly strong at systematic
+- **openai/o3**: The o-series models are particularly strong at systematic
   bug-hunting. They methodically trace execution paths, track state through
   branches, and identify edge cases. Best choice when you suspect there's a bug
   and need to find it.

--- a/.pi/skills/review-roulette/SKILL.md
+++ b/.pi/skills/review-roulette/SKILL.md
@@ -17,11 +17,13 @@ Run `${PI_CMD:-pi} --list-models` via bash to get the current list of models wit
 valid API keys. **Eligible models** are those that show `thinking: yes` in the
 output — these are the reasoning-capable / premium models.
 
+**Excluded models**: Never select `openai/o3-pro` — it is prohibitively
+expensive. If it appears in the model list, skip it entirely.
+
 Example reasoning models you might see (provider/model format):
 
 - `anthropic/claude-opus-4-6`
 - `anthropic/claude-sonnet-4-5` (with thinking)
-- `openai/o3-pro`
 - `openai/o3`
 - `openai/o4-mini`
 - `openai/gpt-5-pro`


### PR DESCRIPTION
## Summary
- Adds explicit prohibition of `openai/o3-pro` in the `review-model-guidance` and `review-roulette` pi-provider skills due to its extreme cost
- Removes o3-pro from all model recommendation lists and examples, promotes `openai/o3` as the recommended alternative
- Adds a "Forbidden Models" section to `review-model-guidance` and an exclusion note to `review-roulette`

## Test plan
- [ ] Verify `review-model-guidance/SKILL.md` no longer contains `o3-pro` as a selectable model
- [ ] Verify `review-roulette/SKILL.md` excludes `o3-pro` from eligible models
- [ ] Run a review with the pi-provider and confirm o3-pro is not selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)