### PR TITLE
Fix council config immediately marked dirty on load

### DIFF
--- a/.changeset/fix-dirty-council-load.md
+++ b/.changeset/fix-dirty-council-load.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Fix council config immediately showing as dirty when selecting a saved council from the dropdown

--- a/public/js/components/AdvancedConfigTab.js
+++ b/public/js/components/AdvancedConfigTab.js
@@ -628,6 +628,7 @@ class AdvancedConfigTab {
 
     // Dirty state tracking via event delegation
     panel.addEventListener('change', (e) => {
+      if (e.target.id === 'council-selector') return; // council selector has its own clean/dirty logic
       if (e.target.matches('select, input[type="checkbox"]') || e.target.classList.contains('adv-timeout')) {
         this._markDirty();
       }

--- a/public/js/components/VoiceCentricConfigTab.js
+++ b/public/js/components/VoiceCentricConfigTab.js
@@ -547,6 +547,7 @@ class VoiceCentricConfigTab {
 
     // Dirty state tracking
     panel.addEventListener('change', (e) => {
+      if (e.target.id === 'vc-council-selector') return; // council selector has its own clean/dirty logic
       if (e.target.matches('select, input[type="checkbox"]') || e.target.classList.contains('vc-timeout')) {
         this._markDirty();
       }

--- a/tests/e2e/council-save-button.spec.js
+++ b/tests/e2e/council-save-button.spec.js
@@ -211,4 +211,50 @@ test.describe('Council Save Button', () => {
     const inTabSave = page.locator('#vc-council-save-btn');
     await expect(inTabSave).toHaveClass(/btn-save-council/);
   });
+
+  test('selecting a saved council should NOT immediately mark it dirty', async ({ page }) => {
+    // Seed a council
+    const councilId = await seedCouncil(page, {
+      name: 'Clean Load Council',
+      type: 'council',
+      config: voiceCouncilConfig
+    });
+
+    // Open modal and switch to Council tab
+    await openConfigModalTab(page, 'council');
+
+    // Select the seeded council from the dropdown
+    await page.locator('#vc-council-selector').selectOption(councilId);
+
+    // The in-tab save button should be disabled (not dirty)
+    const saveBtn = page.locator('#vc-council-save-btn');
+    await expect(saveBtn).toBeDisabled();
+
+    // The dirty hint in the footer should be hidden
+    const dirtyHint = page.locator('#council-footer-left');
+    await expect(dirtyHint).toBeHidden();
+  });
+
+  test('selecting a saved advanced council should NOT immediately mark it dirty', async ({ page }) => {
+    // Seed an advanced council
+    const councilId = await seedCouncil(page, {
+      name: 'Clean Load Advanced Council',
+      type: 'advanced',
+      config: advancedCouncilConfig
+    });
+
+    // Open modal and switch to Advanced tab
+    await openConfigModalTab(page, 'advanced');
+
+    // Select the seeded council from the dropdown
+    await page.locator('#council-selector').selectOption(councilId);
+
+    // The in-tab save button should be disabled (not dirty)
+    const saveBtn = page.locator('#council-save-btn');
+    await expect(saveBtn).toBeDisabled();
+
+    // The dirty hint in the footer should be hidden
+    const dirtyHint = page.locator('#council-footer-left');
+    await expect(dirtyHint).toBeHidden();
+  });
 });


### PR DESCRIPTION
## Summary
- **Bug**: Selecting a saved Council from the dropdown in the analysis config modal immediately marked the config as dirty (save button enabled), even though nothing was changed.
- **Root cause**: The generic `change` event listener on the config panel caught the council selector's own change event during bubbling, calling `_markDirty()` *after* the council-specific handler had already called `_markClean()`.
- **Fix**: Skip the council selector element in the generic dirty tracking listener in both `VoiceCentricConfigTab` and `AdvancedConfigTab`, since it manages its own clean/dirty state.

## Test plan
- [x] Added E2E regression tests for both Council and Advanced tabs verifying a freshly selected council is not dirty
- [x] All 6 council save button E2E tests pass
- [x] All 3,449 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)