### PR TITLE
Add dismiss buttons to chat panel action bar

### DIFF
--- a/.changeset/curly-moose-unite.md
+++ b/.changeset/curly-moose-unite.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Add dismiss buttons to chat panel action bar for suggestions and comments

--- a/.pi/skills/pair-review-api/SKILL.md
+++ b/.pi/skills/pair-review-api/SKILL.md
@@ -72,6 +72,8 @@ curl -s -X PUT http://localhost:PORT/api/reviews/REVIEW_ID/comments/COMMENT_ID \
 
 ### Delete a comment
 
+> **Terminology note:** The UI refers to this operation as "dismiss." When a user asks to "dismiss a comment," use this DELETE endpoint.
+
 Soft-deletes the comment. If the comment was adopted from an AI suggestion, the parent suggestion is automatically transitioned to "dismissed" status.
 
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,6 +136,9 @@ Test structure:
 
 ## Learnings
 
+### Directory Conventions
+- When modifying code in a directory, check for a `CONVENTIONS.md` in that directory or its parent.
+
 ### Local Mode and PR Mode Parity
 - Features must work in BOTH Local mode (`/local/:reviewId`) and PR mode (`/pr/:owner/:repo/:number`)
 - These modes have parallel but separate implementations:

--- a/plans/chat-panel-dismiss-buttons.md
+++ b/plans/chat-panel-dismiss-buttons.md
@@ -1,0 +1,59 @@
+# Add Dismiss Buttons to Chat Panel Action Bar
+
+## Context
+
+When the chat panel is opened with context (an AI suggestion or a user comment), an action bar appears with shortcut buttons ("Adopt with AI edits" for suggestions, "Update comment" for comments). These buttons populate the chat input with a predefined message and send it immediately.
+
+We want to add **dismiss** buttons alongside the existing action buttons so users can quickly dismiss suggestions or comments directly from the chat panel. These buttons should be styled in red (danger color) to visually distinguish them from the positive actions.
+
+## Changes
+
+### 1. HTML — Add dismiss buttons (`public/js/components/ChatPanel.js`)
+
+Add two new buttons to the `.chat-panel__action-bar` div (after the existing buttons, lines ~77 and ~83):
+
+- **"Dismiss suggestion"** button — class `chat-panel__action-btn--dismiss-suggestion`, displayed when context is a suggestion
+- **"Dismiss comment"** button — class `chat-panel__action-btn--dismiss-comment`, displayed when context is a comment
+
+Use an X icon SVG (matching the existing dismiss icon pattern in the codebase).
+
+### 2. JS — Wire up the new buttons (`public/js/components/ChatPanel.js`)
+
+- Query the new button elements in the constructor (alongside `this.adoptBtn` and `this.updateBtn` at ~line 115-116)
+- Bind click event listeners (alongside existing ones at ~line 139-140)
+- Add handler methods following the same pattern as `_handleAdoptClick` and `_handleUpdateClick`:
+  - `_handleDismissSuggestionClick()` — populates input with a message like: `"Please dismiss this AI suggestion using the pair-review API. The suggestion ID is {id}."` and calls `sendMessage()`
+  - `_handleDismissCommentClick()` — populates input with a message like: `"Please dismiss this comment using the pair-review API. The comment ID is {id}."` and calls `sendMessage()`
+- Update `_updateActionButtons()` to show/hide and disable the new buttons using the same logic as the existing ones (suggestion → show dismiss-suggestion; comment → show dismiss-comment)
+
+### 3. CSS — Red styling (`public/css/pr.css`)
+
+Add styles for both dismiss button variants after the existing `--update` styles (~line 11238):
+
+```css
+.chat-panel__action-btn--dismiss-suggestion,
+.chat-panel__action-btn--dismiss-comment {
+  background: var(--color-danger, #d1242f);
+  border-color: var(--color-danger, #d1242f);
+  color: #ffffff;
+}
+
+.chat-panel__action-btn--dismiss-suggestion:hover:not(:disabled),
+.chat-panel__action-btn--dismiss-comment:hover:not(:disabled) {
+  background: var(--color-danger-hover, #b91c1c);
+  border-color: var(--color-danger-hover, #b91c1c);
+  color: #ffffff;
+}
+```
+
+## Files to modify
+
+1. `public/js/components/ChatPanel.js` — HTML, element refs, event listeners, handlers, visibility logic
+2. `public/css/pr.css` — Red button styles
+
+## Verification
+
+- Run E2E tests: `npm run test:e2e`
+- Manual: Open chat panel from an AI suggestion → should see "Adopt with AI edits" (blue) + "Dismiss suggestion" (red)
+- Manual: Open chat panel from a user comment → should see "Update comment" (blue) + "Dismiss comment" (red)
+- Clicking either dismiss button should populate and send a dismiss message in the chat

