### PR TITLE
fix: replace deprecated Gemini CLI --yolo flag

### DIFF
--- a/.changeset/gemini-yolo-flag-deprecation.md
+++ b/.changeset/gemini-yolo-flag-deprecation.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Replace deprecated Gemini CLI `--yolo` flag with `--approval-mode yolo`

--- a/src/ai/gemini-provider.js
+++ b/src/ai/gemini-provider.js
@@ -115,9 +115,9 @@ class GeminiProvider extends AIProvider {
     // Use --output-format stream-json for JSONL streaming output (better debugging visibility)
     let baseArgs;
     if (configOverrides.yolo) {
-      // In yolo mode, use Gemini's --yolo flag to auto-approve all tools
-      // (including write operations and destructive shell commands)
-      baseArgs = ['-m', model, '-o', 'stream-json', '--yolo'];
+      // In yolo mode, auto-approve all tools (including write operations and destructive shell commands)
+      // Note: --yolo is deprecated in favor of --approval-mode=yolo
+      baseArgs = ['-m', model, '-o', 'stream-json', '--approval-mode', 'yolo'];
     } else {
       const readOnlyTools = [
         // File system tools (read-only)

--- a/tests/unit/gemini-provider.test.js
+++ b/tests/unit/gemini-provider.test.js
@@ -185,22 +185,23 @@ describe('GeminiProvider', () => {
     });
 
     describe('yolo mode', () => {
-      it('should include --allowed-tools and no --yolo flag by default', () => {
+      it('should include --allowed-tools and no --approval-mode by default', () => {
         const provider = new GeminiProvider('gemini-2.5-pro');
         expect(provider.args).toContain('--allowed-tools');
-        expect(provider.args).not.toContain('--yolo');
+        expect(provider.args).not.toContain('--approval-mode');
       });
 
-      it('should use --yolo instead of --allowed-tools when yolo is true', () => {
+      it('should use --approval-mode=yolo instead of --allowed-tools when yolo is true', () => {
         const provider = new GeminiProvider('gemini-2.5-pro', { yolo: true });
-        expect(provider.args).toContain('--yolo');
+        expect(provider.args).toContain('--approval-mode');
+        expect(provider.args[provider.args.indexOf('--approval-mode') + 1]).toBe('yolo');
         expect(provider.args).not.toContain('--allowed-tools');
       });
 
       it('should use --allowed-tools when yolo is explicitly false', () => {
         const provider = new GeminiProvider('gemini-2.5-pro', { yolo: false });
         expect(provider.args).toContain('--allowed-tools');
-        expect(provider.args).not.toContain('--yolo');
+        expect(provider.args).not.toContain('--approval-mode');
       });
     });
   });


### PR DESCRIPTION
## Summary
- Replace deprecated `--yolo` flag with `--approval-mode yolo` in Gemini provider
- Update corresponding tests
- Part of #325 (broader Gemini CLI flag migration)

## Test plan
- [x] Unit tests updated and passing (60/60)

🤖 Generated with [Claude Code](https://claude.com/claude-code)