### PR TITLE
Enhance chat agent with task extension and review context

### DIFF
--- a/.changeset/chat-agent-enhancements.md
+++ b/.changeset/chat-agent-enhancements.md
@@ -1,0 +1,10 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Enhance chat agent with task extension and review context guidance
+
+- Load the task extension (`-e .pi/extensions/task`) for chat agent sessions, enabling subagent delegation
+- Add review context to the system prompt so the agent knows the correct `git diff` command for the review type (local vs PR)
+- Pass the absolute path to the pair-review-api SKILL.md in the system prompt to reduce agent fumbling
+- Fix skill file read suppression to check both `path` and `file_path` arg names

--- a/src/chat/pi-bridge.js
+++ b/src/chat/pi-bridge.js
@@ -31,6 +31,7 @@ class PiBridge extends EventEmitter {
    * @param {string} [options.tools] - Comma-separated tool list (default: 'read,grep,find,ls')
    * @param {string} [options.piCommand] - Override Pi command (default: 'pi')
    * @param {string[]} [options.skills] - Array of skill file paths to load via --skill
+   * @param {string[]} [options.extensions] - Array of extension directory paths to load via -e
    * @param {string} [options.sessionPath] - Path to a session file for resumption
    */
   constructor(options = {}) {
@@ -42,6 +43,7 @@ class PiBridge extends EventEmitter {
     this.tools = options.tools || 'read,grep,find,ls';
     this.piCommand = options.piCommand || process.env.PAIR_REVIEW_PI_CMD || 'pi';
     this.skills = options.skills || [];
+    this.extensions = options.extensions || [];
     this.sessionPath = options.sessionPath || null;
 
     this._process = null;
@@ -266,6 +268,15 @@ class PiBridge extends EventEmitter {
 
     for (const skill of this.skills) {
       args.push('--skill', skill);
+    }
+
+    // Load extensions via -e (e.g., task extension for subagent delegation).
+    // --no-extensions prevents auto-discovery; only explicitly listed ones load.
+    if (this.extensions.length > 0) {
+      args.push('--no-extensions');
+      for (const ext of this.extensions) {
+        args.push('-e', ext);
+      }
     }
 
     return args;

--- a/src/chat/session-manager.js
+++ b/src/chat/session-manager.js
@@ -13,6 +13,7 @@ const PiBridge = require('./pi-bridge');
 const logger = require('../utils/logger');
 
 const pairReviewSkillPath = path.resolve(__dirname, '../../.pi/skills/pair-review-api/SKILL.md');
+const taskExtensionDir = path.resolve(__dirname, '../../.pi/extensions/task');
 
 const CHAT_TOOLS = 'read,bash,grep,find,ls';
 
@@ -61,7 +62,8 @@ class ChatSessionManager {
       cwd,
       systemPrompt,
       tools: CHAT_TOOLS,
-      skills: [pairReviewSkillPath]
+      skills: [pairReviewSkillPath],
+      extensions: [taskExtensionDir]
     });
 
     const listeners = {
@@ -410,6 +412,7 @@ class ChatSessionManager {
       systemPrompt,
       tools: CHAT_TOOLS,
       skills: [pairReviewSkillPath],
+      extensions: [taskExtensionDir],
       sessionPath: row.agent_session_id
     });
 


### PR DESCRIPTION
## Summary
- Load the task extension (`-e .pi/extensions/task --no-extensions`) for chat agent sessions, giving the agent subagent delegation capability (matching what analysis runs already have)
- Add a "Viewing Code Changes" section to the chat system prompt with the correct `git diff` command per review type — `git diff` for local reviews, `git diff base...head` with exact SHAs for PR reviews — plus negative guardrails against common model mistakes like `git diff HEAD~1`
- Pass the absolute path to `pair-review-api/SKILL.md` in the system prompt so the agent doesn't fumble finding it
- Fix skill file read suppression to check both `path` and `file_path` arg names (Pi uses `path`, not `file_path`)

## Test plan
- [x] Unit tests pass (prompt-builder: 54, pi-bridge: 42, session-manager: 58)
- [x] Integration tests pass (chat-routes: 67)
- [ ] Manual: start a local review chat session, verify agent uses `git diff` (not `git diff HEAD`)
- [ ] Manual: start a PR review chat session, verify agent uses `git diff base...head` with correct SHAs
- [ ] Manual: verify skill file read badge is suppressed in chat UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)