### PR TITLE
Update provider model definitions for Feb 2026

### DIFF
--- a/.changeset/update-provider-models.md
+++ b/.changeset/update-provider-models.md
@@ -1,0 +1,10 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Update built-in model definitions for Gemini, Copilot, and Cursor Agent providers
+
+- Gemini: Drop `-preview` suffix from gemini-3-flash and gemini-3-pro (with aliases for backward compat), add gemini-3.1-pro
+- Copilot: Add claude-sonnet-4.6 (new default), gpt-5.3-codex, claude-opus-4.6-fast; demote sonnet-4.5
+- Cursor Agent: Add sonnet-4.6-thinking (new default), gemini-3.1-pro, gpt-5.3-codex-xhigh; demote sonnet-4.5-thinking
+- Extract default model constants to reduce duplication across constructor and getDefaultModel()

--- a/src/ai/copilot-provider.js
+++ b/src/ai/copilot-provider.js
@@ -21,9 +21,10 @@ const BIN_DIR = path.join(__dirname, '..', '..', 'bin');
  *
  * GitHub Copilot CLI supports multiple AI models including OpenAI,
  * Anthropic, and Google models via the --model flag.
- * Available models (as of Feb 2026): claude-haiku-4.5, claude-sonnet-4.5,
- * gemini-3-pro-preview, gpt-5.2-codex, claude-opus-4.5,
- * claude-opus-4.6. Default is claude-sonnet-4.5.
+ * Available models (as of Feb 2026): claude-haiku-4.5, claude-sonnet-4.6,
+ * claude-sonnet-4.5, gemini-3-pro-preview, gpt-5.2-codex, gpt-5.3-codex,
+ * claude-opus-4.5, claude-opus-4.6, claude-opus-4.6-fast.
+ * Default is claude-sonnet-4.6.
  */
 const COPILOT_MODELS = [
   {
@@ -36,14 +37,23 @@ const COPILOT_MODELS = [
     badgeClass: 'badge-speed'
   },
   {
-    id: 'claude-sonnet-4.5',
-    name: 'Claude Sonnet 4.5',
+    id: 'claude-sonnet-4.6',
+    name: 'Claude Sonnet 4.6',
     tier: 'balanced',
-    tagline: 'Reliable Review',
-    description: 'Copilot default—strong code understanding with excellent quality-to-cost ratio',
+    tagline: 'Best Balance',
+    description: 'Latest Sonnet—excellent code understanding with fast turnaround',
     badge: 'Recommended',
     badgeClass: 'badge-recommended',
     default: true
+  },
+  {
+    id: 'claude-sonnet-4.5',
+    name: 'Claude Sonnet 4.5',
+    tier: 'balanced',
+    tagline: 'Previous Gen',
+    description: 'Previous generation Sonnet—strong code understanding with excellent quality-to-cost ratio',
+    badge: 'Previous Gen',
+    badgeClass: 'badge-balanced'
   },
   {
     id: 'gemini-3-pro-preview',
@@ -64,6 +74,15 @@ const COPILOT_MODELS = [
     badgeClass: 'badge-balanced'
   },
   {
+    id: 'gpt-5.3-codex',
+    name: 'GPT-5.3 Codex',
+    tier: 'thorough',
+    tagline: 'Deep Code Analysis',
+    description: 'Most capable OpenAI coding model—frontier performance for complex multi-file reviews',
+    badge: 'Thorough',
+    badgeClass: 'badge-power'
+  },
+  {
     id: 'claude-opus-4.5',
     name: 'Claude Opus 4.5',
     tier: 'thorough',
@@ -80,8 +99,19 @@ const COPILOT_MODELS = [
     description: 'Most capable model for critical code reviews—deep reasoning for security and architecture',
     badge: 'Premium',
     badgeClass: 'badge-premium'
+  },
+  {
+    id: 'claude-opus-4.6-fast',
+    name: 'Claude Opus 4.6 Fast',
+    tier: 'thorough',
+    tagline: 'Fast Opus',
+    description: 'Opus-level analysis at reduced latency—preview mode for faster deep reviews',
+    badge: 'Preview',
+    badgeClass: 'badge-premium'
   }
 ];
+
+const DEFAULT_COPILOT_MODEL = 'claude-sonnet-4.6';
 
 class CopilotProvider extends AIProvider {
   /**
@@ -92,7 +122,7 @@ class CopilotProvider extends AIProvider {
    * @param {Object} configOverrides.env - Additional environment variables
    * @param {Object[]} configOverrides.models - Custom model definitions
    */
-  constructor(model = 'claude-sonnet-4.5', configOverrides = {}) {
+  constructor(model = DEFAULT_COPILOT_MODEL, configOverrides = {}) {
     super(model);
 
     // Command precedence: ENV > config > default
@@ -462,7 +492,7 @@ class CopilotProvider extends AIProvider {
   }
 
   static getDefaultModel() {
-    return 'claude-sonnet-4.5';
+    return DEFAULT_COPILOT_MODEL;
   }
 
   static getInstallInstructions() {

--- a/src/ai/cursor-agent-provider.js
+++ b/src/ai/cursor-agent-provider.js
@@ -31,8 +31,8 @@ const BIN_DIR = path.join(__dirname, '..', '..', 'bin');
  * Tier structure:
  * - free (auto): Cursor's default auto-routing model
  * - fast (composer-1, gpt-5.3-codex-fast, gemini-3-flash): Quick analysis
- * - balanced (composer-1.5, sonnet-4.5-thinking, gemini-3-pro): Recommended for most reviews
- * - thorough (gpt-5.3-codex-high, opus-4.5-thinking, opus-4.6-thinking): Deep analysis for complex code
+ * - balanced (composer-1.5, sonnet-4.6-thinking, sonnet-4.5-thinking, gemini-3-pro, gemini-3.1-pro): Recommended for most reviews
+ * - thorough (gpt-5.3-codex-high, gpt-5.3-codex-xhigh, opus-4.5-thinking, opus-4.6-thinking): Deep analysis for complex code
  */
 const CURSOR_AGENT_MODELS = [
   {
@@ -81,14 +81,23 @@ const CURSOR_AGENT_MODELS = [
     badgeClass: 'badge-speed'
   },
   {
-    id: 'sonnet-4.5-thinking',
-    name: 'Claude 4.5 Sonnet (Thinking)',
+    id: 'sonnet-4.6-thinking',
+    name: 'Claude 4.6 Sonnet (Thinking)',
     tier: 'balanced',
     tagline: 'Best Balance',
-    description: 'Extended thinking for thorough analysis with excellent quality-to-cost ratio',
+    description: 'Latest Sonnet with extended thinking—excellent quality-to-cost ratio for thorough reviews',
     badge: 'Recommended',
     badgeClass: 'badge-recommended',
     default: true
+  },
+  {
+    id: 'sonnet-4.5-thinking',
+    name: 'Claude 4.5 Sonnet (Thinking)',
+    tier: 'balanced',
+    tagline: 'Previous Gen',
+    description: 'Previous generation extended thinking—still strong for thorough analysis',
+    badge: 'Previous Gen',
+    badgeClass: 'badge-balanced'
   },
   {
     id: 'gemini-3-pro',
@@ -100,12 +109,30 @@ const CURSOR_AGENT_MODELS = [
     badgeClass: 'badge-balanced'
   },
   {
+    id: 'gemini-3.1-pro',
+    name: 'Gemini 3.1 Pro',
+    tier: 'balanced',
+    tagline: 'Latest Gemini',
+    description: 'Newest Gemini model—cutting-edge reasoning for complex multi-file reviews',
+    badge: 'Latest',
+    badgeClass: 'badge-balanced'
+  },
+  {
     id: 'gpt-5.3-codex-high',
     name: 'GPT-5.3 Codex High',
     tier: 'thorough',
     tagline: 'Deep Code Analysis',
     description: "OpenAI's latest and most capable for complex code review with deep reasoning",
     badge: 'Thorough',
+    badgeClass: 'badge-power'
+  },
+  {
+    id: 'gpt-5.3-codex-xhigh',
+    name: 'GPT-5.3 Codex Extra High',
+    tier: 'thorough',
+    tagline: 'Maximum Reasoning',
+    description: 'Highest reasoning effort for the most complex architectural reviews',
+    badge: 'Maximum',
     badgeClass: 'badge-power'
   },
   {
@@ -128,6 +155,8 @@ const CURSOR_AGENT_MODELS = [
   }
 ];
 
+const DEFAULT_CURSOR_AGENT_MODEL = 'sonnet-4.6-thinking';
+
 class CursorAgentProvider extends AIProvider {
   /**
    * @param {string} model - Model identifier
@@ -137,7 +166,7 @@ class CursorAgentProvider extends AIProvider {
    * @param {Object} configOverrides.env - Additional environment variables
    * @param {Object[]} configOverrides.models - Custom model definitions
    */
-  constructor(model = 'sonnet-4.5-thinking', configOverrides = {}) {
+  constructor(model = DEFAULT_CURSOR_AGENT_MODEL, configOverrides = {}) {
     super(model);
 
     // Command precedence: ENV > config > default
@@ -790,7 +819,7 @@ class CursorAgentProvider extends AIProvider {
   }
 
   static getDefaultModel() {
-    return 'sonnet-4.5-thinking';
+    return DEFAULT_CURSOR_AGENT_MODEL;
   }
 
   static getInstallInstructions() {

--- a/src/ai/gemini-provider.js
+++ b/src/ai/gemini-provider.js
@@ -21,7 +21,8 @@ const BIN_DIR = path.join(__dirname, '..', '..', 'bin');
  */
 const GEMINI_MODELS = [
   {
-    id: 'gemini-3-flash-preview',
+    id: 'gemini-3-flash',
+    aliases: ['gemini-3-flash-preview'],
     name: '3.0 Flash',
     tier: 'fast',
     tagline: 'Rapid Sanity Check',
@@ -40,15 +41,27 @@ const GEMINI_MODELS = [
     default: true
   },
   {
-    id: 'gemini-3-pro-preview',
+    id: 'gemini-3-pro',
+    aliases: ['gemini-3-pro-preview'],
     name: '3.0 Pro',
     tier: 'thorough',
     tagline: 'Architectural Audit',
     description: 'Most intelligent Gemini model—advanced reasoning for deep architectural analysis',
     badge: 'Deep Dive',
     badgeClass: 'badge-power'
+  },
+  {
+    id: 'gemini-3.1-pro',
+    name: '3.1 Pro',
+    tier: 'thorough',
+    tagline: 'Latest & Greatest',
+    description: 'Newest Gemini model—cutting-edge reasoning for complex architectural reviews',
+    badge: 'Latest',
+    badgeClass: 'badge-power'
   }
 ];
+
+const DEFAULT_GEMINI_MODEL = 'gemini-2.5-pro';
 
 class GeminiProvider extends AIProvider {
   /**
@@ -59,7 +72,7 @@ class GeminiProvider extends AIProvider {
    * @param {Object} configOverrides.env - Additional environment variables
    * @param {Object[]} configOverrides.models - Custom model definitions
    */
-  constructor(model = 'gemini-2.5-pro', configOverrides = {}) {
+  constructor(model = DEFAULT_GEMINI_MODEL, configOverrides = {}) {
     super(model);
 
     // Command precedence: ENV > config > default
@@ -690,7 +703,7 @@ class GeminiProvider extends AIProvider {
   }
 
   static getDefaultModel() {
-    return 'gemini-2.5-pro';
+    return DEFAULT_GEMINI_MODEL;
   }
 
   static getInstallInstructions() {

--- a/tests/unit/copilot-provider.test.js
+++ b/tests/unit/copilot-provider.test.js
@@ -48,7 +48,7 @@ describe('CopilotProvider', () => {
     });
 
     it('should return default model', () => {
-      expect(CopilotProvider.getDefaultModel()).toBe('claude-sonnet-4.5');
+      expect(CopilotProvider.getDefaultModel()).toBe('claude-sonnet-4.6');
     });
 
     it('should return array of models', () => {
@@ -74,7 +74,7 @@ describe('CopilotProvider', () => {
       const models = CopilotProvider.getModels();
       const defaultModels = models.filter(m => m.default);
       expect(defaultModels).toHaveLength(1);
-      expect(defaultModels[0].id).toBe('claude-sonnet-4.5');
+      expect(defaultModels[0].id).toBe('claude-sonnet-4.6');
     });
 
     it('should return install instructions with correct GitHub Copilot package', () => {
@@ -103,21 +103,23 @@ describe('CopilotProvider', () => {
       const models = CopilotProvider.getModels();
       const balancedModels = models.filter(m => m.tier === 'balanced');
       expect(balancedModels.length).toBeGreaterThan(0);
-      expect(balancedModels[0].id).toBe('claude-sonnet-4.5');
+      expect(balancedModels[0].id).toBe('claude-sonnet-4.6');
     });
 
     it('should have thorough tier models', () => {
       const models = CopilotProvider.getModels();
       const thoroughModels = models.filter(m => m.tier === 'thorough');
-      expect(thoroughModels.length).toBe(2);
+      expect(thoroughModels.length).toBe(4);
       const thoroughIds = thoroughModels.map(m => m.id);
+      expect(thoroughIds).toContain('gpt-5.3-codex');
       expect(thoroughIds).toContain('claude-opus-4.5');
       expect(thoroughIds).toContain('claude-opus-4.6');
+      expect(thoroughIds).toContain('claude-opus-4.6-fast');
     });
 
-    it('should have exactly 7 models covering tiers', () => {
+    it('should have exactly 9 models covering tiers', () => {
       const models = CopilotProvider.getModels();
-      expect(models).toHaveLength(6);
+      expect(models).toHaveLength(9);
 
       const tiers = models.map(m => m.tier);
       expect(tiers).toContain('fast');
@@ -129,7 +131,7 @@ describe('CopilotProvider', () => {
   describe('constructor', () => {
     it('should create instance with default model', () => {
       const provider = new CopilotProvider();
-      expect(provider.model).toBe('claude-sonnet-4.5');
+      expect(provider.model).toBe('claude-sonnet-4.6');
     });
 
     it('should create instance with custom model', () => {
@@ -266,7 +268,7 @@ describe('CopilotProvider', () => {
       expect(balancedModel.badgeClass).toBe('badge-recommended');
 
       const thoroughModels = models.filter(m => m.tier === 'thorough');
-      expect(thoroughModels.length).toBe(2);
+      expect(thoroughModels.length).toBe(4);
     });
 
     it('should have meaningful taglines for each model', () => {

--- a/tests/unit/cursor-agent-provider.test.js
+++ b/tests/unit/cursor-agent-provider.test.js
@@ -56,14 +56,14 @@ describe('CursorAgentProvider', () => {
       expect(CursorAgentProvider.getProviderId()).toBe('cursor-agent');
     });
 
-    it('should return sonnet-4.5-thinking as default model', () => {
-      expect(CursorAgentProvider.getDefaultModel()).toBe('sonnet-4.5-thinking');
+    it('should return sonnet-4.6-thinking as default model', () => {
+      expect(CursorAgentProvider.getDefaultModel()).toBe('sonnet-4.6-thinking');
     });
 
     it('should return array of models with expected structure', () => {
       const models = CursorAgentProvider.getModels();
       expect(Array.isArray(models)).toBe(true);
-      expect(models.length).toBe(10);
+      expect(models.length).toBe(13);
 
       // Check that we have the expected model IDs
       const modelIds = models.map(m => m.id);
@@ -72,17 +72,20 @@ describe('CursorAgentProvider', () => {
       expect(modelIds).toContain('composer-1');
       expect(modelIds).toContain('gpt-5.3-codex-fast');
       expect(modelIds).toContain('gemini-3-flash');
+      expect(modelIds).toContain('sonnet-4.6-thinking');
       expect(modelIds).toContain('sonnet-4.5-thinking');
       expect(modelIds).toContain('gemini-3-pro');
+      expect(modelIds).toContain('gemini-3.1-pro');
       expect(modelIds).toContain('gpt-5.3-codex-high');
+      expect(modelIds).toContain('gpt-5.3-codex-xhigh');
       expect(modelIds).toContain('opus-4.5-thinking');
       expect(modelIds).toContain('opus-4.6-thinking');
 
       // Check model structure for the default model
-      const defaultModel = models.find(m => m.id === 'sonnet-4.5-thinking');
+      const defaultModel = models.find(m => m.id === 'sonnet-4.6-thinking');
       expect(defaultModel).toMatchObject({
-        id: 'sonnet-4.5-thinking',
-        name: 'Claude 4.5 Sonnet (Thinking)',
+        id: 'sonnet-4.6-thinking',
+        name: 'Claude 4.6 Sonnet (Thinking)',
         tier: 'balanced',
         default: true
       });
@@ -96,9 +99,12 @@ describe('CursorAgentProvider', () => {
       expect(tierMap['composer-1']).toBe('fast');
       expect(tierMap['gpt-5.3-codex-fast']).toBe('fast');
       expect(tierMap['gemini-3-flash']).toBe('fast');
+      expect(tierMap['sonnet-4.6-thinking']).toBe('balanced');
       expect(tierMap['sonnet-4.5-thinking']).toBe('balanced');
       expect(tierMap['gemini-3-pro']).toBe('balanced');
+      expect(tierMap['gemini-3.1-pro']).toBe('balanced');
       expect(tierMap['gpt-5.3-codex-high']).toBe('thorough');
+      expect(tierMap['gpt-5.3-codex-xhigh']).toBe('thorough');
       expect(tierMap['opus-4.5-thinking']).toBe('thorough');
       expect(tierMap['opus-4.6-thinking']).toBe('thorough');
     });
@@ -113,7 +119,7 @@ describe('CursorAgentProvider', () => {
   describe('constructor', () => {
     it('should create instance with default model', () => {
       const provider = new CursorAgentProvider();
-      expect(provider.model).toBe('sonnet-4.5-thinking');
+      expect(provider.model).toBe('sonnet-4.6-thinking');
     });
 
     it('should create instance with specified model', () => {

--- a/tests/unit/gemini-provider.test.js
+++ b/tests/unit/gemini-provider.test.js
@@ -60,13 +60,14 @@ describe('GeminiProvider', () => {
     it('should return array of models with expected structure', () => {
       const models = GeminiProvider.getModels();
       expect(Array.isArray(models)).toBe(true);
-      expect(models.length).toBe(3);
+      expect(models.length).toBe(4);
 
       // Check that we have the expected model IDs
       const modelIds = models.map(m => m.id);
-      expect(modelIds).toContain('gemini-3-flash-preview');
+      expect(modelIds).toContain('gemini-3-flash');
       expect(modelIds).toContain('gemini-2.5-pro');
-      expect(modelIds).toContain('gemini-3-pro-preview');
+      expect(modelIds).toContain('gemini-3-pro');
+      expect(modelIds).toContain('gemini-3.1-pro');
 
       // Check model structure
       const defaultModel = models.find(m => m.id === 'gemini-2.5-pro');
@@ -92,8 +93,8 @@ describe('GeminiProvider', () => {
     });
 
     it('should create instance with specified model', () => {
-      const provider = new GeminiProvider('gemini-3-pro-preview');
-      expect(provider.model).toBe('gemini-3-pro-preview');
+      const provider = new GeminiProvider('gemini-3-pro');
+      expect(provider.model).toBe('gemini-3-pro');
     });
 
     it('should use default gemini command', () => {
@@ -125,9 +126,9 @@ describe('GeminiProvider', () => {
     });
 
     it('should configure base args correctly with stream-json output', () => {
-      const provider = new GeminiProvider('gemini-3-flash-preview');
+      const provider = new GeminiProvider('gemini-3-flash');
       expect(provider.args).toContain('-m');
-      expect(provider.args).toContain('gemini-3-flash-preview');
+      expect(provider.args).toContain('gemini-3-flash');
       expect(provider.args).toContain('-o');
       expect(provider.args).toContain('stream-json');
       expect(provider.args).toContain('--allowed-tools');
@@ -143,9 +144,9 @@ describe('GeminiProvider', () => {
     });
 
     it('should merge model-specific extra_args from config', () => {
-      const provider = new GeminiProvider('gemini-3-pro-preview', {
+      const provider = new GeminiProvider('gemini-3-pro', {
         models: [
-          { id: 'gemini-3-pro-preview', extra_args: ['--special-flag'] }
+          { id: 'gemini-3-pro', extra_args: ['--special-flag'] }
         ]
       });
       expect(provider.args).toContain('--special-flag');
@@ -174,10 +175,10 @@ describe('GeminiProvider', () => {
     });
 
     it('should merge model-specific env over provider env', () => {
-      const provider = new GeminiProvider('gemini-3-pro-preview', {
+      const provider = new GeminiProvider('gemini-3-pro', {
         env: { VAR1: 'provider' },
         models: [
-          { id: 'gemini-3-pro-preview', env: { VAR1: 'model', VAR2: 'extra' } }
+          { id: 'gemini-3-pro', env: { VAR1: 'model', VAR2: 'extra' } }
         ]
       });
       expect(provider.extraEnv.VAR1).toBe('model');
@@ -425,11 +426,11 @@ describe('GeminiProvider', () => {
   describe('getExtractionConfig', () => {
     it('should return correct config for default command', () => {
       const provider = new GeminiProvider();
-      const config = provider.getExtractionConfig('gemini-3-flash-preview');
+      const config = provider.getExtractionConfig('gemini-3-flash');
 
       expect(config.command).toBe('gemini');
       expect(config.args).toContain('-m');
-      expect(config.args).toContain('gemini-3-flash-preview');
+      expect(config.args).toContain('gemini-3-flash');
       expect(config.args).toContain('-o');
       expect(config.args).toContain('text');
       expect(config.useShell).toBe(false);
@@ -439,7 +440,7 @@ describe('GeminiProvider', () => {
     it('should use shell mode for multi-word command', () => {
       process.env.PAIR_REVIEW_GEMINI_CMD = 'docker run gemini';
       const provider = new GeminiProvider();
-      const config = provider.getExtractionConfig('gemini-3-flash-preview');
+      const config = provider.getExtractionConfig('gemini-3-flash');
 
       expect(config.useShell).toBe(true);
       expect(config.command).toContain('docker run gemini');

--- a/tests/unit/llm-extraction.test.js
+++ b/tests/unit/llm-extraction.test.js
@@ -38,9 +38,9 @@ describe('LLM-based JSON extraction fallback', () => {
       expect(provider.getFastTierModel()).toBe('haiku');
     });
 
-    it('should return fast-tier model for Gemini (gemini-3-flash-preview)', () => {
+    it('should return fast-tier model for Gemini (gemini-3-flash)', () => {
       const provider = new GeminiProvider('gemini-2.5-pro');
-      expect(provider.getFastTierModel()).toBe('gemini-3-flash-preview');
+      expect(provider.getFastTierModel()).toBe('gemini-3-flash');
     });
 
     it('should return fast-tier model for Codex (gpt-5.1-codex-mini)', () => {
@@ -103,7 +103,7 @@ describe('LLM-based JSON extraction fallback', () => {
     describe('GeminiProvider', () => {
       it('should return valid config', () => {
         const provider = new GeminiProvider();
-        const config = provider.getExtractionConfig('gemini-3-flash-preview');
+        const config = provider.getExtractionConfig('gemini-3-flash');
 
         expect(config).toHaveProperty('command');
         expect(config).toHaveProperty('args');
@@ -112,7 +112,7 @@ describe('LLM-based JSON extraction fallback', () => {
 
       it('should use text output format for extraction', () => {
         const provider = new GeminiProvider();
-        const config = provider.getExtractionConfig('gemini-3-flash-preview');
+        const config = provider.getExtractionConfig('gemini-3-flash');
 
         // For extraction, we use -o text to get raw JSON without wrapper
         expect(config.args).toContain('text');
@@ -120,9 +120,9 @@ describe('LLM-based JSON extraction fallback', () => {
 
       it('should include model in args', () => {
         const provider = new GeminiProvider();
-        const config = provider.getExtractionConfig('gemini-3-flash-preview');
+        const config = provider.getExtractionConfig('gemini-3-flash');
 
-        expect(config.args).toContain('gemini-3-flash-preview');
+        expect(config.args).toContain('gemini-3-flash');
       });
     });
 
@@ -190,7 +190,7 @@ describe('LLM-based JSON extraction fallback', () => {
     it('all providers should have fast-tier models defined', () => {
       const providers = [
         { Class: ClaudeProvider, expectedFast: 'haiku' },
-        { Class: GeminiProvider, expectedFast: 'gemini-3-flash-preview' },
+        { Class: GeminiProvider, expectedFast: 'gemini-3-flash' },
         { Class: CodexProvider, expectedFast: 'gpt-5.1-codex-mini' },
         { Class: CopilotProvider, expectedFast: 'claude-haiku-4.5' },
       ];


### PR DESCRIPTION
## Summary
- **Gemini**: Drop `-preview` suffix from `gemini-3-flash` and `gemini-3-pro` (aliases added for backward compat), add new `gemini-3.1-pro` (released Feb 19)
- **Copilot**: Add `claude-sonnet-4.6` (new default), `gpt-5.3-codex`, `claude-opus-4.6-fast`; demote `claude-sonnet-4.5` to Previous Gen
- **Cursor Agent**: Add `sonnet-4.6-thinking` (new default), `gemini-3.1-pro`, `gpt-5.3-codex-xhigh`; demote `sonnet-4.5-thinking` to Previous Gen
- Extract default model constants to reduce duplication between constructor defaults and `getDefaultModel()`
- Claude and Codex providers were already up to date

## Test plan
- [x] All 4,137 unit tests passing
- [ ] Verify model selection UI shows updated models for each provider
- [ ] Verify Gemini aliases resolve correctly for users with old `*-preview` IDs in config

🤖 Generated with [Claude Code](https://claude.com/claude-code)