### PR TITLE
Add reasoning popover to AI suggestion headers

### DIFF
--- a/.changeset/reasoning-popover-ui.md
+++ b/.changeset/reasoning-popover-ui.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Add reasoning popover to AI suggestions with brain icon button in header

--- a/public/css/pr.css
+++ b/public/css/pr.css
@@ -1722,7 +1722,7 @@ tr.newly-expanded .d2h-code-line-ctn {
   /* Explicitly list transitions to exclude max-width - prevents flicker on sidebar toggle */
   transition: box-shadow 0.2s ease, opacity 0.2s ease, background 0.2s ease, border-color 0.2s ease;
   animation: slideUp 0.3s ease;
-  overflow: hidden;
+  overflow: visible;
   word-break: break-word;
   /* Viewport-based max-width: total viewport minus sidebar, AI panel, and minimal padding */
   max-width: calc(100vw - var(--sidebar-width) - var(--ai-panel-width) - 64px);
@@ -2072,59 +2072,154 @@ tr.newly-expanded .d2h-code-line-ctn {
   color: var(--color-text-secondary);
 }
 
-/* Reasoning section (collapsible) */
-.ai-suggestion-reasoning {
-  padding: 0 16px 8px;
-  font-size: 0.8125rem;
-}
-
-.reasoning-toggle {
+/* Reasoning brain icon button */
+.ai-suggestion-header-right {
+  position: relative;
   display: flex;
   align-items: center;
-  gap: 4px;
-  cursor: pointer;
-  color: var(--color-text-tertiary, #6e7681);
-  font-size: 0.75rem;
-  font-weight: 500;
-  padding: 4px 0;
-  user-select: none;
 }
 
-.reasoning-toggle:hover {
+.btn-reasoning-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: 1px solid var(--color-border-secondary, rgba(255, 255, 255, 0.06));
+  border-radius: 6px;
+  background: transparent;
+  color: var(--color-text-tertiary, #6e7681);
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.btn-reasoning-toggle:hover {
+  color: var(--color-text-secondary, #8b949e);
+  background: var(--color-bg-tertiary, rgba(255, 255, 255, 0.04));
+  border-color: var(--color-border-primary, rgba(255, 255, 255, 0.1));
+}
+
+.btn-reasoning-toggle.active {
+  color: var(--color-accent, #2f81f7);
+  background: var(--color-bg-tertiary, rgba(255, 255, 255, 0.04));
+  border-color: var(--color-accent, #2f81f7);
+}
+
+/* Reasoning popover */
+.reasoning-popover {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  z-index: 1000;
+  width: min(400px, 90vw);
+  max-height: 400px;
+  overflow-y: auto;
+  background: var(--color-bg-primary, #0d1117);
+  border: 1px solid var(--color-border-primary, rgba(255, 255, 255, 0.1));
+  border-radius: 8px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4), 0 2px 8px rgba(0, 0, 0, 0.2);
+}
+
+.reasoning-popover-arrow {
+  position: absolute;
+  top: -6px;
+  right: 10px;
+  width: 12px;
+  height: 12px;
+  background: var(--color-bg-primary, #0d1117);
+  border-top: 1px solid var(--color-border-primary, rgba(255, 255, 255, 0.1));
+  border-left: 1px solid var(--color-border-primary, rgba(255, 255, 255, 0.1));
+  transform: rotate(45deg);
+}
+
+.reasoning-popover-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 12px 8px 16px;
+  border-bottom: 1px solid var(--color-border-secondary, rgba(255, 255, 255, 0.06));
+}
+
+.reasoning-popover-title {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--color-text-primary, #e6edf3);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.reasoning-popover-close {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border: none;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--color-text-tertiary, #6e7681);
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.reasoning-popover-close:hover {
+  color: var(--color-text-secondary, #8b949e);
+  background: var(--color-bg-tertiary, rgba(255, 255, 255, 0.04));
+}
+
+.reasoning-popover-content {
+  padding: 12px 16px;
+  font-size: 0.8125rem;
+  line-height: 1.6;
   color: var(--color-text-secondary, #8b949e);
 }
 
-.reasoning-chevron {
-  font-size: 0.625rem;
-  transition: transform 0.15s ease;
-  display: inline-block;
+.reasoning-popover-content p {
+  margin: 0 0 8px;
 }
 
-.ai-suggestion-reasoning:not(.collapsed) .reasoning-chevron {
-  transform: rotate(90deg);
+.reasoning-popover-content p:last-child {
+  margin-bottom: 0;
 }
 
-.reasoning-content {
-  margin: 4px 0 0;
+.reasoning-popover-content ul,
+.reasoning-popover-content ol {
+  margin: 4px 0 8px;
   padding-left: 20px;
-  color: var(--color-text-tertiary, #6e7681);
-  line-height: 1.5;
 }
 
-.reasoning-content li {
+.reasoning-popover-content li {
   margin: 2px 0;
 }
 
-.ai-suggestion-reasoning.collapsed .reasoning-content {
+.reasoning-popover-content code {
+  padding: 2px 6px;
+  background: var(--color-bg-tertiary, rgba(255, 255, 255, 0.04));
+  border-radius: 3px;
+  font-size: 0.75rem;
+}
+
+.reasoning-popover-content pre {
+  margin: 8px 0;
+  padding: 8px 12px;
+  background: var(--color-bg-tertiary, rgba(255, 255, 255, 0.04));
+  border-radius: 6px;
+  overflow-x: auto;
+}
+
+.reasoning-popover-content pre code {
+  padding: 0;
+  background: none;
+}
+
+/* Hide reasoning button when suggestion is collapsed */
+.ai-suggestion.collapsed .ai-suggestion-header-right {
   display: none;
 }
 
-/* Hide reasoning when suggestion is collapsed */
-.ai-suggestion.collapsed .ai-suggestion-reasoning {
-  display: none;
-}
-
-.file-comment-card.ai-suggestion.collapsed .ai-suggestion-reasoning {
+.file-comment-card.ai-suggestion.collapsed .ai-suggestion-header-right {
   display: none;
 }
 
@@ -2352,7 +2447,7 @@ tr.newly-expanded .d2h-code-line-ctn {
   border: 1px solid var(--ai-border, rgba(245, 158, 11, 0.3));
   border-left: 3px solid var(--ai-primary, #f59e0b);
   border-radius: 6px;
-  overflow: hidden;
+  overflow: visible;
   box-shadow: 0 0 20px var(--ai-glow, rgba(245, 158, 11, 0.2));
 }
 

--- a/public/js/modules/file-comment-manager.js
+++ b/public/js/modules/file-comment-manager.js
@@ -455,6 +455,13 @@ class FileCommentManager {
           ${categoryLabel ? `<span class="ai-suggestion-category">${this.escapeHtml(categoryLabel)}</span>` : ''}
           <span class="ai-title">${this.escapeHtml(suggestion.title || '')}</span>
         </div>
+        ${suggestion.reasoning && suggestion.reasoning.length > 0 ? `
+        <div class="ai-suggestion-header-right">
+          <button class="btn-reasoning-toggle" title="View reasoning" data-suggestion-id="${suggestion.id}" data-reasoning="${encodeURIComponent(JSON.stringify(suggestion.reasoning))}">
+            <svg viewBox="0 0 24 24" width="14" height="14" fill="currentColor"><path d="M21.33 12.91c.09 1.55-.62 3.04-1.89 3.95l.77 1.49c.23.45.26.98.06 1.45c-.19.47-.58.84-1.06 1l-.79.25a1.69 1.69 0 0 1-1.86-.55L14.44 18c-.89-.15-1.73-.53-2.44-1.1c-.5.15-1 .23-1.5.23c-.88 0-1.76-.27-2.5-.79c-.53.16-1.07.23-1.62.22c-.79.01-1.57-.15-2.3-.45a4.1 4.1 0 0 1-2.43-3.61c-.08-.72.04-1.45.35-2.11c-.29-.75-.32-1.57-.07-2.33C2.3 7.11 3 6.32 3.87 5.82c.58-1.69 2.21-2.82 4-2.7c1.6-1.5 4.05-1.66 5.83-.37c.42-.11.86-.17 1.3-.17c1.36-.03 2.65.57 3.5 1.64c2.04.53 3.5 2.35 3.58 4.47c.05 1.11-.25 2.2-.86 3.13c.07.36.11.72.11 1.09m-5-1.41c.57.07 1.02.5 1.02 1.07a1 1 0 0 1-1 1h-.63c-.32.9-.88 1.69-1.62 2.29c.25.09.51.14.77.21c5.13-.07 4.53-3.2 4.53-3.25a2.59 2.59 0 0 0-2.69-2.49a1 1 0 0 1-1-1a1 1 0 0 1 1-1c1.23.03 2.41.49 3.33 1.3c.05-.29.08-.59.08-.89c-.06-1.24-.62-2.32-2.87-2.53c-1.25-2.96-4.4-1.32-4.4-.4c-.03.23.21.72.25.75a1 1 0 0 1 1 1c0 .55-.45 1-1 1c-.53-.02-1.03-.22-1.43-.56c-.48.31-1.03.5-1.6.56c-.57.05-1.04-.35-1.07-.9a.97.97 0 0 1 .88-1.1c.16-.02.94-.14.94-.77c0-.66.25-1.29.68-1.79c-.92-.25-1.91.08-2.91 1.29C6.75 5 6 5.25 5.45 7.2C4.5 7.67 4 8 3.78 9c1.08-.22 2.19-.13 3.22.25c.5.19.78.75.59 1.29c-.19.52-.77.78-1.29.59c-.73-.32-1.55-.34-2.3-.06c-.32.27-.32.83-.32 1.27c0 .74.37 1.43 1 1.83c.53.27 1.12.41 1.71.4q-.225-.39-.39-.81a1.038 1.038 0 0 1 1.96-.68c.4 1.14 1.42 1.92 2.62 2.05c1.37-.07 2.59-.88 3.19-2.13c.23-1.38 1.34-1.5 2.56-1.5m2 7.47l-.62-1.3l-.71.16l1 1.25zm-4.65-8.61a1 1 0 0 0-.91-1.03c-.71-.04-1.4.2-1.93.67c-.57.58-.87 1.38-.84 2.19a1 1 0 0 0 1 1c.57 0 1-.45 1-1c0-.27.07-.54.23-.76c.12-.1.27-.15.43-.15c.55.03 1.02-.38 1.02-.92"/></svg>
+          </button>
+        </div>
+        ` : ''}
       </div>
       <div class="ai-suggestion-collapsed-content">
         ${suggestion.type === 'praise'
@@ -472,16 +479,6 @@ class FileCommentManager {
       <div class="ai-suggestion-body">
         ${renderedBody}
       </div>
-      ${suggestion.reasoning && suggestion.reasoning.length > 0 ? `
-      <div class="ai-suggestion-reasoning collapsed">
-        <div class="reasoning-toggle" onclick="this.parentElement.classList.toggle('collapsed')">
-          <span class="reasoning-chevron">&#9654;</span> Reasoning
-        </div>
-        <ul class="reasoning-content">
-          ${suggestion.reasoning.map(step => `<li>${this.escapeHtml(step)}</li>`).join('')}
-        </ul>
-      </div>
-      ` : ''}
       <div class="ai-suggestion-actions">
         <button class="ai-action ai-action-adopt">
           <svg viewBox="0 0 16 16" width="16" height="16"><path fill-rule="evenodd" d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z"></path></svg>


### PR DESCRIPTION
## Summary
- Replaces the old collapsible reasoning list at the bottom of AI suggestions with a brain icon button in the suggestion header that opens a popover
- Popover displays reasoning steps as a markdown-rendered bulleted list with a "Reasoning" header and close button
- Popover is pinned to the brain icon button via CSS absolute positioning, scrolling naturally with the diff view
- Responsive width using `min(400px, 90vw)` for mobile support
- Includes array guard on reasoning data, orphan cleanup on re-analysis, and PR/Local mode parity

## Test plan
- [x] Unit tests pass (3384/3384)
- [ ] Verify brain icon appears in suggestion header when reasoning exists
- [ ] Verify clicking brain icon opens popover with bulleted reasoning
- [ ] Verify popover scrolls with diff view (pinned to button)
- [ ] Verify close button and click-outside dismiss work
- [ ] Verify popover renders correctly on narrow viewports
- [ ] Verify no popover appears for suggestions without reasoning
- [ ] Test in both PR mode and Local mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)