### PR TITLE
Fix cancelled analysis runs incorrectly showing as completed

### DIFF
--- a/.changeset/fix-cancel-analysis-race.md
+++ b/.changeset/fix-cancel-analysis-race.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Fix cancelled analysis runs incorrectly showing as completed due to race condition

--- a/src/database.js
+++ b/src/database.js
@@ -2638,9 +2638,11 @@ class AnalysisRunRepository {
    * @param {string} [updates.summary] - Analysis summary
    * @param {number} [updates.totalSuggestions] - Total suggestions count
    * @param {number} [updates.filesAnalyzed] - Files analyzed count
+   * @param {Object} [options] - Update options
+   * @param {string} [options.skipIfStatus] - Skip the update if the record already has this status (prevents redundant writes)
    * @returns {Promise<boolean>} True if record was updated
    */
-  async update(id, updates) {
+  async update(id, updates, options = {}) {
     const setClauses = [];
     const params = [];
 
@@ -2675,10 +2677,16 @@ class AnalysisRunRepository {
 
     params.push(id);
 
+    let whereClause = 'WHERE id = ?';
+    if (options.skipIfStatus) {
+      whereClause += ' AND status != ?';
+      params.push(options.skipIfStatus);
+    }
+
     const result = await run(this.db, `
       UPDATE analysis_runs
       SET ${setClauses.join(', ')}
-      WHERE id = ?
+      ${whereClause}
     `, params);
 
     return result.changes > 0;

--- a/src/routes/local.js
+++ b/src/routes/local.js
@@ -702,6 +702,7 @@ router.post('/api/local/:reviewId/analyze', async (req, res) => {
     // Store analysis status with separate tracking for each level
     const initialStatus = {
       id: analysisId,
+      runId,
       reviewId,
       repository: repository,
       reviewType: 'local',
@@ -788,6 +789,12 @@ router.post('/api/local/:reviewId/analyze', async (req, res) => {
         const currentStatus = activeAnalyses.get(analysisId);
         if (!currentStatus) {
           logger.warn('Analysis already completed or removed:', analysisId);
+          return;
+        }
+
+        // Check if analysis was cancelled while running
+        if (currentStatus.status === 'cancelled') {
+          logger.info(`Analysis ${analysisId} was cancelled, skipping completion update`);
           return;
         }
 


### PR DESCRIPTION
## Summary
- **Fixed race condition** where cancelling an analysis left the DB record as `completed` instead of `cancelled`. The cancel endpoint now writes `cancelled` to the `analysis_runs` table, and the async `.then()` completion handlers check for cancellation before overwriting status.
- **Added `skipIfStatus` option** to `AnalysisRunRepository.update()` so the analyzer's catch block avoids redundantly overwriting the cancel endpoint's DB write.
- **Both PR and local mode** are patched with the same guards for parity.

## Test plan
- [x] 2 new integration tests covering DB update on cancel and race condition guard
- [x] 3384 unit/integration tests passing
- [x] 216 E2E tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)