### PR TITLE
fix: prevent action buttons from being pushed off-screen by long titles

### DIFF
--- a/.changeset/action-buttons-overflow.md
+++ b/.changeset/action-buttons-overflow.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Fix comment action buttons being pushed off-screen by long title text

--- a/public/css/pr.css
+++ b/public/css/pr.css
@@ -2106,6 +2106,7 @@ tr.newly-expanded .d2h-code-line-ctn {
   position: relative;
   display: flex;
   align-items: center;
+  flex-shrink: 0;
 }
 
 .btn-reasoning-toggle {
@@ -2439,7 +2440,7 @@ tr.newly-expanded .d2h-code-line-ctn {
   text-overflow: ellipsis;
   white-space: nowrap;
   color: var(--color-text-secondary);
-  max-width: 400px;
+  min-width: 0;
   font-size: 13px;
 }
 
@@ -4006,12 +4007,15 @@ tr.line-range-start .d2h-code-line-ctn {
   margin-bottom: 4px;
   padding-bottom: 4px;
   border-bottom: 1px solid rgba(139, 92, 246, 0.1);
+  min-width: 0;
 }
 
 .user-comment-header-left {
   display: flex;
   align-items: center;
   gap: 8px;
+  min-width: 0;
+  overflow: hidden;
 }
 
 .user-comment-line-info {
@@ -4088,6 +4092,9 @@ tr.line-range-start .d2h-code-line-ctn {
   font-size: 12px;
   font-style: italic;
   margin-left: 6px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 /* Eye icon toggle button */
@@ -4156,6 +4163,7 @@ tr.line-range-start .d2h-code-line-ctn {
   align-items: center;
   gap: 4px;
   margin-left: auto;
+  flex-shrink: 0;
 }
 
 /* Hide edit/delete buttons when in editing mode */

--- a/public/js/modules/comment-manager.js
+++ b/public/js/modules/comment-manager.js
@@ -594,12 +594,14 @@ class CommentManager {
     const commentHTML = `
       <div class="${commentClasses}">
         <div class="user-comment-header">
-          <span class="comment-origin-icon">
-            ${commentIcon}
-          </span>
-          <span class="user-comment-line-info">${lineInfo}</span>
-          ${expandedContextIndicator}
-          ${metadataHTML}
+          <div class="user-comment-header-left">
+            <span class="comment-origin-icon">
+              ${commentIcon}
+            </span>
+            <span class="user-comment-line-info">${lineInfo}</span>
+            ${expandedContextIndicator}
+            ${metadataHTML}
+          </div>
           <div class="user-comment-actions">
             <button class="btn-chat-comment" title="Chat about comment" data-chat-comment-id="${comment.id}" data-chat-file="${escapeHtml(comment.file || '')}" data-chat-line-start="${comment.line_start ?? ''}" data-chat-line-end="${comment.line_end || comment.line_start || ''}" data-chat-parent-id="${comment.parent_id || ''}">
               <svg viewBox="0 0 16 16" fill="currentColor"><path d="M1.75 1h8.5c.966 0 1.75.784 1.75 1.75v5.5A1.75 1.75 0 0 1 10.25 10H7.061l-2.574 2.573A1.458 1.458 0 0 1 2 11.543V10h-.25A1.75 1.75 0 0 1 0 8.25v-5.5C0 1.784.784 1 1.75 1ZM1.5 2.75v5.5c0 .138.112.25.25.25h1a.75.75 0 0 1 .75.75v2.19l2.72-2.72a.749.749 0 0 1 .53-.22h3.5a.25.25 0 0 0 .25-.25v-5.5a.25.25 0 0 0-.25-.25h-8.5a.25.25 0 0 0-.25.25Zm13 2a.25.25 0 0 0-.25-.25h-.5a.75.75 0 0 1 0-1.5h.5c.966 0 1.75.784 1.75 1.75v5.5A1.75 1.75 0 0 1 14.25 12H14v1.543a1.458 1.458 0 0 1-2.487 1.03L9.22 12.28a.749.749 0 0 1 .326-1.275.749.749 0 0 1 .734.215l2.22 2.22v-2.19a.75.75 0 0 1 .75-.75h1a.25.25 0 0 0 .25-.25Z"/></svg>
@@ -666,12 +668,14 @@ class CommentManager {
     const commentHTML = `
       <div class="user-comment editing-mode ${comment.parent_id ? 'adopted-comment comment-ai-origin' : 'comment-user-origin'}">
         <div class="user-comment-header">
-          <span class="comment-origin-icon">
-            ${commentIcon}
-          </span>
-          <span class="user-comment-line-info">${lineInfo}</span>
-          ${comment.type === 'praise' ? `<span class="adopted-praise-badge" title="Nice Work"><svg viewBox="0 0 16 16" width="12" height="12"><path d="M8 .25a.75.75 0 01.673.418l1.882 3.815 4.21.612a.75.75 0 01.416 1.279l-3.046 2.97.719 4.192a.75.75 0 01-1.088.791L8 12.347l-3.766 1.98a.75.75 0 01-1.088-.79l.72-4.194L.818 6.374a.75.75 0 01.416-1.28l4.21-.611L7.327.668A.75.75 0 018 .25z"/></svg>Nice Work</span>` : ''}
-          ${comment.title ? `<span class="adopted-title">${escapeHtml(comment.title)}</span>` : ''}
+          <div class="user-comment-header-left">
+            <span class="comment-origin-icon">
+              ${commentIcon}
+            </span>
+            <span class="user-comment-line-info">${lineInfo}</span>
+            ${comment.type === 'praise' ? `<span class="adopted-praise-badge" title="Nice Work"><svg viewBox="0 0 16 16" width="12" height="12"><path d="M8 .25a.75.75 0 01.673.418l1.882 3.815 4.21.612a.75.75 0 01.416 1.279l-3.046 2.97.719 4.192a.75.75 0 01-1.088.791L8 12.347l-3.766 1.98a.75.75 0 01-1.088-.79l.72-4.194L.818 6.374a.75.75 0 01.416-1.28l4.21-.611L7.327.668A.75.75 0 018 .25z"/></svg>Nice Work</span>` : ''}
+            ${comment.title ? `<span class="adopted-title">${escapeHtml(comment.title)}</span>` : ''}
+          </div>
         </div>
         <!-- Hidden body div for saving - pre-populate with markdown rendered content and store original -->
         <div class="user-comment-body" style="display: none;" data-original-markdown="${window.escapeHtmlAttribute(comment.body)}">${window.renderMarkdown ? window.renderMarkdown(comment.body) : escapeHtml(comment.body)}</div>

--- a/public/js/modules/file-comment-manager.js
+++ b/public/js/modules/file-comment-manager.js
@@ -377,12 +377,14 @@ class FileCommentManager {
     // Use same structure as line-level user comments
     card.innerHTML = `
       <div class="user-comment-header">
-        <span class="comment-origin-icon">
-          ${commentIcon}
-        </span>
-        <span class="file-comment-badge" title="Comment applies to the entire file">File comment</span>
-        ${praiseBadge}
-        ${titleHtml}
+        <div class="user-comment-header-left">
+          <span class="comment-origin-icon">
+            ${commentIcon}
+          </span>
+          <span class="file-comment-badge" title="Comment applies to the entire file">File comment</span>
+          ${praiseBadge}
+          ${titleHtml}
+        </div>
         <div class="user-comment-actions">
           <button class="btn-chat-comment" title="Chat about comment" data-chat-comment-id="${comment.id}" data-chat-file="${this.escapeHtml(comment.file || '')}" data-chat-parent-id="${comment.parent_id || ''}">
             <svg viewBox="0 0 16 16" fill="currentColor"><path d="M1.75 1h8.5c.966 0 1.75.784 1.75 1.75v5.5A1.75 1.75 0 0 1 10.25 10H7.061l-2.574 2.573A1.458 1.458 0 0 1 2 11.543V10h-.25A1.75 1.75 0 0 1 0 8.25v-5.5C0 1.784.784 1 1.75 1ZM1.5 2.75v5.5c0 .138.112.25.25.25h1a.75.75 0 0 1 .75.75v2.19l2.72-2.72a.749.749 0 0 1 .53-.22h3.5a.25.25 0 0 0 .25-.25v-5.5a.25.25 0 0 0-.25-.25h-8.5a.25.25 0 0 0-.25.25Zm13 2a.25.25 0 0 0-.25-.25h-.5a.75.75 0 0 1 0-1.5h.5c.966 0 1.75.784 1.75 1.75v5.5A1.75 1.75 0 0 1 14.25 12H14v1.543a1.458 1.458 0 0 1-2.487 1.03L9.22 12.28a.749.749 0 0 1 .326-1.275.749.749 0 0 1 .734.215l2.22 2.22v-2.19a.75.75 0 0 1 .75-.75h1a.25.25 0 0 0 .25-.25Z"/></svg>


### PR DESCRIPTION
## Summary
- Wraps left-side user comment header items in a `user-comment-header-left` flex container with `min-width: 0` and `overflow: hidden` so long titles truncate with ellipsis
- Adds `flex-shrink: 0` to `.user-comment-actions` and `.ai-suggestion-header-right` so action buttons never get compressed or pushed off-screen
- Replaces fixed `max-width: 400px` on `.collapsed-title` with `min-width: 0` for responsive truncation
- Applies to line-level comments, file-level comments, edit-mode comments, and collapsed suggestion headers

## Test plan
- [ ] Adopt a suggestion with a long title — verify action buttons (chat, edit, delete) remain visible
- [ ] Check collapsed suggestion rows with long titles — verify Show button and other controls remain visible
- [ ] Verify file-level comments with long titles also truncate properly
- [ ] Check both light and dark themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)