### PR TITLE
fix: add GitHub suggestion block syntax to AI review prompts

### DIFF
--- a/.changeset/github-suggestion-syntax.md
+++ b/.changeset/github-suggestion-syntax.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Instruct AI reviewers to use GitHub suggestion block syntax for literal code/content changes, making suggestions directly adoptable in GitHub PRs

--- a/plugin-code-critic/skills/analyze/references/level1-balanced.md
+++ b/plugin-code-critic/skills/analyze/references/level1-balanced.md
@@ -92,6 +92,15 @@ Do NOT modify files or run write commands. Analyze and report only.
   "summary": "Brief summary of findings"
 }
 
+### GitHub Suggestion Syntax
+When suggesting a specific change, **embed** a GitHub suggestion block within the "suggestion" field:
+
+```suggestion
+replacement content here
+```
+
+The content inside the block is the complete replacement for the commented line(s). Do not include explanation inside the block — any explanation should appear as plain text outside it. For non-specific suggestions, use plain text only.
+
 ## Line Number Reference (old_or_new field)
 The "old_or_new" field indicates which line number column to use:
 - **"NEW"** (default): Use the NEW column number for:

--- a/plugin-code-critic/skills/analyze/references/level1-fast.md
+++ b/plugin-code-critic/skills/analyze/references/level1-fast.md
@@ -78,6 +78,15 @@ Annotated diff tool, `cat -n`, ls, find, grep. Do NOT modify files.
   "summary": "Brief summary"
 }
 
+### GitHub Suggestion Syntax
+When suggesting a specific change, **embed** a GitHub suggestion block within the "suggestion" field:
+
+```suggestion
+replacement content here
+```
+
+The content inside the block is the complete replacement for the commented line(s). Do not include explanation inside the block — any explanation should appear as plain text outside it. For non-specific suggestions, use plain text only.
+
 ## Line Numbers (old_or_new)
 - "NEW" (default): added [+] and context lines
 - "OLD": deleted [-] lines only

--- a/plugin-code-critic/skills/analyze/references/level1-thorough.md
+++ b/plugin-code-critic/skills/analyze/references/level1-thorough.md
@@ -138,6 +138,15 @@ Output JSON with this structure:
   "summary": "Brief summary of findings"
 }
 
+### GitHub Suggestion Syntax
+When suggesting a specific change, **embed** a GitHub suggestion block within the "suggestion" field:
+
+```suggestion
+replacement content here
+```
+
+The content inside the block is the complete replacement for the commented line(s). Do not include explanation inside the block — any explanation should appear as plain text outside it. For non-specific suggestions, use plain text only.
+
 ## Line Number Reference (old_or_new field)
 The "old_or_new" field indicates which line number column to use:
 - **"NEW"** (default): Use the NEW column number. This is correct for:

--- a/plugin-code-critic/skills/analyze/references/level2-balanced.md
+++ b/plugin-code-critic/skills/analyze/references/level2-balanced.md
@@ -103,6 +103,15 @@ Note: You may use parallel read-only Tasks to examine multiple files simultaneou
   "summary": "Brief summary of file context findings"
 }
 
+### GitHub Suggestion Syntax
+When suggesting a specific change, **embed** a GitHub suggestion block within the "suggestion" field:
+
+```suggestion
+replacement content here
+```
+
+The content inside the block is the complete replacement for the commented line(s). Do not include explanation inside the block — any explanation should appear as plain text outside it. For non-specific suggestions, use plain text only.
+
 ## Line Number Reference (old_or_new field)
 - **"NEW"** (default): For ADDED [+] lines and CONTEXT lines
 - **"OLD"**: ONLY for DELETED [-] lines

--- a/plugin-code-critic/skills/analyze/references/level2-fast.md
+++ b/plugin-code-critic/skills/analyze/references/level2-fast.md
@@ -87,6 +87,15 @@ Annotated diff tool (preferred), `cat -n <file>`, ls, find, grep. Do NOT modify 
   "summary": "Brief summary"
 }
 
+### GitHub Suggestion Syntax
+When suggesting a specific change, **embed** a GitHub suggestion block within the "suggestion" field:
+
+```suggestion
+replacement content here
+```
+
+The content inside the block is the complete replacement for the commented line(s). Do not include explanation inside the block — any explanation should appear as plain text outside it. For non-specific suggestions, use plain text only.
+
 ## Line Numbers
 "NEW" (default): added [+] and context lines. "OLD": only deleted [-] lines.
 

