### PR TITLE
Fix analysis runs dropdown overlapped by resize handle

### DIFF
--- a/.changeset/analysis-dropdown-zindex.md
+++ b/.changeset/analysis-dropdown-zindex.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Fix analysis runs dropdown being overlapped by the review panel resize handle due to CSS stacking context

--- a/public/css/pr.css
+++ b/public/css/pr.css
@@ -6576,6 +6576,11 @@ body:not([data-theme="dark"]) .theme-icon-light {
   z-index: 2;
 }
 
+/* When dropdown is open, lift above resize-handle (z-index:10) */
+.ai-panel > .analysis-context.open {
+  z-index: 11;
+}
+
 /* Prevent text selection during drag */
 body.resizing {
   user-select: none;


### PR DESCRIPTION
## Summary
- Fix z-index stacking context bug where the review panel resize handle (`z-index: 10`) painted over the analysis runs dropdown
- The dropdown was trapped inside `.analysis-context`'s stacking context (`z-index: 2`), so its own `z-index: 1100` was irrelevant in the parent context
- When the dropdown is open (`.analysis-context.open`), promote it to `z-index: 11` so it sits above the resize handle

## Test plan
- [ ] Open the analysis runs dropdown/popover
- [ ] Verify the resize handle border no longer overlaps it
- [ ] Verify the resize handle still works correctly when the dropdown is closed

🤖 Generated with [Claude Code](https://claude.com/claude-code)