### PR TITLE
fix: disambiguate consolidation progress updates

### DIFF
--- a/.changeset/consolidation-progress-disambiguation.md
+++ b/.changeset/consolidation-progress-disambiguation.md
@@ -1,0 +1,10 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Fix consolidation progress disambiguation in review councils
+
+Per-reviewer orchestration progress updates (with voiceId) no longer pollute the shared
+consolidation state (steps, consolidationStep, streamEvent). This prevents progress from
+individual reviewer's cross-level orchestration from being confused with the overall
+cross-voice or cross-level consolidation in the progress dialog.

--- a/public/js/components/CouncilProgressModal.js
+++ b/public/js/components/CouncilProgressModal.js
@@ -520,7 +520,9 @@ class CouncilProgressModal {
 
     // Handle per-voice orchestration updates (level 4):
     // In voice-centric mode, each reviewer has a consolidation child at data-vc-level="4".
-    // The backend tracks per-voice orchestration state in levels[4].voices.
+    // The backend tracks per-voice orchestration state in levels[4].voices, including
+    // per-voice streamEvent. The shared levels[4].streamEvent is only for the overall
+    // cross-voice consolidation (no voiceId).
     const level4 = status.levels[4];
     if (level4) {
       if (level4.voices) {
@@ -529,12 +531,7 @@ class CouncilProgressModal {
         }
       }
 
-      // Update stream event text for the active voice's orchestration step
-      if (level4.streamEvent?.text && level4.voiceId) {
-        this._setVoiceCentricStreamText(level4.voiceId, 4, level4.streamEvent.text);
-      }
-
-      // Handle cross-reviewer consolidation section (no voiceId — shared consolidation)
+      // Handle cross-reviewer consolidation section (shared consolidation state only)
       this._updateConsolidation(level4);
     }
 

--- a/src/routes/shared.js
+++ b/src/routes/shared.js
@@ -231,16 +231,34 @@ function createProgressCallback(analysisId) {
         }
       }
 
