### PR TITLE
Fix review panel comment item height

### DIFF
--- a/.changeset/fix-comment-item-height.md
+++ b/.changeset/fix-comment-item-height.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Fix review panel comment items being too short to accommodate stacked chat and dismiss buttons. Comment items now match the height of AI suggestion items.

--- a/public/css/pr.css
+++ b/public/css/pr.css
@@ -8060,6 +8060,7 @@ body.resizing * {
   display: flex;
   align-items: stretch;
   position: relative;
+  min-height: 56px; /* Accommodate stacked chat + action buttons */
 }
 
 .finding-item-wrapper .finding-item {


### PR DESCRIPTION
## Summary
- Comment items in the Review panel were too short to accommodate the stacked chat and dismiss buttons, causing overlap
- Added `min-height: 56px` to `.finding-item-wrapper` so comment items match the height of AI suggestion items

## Test plan
- [ ] Open a review with both AI suggestions and user comments in the Review panel
- [ ] Verify comment items are tall enough for the chat and dismiss buttons without overlap
- [ ] Verify AI suggestion items are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)