### PR TITLE
Fix progress dialog not reopening during single-model analysis

### DIFF
--- a/.changeset/fix-reopen-progress-dialog.md
+++ b/.changeset/fix-reopen-progress-dialog.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Fix progress dialog not reopening when clicking Analyzing button during single-model analysis

--- a/public/js/components/CouncilProgressModal.js
+++ b/public/js/components/CouncilProgressModal.js
@@ -111,7 +111,7 @@ class CouncilProgressModal {
    */
   reopenFromBackground() {
     this.isRunningInBackground = false;
-    if (this.currentAnalysisId && this.councilConfig) {
+    if (this.currentAnalysisId) {
       // Don't rebuild — just re-show the existing DOM
       this.isVisible = true;
       this.modal.style.display = 'flex';

--- a/tests/unit/council-progress-modal.test.js
+++ b/tests/unit/council-progress-modal.test.js
@@ -835,6 +835,85 @@ describe('CouncilProgressModal', () => {
     });
   });
 
+  describe('reopenFromBackground', () => {
+    it('re-shows modal for single-model analysis (councilConfig is null)', () => {
+      const { modal, modalContainer } = createTestCouncilProgressModal();
+
+      // Simulate a single-model analysis: councilConfig is null
+      modal.currentAnalysisId = 'test-analysis-123';
+      modal.councilConfig = null;
+      modal.isRunningInBackground = true;
+      modalContainer.style.display = 'none';
+
+      modal.reopenFromBackground();
+
+      expect(modal.isVisible).toBe(true);
+      expect(modalContainer.style.display).toBe('flex');
+      expect(modal.isRunningInBackground).toBe(false);
+    });
+
+    it('re-shows modal for council analysis (councilConfig is set)', () => {
+      const { modal, modalContainer } = createTestCouncilProgressModal();
+
+      modal.currentAnalysisId = 'test-analysis-456';
+      modal.councilConfig = { levels: { '1': { enabled: true } } };
+      modal.isRunningInBackground = true;
+      modalContainer.style.display = 'none';
+
+      modal.reopenFromBackground();
+
+      expect(modal.isVisible).toBe(true);
+      expect(modalContainer.style.display).toBe('flex');
+      expect(modal.isRunningInBackground).toBe(false);
+    });
+
+    it('does not re-show modal when no analysis is running', () => {
+      const { modal, modalContainer } = createTestCouncilProgressModal();
+
+      modal.currentAnalysisId = null;
+      modal.isRunningInBackground = true;
+      modalContainer.style.display = 'none';
+
+      modal.reopenFromBackground();
+
+      expect(modal.isVisible).toBeFalsy();
+      expect(modalContainer.style.display).toBe('none');
+      expect(modal.isRunningInBackground).toBe(false);
+    });
+
+    it('hides status indicator when reopening', () => {
+      const { modal } = createTestCouncilProgressModal();
+      const originalStatusIndicator = window.statusIndicator;
+
+      const mockStatusIndicator = { hide: vi.fn() };
+      window.statusIndicator = mockStatusIndicator;
+
+      modal.currentAnalysisId = 'test-analysis-789';
+      modal.isRunningInBackground = true;
+
+      modal.reopenFromBackground();
+
+      expect(mockStatusIndicator.hide).toHaveBeenCalled();
+
+      window.statusIndicator = originalStatusIndicator;
+    });
+
+    it('hides status indicator even when no analysis is running', () => {
+      const { modal } = createTestCouncilProgressModal();
+      const mockStatusIndicator = { hide: vi.fn() };
+      window.statusIndicator = mockStatusIndicator;
+
+      modal.currentAnalysisId = null;
+      modal.isRunningInBackground = true;
+
+      modal.reopenFromBackground();
+
+      expect(mockStatusIndicator.hide).toHaveBeenCalled();
+
+      delete window.statusIndicator;
+    });
+  });
+
   describe('_updateVoiceCentric — per-voice orchestration (level 4)', () => {
     it('updates per-voice consolidation row when level 4 has voices map', () => {
       const { modal } = createTestCouncilProgressModal();


### PR DESCRIPTION
## Summary
- Fix bug where clicking the "Analyzing" button during a running single-model analysis failed to reopen the progress dialog
- Root cause: `reopenFromBackground()` guarded on `this.councilConfig`, which is `null` for single-model analyses — removed the unnecessary check since `currentAnalysisId` alone suffices
- Add regression tests covering single-model reopen, council reopen, no-analysis guard, and unconditional statusIndicator cleanup

## Test plan
- [x] All 42 unit tests pass (`npx vitest run tests/unit/council-progress-modal.test.js`)
- [ ] Manual: start a single-model analysis, close the progress dialog, click the "Analyzing" button — dialog should reopen
- [ ] Manual: same flow with a council analysis — dialog should reopen

🤖 Generated with [Claude Code](https://claude.com/claude-code)