### PR TITLE
Add missing Toast.showInfo() method

### DIFF
--- a/.changeset/add-toast-showinfo.md
+++ b/.changeset/add-toast-showinfo.md
@@ -1,0 +1,7 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Add missing `showInfo()` method to Toast component
+
+The Toast class only defined `showSuccess`, `showError`, and `showWarning`, but `showInfo` was called in three places, causing runtime errors. Added the method with a GitHub-style info icon and blue styling for both light and dark themes.

--- a/public/css/pr.css
+++ b/public/css/pr.css
@@ -5075,6 +5075,12 @@ tr.line-range-start .d2h-code-line-ctn {
   border: 1px solid #bf8700;
 }
 
+.toast-info {
+  background-color: #0969da;
+  color: white;
+  border: 1px solid #0550ae;
+}
+
 .toast-content {
   display: flex;
   align-items: center;
@@ -5115,6 +5121,11 @@ tr.line-range-start .d2h-code-line-ctn {
 [data-theme="dark"] .toast-warning {
   background-color: #9e6a03;
   border-color: #d29922;
+}
+
+[data-theme="dark"] .toast-info {
+  background-color: #1f6feb;
+  border-color: #58a6ff;
 }
 
 /* Loading spinner for buttons */

--- a/public/js/components/Toast.js
+++ b/public/js/components/Toast.js
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 /**
  * Toast Notification Component
- * Shows temporary success/error messages at the top of the page
+ * Shows temporary success/error/warning/info messages at the top of the page
  */
 class Toast {
   constructor() {
@@ -93,6 +93,27 @@ class Toast {
       <div class="toast-content">
         <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" class="toast-icon">
           <path d="M6.457 1.047c.659-1.234 2.427-1.234 3.086 0l6.082 11.378A1.75 1.75 0 0 1 14.082 15H1.918a1.75 1.75 0 0 1-1.543-2.575Zm1.763.707a.25.25 0 0 0-.44 0L1.698 13.132a.25.25 0 0 0 .22.368h12.164a.25.25 0 0 0 .22-.368Zm.53 3.996v2.5a.75.75 0 0 1-1.5 0v-2.5a.75.75 0 0 1 1.5 0ZM9 11a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z"></path>
+        </svg>
+        <span class="toast-message">${message}</span>
+      </div>
+    `;
+
+    this.showToast(toast, duration);
+  }
+
+  /**
+   * Show an info toast
+   * @param {string} message - The message to display
+   * @param {number} duration - Duration in ms (default: 5000)
+   */
+  showInfo(message, duration = 5000) {
+    const toast = document.createElement('div');
+    toast.className = 'toast toast-info';
+
+    toast.innerHTML = `
+      <div class="toast-content">
+        <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" class="toast-icon">
+          <path d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8Zm8-6.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13ZM6.5 7.75A.75.75 0 0 1 7.25 7h1a.75.75 0 0 1 .75.75v2.75h.25a.75.75 0 0 1 0 1.5h-2a.75.75 0 0 1 0-1.5h.25v-2h-.25a.75.75 0 0 1-.75-.75ZM8 6a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
         </svg>
         <span class="toast-message">${message}</span>
       </div>


### PR DESCRIPTION
The Toast class defined showSuccess, showError, and showWarning but never implemented showInfo, which was called in three places — causing runtime errors. Added the method with a GitHub-style info circle icon and blue styling for both light and dark themes.