### PR TITLE
feat: add cursor-acp chat provider

### DIFF
--- a/.changeset/cursor-acp-chat-provider.md
+++ b/.changeset/cursor-acp-chat-provider.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": minor
+---
+
+feat: add cursor-acp as a chat provider for Cursor's ACP support

--- a/README.md
+++ b/README.md
@@ -483,7 +483,7 @@ Configure your preferred models in `providers.pi.models` — see [AI Provider Co
 }
 ```
 
-Available chat provider IDs: `pi`, `claude`, `codex`, `copilot-acp`, `gemini-acp`, `opencode-acp`. Each supports `command`, `args` (replaces defaults), `extra_args` (appends), and `env` overrides.
+Available chat provider IDs: `pi`, `claude`, `codex`, `copilot-acp`, `gemini-acp`, `opencode-acp`, `cursor-acp`. Each supports `command`, `args` (replaces defaults), `extra_args` (appends), and `env` overrides.
 
 **Keyboard shortcut:** Press `p` then `c` to toggle the chat panel.
 

--- a/config.example.json
+++ b/config.example.json
@@ -192,7 +192,7 @@
   },
 
   "chat_providers": {
-    "_comment": "Chat provider command overrides. Separate from 'providers' (AI analysis). Chat providers are: pi, claude, codex, copilot-acp, gemini-acp, opencode-acp. Supports 'command', 'args' (replaces defaults), 'extra_args' (appends), and 'env' overrides.",
+    "_comment": "Chat provider command overrides. Separate from 'providers' (AI analysis). Chat providers are: pi, claude, codex, copilot-acp, gemini-acp, opencode-acp, cursor-acp. Supports 'command', 'args' (replaces defaults), 'extra_args' (appends), and 'env' overrides.",
     "claude": {
       "_comment": "Example: use a wrapper script for Claude chat",
       "command": "claude"

--- a/src/chat/chat-providers.js
+++ b/src/chat/chat-providers.js
@@ -2,7 +2,7 @@
 /**
  * Chat Provider Registry
  *
- * Defines named chat providers (Pi, Copilot, Gemini, OpenCode, Claude, Codex) with their
+ * Defines named chat providers (Pi, Copilot, Gemini, OpenCode, Claude, Codex, Cursor) with their
  * default commands/args, config overrides, and availability checks.
  */
 
@@ -44,6 +44,14 @@ const CHAT_PROVIDERS = {
     name: 'OpenCode (ACP)',
     type: 'acp',
     command: 'opencode',
+    args: ['acp'],
+    env: {},
+  },
+  'cursor-acp': {
+    id: 'cursor-acp',
+    name: 'Cursor (ACP)',
+    type: 'acp',
+    command: 'agent',
     args: ['acp'],
     env: {},
   },

--- a/src/config.js
+++ b/src/config.js
@@ -23,7 +23,7 @@ const DEFAULT_CONFIG = {
   db_name: "",  // Custom database filename (default: database.db). Useful for per-worktree isolation.
   yolo: false,  // When true, skips fine-grained AI provider permission setup (equivalent to --yolo CLI flag)
   enable_chat: true,  // When true, enables the chat panel feature (uses chat_provider)
-  chat_provider: "pi",  // Chat provider: 'pi', 'copilot-acp', 'gemini-acp', 'opencode-acp', 'codex'
+  chat_provider: "pi",  // Chat provider: 'pi', 'copilot-acp', 'gemini-acp', 'opencode-acp', 'cursor-acp', 'codex'
   comment_format: "legacy",  // Comment format preset or custom template for adopted suggestions
   chat: { enable_shortcuts: true },  // Chat panel settings (enable_shortcuts: show action shortcut buttons)
   providers: {},  // Custom AI analysis provider configurations (overrides built-in defaults)

--- a/tests/unit/chat/chat-providers.test.js
+++ b/tests/unit/chat/chat-providers.test.js
@@ -89,6 +89,18 @@ describe('chat-providers', () => {
       });
     });
 
+    it('should return cursor-acp provider with correct defaults', () => {
+      const cursor = getChatProvider('cursor-acp');
+      expect(cursor).toEqual({
+        id: 'cursor-acp',
+        name: 'Cursor (ACP)',
+        type: 'acp',
+        command: 'agent',
+        args: ['acp'],
+        env: {},
+      });
+    });
+
     it('should return null for unknown provider', () => {
       expect(getChatProvider('unknown')).toBeNull();
     });
@@ -153,14 +165,15 @@ describe('chat-providers', () => {
   });
 
   describe('getAllChatProviders', () => {
-    it('should return all six providers', () => {
+    it('should return all seven providers', () => {
       const providers = getAllChatProviders();
-      expect(providers).toHaveLength(6);
+      expect(providers).toHaveLength(7);
       const ids = providers.map(p => p.id);
       expect(ids).toContain('pi');
       expect(ids).toContain('copilot-acp');
       expect(ids).toContain('gemini-acp');
       expect(ids).toContain('opencode-acp');
+      expect(ids).toContain('cursor-acp');
       expect(ids).toContain('claude');
       expect(ids).toContain('codex');
     });
@@ -190,6 +203,10 @@ describe('chat-providers', () => {
 
     it('should return true for opencode-acp', () => {
       expect(isAcpProvider('opencode-acp')).toBe(true);
+    });
+
+    it('should return true for cursor-acp', () => {
+      expect(isAcpProvider('cursor-acp')).toBe(true);
     });
 
     it('should return false for unknown provider', () => {
@@ -351,6 +368,7 @@ describe('chat-providers', () => {
       expect(cache['copilot-acp']).toEqual({ available: true });
       expect(cache['gemini-acp']).toEqual({ available: true });
       expect(cache['opencode-acp']).toEqual({ available: true });
+      expect(cache['cursor-acp']).toEqual({ available: true });
       expect(cache['claude']).toEqual({ available: true });
       expect(cache.codex).toEqual({ available: true });
     });


### PR DESCRIPTION
## Summary
- Registers Cursor's ACP mode (`agent acp`) as a new chat provider
- Adds `cursor-acp` to the chat provider registry, config docs, README, and example config
- Includes unit tests for the new provider entry

## Test plan
- [x] All 44 chat-providers unit tests pass
- [x] All 430 chat unit tests pass
- [ ] Manual: set `chat_provider: "cursor-acp"` and verify Cursor appears in chat panel dropdown
- [ ] Manual: send a message through Cursor ACP chat session

🤖 Generated with [Claude Code](https://claude.com/claude-code)