### PR TITLE
fix: include .pi/ directory in npm package

### DIFF
--- a/.changeset/ship-pi-directory.md
+++ b/.changeset/ship-pi-directory.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Include .pi/ directory in npm package so Pi provider skills and extensions are available after install

--- a/.pi/skills/pair-review-api/SKILL.md
+++ b/.pi/skills/pair-review-api/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: pair-review-api
+description: Reference for the pair-review HTTP API. Load this skill to create, update, and delete review comments, adopt or dismiss AI suggestions, manage context files, expand diff hunks, and trigger or monitor analyses via curl.
+---
+
 # Pair-Review API Skill
 
 You have **read-only access to the filesystem**. To modify the review (create comments, adopt suggestions, trigger analysis) or interact with the pair-review app, you MUST use the pair-review API via `curl`.

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "git-diff-lines": "bin/git-diff-lines"
   },
   "files": [
+    ".pi/",
     "bin/",
     "src/",
     "public/",


### PR DESCRIPTION
## Summary
- Add `.pi/` to the `files` whitelist in `package.json` so Pi provider skills and extensions are actually included in the published npm package
- Add missing YAML frontmatter (`name`, `description`) to `.pi/skills/pair-review-api/SKILL.md` so Pi recognizes it as a valid skill file

## Context
The `files` field in `package.json` acts as a whitelist — only listed entries ship. `.pi/` was missing, so anyone installing via npm and using the Pi provider would get `ENOENT` errors when the code tried to load skills from `.pi/extensions/task`, `.pi/skills/review-model-guidance/SKILL.md`, `.pi/skills/review-roulette/SKILL.md`, or `.pi/skills/pair-review-api/SKILL.md`.

## Test plan
- [ ] Verify `npm pack --dry-run` includes `.pi/` contents
- [ ] Verify Pi chat sessions load the pair-review-api skill without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)