--- a/public/css/pr.css
+++ b/public/css/pr.css
@@ -11077,7 +11077,7 @@ body.resizing * {
 }
 
 .chat-panel__context-remove:hover {
-  background: var(--color-danger, #d0242f);
+  background: var(--color-danger, #d1242f);
   color: #ffffff;
 }
 
@@ -11237,6 +11237,20 @@ body.resizing * {
   color: #ffffff;
 }
 
+.chat-panel__action-btn--dismiss-suggestion,
+.chat-panel__action-btn--dismiss-comment {
+  background: var(--color-danger, #d1242f);
+  border-color: var(--color-danger, #d1242f);
+  color: #ffffff;
+}
+
+.chat-panel__action-btn--dismiss-suggestion:hover:not(:disabled),
+.chat-panel__action-btn--dismiss-comment:hover:not(:disabled) {
+  background: var(--color-danger-hover, #b91c1c);
+  border-color: var(--color-danger-hover, #b91c1c);
+  color: #ffffff;
+}
+
 /* Chat Input Area */
 .chat-panel__input-area {
   display: flex;
@@ -11325,7 +11339,7 @@ body.resizing * {
   height: 28px;
   border: none;
   border-radius: 6px;
-  background: var(--color-danger, #d0242f);
+  background: var(--color-danger, #d1242f);
   color: white;
   cursor: pointer;
   flex-shrink: 0;

--- a/src/chat/CONVENTIONS.md
+++ b/src/chat/CONVENTIONS.md
@@ -1,0 +1,18 @@
+# Chat Module Conventions
+
+## Action handler pattern (ChatPanel.js)
+
+All action handlers (adopt, update, dismiss) follow identical structure:
+1. Guard: if streaming or no `_contextItemId`, return early
+2. Set `_pendingActionContext` with `{ type, itemId }`
+3. Set `inputEl.value` to clean, human-readable text (NO item IDs)
+4. Call `sendMessage()`
+
+See `_handleAdoptClick` as the canonical example. New action handlers must follow this pattern.
+
+## Action metadata separation
+
+Item IDs never appear in user-visible message text. They flow through:
+`_pendingActionContext` (frontend) → `actionContext` (API payload) → `[Action: ...]` hint (agent-facing message in session-manager.js)
+
+This keeps the chat transcript clean while giving the agent structured metadata it can parse reliably.

--- a/src/routes/chat.js
+++ b/src/routes/chat.js
@@ -280,7 +280,7 @@ router.post('/api/chat/session', async (req, res) => {
 router.post('/api/chat/session/:id/message', async (req, res) => {
   try {
     const sessionId = parseInt(req.params.id, 10);
-    const { content, context, contextData } = req.body || {};
+    const { content, context, contextData, actionContext } = req.body || {};
 
     if (!content) {
       return res.status(400).json({ error: 'Missing required field: content' });
@@ -322,7 +322,7 @@ router.post('/api/chat/session/:id/message', async (req, res) => {
     }
 
     logger.debug(`[ChatRoute] Forwarding message to session ${sessionId} (${content.length} chars)`);
-    const result = await chatSessionManager.sendMessage(sessionId, content, { context, contextData });
+    const result = await chatSessionManager.sendMessage(sessionId, content, { context, contextData, actionContext });
     logger.debug(`[ChatRoute] Message stored as ID ${result.id}, awaiting agent response via SSE`);
     res.json({ data: { messageId: result.id } });
   } catch (error) {


### PR DESCRIPTION
## Summary
- Add red **Dismiss suggestion** and **Dismiss comment** buttons to the chat panel action bar alongside the existing adopt/update buttons
- Refactor all four action handlers to pass item IDs via structured `actionContext` metadata instead of embedding them in user-visible chat text — keeps the transcript clean while giving the agent reliable structured data
- Extract shared `DISMISS_ICON` constant to eliminate SVG duplication
- Fix `#d0242f` → `#d1242f` fallback drift in existing CSS
- Add terminology note in SKILL.md bridging "dismiss" → DELETE endpoint
- Add `src/chat/CONVENTIONS.md` documenting the action handler pattern

## Test plan
- [x] E2E tests pass (233/233)
- [x] Unit tests pass with new dismiss handler coverage (381/381)
- [ ] Manual: open chat from AI suggestion → see "Adopt with AI edits" (blue) + "Dismiss suggestion" (red)
- [ ] Manual: open chat from user comment → see "Update comment" (blue) + "Dismiss comment" (red)
- [ ] Manual: clicking dismiss sends clean message (no raw IDs visible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)