### PR TITLE
Add chat instructions to repository settings

### DIFF
--- a/.changeset/chat-instructions.md
+++ b/.changeset/chat-instructions.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": minor
+---
+
+Add chat instructions to repository settings for customizing chat session system prompts

--- a/public/js/repo-settings.js
+++ b/public/js/repo-settings.js
@@ -200,6 +200,16 @@ class RepoSettingsPage {
       });
     }
 
+    // Chat instructions textarea
+    const chatTextarea = document.getElementById('chat-instructions');
+    if (chatTextarea) {
+      chatTextarea.addEventListener('input', () => {
+        this.currentSettings.default_chat_instructions = chatTextarea.value;
+        this.updateChatCharCount(chatTextarea.value.length);
+        this.checkForChanges();
+      });
+    }
+
     // Analysis mode segmented control
     const modeToggle = document.getElementById('analysis-mode-toggle');
     if (modeToggle) {
@@ -814,7 +824,8 @@ class RepoSettingsPage {
         default_tab: settings.default_tab || 'single',
         default_council_id: settings.default_council_id || null,
         default_instructions: settings.default_instructions || '',
-        local_path: settings.local_path || null
+        local_path: settings.local_path || null,
+        default_chat_instructions: settings.default_chat_instructions || ''
       };
 
       // Set current settings
@@ -832,7 +843,8 @@ class RepoSettingsPage {
         default_tab: 'single',
         default_council_id: null,
         default_instructions: '',
-        local_path: null
+        local_path: null,
+        default_chat_instructions: ''
       };
       this.currentSettings = { ...this.originalSettings };
       this.updateUI();
@@ -887,6 +899,13 @@ class RepoSettingsPage {
       this.updateCharCount(textarea.value.length);
     }
 
+    // Update chat instructions textarea
+    const chatTextarea = document.getElementById('chat-instructions');
+    if (chatTextarea) {
+      chatTextarea.value = this.currentSettings.default_chat_instructions || '';
+      this.updateChatCharCount(chatTextarea.value.length);
+    }
+
     // Update local path display
     this.updateLocalPathDisplay();
   }
@@ -923,6 +942,13 @@ class RepoSettingsPage {
     }
   }
 
+  updateChatCharCount(count) {
+    const charCountEl = document.getElementById('chat-char-count');
+    if (charCountEl) {
+      charCountEl.textContent = count;
+    }
+  }
+
   checkForChanges() {
     // Use nullish coalescing to normalize null/undefined for consistent comparison
     const providerChanged = (this.currentSettings.default_provider ?? null) !== (this.originalSettings.default_provider ?? null);
@@ -930,8 +956,9 @@ class RepoSettingsPage {
     const tabChanged = (this.currentSettings.default_tab ?? 'single') !== (this.originalSettings.default_tab ?? 'single');
     const councilChanged = (this.currentSettings.default_council_id ?? null) !== (this.originalSettings.default_council_id ?? null);
     const instructionsChanged = (this.currentSettings.default_instructions ?? '') !== (this.originalSettings.default_instructions ?? '');
+    const chatInstructionsChanged = (this.currentSettings.default_chat_instructions ?? '') !== (this.originalSettings.default_chat_instructions ?? '');
 
-    this.hasUnsavedChanges = providerChanged || modelChanged || tabChanged || councilChanged || instructionsChanged;
+    this.hasUnsavedChanges = providerChanged || modelChanged || tabChanged || councilChanged || instructionsChanged || chatInstructionsChanged;
 
     // Show/hide action bar
     const actionBar = document.getElementById('action-bar');
@@ -965,7 +992,8 @@ class RepoSettingsPage {
           default_model: this.currentSettings.default_model,
           default_tab: this.currentSettings.default_tab,
           default_council_id: this.currentSettings.default_council_id,
-          default_instructions: this.currentSettings.default_instructions
+          default_instructions: this.currentSettings.default_instructions,
+          default_chat_instructions: this.currentSettings.default_chat_instructions
         })
       });
 
@@ -1039,7 +1067,8 @@ class RepoSettingsPage {
           default_tab: null,
           default_council_id: null,
           default_instructions: '',
-          local_path: null
+          local_path: null,
+          default_chat_instructions: ''
         })
       });
 
