### PR TITLE
Hide skill file read from chat UI

### DIFF
--- a/.changeset/hide-skill-file-read.md
+++ b/.changeset/hide-skill-file-read.md
@@ -1,0 +1,7 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Hide skill file read from chat UI
+
+Suppress the Read tool badge when the chat agent loads the pair-review-api skill file, and instruct the agent not to mention it.

--- a/src/chat/prompt-builder.js
+++ b/src/chat/prompt-builder.js
@@ -52,7 +52,8 @@ function buildChatPrompt({ review, chatInstructions }) {
 
   // API capability — MUST load the skill for endpoint details
   sections.push(
-    'You MUST load the pair-review-api skill for endpoint details. With it you can create, update, and delete review comments, adopt or dismiss AI suggestions, and trigger new analyses via curl.'
+    'You MUST load the pair-review-api skill for endpoint details. With it you can create, update, and delete review comments, adopt or dismiss AI suggestions, and trigger new analyses via curl.\n' +
+    'IMPORTANT: Do NOT mention that you are reading a skill file, loading API documentation, or consulting reference material. Just use the API naturally as if you already know it.'
   );
 
   // File reference syntax and context files

--- a/src/routes/chat.js
+++ b/src/routes/chat.js
@@ -92,6 +92,20 @@ function registerSSEBroadcast(chatSessionManager, sessionId, port) {
         }
       }
 
+      // Suppress tool badges for reading the API skill file
+      if (data.toolName?.toLowerCase() === 'read' && data.status === 'start') {
+        if ((data.args?.file_path || '').endsWith('pair-review-api/SKILL.md')) {
+          hiddenToolCallIds.add(data.toolCallId);
+          return;
+        }
+      }
+
+      // Suppress follow-up events (update/end) for any hidden tool call
+      if (hiddenToolCallIds.has(data.toolCallId)) {
+        if (data.status === 'end') hiddenToolCallIds.delete(data.toolCallId);
+        return;
+      }
+
       const event = { type: 'tool_use', toolName: data.toolName, status: data.status };
       if (data.args) {
         event.toolInput = data.args;


### PR DESCRIPTION
## Summary
- Suppress the `Read` tool badge in the chat panel when the agent loads the `pair-review-api/SKILL.md` skill file
- Instruct the chat agent (via system prompt) not to mention that it's reading reference material

## Test plan
- [ ] Open a chat session and trigger an action that requires the API skill (e.g. adopt a suggestion)
- [ ] Verify no "Read" tool badge appears for the skill file load
- [ ] Verify the agent doesn't say "let me read the API docs" or similar

🤖 Generated with [Claude Code](https://claude.com/claude-code)