-      currentStatus.levels[levelKey].streamEvent = evt;
-      // Propagate voiceId so council progress modal can identify active voice
-      if (progressUpdate.voiceId) {
-        currentStatus.levels[levelKey].voiceId = progressUpdate.voiceId;
-      }
-      // Propagate consolidation step so frontend can identify active consolidation child
-      if (consolidationMatch) {
-        currentStatus.levels[levelKey].consolidationStep = `L${consolidationMatch[1]}`;
-      } else if (level === 'orchestration') {
-        currentStatus.levels[levelKey].consolidationStep = 'orchestration';
+      // Per-voice orchestration streams: store in voices map, not shared state.
+      // This prevents per-reviewer orchestration (within each voice's analysis)
+      // from overwriting the shared consolidation streamEvent/consolidationStep.
+      const isPerVoiceOrchestration = (level === 'orchestration' || consolidationMatch) && progressUpdate.voiceId;
+      if (isPerVoiceOrchestration) {
+        if (!currentStatus.levels[levelKey].voices) {
+          currentStatus.levels[levelKey].voices = {};
+        }
+        if (!currentStatus.levels[levelKey].voices[progressUpdate.voiceId]) {
+          currentStatus.levels[levelKey].voices[progressUpdate.voiceId] = { status: 'running' };
+        }
+        currentStatus.levels[levelKey].voices[progressUpdate.voiceId].streamEvent = evt;
+      // Levels 1-3: stream events are stored in the shared levels[n].streamEvent field
+      // with voiceId as a routing discriminator (only one voice streams per level at a time).
+      // Level 4 is different (handled above) because it has both per-voice orchestration
+      // AND shared cross-voice consolidation, requiring separate storage paths.
+      } else {
+        currentStatus.levels[levelKey].streamEvent = evt;
+        // Propagate voiceId so council progress modal can identify active voice
+        if (progressUpdate.voiceId) {
+          currentStatus.levels[levelKey].voiceId = progressUpdate.voiceId;
+        }
+        // Propagate consolidation step so frontend can identify active consolidation child
+        if (consolidationMatch) {
+          currentStatus.levels[levelKey].consolidationStep = `L${consolidationMatch[1]}`;
+        } else if (level === 'orchestration') {
+          currentStatus.levels[levelKey].consolidationStep = 'orchestration';
+        }
       }
       activeAnalyses.set(analysisId, currentStatus);
 
@@ -295,48 +313,51 @@ function createProgressCallback(analysisId) {
     // Both maps must be preserved across updates since each progress event only
     // reports on a single step or voice at a time.
     if (level === 'orchestration' || consolidationMatch) {
-      const step = consolidationMatch ? `L${consolidationMatch[1]}` : 'orchestration';
-      // Preserve existing consolidation steps when updating level 4
-      const existing = currentStatus.levels[4] || {};
-      const steps = { ...(existing.steps || {}) };
-      steps[step] = {
-        status: progressUpdate.status || 'running',
-        progress: progressUpdate.progress || (consolidationMatch ? 'Consolidating...' : 'Finalizing results...')
-      };
-      // Derive the top-level consolidation status from the aggregate of step statuses
-      // so that a single step completing doesn't mark the whole phase as completed
-      const stepStatuses = Object.values(steps).map(s => s.status);
-      const derivedStatus = stepStatuses.every(s => s === 'completed') ? 'completed'
-        : stepStatuses.some(s => s === 'failed') ? 'failed'
-        : stepStatuses.some(s => s === 'running') ? 'running'
-        : progressUpdate.status || 'running';
-      // Preserve existing per-voice orchestration states when rebuilding level 4
-      const existingVoices = existing.voices ? { ...existing.voices } : undefined;
-      currentStatus.levels[4] = {
-        status: derivedStatus,
-        progress: progressUpdate.progress || (consolidationMatch ? 'Consolidating...' : 'Finalizing results...'),
-        streamEvent: existing.streamEvent,
-        consolidationStep: step,
-        steps,
-        voices: existingVoices
-      };
-
-      // Track per-voice orchestration state (voice-centric council mode):
-      // When a voiceId is present, store per-voice status in levels[4].voices
-      // so the frontend can update individual reviewer's consolidation row.
+      // Per-voice orchestration updates (voiceId present): only update the per-voice
+      // entry in levels[4].voices. Do NOT touch the shared consolidation state (steps,
+      // consolidationStep, streamEvent, top-level progress). This prevents per-reviewer
+      // orchestration (within each voice's analysis) from being confused with the
+      // overall cross-voice or cross-level consolidation.
       if (progressUpdate.voiceId) {
-        if (!currentStatus.levels[4].voices) {
-          currentStatus.levels[4].voices = {};
-        }
-        currentStatus.levels[4].voices[progressUpdate.voiceId] = {
-          status: progressUpdate.status || 'running',
-          progress: progressUpdate.progress || 'Consolidating...'
+        const existing = currentStatus.levels[4] || {};
+        const existingVoices = existing.voices ? { ...existing.voices } : {};
+        const prev = existingVoices[progressUpdate.voiceId] || {};
+        const voiceStatus = progressUpdate.status || 'running';
+        existingVoices[progressUpdate.voiceId] = voiceStatus === 'running'
+          ? { ...prev, status: voiceStatus, progress: progressUpdate.progress || 'Consolidating...' }
+          : { status: voiceStatus, progress: progressUpdate.progress || 'Consolidating...' };
+        currentStatus.levels[4] = {
+          ...existing,
+          voices: existingVoices,
+          voiceId: progressUpdate.voiceId
         };
-        // Last-writer-wins: reflects whichever voice reported most recently.
-        // Intentional — mirrors levels 1-3 behavior (line ~334) and the frontend
-        // uses per-voice detail from the `voices` map, not this top-level field.
-        // This field exists for backward compat with single-model progress routing.
-        currentStatus.levels[4].voiceId = progressUpdate.voiceId;
+      } else {
+        // Shared consolidation update (no voiceId): update steps map and derive
+        // aggregate status. This is the cross-level or cross-voice consolidation.
+        const step = consolidationMatch ? `L${consolidationMatch[1]}` : 'orchestration';
+        const existing = currentStatus.levels[4] || {};
+        const steps = { ...(existing.steps || {}) };
+        steps[step] = {
+          status: progressUpdate.status || 'running',
+          progress: progressUpdate.progress || (consolidationMatch ? 'Consolidating...' : 'Finalizing results...')
+        };
+        // Derive the top-level consolidation status from the aggregate of step statuses
+        // so that a single step completing doesn't mark the whole phase as completed
+        const stepStatuses = Object.values(steps).map(s => s.status);
+        const derivedStatus = stepStatuses.every(s => s === 'completed') ? 'completed'
+          : stepStatuses.some(s => s === 'failed') ? 'failed'
+          : stepStatuses.some(s => s === 'running') ? 'running'
+          : progressUpdate.status || 'running';
+        // Preserve existing per-voice orchestration states when rebuilding level 4
+        const existingVoices = existing.voices ? { ...existing.voices } : undefined;
+        currentStatus.levels[4] = {
+          status: derivedStatus,
+          progress: progressUpdate.progress || (consolidationMatch ? 'Consolidating...' : 'Finalizing results...'),
+          streamEvent: existing.streamEvent,
+          consolidationStep: step,
+          steps,
+          voices: existingVoices
+        };
       }
     }
 

--- a/tests/unit/council-progress-modal.test.js
+++ b/tests/unit/council-progress-modal.test.js
@@ -987,12 +987,12 @@ describe('CouncilProgressModal', () => {
       );
     });
 
-    it('updates stream text for active voice orchestration step', () => {
+    it('updates stream text for active voice orchestration step from voices map', () => {
       const { modal } = createTestCouncilProgressModal();
 
       modal._renderMode = 'council';
 
-      vi.spyOn(modal, '_setVoiceCentricLevelState').mockImplementation(() => {});
+      const setLevelStateSpy = vi.spyOn(modal, '_setVoiceCentricLevelState').mockImplementation(() => {});
       vi.spyOn(modal, '_refreshAllVoiceHeaders').mockImplementation(() => {});
       vi.spyOn(modal, '_updateConsolidation').mockImplementation(() => {});
       const setStreamTextSpy = vi.spyOn(modal, '_setVoiceCentricStreamText').mockImplementation(() => {});
@@ -1001,15 +1001,72 @@ describe('CouncilProgressModal', () => {
         levels: {
           4: {
             status: 'running',
-            voiceId: 'claude-opus',
-            streamEvent: { text: 'Merging suggestions...' }
+            voices: {
+              'claude-opus': {
+                status: 'running',
+                streamEvent: { text: 'Merging suggestions...' }
+              }
+            }
           }
         }
       };
 
       modal._updateVoiceCentric(status);
 
-      expect(setStreamTextSpy).toHaveBeenCalledWith('claude-opus', 4, 'Merging suggestions...');
+      // Stream text is handled by _setVoiceCentricLevelState (via the snippet element),
+      // not by a separate _setVoiceCentricStreamText call
+      expect(setStreamTextSpy).not.toHaveBeenCalled();
+      expect(setLevelStateSpy).toHaveBeenCalledWith('claude-opus', 4, 'running', {
+        status: 'running',
+        streamEvent: { text: 'Merging suggestions...' }
+      });
+    });
+
+    it('routes per-voice and shared stream events independently', () => {
+      const { modal } = createTestCouncilProgressModal();
+
+      modal._renderMode = 'council';
+
+      const setLevelStateSpy = vi.spyOn(modal, '_setVoiceCentricLevelState').mockImplementation(() => {});
+      vi.spyOn(modal, '_refreshAllVoiceHeaders').mockImplementation(() => {});
+      vi.spyOn(modal, '_updateConsolidation').mockImplementation(() => {});
+      const setStreamTextSpy = vi.spyOn(modal, '_setVoiceCentricStreamText').mockImplementation(() => {});
+
+      // Status has both per-voice stream events in voices map AND a shared
+      // streamEvent (for cross-voice consolidation). They should not collide.
+      const status = {
+        levels: {
+          4: {
+            status: 'running',
+            streamEvent: { text: 'Cross-voice consolidation text' },
+            voices: {
+              'claude-opus': {
+                status: 'completed',
+                // No streamEvent — voice is done
+              },
+              'gemini-pro-1': {
+                status: 'running',
+                streamEvent: { text: 'Gemini still orchestrating...' }
+              }
+            }
+          }
+        }
+      };
+
+      modal._updateVoiceCentric(status);
+
+      // Stream text is handled internally by _setVoiceCentricLevelState (via snippet),
+      // not by a separate _setVoiceCentricStreamText call
+      expect(setStreamTextSpy).not.toHaveBeenCalled();
+      // Per-voice states are passed through to _setVoiceCentricLevelState with their full vStatus
+      expect(setLevelStateSpy).toHaveBeenCalledWith('gemini-pro-1', 4, 'running', {
+        status: 'running',
+        streamEvent: { text: 'Gemini still orchestrating...' }
+      });
+      // Completed voice should NOT carry stale stream text
+      expect(setLevelStateSpy).toHaveBeenCalledWith('claude-opus', 4, 'completed', {
+        status: 'completed',
+      });
     });
 
     it('does not update stream text when level 4 has no voiceId', () => {

--- a/tests/unit/shared.test.js
+++ b/tests/unit/shared.test.js
@@ -874,6 +874,165 @@ describe('createProgressCallback', () => {
       expect(status.levels[4].voices).toBeUndefined();
     });
 
+    // --- Consolidation progress disambiguation tests ---
+
+    it('should NOT update shared steps map for per-voice orchestration (with voiceId)', () => {
+      const callback = createProgressCallback(analysisId);
+
+      callback({
+        level: 'orchestration',
+        status: 'running',
+        progress: 'Per-reviewer consolidation...',
+        voiceId: 'claude-opus'
+      });
+
+      const status = activeAnalyses.get(analysisId);
+      // Per-voice orchestration should ONLY update voices map
+      expect(status.levels[4].voices['claude-opus']).toEqual({
+        status: 'running',
+        progress: 'Per-reviewer consolidation...'
+      });
+      // Shared consolidation state should NOT be set
+      expect(status.levels[4].steps).toBeUndefined();
+      expect(status.levels[4].consolidationStep).toBeUndefined();
+    });
+
+    it('should NOT set consolidationStep for per-voice orchestration stream events', () => {
+      const callback = createProgressCallback(analysisId);
+
+      callback({
+        level: 'orchestration',
+        streamEvent: { type: 'assistant_text', text: 'Reviewer thinking...' },
+        voiceId: 'claude-opus'
+      });
+
+      const status = activeAnalyses.get(analysisId);
+      // Stream event should go to per-voice entry, not shared
+      expect(status.levels[4].voices['claude-opus'].streamEvent).toEqual({
+        type: 'assistant_text',
+        text: 'Reviewer thinking...'
+      });
+      expect(status.levels[4].streamEvent).toBeUndefined();
+      expect(status.levels[4].consolidationStep).toBeUndefined();
+    });
+
+    it('should keep per-voice and shared consolidation state independent', () => {
+      const callback = createProgressCallback(analysisId);
+
+      // Voice 1 starts per-reviewer orchestration
+      callback({
+        level: 'orchestration',
+        status: 'running',
+        progress: 'R1 orchestrating...',
+        voiceId: 'claude-opus'
+      });
+
+      // Voice 2 starts per-reviewer orchestration
+      callback({
+        level: 'orchestration',
+        status: 'running',
+        progress: 'R2 orchestrating...',
+        voiceId: 'gemini-pro-1'
+      });
+
+      // Both voices complete
+      callback({
+        level: 'orchestration',
+        status: 'completed',
+        progress: 'R1 done',
+        voiceId: 'claude-opus'
+      });
+      callback({
+        level: 'orchestration',
+        status: 'completed',
+        progress: 'R2 done',
+        voiceId: 'gemini-pro-1'
+      });
+
+      // Now shared cross-voice consolidation starts (no voiceId)
+      callback({
+        level: 'orchestration',
+        status: 'running',
+        progress: 'Consolidating across reviewers...'
+      });
+
+      const status = activeAnalyses.get(analysisId);
+
+      // Per-voice state should reflect completed
+      expect(status.levels[4].voices['claude-opus'].status).toBe('completed');
+      expect(status.levels[4].voices['gemini-pro-1'].status).toBe('completed');
+
+      // Shared consolidation should be running with its own steps map
+      expect(status.levels[4].status).toBe('running');
+      expect(status.levels[4].steps.orchestration).toEqual({
+        status: 'running',
+        progress: 'Consolidating across reviewers...'
+      });
+      expect(status.levels[4].consolidationStep).toBe('orchestration');
+    });
+
+    it('should not leak per-voice stream events into shared streamEvent', () => {
+      const callback = createProgressCallback(analysisId);
+
+      // Shared consolidation starts
+      callback({
+        level: 'orchestration',
+        status: 'running',
+        progress: 'Cross-level consolidation...'
+      });
+
+      // Shared consolidation streams text
+      callback({
+        level: 'orchestration',
+        streamEvent: { type: 'assistant_text', text: 'Shared analysis text' }
+      });
+
+      // Per-voice stream event arrives (should NOT overwrite shared)
+      callback({
+        level: 'orchestration',
+        streamEvent: { type: 'assistant_text', text: 'Per-voice text' },
+        voiceId: 'claude-opus'
+      });
+
+      const status = activeAnalyses.get(analysisId);
+      // Shared stream should be preserved
+      expect(status.levels[4].streamEvent).toEqual({
+        type: 'assistant_text',
+        text: 'Shared analysis text'
+      });
+      // Per-voice stream should be in voices map
+      expect(status.levels[4].voices['claude-opus'].streamEvent).toEqual({
+        type: 'assistant_text',
+        text: 'Per-voice text'
+      });
+    });
+
+    it('should preserve per-voice state when shared consolidation updates', () => {
+      const callback = createProgressCallback(analysisId);
+
+      // Per-voice orchestration completes
+      callback({
+        level: 'orchestration',
+        status: 'completed',
+        progress: 'Voice done',
+        voiceId: 'claude-opus'
+      });
+
+      // Shared consolidation starts (should NOT destroy voice state)
+      callback({
+        level: 'orchestration',
+        status: 'running',
+        progress: 'Cross-voice consolidation...'
+      });
+
+      const status = activeAnalyses.get(analysisId);
+      expect(status.levels[4].voices['claude-opus']).toEqual({
+        status: 'completed',
+        progress: 'Voice done'
+      });
+      expect(status.levels[4].steps.orchestration.status).toBe('running');
+    });
+
     it('should preserve streamEvent when a different consolidation sub-step sends a status update', () => {
       const callback = createProgressCallback(analysisId);
 


### PR DESCRIPTION
## Summary
- Per-voice orchestration progress (with `voiceId`) was colliding with cross-voice/cross-level consolidation on the same `levels[4]` state, causing the progress dialog to confuse which consolidation step was active
- Per-voice updates now only touch `levels[4].voices[voiceId]` (both stream events and status updates) and never pollute the shared `steps`/`consolidationStep`/`streamEvent`
- Terminal voice transitions (completed/failed) clear stale `streamEvent` data instead of carrying it over

## Test plan
- [x] 143 unit tests pass (89 shared.test.js + 54 council-progress-modal.test.js)
- [x] 247 E2E tests pass (246 passed, 1 skipped)
- [ ] Manual: run reviewer-centric council analysis and verify per-reviewer orchestration progress does not leak into the shared consolidation section
- [ ] Manual: verify cross-voice consolidation progress displays correctly after all reviewers complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)