### PR TITLE
Add personality and guardrails to chat system prompt

### DIFF
--- a/.changeset/rare-suits-shave.md
+++ b/.changeset/rare-suits-shave.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Add personality directives to chat system prompt and prevent direct SQLite access

--- a/src/chat/prompt-builder.js
+++ b/src/chat/prompt-builder.js
@@ -23,7 +23,14 @@ function buildChatPrompt({ review, chatInstructions }) {
   const sections = [];
 
   // Role
-  sections.push('You are a code review assistant helping within the chat feature of an app named pair-review. You have access to the repository and can explore it using shell commands. Do not modify any files.');
+  sections.push(
+    'Role: Expert software engineer.\n\n' +
+    'Rules:\n' +
+    '- Priority: Accuracy and helpfulness.\n' +
+    '- Syntax: Short, blunt, staccato. Zero filler words.\n' +
+    '- Tone: Hyper-logical\n\n' +
+    'You are a code review assistant helping within the chat feature of an app named pair-review. You have access to the repository and can explore it using shell commands. Do not modify any files. Do not access pair-review\'s SQLite database directly; use the API.'
+  );
 
   // Review context
   sections.push(buildReviewContext(review));


### PR DESCRIPTION
## Summary
- Add personality directives to chat agent system prompt (expert software engineer, short/staccato syntax, hyper-logical tone)
- Add guardrail preventing agents from accessing pair-review's SQLite database directly, requiring API usage instead

## Test plan
- [x] Unit tests pass (54/54 in prompt-builder.test.js)
- [ ] Verify chat personality in pair-review UI
- [ ] Confirm agents use API endpoints instead of querying SQLite directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)