### PR TITLE
Add purple hover highlight to reasoning toggle button

### DIFF
--- a/public/css/pr.css
+++ b/public/css/pr.css
@@ -655,6 +655,11 @@
   --comment-primary: #8250df;
   --comment-subtle: rgba(130, 80, 223, 0.08);
   --comment-border: rgba(130, 80, 223, 0.3);
+
+  /* Reasoning toggle hover - deep purple for light backgrounds */
+  --color-reasoning-hover: #7c3aed;
+  --color-reasoning-hover-bg: rgba(124, 58, 237, 0.1);
+  --color-reasoning-hover-border: rgba(124, 58, 237, 0.35);
 }
 
 [data-theme="dark"] {
@@ -741,6 +746,11 @@
   --comment-primary: #a371f7;
   --comment-subtle: rgba(163, 113, 247, 0.1);
   --comment-border: rgba(163, 113, 247, 0.3);
+
+  /* Reasoning toggle hover - rich purple for dark backgrounds */
+  --color-reasoning-hover: #9333ea;
+  --color-reasoning-hover-bg: rgba(147, 51, 234, 0.12);
+  --color-reasoning-hover-border: rgba(147, 51, 234, 0.4);
 }
 
 /* Update PR container styles */
@@ -2095,9 +2105,9 @@ tr.newly-expanded .d2h-code-line-ctn {
 }
 
 .btn-reasoning-toggle:hover {
-  color: var(--color-text-secondary, #8b949e);
-  background: var(--color-bg-tertiary, rgba(255, 255, 255, 0.04));
-  border-color: var(--color-border-primary, rgba(255, 255, 255, 0.1));
+  color: var(--color-reasoning-hover);
+  background: var(--color-reasoning-hover-bg);
+  border-color: var(--color-reasoning-hover-border);
 }
 
 .btn-reasoning-toggle.active {


### PR DESCRIPTION
## Summary
- Adds a purple hover effect to the reasoning (brain icon) toggle button on AI suggestions
- Uses theme-aware CSS custom properties: deeper violet (`#7c3aed`) for light mode, rich purple (`#9333ea`) for dark mode
- Creates a clear visual progression: neutral → purple hover → blue active

## Test plan
- [ ] Open a review with AI suggestions that have reasoning
- [ ] Hover over the reasoning button in dark mode — verify purple highlight
- [ ] Switch to light mode — verify deeper purple is legible against light background
- [ ] Click the button — verify active state remains blue

🤖 Generated with [Claude Code](https://claude.com/claude-code)