### PR TITLE
fix: discover Pi session file via get_state for chat resume

### DIFF
--- a/.changeset/fix-pi-chat-resume.md
+++ b/.changeset/fix-pi-chat-resume.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Fix Pi chat session resume by querying `get_state` after startup to discover and persist the session file path

--- a/src/chat/pi-bridge.js
+++ b/src/chat/pi-bridge.js
@@ -53,6 +53,8 @@ class PiBridge extends EventEmitter {
     // Accumulate text across streaming deltas for each turn
     this._accumulatedText = '';
     this._inMessage = false;
+    // Pending callbacks for RPC responses keyed by command type
+    this._pendingCallbacks = new Map();
   }
 
   /**
@@ -145,7 +147,7 @@ class PiBridge extends EventEmitter {
           resolve();
         }
       });
-    });
+    }).then(() => this._querySessionFile());
   }
 
   /**
@@ -283,6 +285,53 @@ class PiBridge extends EventEmitter {
   }
 
   /**
+   * Query Pi's get_state command to discover the session file path.
+   * Pi's RPC protocol does not emit a 'session' event on its own, so we
+   * must explicitly ask for the state after startup.  The response contains
+   * a `sessionFile` field that we store and emit as a 'session' event so
+   * the session-manager can persist the agent_session_id.
+   * @returns {Promise<void>}
+   */
+  _querySessionFile() {
+    if (!this.isReady()) return Promise.resolve();
+
+    return new Promise((resolve) => {
+      let timeout;
+      // Register a callback for the get_state response
+      this._pendingCallbacks.set('get_state', (event) => {
+        clearTimeout(timeout);
+        if (event.success && event.data && event.data.sessionFile) {
+          this.sessionPath = event.data.sessionFile;
+          this.emit('session', { sessionFile: event.data.sessionFile });
+          logger.info(`[PiBridge] Discovered session file: ${event.data.sessionFile}`);
+        } else {
+          logger.debug('[PiBridge] get_state did not return a sessionFile');
+        }
+        resolve();
+      });
+
+      // Safety timeout — don't block startup forever if Pi never responds
+      timeout = setTimeout(() => {
+        if (this._pendingCallbacks.has('get_state')) {
+          this._pendingCallbacks.delete('get_state');
+          logger.debug('[PiBridge] get_state timed out');
+          resolve();
+        }
+      }, 5000);
+      // Don't let this timer keep the process alive
+      if (timeout.unref) timeout.unref();
+
+      try {
+        this._write(JSON.stringify({ type: 'get_state' }));
+      } catch (err) {
+        this._pendingCallbacks.delete('get_state');
+        logger.debug(`[PiBridge] Failed to send get_state: ${err.message}`);
+        resolve();
+      }
+    });
+  }
+
+  /**
    * Write a JSON command line to the process stdin.
    * @param {string} jsonLine - The JSON string (without trailing newline)
    */
