### PR TITLE
fix: improve chat agent guardrails for suggestions and file display

### DIFF
--- a/.changeset/chat-prompt-guardrails.md
+++ b/.changeset/chat-prompt-guardrails.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Improve chat agent behavior: prevent overeager adoption/dismissal of suggestions (only act when user explicitly asks) and guide the agent to add context files when users ask to see code

--- a/public/js/components/ChatPanel.js
+++ b/public/js/components/ChatPanel.js
@@ -2827,7 +2827,7 @@ class ChatPanel {
   _handleDismissCommentClick() {
     if (this.isStreaming || !this._contextItemId) return;
     this._pendingActionContext = { type: 'dismiss-comment', itemId: this._contextItemId };
-    this.inputEl.value = 'Please delete this comment.';
+    this.inputEl.value = 'Please dismiss this comment.';
     this.sendMessage();
   }
 

--- a/src/chat/prompt-builder.js
+++ b/src/chat/prompt-builder.js
@@ -44,6 +44,7 @@ function buildChatPrompt({ review, prData, skillPath, chatInstructions }) {
     '- **Comments** are human-curated review findings (created by the reviewer).',
     '- **Suggestions** are AI-generated findings from analysis runs.',
     '- **Workflow**: AI generates suggestions → reviewer triages (adopt, edit, or dismiss) → adopted suggestions become comments.',
+    '- **IMPORTANT**: Do NOT adopt, dismiss, or modify suggestions or comments unless the user explicitly asks you to. Your role is to discuss and explain — the reviewer decides what action to take.',
     '- **Analysis runs** are the process that produces suggestions. Each run has a provider, model, tier, and status.',
     '- **Review ID** is a stable integer identifying this review session, used in all API calls.'
   ];
@@ -69,7 +70,11 @@ function buildChatPrompt({ review, prData, skillPath, chatInstructions }) {
     'These become clickable links in the UI. Do NOT use backtick code spans for file references you want to be clickable.\n\n' +
     'Files in the diff can be referenced freely. Files outside the diff can also be referenced; ' +
     'to make them visible in the diff panel, add them as context files via the API (see skill). ' +
-    'Add context files judiciously — only when directly relevant, with focused line ranges.'
+    'Add context files judiciously — only when directly relevant, with focused line ranges.\n\n' +
+    'When the user asks to see code (e.g. "Show me…", "Where is…", "What does X look like?"), ' +
+    'add the relevant file as a context file with a focused line range so it appears in the diff panel. ' +
+    'When explaining code, prefer referencing specific line ranges (e.g. [[file:path.js:10-25]]) ' +
+    'over quoting large blocks in your response. Short inline snippets (a few lines) are fine when they clarify the explanation.'
   );
 
   // Tool usage discipline — avoid unnecessary Task delegation

--- a/tests/unit/chat-panel.test.js
+++ b/tests/unit/chat-panel.test.js
@@ -544,7 +544,7 @@ describe('ChatPanel', () => {
 
       chatPanel._handleDismissCommentClick();
 
-      expect(chatPanel.inputEl.value).toContain('delete');
+      expect(chatPanel.inputEl.value).toContain('dismiss');
       expect(chatPanel.inputEl.value).not.toContain('77');
       expect(chatPanel._pendingActionContext).toEqual({ type: 'dismiss-comment', itemId: 77 });
       expect(sendSpy).toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- Prevent the chat agent from eagerly adopting/dismissing suggestions or comments without explicit user instruction
- Guide the agent to add context files when users ask to see code ("Show me…", "Where is…", etc.)
- Allow short inline snippets alongside file-range references for clearer explanations
- Change dismiss-comment action text from "delete" to "dismiss" for consistency

## Test plan
- [x] Unit tests pass (337/337 in chat-panel.test.js)
- [x] Full test suite passes (4250/4250)

🤖 Generated with [Claude Code](https://claude.com/claude-code)