@@ -1054,7 +1083,8 @@ class RepoSettingsPage {
         default_tab: 'single',
         default_council_id: null,
         default_instructions: '',
-        local_path: null
+        local_path: null,
+        default_chat_instructions: ''
       };
       this.currentSettings = { ...this.originalSettings };
       this.hasUnsavedChanges = false;

--- a/public/repo-settings.html
+++ b/public/repo-settings.html
@@ -166,6 +166,38 @@ Examples:
                         </div>
                     </section>
 
+                    <!-- Chat Instructions Section -->
+                    <section class="settings-section">
+                        <div class="section-header">
+                            <h2>
+                                Chat Instructions
+                            </h2>
+                            <p class="section-description">
+                                These instructions will be appended to the system prompt when starting chat sessions for this repository.
+                                Use this for guiding the chat assistant's behavior, tone, or focus areas.
+                            </p>
+                        </div>
+                        <div class="instructions-wrapper">
+                            <textarea
+                                id="chat-instructions"
+                                name="default_chat_instructions"
+                                class="instructions-textarea"
+                                placeholder="Enter instructions for chat sessions...
+
+Examples:
+• Always reference the project's coding standards when answering
+• Focus on explaining the reasoning behind suggestions
+• When discussing tests, prefer integration tests over unit tests
+• Use concise responses unless asked for detail"
+                                rows="6"
+                            ></textarea>
+                            <div class="textarea-footer">
+                                <span class="char-count"><span id="chat-char-count">0</span> characters</span>
+                                <span class="textarea-hint">Markdown supported</span>
+                            </div>
+                        </div>
+                    </section>
+
                     <!-- Repository Location Section -->
                     <section class="settings-section" id="local-path-section">
                         <div class="section-header">

--- a/src/chat/prompt-builder.js
+++ b/src/chat/prompt-builder.js
@@ -16,9 +16,10 @@ const logger = require('../utils/logger');
  * it is injected once per session via the initial context instead.
  * @param {Object} options
  * @param {Object} options.review - Review metadata {id, pr_number, repository, review_type, local_path, name}
+ * @param {string} [options.chatInstructions] - Custom instructions from repo settings to append to system prompt
  * @returns {string} System prompt for the chat agent
  */
