### PR TITLE
Persist tier on analysis_runs, remove getTierForModel

### DIFF
--- a/.changeset/persist-tier-on-analysis-runs.md
+++ b/.changeset/persist-tier-on-analysis-runs.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Persist analysis tier on the analysis_runs database record instead of deriving it from the model name at query time

--- a/public/js/modules/analysis-history.js
+++ b/public/js/modules/analysis-history.js
@@ -403,8 +403,7 @@ class AnalysisHistoryManager {
     const duration = this.formatDuration(run.started_at, run.completed_at);
     const suggestionCount = run.total_suggestions || 0;
 
-    // Get the tier for this analysis run's model
-    const tier = this.getTierForModel(run.model);
+    const tier = run.tier || null;
 
     // Format HEAD SHA - show abbreviated version with full SHA in title
     const headSha = run.head_sha;
@@ -440,7 +439,7 @@ class AnalysisHistoryManager {
       </div>
       <div class="analysis-preview-row">
         <span class="analysis-preview-label">Tier</span>
-        <span class="analysis-preview-value">${this.escapeHtml(tier || 'unknown')}</span>
+        <span class="analysis-preview-value">${this.escapeHtml(this.formatTierDisplayName(tier) || 'unknown')}</span>
       </div>`;
     }
 
@@ -832,57 +831,6 @@ class AnalysisHistoryManager {
       'cancelled': { text: 'cancelled', cssClass: 'analysis-preview-status-cancelled' }
     };
     return statusMap[status] || { text: status || 'unknown', cssClass: 'analysis-preview-status-unknown' };
-  }
-
-  /**
-   * Get the tier for a given model ID
-   * Maps model IDs to their corresponding tiers (fast, balanced, thorough)
-   * @param {string} modelId - The model identifier (e.g., 'haiku', 'sonnet', 'opus', 'flash', 'pro')
-   * @returns {string|null} The tier name or null if unknown
-   */
-  getTierForModel(modelId) {
-    if (!modelId) return null;
-
-    // Model to tier mapping (matches backend provider definitions)
-    const modelTiers = {
-      // Claude models
-      'haiku': 'fast',
-      'sonnet': 'balanced',
-      'sonnet-4.5': 'balanced',
-      'sonnet-4.6': 'balanced',
-      'opus': 'thorough',
-      'opus-4.5': 'thorough',
-      'opus-4.6-low': 'balanced',
-      'opus-4.6-medium': 'balanced',
-      'opus-4.6-1m': 'balanced',
-      // Gemini models
-      'flash': 'fast',
-      'pro': 'balanced',
-      'ultra': 'thorough',
-      // Codex/OpenAI models
-      'gpt-4o-mini': 'fast',
-      'gpt-4o': 'balanced',
-      'o1': 'thorough',
-      'o1-mini': 'balanced',
-      // Copilot models
-      'gpt-4': 'balanced',
-      // Pi models
-      'default': 'balanced',
-      'multi-model': 'thorough',
-      'review-roulette': 'thorough'
-    };
-
-    return modelTiers[modelId] || null;
-  }
-
-  /**
-   * Format a tier name for display (uppercase, used for badges)
-   * @param {string} tier - The tier identifier (e.g., 'fast', 'balanced', 'thorough')
-   * @returns {string} Display name in uppercase
-   */
-  formatTierName(tier) {
-    if (!tier) return '';
-    return tier.toUpperCase();
   }
 
   /**

--- a/src/ai/analyzer.js
+++ b/src/ai/analyzer.js
@@ -17,6 +17,7 @@ const {
   buildAnalysisLineNumberGuidance,
   buildOrchestrationLineNumberGuidance: buildOrchestrationGuidance,
 } = require('./prompts/line-number-guidance');
+const { resolveTier } = require('./prompts/config');
 const { registerProcess, isAnalysisCancelled, CancellationError } = require('../routes/shared');
 const { AnalysisRunRepository, CommentRepository } = require('../database');
 const { mergeInstructions } = require('../utils/instructions');
@@ -175,6 +176,7 @@ class Analyzer {
           reviewId: prId,  // prId is actually review.id (works for both PR and local modes)
           provider: this.provider,
           model: this.model,
+          tier: options.tier ? resolveTier(options.tier) : 'balanced',
           customInstructions: mergedInstructions,  // Keep for backward compat
           repoInstructions,
           requestInstructions,
@@ -212,7 +214,7 @@ class Analyzer {
       if (mergedInstructions) {
         logger.info(`${logPrefix}Custom instructions provided: ${mergedInstructions.length} chars`);
       }
-      const tier = options.tier || 'balanced';
+      const tier = options.tier ? resolveTier(options.tier) : 'balanced';
 
       // Build the promises array for each level based on enabledLevels
       const levelAnalyzers = [
@@ -2664,6 +2666,7 @@ File-level suggestions should NOT have a line number. They apply to the entire f
           reviewId,
           provider: 'council',
           model: 'voice-centric',
+          tier: null,
           customInstructions: mergedInstructions,
           repoInstructions: instructions?.repoInstructions || null,
           requestInstructions: instructions?.requestInstructions || null,
@@ -2760,6 +2763,7 @@ File-level suggestions should NOT have a line number. They apply to the entire f
           reviewId,
           provider: voice.provider,
           model: voice.model,
+          tier: voiceTier,
           customInstructions: mergedInstructions,
           repoInstructions: instructions?.repoInstructions || null,
           requestInstructions: instructions?.requestInstructions || null,

--- a/src/ai/prompts/config.js
+++ b/src/ai/prompts/config.js
@@ -4,7 +4,7 @@
  *
  * Defines tier mappings for the prompt system.
  * Note: Provider-specific model-to-tier mappings are defined in each provider's
- * getModels() method. Use getTierForModel() from src/ai/provider.js to query them.
+ * getModels() method. The tier is persisted on each analysis_runs record at creation time.
  */
 
 /**
@@ -20,6 +20,11 @@ const TIER_ALIASES = {
  * Internal capability tiers
  */
 const TIERS = ['fast', 'balanced', 'thorough'];
+
+/**
+ * All accepted tier values (internal tiers + user-facing aliases)
+ */
+const VALID_TIERS = [...TIERS, ...Object.keys(TIER_ALIASES)];
 
 /**
  * Prompt types (analysis levels)
@@ -44,6 +49,7 @@ function resolveTier(tierOrAlias) {
 module.exports = {
   TIER_ALIASES,
   TIERS,
+  VALID_TIERS,
   PROMPT_TYPES,
   resolveTier
 };

--- a/tests/integration/database.test.js
+++ b/tests/integration/database.test.js
@@ -1915,13 +1915,15 @@ describe('AnalysisRunRepository', () => {
         reviewId: testReview.id,
         provider: 'claude',
         model: 'sonnet',
-        customInstructions: 'Focus on security issues'
+        customInstructions: 'Focus on security issues',
+        tier: 'balanced'
       });
 
       expect(result.id).toBe(runId);
       expect(result.provider).toBe('claude');
       expect(result.model).toBe('sonnet');
       expect(result.custom_instructions).toBe('Focus on security issues');
+      expect(result.tier).toBe('balanced');
     });
 
     it('should create an analysis run with head_sha for traceability', async () => {
@@ -1948,6 +1950,33 @@ describe('AnalysisRunRepository', () => {
 
       expect(result.id).toBe(runId);
       expect(result.head_sha).toBeNull();
+    });
+
+    it('should create an analysis run with tier field', async () => {
+      const runId = 'test-run-with-tier';
+      const result = await analysisRunRepo.create({
+        id: runId,
+        reviewId: testReview.id,
+        provider: 'claude',
+        model: 'opus',
+        tier: 'thorough'
+      });
+
+      expect(result.id).toBe(runId);
+      expect(result.tier).toBe('thorough');
+    });
+
+    it('should default tier to null when not provided', async () => {
+      const runId = 'test-run-no-tier';
+      const result = await analysisRunRepo.create({
+        id: runId,
+        reviewId: testReview.id,
+        provider: 'claude',
+        model: 'sonnet'
+      });
+
+      expect(result.id).toBe(runId);
+      expect(result.tier).toBeNull();
     });
   });
 

--- a/tests/unit/analysis-history.test.js
+++ b/tests/unit/analysis-history.test.js
@@ -755,95 +755,29 @@ describe('AnalysisHistoryManager', () => {
     });
   });
 
-  describe('getTierForModel()', () => {
-    it('should return fast tier for fast models', () => {
+  describe('formatTierDisplayName()', () => {
+    it('should return title-case tier name', () => {
       const manager = new AnalysisHistoryManager({
         reviewId: 1,
         mode: 'pr',
         onSelectionChange: vi.fn()
       });
 
-      expect(manager.getTierForModel('haiku')).toBe('fast');
-      expect(manager.getTierForModel('flash')).toBe('fast');
-      expect(manager.getTierForModel('gpt-4o-mini')).toBe('fast');
+      expect(manager.formatTierDisplayName('fast')).toBe('Fast');
+      expect(manager.formatTierDisplayName('balanced')).toBe('Balanced');
+      expect(manager.formatTierDisplayName('thorough')).toBe('Thorough');
     });
 
-    it('should return balanced tier for balanced models', () => {
+    it('should return empty string for null, undefined, or empty string', () => {
       const manager = new AnalysisHistoryManager({
         reviewId: 1,
         mode: 'pr',
         onSelectionChange: vi.fn()
       });
 
-      expect(manager.getTierForModel('sonnet')).toBe('balanced');
-      expect(manager.getTierForModel('pro')).toBe('balanced');
-      expect(manager.getTierForModel('gpt-4o')).toBe('balanced');
-      expect(manager.getTierForModel('gpt-4')).toBe('balanced');
-      expect(manager.getTierForModel('o1-mini')).toBe('balanced');
-      expect(manager.getTierForModel('default')).toBe('balanced');
-    });
-
-    it('should return thorough tier for thorough models', () => {
-      const manager = new AnalysisHistoryManager({
-        reviewId: 1,
-        mode: 'pr',
-        onSelectionChange: vi.fn()
-      });
-
-      expect(manager.getTierForModel('opus')).toBe('thorough');
-      expect(manager.getTierForModel('ultra')).toBe('thorough');
-      expect(manager.getTierForModel('o1')).toBe('thorough');
-      expect(manager.getTierForModel('multi-model')).toBe('thorough');
-      expect(manager.getTierForModel('review-roulette')).toBe('thorough');
-    });
-
-    it('should return null for unknown models', () => {
-      const manager = new AnalysisHistoryManager({
-        reviewId: 1,
-        mode: 'pr',
-        onSelectionChange: vi.fn()
-      });
-
-      expect(manager.getTierForModel('unknown-model')).toBe(null);
-      expect(manager.getTierForModel('custom-model')).toBe(null);
-    });
-
-    it('should return null for null or undefined input', () => {
-      const manager = new AnalysisHistoryManager({
-        reviewId: 1,
-        mode: 'pr',
-        onSelectionChange: vi.fn()
-      });
-
-      expect(manager.getTierForModel(null)).toBe(null);
-      expect(manager.getTierForModel(undefined)).toBe(null);
-      expect(manager.getTierForModel('')).toBe(null);
-    });
-  });
-
-  describe('formatTierName()', () => {
-    it('should return uppercase tier name', () => {
-      const manager = new AnalysisHistoryManager({
-        reviewId: 1,
-        mode: 'pr',
-        onSelectionChange: vi.fn()
-      });
-
-      expect(manager.formatTierName('fast')).toBe('FAST');
-      expect(manager.formatTierName('balanced')).toBe('BALANCED');
-      expect(manager.formatTierName('thorough')).toBe('THOROUGH');
-    });
-
-    it('should return empty string for null or undefined', () => {
-      const manager = new AnalysisHistoryManager({
-        reviewId: 1,
-        mode: 'pr',
-        onSelectionChange: vi.fn()
-      });
-
-      expect(manager.formatTierName(null)).toBe('');
-      expect(manager.formatTierName(undefined)).toBe('');
-      expect(manager.formatTierName('')).toBe('');
+      expect(manager.formatTierDisplayName(null)).toBe('');
+      expect(manager.formatTierDisplayName(undefined)).toBe('');
+      expect(manager.formatTierDisplayName('')).toBe('');
     });
   });
 
@@ -856,11 +790,12 @@ describe('AnalysisHistoryManager', () => {
       });
       manager.init();
 
-      // Set up runs with a known model
+      // Set up runs with a known model and tier from the database
       manager.runs = [{
         id: 'run-123',
         model: 'sonnet',
         provider: 'claude',
+        tier: 'balanced',
         started_at: '2024-01-15T10:00:00Z',
         completed_at: '2024-01-15T10:01:00Z',
         total_suggestions: 5
@@ -868,9 +803,9 @@ describe('AnalysisHistoryManager', () => {
 
       manager.updatePreviewPanel('run-123');
 
-      // Check that the HTML includes the tier (lowercase per code review feedback)
+      // Check that the HTML includes the tier in title-case via formatTierDisplayName
       const previewPanel = mockDocument._elements['analysis-context-preview'];
-      expect(previewPanel.innerHTML).toContain('balanced');
+      expect(previewPanel.innerHTML).toContain('Balanced');
     });
 
     it('should include fast tier for fast models', () => {
@@ -885,6 +820,7 @@ describe('AnalysisHistoryManager', () => {
         id: 'run-123',
         model: 'haiku',
         provider: 'claude',
+        tier: 'fast',
         started_at: '2024-01-15T10:00:00Z',
         completed_at: '2024-01-15T10:01:00Z',
         total_suggestions: 3
@@ -893,7 +829,7 @@ describe('AnalysisHistoryManager', () => {
       manager.updatePreviewPanel('run-123');
 
       const previewPanel = mockDocument._elements['analysis-context-preview'];
-      expect(previewPanel.innerHTML).toContain('fast');
+      expect(previewPanel.innerHTML).toContain('Fast');
     });
 
     it('should include thorough tier for thorough models', () => {
@@ -908,6 +844,7 @@ describe('AnalysisHistoryManager', () => {
         id: 'run-123',
         model: 'opus',
         provider: 'claude',
+        tier: 'thorough',
         started_at: '2024-01-15T10:00:00Z',
         completed_at: '2024-01-15T10:01:00Z',
         total_suggestions: 8
@@ -916,7 +853,7 @@ describe('AnalysisHistoryManager', () => {
       manager.updatePreviewPanel('run-123');
 
       const previewPanel = mockDocument._elements['analysis-context-preview'];
-      expect(previewPanel.innerHTML).toContain('thorough');
+      expect(previewPanel.innerHTML).toContain('Thorough');
     });
 
     it('should show unknown tier for unknown models', () => {

--- a/tests/utils/schema.js
+++ b/tests/utils/schema.js
@@ -120,6 +120,7 @@ const SCHEMA_SQL = {
       review_id INTEGER NOT NULL,
       provider TEXT,
       model TEXT,
+      tier TEXT,
       custom_instructions TEXT,
       repo_instructions TEXT,
       request_instructions TEXT,


### PR DESCRIPTION
## Summary

- Store the analysis tier (`fast`/`balanced`/`thorough`) directly on the `analysis_runs` record at creation time instead of deriving it from the model name at query time
- Eliminates fragile model-to-tier mappings that were duplicated between backend (`getTierForModel`) and frontend (hardcoded dictionary)
- Consolidates `VALID_TIERS`, `TIER_ALIASES`, and `DEFAULT_TIER` into `src/ai/prompts/config.js` as the single source of truth

## Changes

**Database**: New `tier TEXT` column on `analysis_runs` (migration 22), persisted at all 9 `create()` call sites

**Removed**: `getTierForModel()` from both `provider.js` and the frontend `analysis-history.js`

**Backward compat**: `enrichRun()` helper in `analyses.js` applies runtime tier fallback for historical runs by looking up the currently configured provider+model

**Tier validation**: All ingress points (local.js, pr.js, mcp.js, analyses.js) now validate and normalize tier aliases (`free`→`fast`, `standard`→`balanced`, `premium`→`thorough`) via `resolveTier()` before storage

**Consolidation**: `VALID_TIERS` exported from `prompts/config.js` and imported at module scope everywhere; `provider.js` now uses canonical `TIER_ALIASES` instead of its own incomplete copy

## Test plan

- [x] All 3688 unit/integration tests pass
- [ ] E2E tests pass
- [ ] Manual: start analysis in the UI, verify tier displays in analysis history panel
- [ ] Manual: verify historical runs show inferred tier (not "unknown")

🤖 Generated with [Claude Code](https://claude.com/claude-code)