### PR TITLE
Make file reference links clickable during streaming

### DIFF
--- a/.changeset/streaming-file-links.md
+++ b/.changeset/streaming-file-links.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Make file reference links clickable during chat response streaming instead of only after completion

--- a/public/js/components/ChatPanel.js
+++ b/public/js/components/ChatPanel.js
@@ -2135,6 +2135,7 @@ class ChatPanel {
     const bubble = streamingMsg.querySelector('.chat-panel__bubble');
     if (bubble) {
       bubble.innerHTML = this.renderMarkdown(text) + '<span class="chat-panel__cursor"></span>';
+      this._linkifyFileReferences(bubble);
     }
     this.scrollToBottom();
   }


### PR DESCRIPTION
## Summary
- File reference links (`[[file:...]]`) in the chat panel now become clickable as they appear during streaming, rather than only after the full response completes
- Adds `_linkifyFileReferences()` call to `updateStreamingMessage()` to match the existing behavior in `finalizeStreamingMessage()` and `addMessage()`

## Test plan
- [x] Unit tests pass (400/400)
- [ ] Open a chat session, ask the agent a question that produces file references
- [ ] Verify file links are clickable while the response is still streaming
- [ ] Verify links still work correctly after streaming completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)