### PR TITLE
Add configurable database names for per-worktree isolation

### DIFF
--- a/.changeset/configurable-db-name.md
+++ b/.changeset/configurable-db-name.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": minor
+---
+
+Add configurable database names for per-worktree isolation. Set `db_name` in config or `PAIR_REVIEW_DB_NAME` env var to use a custom database file, preventing schema conflicts when switching branches during development. Also supports local `.pair-review/config.json` overrides.

--- a/src/local-review.js
+++ b/src/local-review.js
@@ -4,7 +4,7 @@ const { promisify } = require('util');
 const crypto = require('crypto');
 const path = require('path');
 const fs = require('fs').promises;
-const { loadConfig, showWelcomeMessage } = require('./config');
+const { loadConfig, showWelcomeMessage, resolveDbName } = require('./config');
 const logger = require('./utils/logger');
 
 const execAsync = promisify(exec);
@@ -520,7 +520,7 @@ async function handleLocalReview(targetPath, flags = {}) {
 
     // Initialize database
     console.log('Initializing database...');
-    db = await initializeDatabase();
+    db = await initializeDatabase(resolveDbName(config));
 
     // Check for existing session or create new one
     const reviewRepo = new ReviewRepository(db);

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 const fs = require('fs');
-const { loadConfig, getConfigDir, getGitHubToken, showWelcomeMessage } = require('./config');
+const { loadConfig, getConfigDir, getGitHubToken, showWelcomeMessage, resolveDbName } = require('./config');
 const { initializeDatabase, run, queryOne, query, migrateExistingWorktrees, WorktreeRepository, ReviewRepository, RepoSettingsRepository, GitHubReviewRepository } = require('./database');
 const { PRArgumentParser } = require('./github/parser');
 const { GitHubClient } = require('./github/client');
@@ -307,7 +307,8 @@ CONFIG FILE:
       "port": 7247,
       "theme": "light",
       "debug_stream": false,
-      "yolo": false
+      "yolo": false,
+      "db_name": "dev.db"
     }
 
 GITHUB TOKEN:
@@ -328,6 +329,11 @@ ENVIRONMENT VARIABLES:
     PAIR_REVIEW_GEMINI_CMD  Custom Gemini CLI command (default: gemini)
     PAIR_REVIEW_CODEX_CMD   Custom Codex CLI command (default: codex)
     PAIR_REVIEW_MODEL       Default AI model (e.g., opus, sonnet, haiku)
+    PAIR_REVIEW_DB_NAME     Custom database filename (overrides config)
+
+LOCAL CONFIG:
+    Place a .pair-review/config.json in your working directory to override
+    global settings (e.g., db_name for per-worktree database isolation).
 
 AI PROVIDERS:
     Claude (default): Requires 'claude' CLI installed
@@ -346,10 +352,10 @@ AI PROVIDERS:
     if (isFirstRun) {
       showWelcomeMessage();
     }
-    
+
     // Initialize database
     console.log('Initializing database...');
-    db = await initializeDatabase();
+    db = await initializeDatabase(resolveDbName(config));
 
     // Migrate existing worktrees to database (if any)
     const path = require('path');

--- a/src/mcp-stdio.js
+++ b/src/mcp-stdio.js
@@ -32,14 +32,11 @@ async function startMCPStdio() {
 
   const { initializeDatabase } = require('./database');
   const { startServer } = require('./server');
-  const { loadConfig } = require('./config');
+  const { loadConfig, resolveDbName } = require('./config');
   const { createMCPServer } = require('./routes/mcp');
   const { StdioServerTransport } = require('@modelcontextprotocol/sdk/server/stdio.js');
 
-  const db = await initializeDatabase();
-  const port = await startServer(db);
-
-  // Load config so start_analysis can resolve provider/model
+  // Load config BEFORE database so we can resolve db_name
   let config = {};
   try {
     const loaded = await loadConfig();
@@ -47,6 +44,9 @@ async function startMCPStdio() {
   } catch (err) {
     console.error(`[MCP] Warning: failed to load config, using defaults: ${err.message}`);
   }
+
+  const db = await initializeDatabase(resolveDbName(config));
+  const port = await startServer(db);
 
   const mcpServer = createMCPServer(db, { port, config });
   const transport = new StdioServerTransport();


### PR DESCRIPTION
## Summary
- Adds `db_name` config option and `PAIR_REVIEW_DB_NAME` env var to specify a custom database filename, preventing schema corruption when switching between branches during development
- Supports local `.pair-review/config.json` in the working directory that overrides global config (useful for per-worktree settings)
- Warns when `dev_mode` is enabled without a custom `db_name` configured
- Fixes config/database initialization ordering in MCP stdio mode

## Test plan
- [x] Unit tests: 10 new tests for `resolveDbName` and `warnIfDevModeWithoutDbName` (32 total in config.test.js)
- [x] Full unit + integration suite: 3430 tests passing
- [x] E2E tests: 216 passing
- [ ] Manual: create `.pair-review/config.json` with `{"db_name": "test.db"}` in CWD, verify `~/.pair-review/test.db` is used
- [ ] Manual: `PAIR_REVIEW_DB_NAME=env-test.db npx pair-review --local`, verify env var takes precedence

🤖 Generated with [Claude Code](https://claude.com/claude-code)