--- a/plugin-code-critic/skills/analyze/references/level2-thorough.md
+++ b/plugin-code-critic/skills/analyze/references/level2-thorough.md
@@ -177,6 +177,15 @@ Output JSON with this structure:
   "summary": "Brief summary of file context findings"
 }
 
+### GitHub Suggestion Syntax
+When suggesting a specific change, **embed** a GitHub suggestion block within the "suggestion" field:
+
+```suggestion
+replacement content here
+```
+
+The content inside the block is the complete replacement for the commented line(s). Do not include explanation inside the block — any explanation should appear as plain text outside it. For non-specific suggestions, use plain text only.
+
 ## old_or_new Field Reference
 Use "NEW" (the default) for added lines [+] and context lines. Use "OLD" only for deleted lines [-]. When uncertain, use "NEW".
 

--- a/plugin-code-critic/skills/analyze/references/level3-balanced.md
+++ b/plugin-code-critic/skills/analyze/references/level3-balanced.md
@@ -140,6 +140,15 @@ Output JSON with this structure:
   "summary": "Brief summary of how these changes connect to and impact the codebase"
 }
 
+### GitHub Suggestion Syntax
+When suggesting a specific change, **embed** a GitHub suggestion block within the "suggestion" field:
+
+```suggestion
+replacement content here
+```
+
+The content inside the block is the complete replacement for the commented line(s). Do not include explanation inside the block — any explanation should appear as plain text outside it. For non-specific suggestions, use plain text only.
+
 ## Line Number Reference (old_or_new field)
 The "old_or_new" field indicates which line number column to use:
 - **"NEW"** (default): Use the NEW column number. This is correct for:

--- a/plugin-code-critic/skills/analyze/references/level3-fast.md
+++ b/plugin-code-critic/skills/analyze/references/level3-fast.md
@@ -110,6 +110,15 @@ Output JSON with this structure:
   "summary": "Brief summary of how these changes connect to and impact the codebase"
 }
 
+### GitHub Suggestion Syntax
+When suggesting a specific change, **embed** a GitHub suggestion block within the "suggestion" field:
+
+```suggestion
+replacement content here
+```
+
+The content inside the block is the complete replacement for the commented line(s). Do not include explanation inside the block — any explanation should appear as plain text outside it. For non-specific suggestions, use plain text only.
+
 ## Line Numbers (old_or_new)
 - **"NEW"** (default): For added lines [+] and context lines
 - **"OLD"**: Only for deleted lines [-]

--- a/plugin-code-critic/skills/analyze/references/level3-thorough.md
+++ b/plugin-code-critic/skills/analyze/references/level3-thorough.md
@@ -251,6 +251,15 @@ Output JSON with this structure:
   "summary": "Brief summary of how these changes connect to and impact the codebase"
 }
 
+### GitHub Suggestion Syntax
+When suggesting a specific change, **embed** a GitHub suggestion block within the "suggestion" field:
+
+```suggestion
+replacement content here
+```
+
+The content inside the block is the complete replacement for the commented line(s). Do not include explanation inside the block — any explanation should appear as plain text outside it. For non-specific suggestions, use plain text only.
+
 ## Line Number Reference (old_or_new field)
 The "old_or_new" field indicates which line number column to use:
 - **"NEW"** (default): Use the NEW column number. This is correct for:

--- a/plugin-code-critic/skills/analyze/references/orchestration-balanced.md
+++ b/plugin-code-critic/skills/analyze/references/orchestration-balanced.md
@@ -120,6 +120,15 @@ Output JSON with this structure:
   "summary": "Brief summary of the key findings and their significance to the reviewer. Focus on WHAT was found, not HOW it was found. Do NOT mention 'orchestration', 'levels', 'merged from Level 1/2/3' etc. Write as if a single reviewer produced this analysis."
 }
 
+### GitHub Suggestion Syntax
+When suggesting a specific change, **embed** a GitHub suggestion block within the "suggestion" field:
+
+```suggestion
+replacement content here
+```
+
+The content inside the block is the complete replacement for the commented line(s). Do not include explanation inside the block — any explanation should appear as plain text outside it. For non-specific suggestions, use plain text only.
+
 ## Line Number Reference (old_or_new field)
 The "old_or_new" field indicates which line number column to use:
 - **"NEW"** (default): Correct for ADDED lines and CONTEXT lines (unchanged lines in both versions)

