### PR TITLE
fix: scope context file updateRange to review_id (IDOR)

### DIFF
--- a/.changeset/scope-update-range-review-id.md
+++ b/.changeset/scope-update-range-review-id.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Scope context file updateRange to review_id to prevent cross-review modifications

--- a/src/database.js
+++ b/src/database.js
@@ -3394,14 +3394,15 @@ class ContextFileRepository {
   /**
    * Update the line range of an existing context file record
    * @param {number} id - Context file record ID
+   * @param {number} reviewId - Review ID (ensures update is scoped to the correct review)
    * @param {number} lineStart - New start line number
    * @param {number} lineEnd - New end line number
    * @returns {Promise<boolean>} True if record was updated
    */
-  async updateRange(id, lineStart, lineEnd) {
+  async updateRange(id, reviewId, lineStart, lineEnd) {
     const result = await run(this.db, `
-      UPDATE context_files SET line_start = ?, line_end = ? WHERE id = ?
-    `, [lineStart, lineEnd, id]);
+      UPDATE context_files SET line_start = ?, line_end = ? WHERE id = ? AND review_id = ?
+    `, [lineStart, lineEnd, id, reviewId]);
 
     return result.changes > 0;
   }

--- a/src/routes/context-files.js
+++ b/src/routes/context-files.js
@@ -209,7 +209,7 @@ router.patch('/api/reviews/:reviewId/context-files/:id', validateReviewId, async
     const db = req.app.get('db');
     const contextFileRepo = new ContextFileRepository(db);
 
-    const updated = await contextFileRepo.updateRange(id, lineStart, lineEnd);
+    const updated = await contextFileRepo.updateRange(id, req.reviewId, lineStart, lineEnd);
 
     if (!updated) {
       return res.status(404).json({ error: 'Context file not found' });

--- a/src/utils/auto-context.js
+++ b/src/utils/auto-context.js
@@ -67,7 +67,7 @@ async function ensureContextFileForComment(db, review, { file, line_start, line_
           newEnd = newStart + MAX_RANGE - 1;
         }
 
-        await contextFileRepo.updateRange(overlapping.id, newStart, newEnd);
+        await contextFileRepo.updateRange(overlapping.id, review.id, newStart, newEnd);
         return { created: false, expanded: true, contextFileId: overlapping.id };
       }
 

--- a/tests/unit/auto-context.test.js
+++ b/tests/unit/auto-context.test.js
@@ -170,7 +170,7 @@ describe('ensureContextFileForComment', () => {
     // Desired range: [40, 65]. Existing: [50, 60].
     // Union: [min(50,40), max(60,65)] = [40, 65]
     expect(result).toEqual({ created: false, expanded: true, contextFileId: 77 });
-    expect(mockUpdateRange).toHaveBeenCalledWith(77, 40, 65);
+    expect(mockUpdateRange).toHaveBeenCalledWith(77, 42, 40, 65);
     expect(mockAdd).not.toHaveBeenCalled();
   });
 
@@ -273,7 +273,7 @@ describe('ensureContextFileForComment', () => {
     // Desired range: [105, 135]. Entry [90, 120] overlaps, so expand it.
     // Union: [min(90,105), max(120,135)] = [90, 135]
     expect(result).toEqual({ created: false, expanded: true, contextFileId: 11 });
-    expect(mockUpdateRange).toHaveBeenCalledWith(11, 90, 135);
+    expect(mockUpdateRange).toHaveBeenCalledWith(11, 42, 90, 135);
     expect(mockAdd).not.toHaveBeenCalled();
   });
 
@@ -315,7 +315,7 @@ describe('ensureContextFileForComment', () => {
     // Union: [min(1,380), max(400,510)] = [1, 510] => 510 lines, exceeds 500
     // Clamped: [1, 1+499] = [1, 500]
     expect(result).toEqual({ created: false, expanded: true, contextFileId: 88 });
-    expect(mockUpdateRange).toHaveBeenCalledWith(88, 1, 500);
+    expect(mockUpdateRange).toHaveBeenCalledWith(88, 42, 1, 500);
     expect(mockAdd).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/context-file-repository.test.js
+++ b/tests/unit/context-file-repository.test.js
@@ -115,7 +115,7 @@ describe('ContextFileRepository', () => {
     it('should successfully update line_start and line_end', async () => {
       const record = await contextFileRepo.add(reviewId, 'src/utils.js', 10, 25, 'helper function');
 
-      await contextFileRepo.updateRange(record.id, 5, 50);
+      await contextFileRepo.updateRange(record.id, reviewId, 5, 50);
 
       // Verify the update persisted
       const results = await contextFileRepo.getByReviewId(reviewId);
@@ -127,13 +127,13 @@ describe('ContextFileRepository', () => {
     it('should return true on success', async () => {
       const record = await contextFileRepo.add(reviewId, 'src/utils.js', 10, 25);
 
-      const updated = await contextFileRepo.updateRange(record.id, 1, 100);
+      const updated = await contextFileRepo.updateRange(record.id, reviewId, 1, 100);
 
       expect(updated).toBe(true);
     });
 
     it('should return false when id does not exist', async () => {
-      const updated = await contextFileRepo.updateRange(99999, 1, 100);
+      const updated = await contextFileRepo.updateRange(99999, reviewId, 1, 100);
 
       expect(updated).toBe(false);
     });


### PR DESCRIPTION
The updateRange method only filtered by context file ID, allowing cross-review modifications. Add review_id to the WHERE clause and pass it from all call sites.