### PR TITLE
fix: use process.execPath for child process spawning

### DIFF
--- a/.changeset/use-process-execpath.md
+++ b/.changeset/use-process-execpath.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Use `process.execPath` instead of `'node'` when spawning the child process, fixing native module ABI mismatch errors when installed via Nix or other package managers that bundle a specific Node.js version

--- a/bin/pair-review.js
+++ b/bin/pair-review.js
@@ -26,7 +26,7 @@ async function main() {
       : 'inherit';
 
     // Spawn the main process with arguments
-    const app = spawn('node', [mainPath, ...args], {
+    const app = spawn(process.execPath, [mainPath, ...args], {
       stdio: stdioOption
     });
 


### PR DESCRIPTION
Use `process.execPath` instead of `'node'` when spawning the child process in `bin/pair-review.js`, fixing native module ABI mismatch errors when installed via Nix or other package managers that bundle a specific Node.js version

Closes #237