--- a/plugin-code-critic/skills/analyze/references/orchestration-fast.md
+++ b/plugin-code-critic/skills/analyze/references/orchestration-fast.md
@@ -97,6 +97,15 @@ Use "Consider...", "Worth noting..." - guidance not mandates.
   "summary": "Key findings as if from single reviewer (no mention of levels/orchestration)"
 }
 
+### GitHub Suggestion Syntax
+When suggesting a specific change, **embed** a GitHub suggestion block within the "suggestion" field:
+
+```suggestion
+replacement content here
+```
+
+The content inside the block is the complete replacement for the commented line(s). Do not include explanation inside the block — any explanation should appear as plain text outside it. For non-specific suggestions, use plain text only.
+
 ## old_or_new
 "NEW" (default): added [+] and context lines. "OLD": deleted [-] only. Preserve from input.
 

--- a/plugin-code-critic/skills/analyze/references/orchestration-thorough.md
+++ b/plugin-code-critic/skills/analyze/references/orchestration-thorough.md
@@ -250,6 +250,15 @@ Output JSON with this structure:
   "summary": "Brief summary of the key findings and their significance to the reviewer. Focus on WHAT was found, not HOW it was found. Do NOT mention 'orchestration', 'levels', 'merged from Level 1/2/3' etc. Write as if a single reviewer produced this analysis."
 }
 
+### GitHub Suggestion Syntax
+When suggesting a specific change, **embed** a GitHub suggestion block within the "suggestion" field:
+
+```suggestion
+replacement content here
+```
+
+The content inside the block is the complete replacement for the commented line(s). Do not include explanation inside the block — any explanation should appear as plain text outside it. For non-specific suggestions, use plain text only.
+
 ## Line Number Reference (old_or_new field)
 The "old_or_new" field indicates which line number column to use:
 - **"NEW"** (default): Use the NEW column number. This is correct for:

--- a/src/ai/analyzer.js
+++ b/src/ai/analyzer.js
@@ -3505,8 +3505,12 @@ File-level suggestions should NOT have a line number. They apply to the entire f
         continue;
       }
 
+      const suggestionText = suggestion.suggestion;
+      const hasSuggestionBlock = suggestionText?.trimStart().startsWith('```suggestion');
       const body = suggestion.description +
-        (suggestion.suggestion ? '\n\n**Suggestion:** ' + suggestion.suggestion : '');
+        (suggestionText
+          ? (hasSuggestionBlock ? '\n\n' + suggestionText : '\n\n**Suggestion:** ' + suggestionText)
+          : '');
 
       const isFileLevel = suggestion.is_file_level === true || suggestion.line_start === null ? 1 : 0;
       const side = suggestion.old_or_new === 'OLD' ? 'LEFT' : 'RIGHT';

--- a/src/ai/prompts/baseline/consolidation/balanced.js
+++ b/src/ai/prompts/baseline/consolidation/balanced.js
@@ -118,6 +118,15 @@ Output JSON with this structure:
   }],
   "summary": "Brief consolidation summary. Write as if a single reviewer produced this analysis — do NOT mention 'consolidation', 'merging', or 'multiple reviewers'."
 }
