### PR TITLE
Fix suggestion context bugs in chat panel

### DIFF
--- a/.changeset/suggestion-chat-bugs.md
+++ b/.changeset/suggestion-chat-bugs.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Fix chat panel suggestion bugs: hide lingering context tooltip when removing a pending suggestion card, and prevent "Chat" on a suggestion from loading the previous session instead of staying in the current new conversation

--- a/public/js/components/ChatPanel.js
+++ b/public/js/components/ChatPanel.js
@@ -373,8 +373,11 @@ class ChatPanel {
     // Ensure SSE is connected (but don't create a session yet — lazy creation)
     this._ensureGlobalSSE();
 
-    // Load MRU session with message history (if any previous sessions exist)
-    if (!this.currentSessionId) {
+    // Load MRU session with message history (if any previous sessions exist).
+    // Skip when opening with explicit context (suggestion/comment/file) — the
+    // user wants a *new* conversation about that item, not to resume the last one.
+    const hasExplicitContext = !!(options.suggestionContext || options.commentContext || options.fileContext);
+    if (!this.currentSessionId && !hasExplicitContext) {
       await this._loadMRUSession();
     }
 
@@ -1275,6 +1278,10 @@ class ChatPanel {
       this._pendingContext.splice(idx, 1);
       this._pendingContextData.splice(idx, 1);
     }
+    // Hide context tooltip – mouseleave won't fire on a removed element
+    clearTimeout(this._ctxTooltipTimer);
+    if (this._ctxTooltipEl) this._ctxTooltipEl.style.display = 'none';
+
     cardEl.remove();
 
     // Re-index remaining removable context cards


### PR DESCRIPTION
## Summary
- **Lingering tooltip**: Hide context tooltip when removing a pending suggestion card — `mouseleave` doesn't fire on removed DOM elements, so the tooltip stayed visible with no way to dismiss it
- **Wrong session loaded**: Skip loading MRU session when opening chat with explicit context (suggestion/comment/file) so the user stays in their current new conversation instead of being redirected to the previous session

## Test plan
- [ ] Add a suggestion to chat as pending context, hover to see tooltip, remove the card — tooltip should disappear
- [ ] Start a new chat conversation, click "Chat" on an AI suggestion — should stay in the new session, not jump to the previous one

🤖 Generated with [Claude Code](https://claude.com/claude-code)