### PR TITLE
Fix chat agent CWD to use review worktree

### DIFF
--- a/.changeset/fix-chat-agent-cwd.md
+++ b/.changeset/fix-chat-agent-cwd.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Fix chat agent CWD to use the review's worktree directory instead of the server's working directory. For PR reviews, the worktree path is now resolved from the worktrees table (matching analysis behavior). Previously, the chat agent could not explore the codebase in PR mode because it launched in the wrong directory.


### PR DESCRIPTION
## Summary
- Chat agent was spawning with `process.cwd()` (the server's directory) instead of the review's worktree for PR reviews, making it unable to explore the codebase
- `review.local_path` is only populated for Local mode reviews; PR worktree paths live in a separate `worktrees` table
- Added `resolveReviewCwd()` helper that resolves the correct directory for both modes (Local: `review.local_path`, PR: `GitWorktreeManager.getWorktreePath()`)
- Fixed all three chat session code paths: create, auto-resume on message, and explicit resume

## Test plan
- [x] All 4,137 unit/integration tests pass
- [ ] Manual: start a chat session on a PR review, verify the agent can read/explore files in the PR's worktree
- [ ] Manual: start a chat session on a local review, verify the agent CWD is the local repo root
- [ ] Manual: resume a chat session on a PR review, verify CWD is still the worktree

🤖 Generated with [Claude Code](https://claude.com/claude-code)