+
+### GitHub Suggestion Syntax
+When suggesting a specific change, **embed** a GitHub suggestion block within the "suggestion" field:
+
+\`\`\`suggestion
+replacement content here
+\`\`\`
+
+The content inside the block is the complete replacement for the commented line(s). Do not include explanation inside the block — any explanation should appear as plain text outside it. For non-specific suggestions, use plain text only.
 </section>
 
 <section name="diff-instructions" required="true">

--- a/src/ai/prompts/baseline/consolidation/fast.js
+++ b/src/ai/prompts/baseline/consolidation/fast.js
@@ -89,6 +89,15 @@ Merge suggestions from multiple AI reviewers. Deduplicate. Resolve conflicts. Ke
   }],
   "summary": "Key findings as if from single reviewer (no mention of consolidation/merging)"
 }
+
+### GitHub Suggestion Syntax
+When suggesting a specific change, **embed** a GitHub suggestion block within the "suggestion" field:
+
+\`\`\`suggestion
+replacement content here
+\`\`\`
+
+The content inside the block is the complete replacement for the commented line(s). Do not include explanation inside the block — any explanation should appear as plain text outside it. For non-specific suggestions, use plain text only.
 </section>
 
 <section name="diff-instructions" required="true" tier="fast">

--- a/src/ai/prompts/baseline/consolidation/thorough.js
+++ b/src/ai/prompts/baseline/consolidation/thorough.js
@@ -173,6 +173,15 @@ Output JSON with this structure:
   }],
   "summary": "Brief summary of the key findings and their significance. Write as if a single reviewer produced this analysis — do NOT mention 'consolidation', 'merging', or 'multiple reviewers'."
 }
+
+### GitHub Suggestion Syntax
+When suggesting a specific change, **embed** a GitHub suggestion block within the "suggestion" field:
+
+\`\`\`suggestion
+replacement content here
+\`\`\`
+
+The content inside the block is the complete replacement for the commented line(s). Do not include explanation inside the block — any explanation should appear as plain text outside it. For non-specific suggestions, use plain text only.
 </section>
 
 <section name="diff-instructions" required="true" tier="thorough">

--- a/src/ai/prompts/baseline/level1/balanced.js
+++ b/src/ai/prompts/baseline/level1/balanced.js
@@ -119,6 +119,15 @@ Do NOT modify files or run write commands. Analyze and report only.
   }],
   "summary": "Brief summary of findings"
 }
+
+### GitHub Suggestion Syntax
+When suggesting a specific change, **embed** a GitHub suggestion block within the "suggestion" field:
+
+\`\`\`suggestion
+replacement content here
+\`\`\`
+
+The content inside the block is the complete replacement for the commented line(s). Do not include explanation inside the block — any explanation should appear as plain text outside it. For non-specific suggestions, use plain text only.
 </section>
 
 <section name="diff-instructions" required="true">

--- a/src/ai/prompts/baseline/level1/fast.js
+++ b/src/ai/prompts/baseline/level1/fast.js
@@ -98,6 +98,15 @@ Annotated diff tool, \`cat -n\`, ls, find, grep. Do NOT modify files.
   }],
   "summary": "Brief summary"
 }
+
+### GitHub Suggestion Syntax
+When suggesting a specific change, **embed** a GitHub suggestion block within the "suggestion" field:
+
+\`\`\`suggestion
+replacement content here
+\`\`\`
+
+The content inside the block is the complete replacement for the commented line(s). Do not include explanation inside the block — any explanation should appear as plain text outside it. For non-specific suggestions, use plain text only.
 </section>
 
 <section name="diff-instructions" required="true" tier="fast">

--- a/src/ai/prompts/baseline/level1/thorough.js
+++ b/src/ai/prompts/baseline/level1/thorough.js
@@ -161,6 +161,15 @@ Output JSON with this structure:
   }],
   "summary": "Brief summary of findings"
 }
+
+### GitHub Suggestion Syntax
+When suggesting a specific change, **embed** a GitHub suggestion block within the "suggestion" field:
+
+\`\`\`suggestion
+replacement content here
+\`\`\`
+
+The content inside the block is the complete replacement for the commented line(s). Do not include explanation inside the block — any explanation should appear as plain text outside it. For non-specific suggestions, use plain text only.
 </section>
 
 <section name="diff-instructions" required="true" tier="thorough">

--- a/src/ai/prompts/baseline/level2/balanced.js
+++ b/src/ai/prompts/baseline/level2/balanced.js
@@ -126,6 +126,15 @@ Note: You may use parallel read-only Tasks to examine multiple files simultaneou
   }],
   "summary": "Brief summary of file context findings"
 }
+
+### GitHub Suggestion Syntax
+When suggesting a specific change, **embed** a GitHub suggestion block within the "suggestion" field:
+
+\`\`\`suggestion
+replacement content here
+\`\`\`
+
+The content inside the block is the complete replacement for the commented line(s). Do not include explanation inside the block — any explanation should appear as plain text outside it. For non-specific suggestions, use plain text only.
 </section>
 
 <section name="diff-instructions" required="true">

--- a/src/ai/prompts/baseline/level2/fast.js
+++ b/src/ai/prompts/baseline/level2/fast.js
@@ -107,6 +107,15 @@ Annotated diff tool (preferred), \`cat -n <file>\`, ls, find, grep. Do NOT modif
   }],
   "summary": "Brief summary"
 }
+
+### GitHub Suggestion Syntax
+When suggesting a specific change, **embed** a GitHub suggestion block within the "suggestion" field:
+
+\`\`\`suggestion
+replacement content here
+\`\`\`
+
+The content inside the block is the complete replacement for the commented line(s). Do not include explanation inside the block — any explanation should appear as plain text outside it. For non-specific suggestions, use plain text only.
 </section>
 
 <section name="diff-instructions" required="true" tier="fast">

--- a/src/ai/prompts/baseline/level2/thorough.js
+++ b/src/ai/prompts/baseline/level2/thorough.js
@@ -201,6 +201,15 @@ Output JSON with this structure:
   }],
   "summary": "Brief summary of file context findings"
 }
+
+### GitHub Suggestion Syntax
+When suggesting a specific change, **embed** a GitHub suggestion block within the "suggestion" field:
+
+\`\`\`suggestion
+replacement content here
+\`\`\`
+
+The content inside the block is the complete replacement for the commented line(s). Do not include explanation inside the block — any explanation should appear as plain text outside it. For non-specific suggestions, use plain text only.
 </section>
 
 <section name="diff-instructions" required="true" tier="thorough">

--- a/src/ai/prompts/baseline/level3/balanced.js
+++ b/src/ai/prompts/baseline/level3/balanced.js
@@ -150,6 +150,15 @@ Output JSON with this structure:
   }],
   "summary": "Brief summary of how these changes connect to and impact the codebase"
 }
+
+### GitHub Suggestion Syntax
+When suggesting a specific change, **embed** a GitHub suggestion block within the "suggestion" field:
+
+\`\`\`suggestion
+replacement content here
+\`\`\`
+
+The content inside the block is the complete replacement for the commented line(s). Do not include explanation inside the block — any explanation should appear as plain text outside it. For non-specific suggestions, use plain text only.
 </section>
 
 <section name="diff-instructions" required="true">

--- a/src/ai/prompts/baseline/level3/fast.js
+++ b/src/ai/prompts/baseline/level3/fast.js
@@ -124,6 +124,15 @@ Output JSON with this structure:
   }],
   "summary": "Brief summary of how these changes connect to and impact the codebase"
 }
+
+### GitHub Suggestion Syntax
+When suggesting a specific change, **embed** a GitHub suggestion block within the "suggestion" field:
+
+\`\`\`suggestion
+replacement content here
+\`\`\`
+
+The content inside the block is the complete replacement for the commented line(s). Do not include explanation inside the block — any explanation should appear as plain text outside it. For non-specific suggestions, use plain text only.
 </section>
 
 <section name="diff-instructions" required="true" tier="fast">

--- a/src/ai/prompts/baseline/level3/thorough.js
+++ b/src/ai/prompts/baseline/level3/thorough.js
@@ -268,6 +268,15 @@ Output JSON with this structure:
   }],
   "summary": "Brief summary of how these changes connect to and impact the codebase"
 }
+
+### GitHub Suggestion Syntax
+When suggesting a specific change, **embed** a GitHub suggestion block within the "suggestion" field:
+
+\`\`\`suggestion
+replacement content here
+\`\`\`
+
+The content inside the block is the complete replacement for the commented line(s). Do not include explanation inside the block — any explanation should appear as plain text outside it. For non-specific suggestions, use plain text only.
 </section>
 
 <section name="diff-instructions" required="true" tier="thorough">

--- a/src/ai/prompts/baseline/orchestration/balanced.js
+++ b/src/ai/prompts/baseline/orchestration/balanced.js
@@ -140,6 +140,15 @@ Output JSON with this structure:
   }],
   "summary": "Brief summary of the key findings and their significance to the reviewer. Focus on WHAT was found, not HOW it was found. Do NOT mention 'orchestration', 'levels', 'merged from Level 1/2/3' etc. Write as if a single reviewer produced this analysis."
 }
+
+### GitHub Suggestion Syntax
+When suggesting a specific change, **embed** a GitHub suggestion block within the "suggestion" field:
+
+\`\`\`suggestion
+replacement content here
+\`\`\`
+
+The content inside the block is the complete replacement for the commented line(s). Do not include explanation inside the block — any explanation should appear as plain text outside it. For non-specific suggestions, use plain text only.
 </section>
 
 <section name="diff-instructions" required="true">

--- a/src/ai/prompts/baseline/orchestration/fast.js
+++ b/src/ai/prompts/baseline/orchestration/fast.js
@@ -120,6 +120,15 @@ Use "Consider...", "Worth noting..." - guidance not mandates.
   }],
   "summary": "Key findings as if from single reviewer (no mention of levels/orchestration)"
 }
+
+### GitHub Suggestion Syntax
+When suggesting a specific change, **embed** a GitHub suggestion block within the "suggestion" field:
+
+\`\`\`suggestion
+replacement content here
+\`\`\`
+
+The content inside the block is the complete replacement for the commented line(s). Do not include explanation inside the block — any explanation should appear as plain text outside it. For non-specific suggestions, use plain text only.
 </section>
 
 <section name="diff-instructions" required="true" tier="fast">

--- a/src/ai/prompts/baseline/orchestration/thorough.js
+++ b/src/ai/prompts/baseline/orchestration/thorough.js
@@ -283,6 +283,15 @@ Output JSON with this structure:
   }],
   "summary": "Brief summary of the key findings and their significance to the reviewer. Focus on WHAT was found, not HOW it was found. Do NOT mention 'orchestration', 'levels', 'merged from Level 1/2/3' etc. Write as if a single reviewer produced this analysis."
 }
+
+### GitHub Suggestion Syntax
+When suggesting a specific change, **embed** a GitHub suggestion block within the "suggestion" field:
+
+\`\`\`suggestion
+replacement content here
+\`\`\`
+
+The content inside the block is the complete replacement for the commented line(s). Do not include explanation inside the block — any explanation should appear as plain text outside it. For non-specific suggestions, use plain text only.
 </section>
 
 <section name="diff-instructions" required="true" tier="thorough">

--- a/src/ai/prompts/shared/output-schema.js
+++ b/src/ai/prompts/shared/output-schema.js
@@ -148,7 +148,16 @@ function buildOutputSchemaSection(schema) {
 Output ONLY valid JSON with no additional text, explanations, or markdown code blocks. Do not wrap the JSON in \`\`\`json blocks. The response must start with { and end with }.
 
 Output JSON with this structure:
-${JSON.stringify(schema, null, 2)}`
+${JSON.stringify(schema, null, 2)}
+
+### GitHub Suggestion Syntax
+When suggesting a specific change, **embed** a GitHub suggestion block within the "suggestion" field:
+
+\`\`\`suggestion
+replacement content here
+\`\`\`
+
+The content inside the block is the complete replacement for the commented line(s). Do not include explanation inside the block — any explanation should appear as plain text outside it. For non-specific suggestions, use plain text only.`
   };
 }
 

