### PR TITLE
Add Analysis Configuration section documenting review councils

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,18 +408,25 @@ This progressive approach keeps analysis focused while catching issues at every 
 
 ### Analysis Configuration
 
-There are three ways to configure which models run your analysis:
+There are three ways to configure which models run your analysis, each building on the last:
 
 **Single Model** — Pick one provider and model. All enabled analysis levels run with that model, and consolidation uses the same model. The simplest option.
 
-**Review Council** — Pick multiple provider+model combinations that all run in parallel across the selected analysis levels. Each reviewer can have its own timeout, instructions, and prompt tier (see [Model Tiers](#model-tiers)). You pick a separate consolidation model that merges everything together. Results consolidate first across levels for each reviewer, then across reviewers — so individual reviewer results are available alongside the overall council result.
+**Review Council** — Pick multiple provider+model combinations that all run in parallel across the selected analysis levels. You pick a separate consolidation model that merges everything together.
+
+- Each reviewer can have its own timeout, instructions, and prompt tier (see [Model Tiers](#model-tiers))
+- Results consolidate first across levels for each reviewer, then across reviewers
+- Individual reviewer results are available alongside the overall council result
 
 **Advanced** — For each enabled analysis level, pick different provider+model combinations. Level 1 might use a fast model while Level 3 uses a thorough one. Supports the same per-model options as Review Council (timeout, instructions, tier). Consolidation model is selected separately. Results consolidate first within each level (if multiple reviewers), then across levels.
+
+The key difference from Review Council is consolidation order: Advanced consolidates within each level first, then across levels, so there are no per-reviewer rollups.
 
 **Example use cases:**
 
 - **Large changesets with Opus 4.6**: Use review council instructions to tell the model to use a Team — it will spawn sub-agents to divide the work
 - **Multi-model parallel review**: Give each model a specific focus area (security, performance, correctness) via per-model instructions and get combined results
+- **Cross-model perspectives**: Run the same analysis across different providers (e.g., Claude, Gemini, GPT) — where models agree signals high-confidence findings, but unique outliers from a single model can be equally valuable, catching issue types that only that model excels at spotting
 
 ### Chat
 


### PR DESCRIPTION
## Summary

- Adds new "Analysis Configuration" subsection under Features documenting the three analysis modes: Single Model, Review Council, and Advanced
- Covers per-model options (timeout, instructions, prompt tier), consolidation strategy differences, and example use cases
- Adds TOC entry for the new section

## Test plan

- [ ] Verify TOC anchor link resolves correctly
- [ ] Confirm Model Tiers cross-reference link works
- [ ] Review content accuracy against actual UI behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)