### PR TITLE
fix: preserve user comments in Review panel when AI analysis completes

### DIFF
--- a/.changeset/fix-missing-comments-after-analysis.md
+++ b/.changeset/fix-missing-comments-after-analysis.md
@@ -1,0 +1,10 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Fix user comments disappearing from Review panel after AI analysis completes
+
+`clearAllFindings()` was clearing both AI suggestions and user comments when a new
+analysis started. Since the analysis completion handler only reloaded AI suggestions,
+user comments were lost until a page refresh. Now `clearAllFindings()` preserves user
+comments, and the analysis completion handler reloads both suggestions and comments.

--- a/public/js/components/AIPanel.js
+++ b/public/js/components/AIPanel.js
@@ -1432,7 +1432,8 @@ class AIPanel {
      */
     clearAllFindings() {
         this.findings = [];
-        this.comments = [];
+        // NOTE: Do NOT clear this.comments here. User comments are independent
+        // of AI analysis and must persist across analysis runs.
         this.currentIndex = -1; // Reset navigation
         this.updateSegmentCounts();
         this.renderFindings();

--- a/public/js/pr.js
+++ b/public/js/pr.js
@@ -498,6 +498,19 @@ class PRManager {
   }
 
   /**
+   * Reload AI suggestions and user comments after an analysis completes.
+   * Shared by the foreground `analysis_completed` handler and the deferred
+   * `_dirtyAnalysis` branch in the visibilitychange listener.
+   */
+  _reloadAfterAnalysis() {
+    const includeDismissed = window.aiPanel?.showDismissedComments ?? false;
+    return Promise.all([
+      this.loadAISuggestions(),
+      this.loadUserComments(includeDismissed)
+    ]);
+  }
+
+  /**
    * Listen for review-scoped CustomEvents dispatched by ChatPanel's
    * WebSocket pub/sub connection.
    */
@@ -558,9 +571,9 @@ class PRManager {
       debounced('analysis', () => {
         if (this.analysisHistoryManager) {
           this.analysisHistoryManager.refresh({ switchToNew: true })
-            .then(() => this.loadAISuggestions());
+            .then(() => this._reloadAfterAnalysis());
         } else {
-          this.loadAISuggestions();
+          this._reloadAfterAnalysis();
         }
       });
     });
@@ -593,9 +606,9 @@ class PRManager {
         this._dirtySuggestions = false; // analysis refresh includes suggestion reload
         if (this.analysisHistoryManager) {
           this.analysisHistoryManager.refresh({ switchToNew: true })
-            .then(() => this.loadAISuggestions());
+            .then(() => this._reloadAfterAnalysis());
         } else {
-          this.loadAISuggestions();
+          this._reloadAfterAnalysis();
         }
       } else if (this._dirtySuggestions) {
         this._dirtySuggestions = false;

--- a/tests/unit/ai-panel-collapse.test.js
+++ b/tests/unit/ai-panel-collapse.test.js
@@ -283,4 +283,42 @@ describe('AIPanel collapsed state persistence', () => {
       expect(panel.renderFindings).not.toHaveBeenCalled();
     });
   });
+
+  describe('clearAllFindings preserves user comments', () => {
+    it('clears AI findings but preserves user comments', () => {
+      const panel = createTestPanel({
+        findings: [{ id: 1, title: 'AI suggestion' }],
+        comments: [
+          { id: 10, body: 'user comment 1' },
+          { id: 11, body: 'user comment 2' },
+        ],
+      });
+      panel.segmentBtns = [];
+      panel.resetLevelFilter = vi.fn();
+      global.document.querySelectorAll = vi.fn(() => []);
+
+      panel.clearAllFindings();
+
+      expect(panel.findings).toEqual([]);
+      expect(panel.comments).toEqual([
+        { id: 10, body: 'user comment 1' },
+        { id: 11, body: 'user comment 2' },
+      ]);
+    });
+
+    it('resets navigation index when clearing findings', () => {
+      const panel = createTestPanel({
+        findings: [{ id: 1 }],
+        comments: [],
+        currentIndex: 3,
+      });
+      panel.segmentBtns = [];
+      panel.resetLevelFilter = vi.fn();
+      global.document.querySelectorAll = vi.fn(() => []);
+
+      panel.clearAllFindings();
+
+      expect(panel.currentIndex).toBe(-1);
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- **Bug**: User comments disappeared from the Review panel whenever a new AI analysis completed. The panel showed "User(0)" even though comments still existed (Submit Review button showed the correct count). Page refresh restored them.
- **Root cause**: `clearAllFindings()` wiped both `this.findings` (AI suggestions) and `this.comments` (user comments) when starting a new analysis. The completion handler only reloaded AI suggestions, so user comments were never restored.
- **Fix**: `clearAllFindings()` no longer clears user comments (they're independent of AI analysis). Extracted `_reloadAfterAnalysis()` to reload both AI suggestions and user comments, used by both the foreground `analysis_completed` handler and the deferred `_dirtyAnalysis` visibility branch.

## Test plan
- [x] Added regression tests for `clearAllFindings()` preserving user comments
- [x] All 4,841 existing tests pass
- [ ] Manual: Add user comments, run AI analysis, verify comments persist in Review panel
- [ ] Manual: Start analysis, switch to another tab, return after completion — verify comments still visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)