### PR TITLE
Fix chat auto-scroll fighting user during streaming

### DIFF
--- a/.changeset/chat-auto-scroll.md
+++ b/.changeset/chat-auto-scroll.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Fix chat auto-scroll fighting user during streaming responses. The chat panel no longer yanks the viewport to the bottom on every streaming chunk — if the user scrolls up, auto-scroll disengages and a "New content" pill appears. Clicking the pill or scrolling back to the bottom re-engages auto-scroll. User-initiated actions (sending messages, adding context cards) always scroll into view.

--- a/public/css/pr.css
+++ b/public/css/pr.css
@@ -10949,6 +10949,15 @@ body.resizing * {
 }
 
 /* Chat Messages Area */
+.chat-panel__messages-wrapper {
+  flex: 1;
+  position: relative;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
 .chat-panel__messages {
   flex: 1;
   overflow-y: auto;
@@ -10969,6 +10978,42 @@ body.resizing * {
 .chat-panel__messages::-webkit-scrollbar-thumb {
   background-color: var(--color-border-primary);
   border-radius: 3px;
+}
+
+/* New Content Pill */
+.chat-panel__new-content-pill {
+  position: absolute;
+  bottom: 8px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 10;
+  padding: 4px 14px;
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 1.4;
+  color: var(--color-text-primary);
+  background: var(--color-bg-secondary);
+  border: 1px solid var(--color-border-primary);
+  border-radius: 20px;
+  cursor: pointer;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
+  opacity: 0;
+  animation: chat-pill-fade-in 0.15s ease-out forwards;
+  white-space: nowrap;
+}
+
+.chat-panel__new-content-pill:hover {
+  background: var(--color-bg-tertiary);
+  border-color: var(--color-border-secondary);
+}
+
+@keyframes chat-pill-fade-in {
+  from { opacity: 0; transform: translateX(-50%) translateY(4px); }
+  to   { opacity: 1; transform: translateX(-50%) translateY(0); }
+}
+
+[data-theme="dark"] .chat-panel__new-content-pill {
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
 }
 
 /* Empty State */


### PR DESCRIPTION
## Summary
- Replace unconditional `scrollToBottom()` with scroll-intent-aware version that uses a `_userScrolledAway` flag to track user scroll direction
- When user scrolls up during streaming, auto-scroll disengages immediately — no more viewport yanking
- A floating "New content" pill appears when auto-scroll is suppressed; clicking it jumps to bottom and re-engages
- User-initiated actions (sending messages, adding context cards, errors) always force-scroll into view
- Streaming chunks and thinking indicators respect user scroll position

## Test plan
- [x] Unit tests added (14 new tests covering force/non-force paths, pill visibility, flag behavior, scroll listener direction tracking)
- [x] All 308 tests passing
- [ ] Manual: Send a message while streaming is in progress — verify viewport stays at user's scroll position
- [ ] Manual: Verify "New content" pill appears and clicking it scrolls to bottom
- [ ] Manual: Verify sending a new message always scrolls to bottom regardless of scroll position
- [ ] Manual: Verify context cards (Ask about this, etc.) scroll into view

🤖 Generated with [Claude Code](https://claude.com/claude-code)