### PR TITLE
Remove BETA badges from Council and Advanced tabs

### DIFF
--- a/public/js/components/AnalysisConfigModal.js
+++ b/public/js/components/AnalysisConfigModal.js
@@ -949,8 +949,8 @@ class AnalysisConfigModal {
       tabBar.className = 'analysis-tab-bar';
       tabBar.innerHTML = `
         <button class="analysis-tab active" data-tab="single">Single Model</button>
-        <button class="analysis-tab" data-tab="council">Council <span class="beta-badge">BETA</span></button>
-        <button class="analysis-tab" data-tab="advanced">Advanced <span class="beta-badge">BETA</span></button>
+        <button class="analysis-tab" data-tab="council">Council</button>
+        <button class="analysis-tab" data-tab="advanced">Advanced</button>
       `;
 
       // Assemble


### PR DESCRIPTION
## Summary
- Remove the `BETA` badge from the Council and Advanced tabs in the Analysis Config modal
- These features are now stable and no longer need the beta designation

## Test plan
- [x] Unit tests pass (3947 tests)
- [x] E2E tests pass (233 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)