### PR TITLE
Fix chat showing as unavailable on first load

### DIFF
--- a/.changeset/fix-chat-availability-race.md
+++ b/.changeset/fix-chat-availability-race.md
@@ -1,0 +1,11 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Fix chat showing as unavailable on first load
+
+Await provider availability check before the server starts listening so the
+`/api/config` endpoint returns accurate `pi_available` status on the very first
+request. Previously the check ran in the background after `app.listen()`,
+causing a race where the frontend would fetch config before the cache was
+populated, making chat appear unavailable until a page reload.

--- a/src/ai/provider-availability.js
+++ b/src/ai/provider-availability.js
@@ -2,7 +2,7 @@
 /**
  * Provider Availability Module
  *
- * Manages background checking of AI provider availability at server startup.
+ * Manages checking of AI provider availability at server startup.
  * Caches results and exposes them for the /api/providers endpoint.
  */
 


### PR DESCRIPTION
## Summary
- Await provider availability check **before** `app.listen()` so `/api/config` returns accurate `pi_available` on the very first request
- Previously the check ran in the background after the server started listening, causing a race where the frontend fetched config before the cache was populated — chat appeared unavailable until a page reload

## Test plan
- [x] Unit tests pass (3,996/3,996)
- [x] E2E tests pass (235/235)
- [ ] Manual: start app fresh, verify chat toggle shows as available on first load (no reload needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)