--- a/src/database.js
+++ b/src/database.js
@@ -2193,8 +2193,12 @@ class CommentRepository {
     }
 
     for (const suggestion of normalized) {
+      const suggestionText = suggestion.suggestion;
+      const hasSuggestionBlock = suggestionText?.trimStart().startsWith('```suggestion');
       const body = suggestion.description +
-        (suggestion.suggestion ? '\n\n**Suggestion:** ' + suggestion.suggestion : '');
+        (suggestionText
+          ? (hasSuggestionBlock ? '\n\n' + suggestionText : '\n\n**Suggestion:** ' + suggestionText)
+          : '');
 
       // File-level suggestions have is_file_level=true or have null line_start
       const isFileLevel = suggestion.is_file_level === true || suggestion.line_start === null ? 1 : 0;


### PR DESCRIPTION
## Summary
- Instructs AI reviewers across all levels (1-3, orchestration, consolidation) and tiers (fast, balanced, thorough) to embed GitHub `suggestion` blocks for literal content changes, making suggestions directly adoptable in GitHub PRs
- Fixes body construction in `database.js` and `analyzer.js` to skip the `**Suggestion:**` prefix when a suggestion block is present, which would otherwise break GitHub's parser
- Adds integration test verifying the prefix-skip behavior

## Test plan
- [x] All 4261 unit/integration tests pass
- [ ] Trigger an AI analysis on a PR and verify suggestions with literal changes use `suggestion` blocks
- [ ] Adopt a suggestion with a `suggestion` block and verify it renders correctly in GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)