### PR TITLE
Fix context files disappearing from diff panel on reload

### DIFF
--- a/.changeset/fix-context-file-reload.md
+++ b/.changeset/fix-context-file-reload.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Fix context files disappearing from the diff panel on review reload by clearing stale in-memory state in `renderDiff()` so that `loadContextFiles()` correctly re-renders them

--- a/plans/fix-context-files-disappear-on-reload.md
+++ b/plans/fix-context-files-disappear-on-reload.md
@@ -1,0 +1,25 @@
+# Fix: Context files disappear from diff panel on reload
+
+## Context
+
+When a review is reloaded (e.g., local diff changes due to staging), context files persist in the File Navigator sidebar but vanish from the diff panel. They should remain visible in both places until explicitly removed.
+
+**Root cause**: `renderDiff()` (pr.js:855) clears the entire diff container with `innerHTML = ''`, destroying context file DOM elements. But `this.contextFiles` in memory still holds the old records. When `loadContextFiles()` runs next, it compares old IDs vs new IDs and finds them identical — so it renders nothing, since it only renders "new" context files (those not in `oldIds`). The sidebar survives because `rebuildFileListWithContext()` is data-driven, not DOM-dependent.
+
+## Fix
+
+**In `renderDiff()` (public/js/pr.js:889)**: Reset `this.contextFiles = []` before calling `this.loadContextFiles()`. After the DOM is cleared, the in-memory state should match (empty). This makes `loadContextFiles()` treat all DB-persisted context files as "new" and re-render them.
+
+```js
+// Line ~889 in renderDiff()
+this.contextFiles = [];       // <-- add this line
+this.loadContextFiles();
+```
+
+**Files to modify**: `public/js/pr.js` (1 line addition)
+
+## Verification
+
+1. Run unit tests: `npm test`
+2. Manual test: Add a context file to a local review, then trigger a reload (stage/unstage files to change the diff). Confirm context file remains visible in both File Navigator and diff panel.
+3. Run E2E tests: `npm run test:e2e`

--- a/public/js/pr.js
+++ b/public/js/pr.js
@@ -886,6 +886,7 @@ class PRManager {
     }
 
     // Load context files after diff is rendered
+    this.contextFiles = [];
     this.loadContextFiles();
   }
 


### PR DESCRIPTION
## Summary
- Context files vanished from the diff panel when a review reloaded (e.g., staging/unstaging in local mode), while persisting in the File Navigator sidebar
- Root cause: `renderDiff()` cleared the DOM with `innerHTML = ''` but left `this.contextFiles` stale in memory, so `loadContextFiles()` treated all files as already rendered and skipped them
- Fix: reset `this.contextFiles = []` before calling `loadContextFiles()` so all DB-persisted context files are re-rendered after a DOM clear

## Test plan
- [x] Unit tests pass (3995 tests)
- [x] E2E tests pass (233 tests)
- [ ] Manual: add a context file to a local review, stage/unstage to trigger reload, confirm context file stays in both sidebar and diff panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)