### PR TITLE
Fix context card dismiss button inaccessible at narrow widths

### DIFF
--- a/.changeset/fix-context-card-dismiss.md
+++ b/.changeset/fix-context-card-dismiss.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Fix context card dismiss button being inaccessible at narrow chat panel widths

--- a/public/css/pr.css
+++ b/public/css/pr.css
@@ -11362,6 +11362,7 @@ body.resizing * {
 
 /* Chat Panel Context Card */
 .chat-panel__context-card {
+  position: relative;
   display: flex;
   align-items: center;
   gap: 6px;
@@ -11391,6 +11392,7 @@ body.resizing * {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  min-width: 0;
   color: var(--color-text-secondary);
 }
 
@@ -11405,9 +11407,12 @@ body.resizing * {
   display: none;
   align-items: center;
   justify-content: center;
+  position: absolute;
+  right: 6px;
+  top: 50%;
+  transform: translateY(-50%);
   width: 16px;
   height: 16px;
-  margin-left: auto;
   padding: 0;
   border: none;
   border-radius: 50%;
@@ -11416,7 +11421,6 @@ body.resizing * {
   font-size: 12px;
   line-height: 1;
   cursor: pointer;
-  flex-shrink: 0;
   transition: background 0.15s ease, color 0.15s ease;
 }
 


### PR DESCRIPTION
Add min-width: 0 to context title element so it properly shrinks in flex layout, preventing the dismiss button from being clipped by the parent's overflow: hidden.