@@ -360,8 +409,12 @@ class PiBridge extends EventEmitter {
         break;
 
       case 'response':
-        // Response to a command (prompt, abort)
-        if (!event.success) {
+        // Route to pending callback if one exists for this command
+        if (event.command && this._pendingCallbacks.has(event.command)) {
+          const callback = this._pendingCallbacks.get(event.command);
+          this._pendingCallbacks.delete(event.command);
+          callback(event);
+        } else if (!event.success) {
           logger.error(`[PiBridge] Command failed: ${event.error}`);
           this.emit('error', { error: new Error(event.error || 'Unknown command error') });
         } else {

--- a/src/routes/chat.js
+++ b/src/routes/chat.js
@@ -494,9 +494,10 @@ router.post('/api/chat/session/:id/resume', async (req, res) => {
       return res.status(404).json({ error: 'Review not found for session' });
     }
 
-    // Pi's --session replays the original conversation; --append-system-prompt
-    // re-injects the review context so the agent retains awareness of the codebase
-    // even if the system prompt was only in the initial session's context.
+    // Pi's --session replays the original conversation;
+    // --append-system-prompt re-injects the review context so the agent retains
+    // awareness of the codebase even if the system prompt was only in the
+    // initial session's context.
     const chatInstructions = await getChatInstructions(db, review);
     const prData = await fetchPrData(db, review);
 

--- a/tests/unit/chat/pi-bridge.test.js
+++ b/tests/unit/chat/pi-bridge.test.js
@@ -25,13 +25,37 @@ const PiBridge = require('../../../src/chat/pi-bridge');
 /**
  * Helper to create a fake child process with real-enough streams for readline.
  */
-function createFakeProcess() {
+/**
+ * Helper to create a fake child process with real-enough streams for readline.
+ * By default, auto-responds to get_state RPC commands so that start() resolves
+ * quickly without hitting the 5s timeout.  Pass { autoRespondGetState: false }
+ * to suppress this and control the response manually.
+ */
+function createFakeProcess({ autoRespondGetState = true } = {}) {
   const proc = new EventEmitter();
   proc.stdin = new PassThrough();
   proc.stdin.writable = true;
   // Keep a spy on the original write so we can assert calls
   const origWrite = proc.stdin.write.bind(proc.stdin);
-  proc.stdin.write = vi.fn((...args) => origWrite(...args));
+  proc.stdin.write = vi.fn((...args) => {
+    origWrite(...args);
+    // Auto-respond to get_state so start() resolves promptly
+    if (autoRespondGetState) {
+      try {
+        const parsed = JSON.parse(String(args[0]).trim());
+        if (parsed.type === 'get_state') {
+          setImmediate(() => {
+            proc.stdout.write(JSON.stringify({
+              type: 'response',
+              command: 'get_state',
+              success: true,
+              data: { sessionFile: '/tmp/auto-session.json' }
+            }) + '\n');
+          });
+        }
+      } catch { /* not JSON, ignore */ }
+    }
+  });
   proc.stdout = new PassThrough();
   proc.stderr = new PassThrough();
   proc.kill = vi.fn();
@@ -166,6 +190,7 @@ describe('PiBridge', () => {
       const args = bridge._buildArgs();
       expect(args).toContain('--session');
       expect(args).toContain('/tmp/session.json');
+      expect(args).not.toContain('--continue');
     });
 
     it('should not include --session when sessionPath is null', () => {
@@ -544,6 +569,152 @@ describe('PiBridge', () => {
       await bridge.sendMessage('new question');
 
       expect(bridge._accumulatedText).toBe('');
+    });
+  });
+
+  describe('session file discovery via get_state', () => {
+    let noAutoProc;
+
+    beforeEach(() => {
+      // Use a fake process that does NOT auto-respond to get_state
+      noAutoProc = createFakeProcess({ autoRespondGetState: false });
+      mockSpawn.mockReturnValue(noAutoProc);
+    });
+
+    it('should send get_state after startup and emit session event on response', async () => {
+      const bridge = new PiBridge();
+      const sessionHandler = vi.fn();
+      bridge.on('session', sessionHandler);
+
+      // Intercept get_state write and respond with session file
+      noAutoProc.stdin.write = vi.fn((data) => {
+        try {
+          const parsed = JSON.parse(String(data).trim());
+          if (parsed.type === 'get_state') {
+            setImmediate(() => {
+              noAutoProc.stdout.write(JSON.stringify({
+                type: 'response',
+                command: 'get_state',
+                success: true,
+                data: { sessionFile: '/tmp/pi-session-abc.json' }
+              }) + '\n');
+            });
+          }
+        } catch { /* ignore */ }
+      });
+
+      await bridge.start();
+
+      expect(bridge.sessionPath).toBe('/tmp/pi-session-abc.json');
+      expect(sessionHandler).toHaveBeenCalledWith(
+        expect.objectContaining({ sessionFile: '/tmp/pi-session-abc.json' })
+      );
+    });
+
+    it('should handle get_state response without sessionFile gracefully', async () => {
+      const bridge = new PiBridge();
+      const sessionHandler = vi.fn();
+      bridge.on('session', sessionHandler);
+
+      noAutoProc.stdin.write = vi.fn((data) => {
+        try {
+          const parsed = JSON.parse(String(data).trim());
+          if (parsed.type === 'get_state') {
+            setImmediate(() => {
+              noAutoProc.stdout.write(JSON.stringify({
+                type: 'response',
+                command: 'get_state',
+                success: true,
+                data: {}
+              }) + '\n');
+            });
+          }
+        } catch { /* ignore */ }
+      });
+
+      await bridge.start();
+
+      expect(bridge.sessionPath).toBeNull();
+      expect(sessionHandler).not.toHaveBeenCalled();
+    });
+
+    it('should handle get_state failure gracefully', async () => {
+      const bridge = new PiBridge();
+      const sessionHandler = vi.fn();
+      bridge.on('session', sessionHandler);
+
+      noAutoProc.stdin.write = vi.fn((data) => {
+        try {
+          const parsed = JSON.parse(String(data).trim());
+          if (parsed.type === 'get_state') {
+            setImmediate(() => {
+              noAutoProc.stdout.write(JSON.stringify({
+                type: 'response',
+                command: 'get_state',
+                success: false,
+                error: 'not supported'
+              }) + '\n');
+            });
+          }
+        } catch { /* ignore */ }
+      });
+
+      await bridge.start();
+
+      expect(bridge.sessionPath).toBeNull();
+      expect(sessionHandler).not.toHaveBeenCalled();
+    });
+
+    it('should resolve start even if get_state times out', async () => {
+      vi.useFakeTimers();
+
+      const bridge = new PiBridge();
+
+      // Don't respond to get_state at all
+      noAutoProc.stdin.write = vi.fn();
+
+      // Start will resolve the spawn promise (via setImmediate), then
+      // _querySessionFile sends get_state and waits for the response or timeout
+      const startPromise = bridge.start();
+
+      // Advance past the setImmediate for spawn ready
+      await vi.advanceTimersByTimeAsync(0);
+
+      // Advance past the 5s timeout for get_state
+      await vi.advanceTimersByTimeAsync(5000);
+
+      await startPromise;
+
+      expect(bridge.sessionPath).toBeNull();
+
+      vi.useRealTimers();
+    });
+
+    it('should route get_state response via pending callback, not emit error', async () => {
+      const bridge = new PiBridge();
+      const errorHandler = vi.fn();
+      bridge.on('error', errorHandler);
+
+      noAutoProc.stdin.write = vi.fn((data) => {
+        try {
+          const parsed = JSON.parse(String(data).trim());
+          if (parsed.type === 'get_state') {
+            setImmediate(() => {
+              noAutoProc.stdout.write(JSON.stringify({
+                type: 'response',
+                command: 'get_state',
+                success: true,
+                data: { sessionFile: '/tmp/sess.json' }
+              }) + '\n');
+            });
+          }
+        } catch { /* ignore */ }
+      });
+
+      await bridge.start();
+
+      // Should NOT have emitted an error — the response was routed to the callback
+      expect(errorHandler).not.toHaveBeenCalled();
     });
   });
 

--- a/tests/unit/chat/session-manager.test.js
+++ b/tests/unit/chat/session-manager.test.js
@@ -34,7 +34,7 @@ const _createdAcpBridges = [];
 const _createdClaudeCodeBridges = [];
 const _createdCodexBridges = [];
 
-function MockPiBridge() {
+function MockPiBridge(options) {
   const bridge = new EventEmitter();
   bridge.start = vi.fn().mockImplementation(() => {
     if (_nextStartFail) {
@@ -49,6 +49,7 @@ function MockPiBridge() {
   bridge.isBusy = vi.fn().mockReturnValue(false);
   bridge.abort = vi.fn();
   bridge._bridgeType = 'pi';
+  bridge._constructorOptions = options || {};
   _createdBridges.push(bridge);
   return bridge;
 }
@@ -672,7 +673,7 @@ describe('ChatSessionManager', () => {
       expect(row.agent_session_id).toBeNull();
     });
 
-    it('should resume session with valid session file', async () => {
+    it('should resume session with valid session file and pass sessionPath', async () => {
       const session = await manager.createSession({ provider: 'pi', reviewId: 1 });
       const sessionFilePath = '/tmp/test-resume-session.json';
 
@@ -692,6 +693,10 @@ describe('ChatSessionManager', () => {
         // DB should show active status
         const row = db.prepare('SELECT status FROM chat_sessions WHERE id = ?').get(session.id);
         expect(row.status).toBe('active');
+
+        // Should pass sessionPath to bridge constructor
+        const resumedBridge = _createdBridges[_createdBridges.length - 1];
+        expect(resumedBridge._constructorOptions.sessionPath).toBe(sessionFilePath);
       } finally {
         try { fs.unlinkSync(sessionFilePath); } catch { /* ignore */ }
       }


### PR DESCRIPTION
## Summary
- Pi's RPC protocol never emits a `session` event, so `agent_session_id` was always NULL in the database, blocking all Pi chat session resume attempts with a 410
- After startup, PiBridge now sends a `get_state` RPC command to Pi, extracts `sessionFile` from the response, and emits a `session` event so the session-manager can persist the path
- Added a pending-callback mechanism for routing RPC responses to specific handlers, with a 5-second safety timeout

## Test plan
- [x] PiBridge emits `session` event with `sessionFile` after `start()` resolves
- [x] Handles missing `sessionFile`, failed `get_state`, and timeout gracefully
- [x] `get_state` response routed via callback without emitting spurious errors
- [x] Session-manager passes `sessionPath` to PiBridge constructor on resume
- [x] All 131 unit tests pass (47 pi-bridge + 84 session-manager)

🤖 Generated with [Claude Code](https://claude.com/claude-code)