### PR TITLE
fix: refresh chat providers on late config fetch

### DIFF
--- a/.changeset/fix-chat-provider-race.md
+++ b/.changeset/fix-chat-provider-race.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Fix chat provider dropdown showing only "Pi" (wrong name) on initial load in local mode by listening for late config fetch completion

--- a/public/js/components/ChatPanel.js
+++ b/public/js/components/ChatPanel.js
@@ -272,6 +272,13 @@ class ChatPanel {
       }
     });
 
+    // Re-read chat providers once the <head> config fetch resolves
+    this._onChatStateChanged = () => {
+      this._chatProviders = window.__pairReview?.chatProviders || [];
+      this._updateTitle();
+    };
+    window.addEventListener('chat-state-changed', this._onChatStateChanged);
+
     this._bindResizeEvents();
   }
 
@@ -3140,6 +3147,7 @@ class ChatPanel {
    */
   destroy() {
     document.removeEventListener('keydown', this._onKeydown);
+    window.removeEventListener('chat-state-changed', this._onChatStateChanged);
     this._closeSubscriptions();
     this.messages = [];
 


### PR DESCRIPTION
## Summary
- Fix race condition where ChatPanel reads `window.__pairReview.chatProviders` once in the constructor, but in local mode the `<head>` config fetch often resolves *after* DOMContentLoaded — leaving the provider list empty
- ChatPanel now listens for `chat-state-changed` to re-read providers and refresh the title when the fetch completes
- Handler is properly cleaned up in `destroy()` following the existing `_onKeydown`/`_onReconnect` pattern

## Test plan
- [ ] Run `npx pair-review --local` from a cold start — chat provider dropdown should show all available providers with correct names on first load
- [ ] Verify refreshing the page still works correctly
- [ ] Verify PR mode is unaffected
- [ ] Unit tests pass (`npm test`)
- [ ] E2E tests pass (`npm run test:e2e`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)