### PR TITLE
fix: re-expand file when unchecking Viewed checkbox

### DIFF
--- a/.changeset/plenty-horses-attack.md
+++ b/.changeset/plenty-horses-attack.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Re-expand collapsed file when unchecking the Viewed checkbox to match GitHub behavior

--- a/public/js/pr.js
+++ b/public/js/pr.js
@@ -1400,6 +1400,15 @@ class PRManager {
       }
     } else {
       this.viewedFiles.delete(filePath);
+      // Auto-expand when unchecking viewed (match GitHub behavior)
+      if (wrapper && wrapper.classList.contains('collapsed')) {
+        wrapper.classList.remove('collapsed');
+        this.collapsedFiles.delete(filePath);
+        const header = wrapper.querySelector('.d2h-file-header');
+        if (header) {
+          window.DiffRenderer.updateFileHeaderState(header, true);
+        }
+      }
     }
 
     // Persist viewed state


### PR DESCRIPTION
## Summary
- Re-expand collapsed file when unchecking the Viewed checkbox, matching GitHub's behavior
- Mirrors the existing auto-collapse that already happens when checking Viewed

## Test plan
- [x] Unit tests pass (`npm test`)
- [x] E2E tests pass (245/245 relevant tests)
- [ ] Manual: check Viewed on a file → it collapses → uncheck Viewed → it re-expands

🤖 Generated with [Claude Code](https://claude.com/claude-code)