-function buildChatPrompt({ review }) {
+function buildChatPrompt({ review, chatInstructions }) {
   const sections = [];
 
   // Role
@@ -46,6 +47,11 @@ function buildChatPrompt({ review }) {
     'Answer questions about this review, the code changes, and any AI suggestions. ' +
     'Be concise and helpful. Use markdown formatting in your responses.'
   );
+
+  // Custom chat instructions from repo settings
+  if (chatInstructions) {
+    sections.push('## Custom Instructions\n\nThe following instructions take precedence over previous guidance.\n\n' + chatInstructions);
+  }
 
   const prompt = sections.join('\n\n');
   logger.debug(`Chat system prompt built: ${prompt.length} chars`);

--- a/src/routes/config.js
+++ b/src/routes/config.js
@@ -111,7 +111,8 @@ router.get('/api/repos/:owner/:repo/settings', async (req, res) => {
         default_model: null,
         local_path: null,
         default_council_id: null,
-        default_tab: null
+        default_tab: null,
+        default_chat_instructions: null
       });
     }
 
@@ -123,6 +124,7 @@ router.get('/api/repos/:owner/:repo/settings', async (req, res) => {
       local_path: settings.local_path,
       default_council_id: settings.default_council_id,
       default_tab: settings.default_tab,
+      default_chat_instructions: settings.default_chat_instructions,
       created_at: settings.created_at,
       updated_at: settings.updated_at
     });
@@ -142,14 +144,14 @@ router.get('/api/repos/:owner/:repo/settings', async (req, res) => {
 router.post('/api/repos/:owner/:repo/settings', async (req, res) => {
   try {
     const { owner, repo } = req.params;
-    const { default_instructions, default_provider, default_model, local_path, default_council_id, default_tab } = req.body;
+    const { default_instructions, default_provider, default_model, local_path, default_council_id, default_tab, default_chat_instructions } = req.body;
     const repository = normalizeRepository(owner, repo);
     const db = req.app.get('db');
 
     // Validate that at least one setting is provided
-    if (default_instructions === undefined && default_provider === undefined && default_model === undefined && local_path === undefined && default_council_id === undefined && default_tab === undefined) {
+    if (default_instructions === undefined && default_provider === undefined && default_model === undefined && local_path === undefined && default_council_id === undefined && default_tab === undefined && default_chat_instructions === undefined) {
       return res.status(400).json({
-        error: 'At least one setting (default_instructions, default_provider, default_model, local_path, default_council_id, or default_tab) must be provided'
+        error: 'At least one setting (default_instructions, default_provider, default_model, local_path, default_council_id, default_tab, or default_chat_instructions) must be provided'
       });
     }
 
@@ -160,7 +162,8 @@ router.post('/api/repos/:owner/:repo/settings', async (req, res) => {
       default_model,
       local_path,
       default_council_id,
-      default_tab
+      default_tab,
+      default_chat_instructions
     });
 
     logger.info(`Saved repo settings for ${repository}`);
@@ -175,6 +178,7 @@ router.post('/api/repos/:owner/:repo/settings', async (req, res) => {
         local_path: settings.local_path,
         default_council_id: settings.default_council_id,
         default_tab: settings.default_tab,
+        default_chat_instructions: settings.default_chat_instructions,
         updated_at: settings.updated_at
       }
     });

--- a/tests/unit/chat/prompt-builder.test.js
+++ b/tests/unit/chat/prompt-builder.test.js
@@ -82,6 +82,44 @@ describe('buildChatPrompt', () => {
     });
   });
 
+  describe('chatInstructions', () => {
+    it('should append custom instructions section when chatInstructions is provided', () => {
+      const prompt = buildChatPrompt({
+        review: { repository: 'owner/repo', pr_number: 1 },
+        chatInstructions: 'Focus on security issues and performance.'
+      });
+
+      expect(prompt).toContain('## Custom Instructions');
+      expect(prompt).toContain('Focus on security issues and performance.');
+    });
+
+    it('should not include custom instructions section when chatInstructions is null', () => {
+      const prompt = buildChatPrompt({
+        review: { repository: 'owner/repo', pr_number: 1 },
+        chatInstructions: null
+      });
+
+      expect(prompt).not.toContain('Custom Instructions');
+    });
+
+    it('should not include custom instructions section when chatInstructions is empty string', () => {
+      const prompt = buildChatPrompt({
+        review: { repository: 'owner/repo', pr_number: 1 },
+        chatInstructions: ''
+      });
+
+      expect(prompt).not.toContain('Custom Instructions');
+    });
+
+    it('should not include custom instructions section when chatInstructions is undefined', () => {
+      const prompt = buildChatPrompt({
+        review: { repository: 'owner/repo', pr_number: 1 }
+      });
+
+      expect(prompt).not.toContain('Custom Instructions');
+    });
+  });
+
   describe('general prompt structure', () => {
     it('should always include role and instructions', () => {
       const prompt = buildChatPrompt({

--- a/tests/utils/schema.js
+++ b/tests/utils/schema.js
@@ -108,6 +108,7 @@ const SCHEMA_SQL = {
       default_model TEXT,
       default_council_id TEXT,
       default_tab TEXT,
+      default_chat_instructions TEXT,
       local_path TEXT,
       created_at TEXT DEFAULT CURRENT_TIMESTAMP,
       updated_at TEXT DEFAULT CURRENT_TIMESTAMP


### PR DESCRIPTION
## Summary

- Adds a `default_chat_instructions` field to repo settings (schema v23) that gets injected into chat session system prompts as a "Custom Instructions" section with precedence over default guidance
- New textarea in the repo settings UI mirrors the existing "Default Instructions" pattern, with character count and change detection
- All three chat route paths (create, auto-resume, explicit resume) fetch and pass instructions via an extracted `getChatInstructions()` helper

## Test plan

- [x] All 3,858 unit/integration tests pass
- [x] All 217 E2E tests pass
- [ ] Manual: open repo settings, enter chat instructions, save, verify persistence on reload
- [ ] Manual: start a chat session and verify the system prompt includes the custom instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)