### PR TITLE
fix: preserve configured model order on single model tab

### DIFF
--- a/.changeset/preserve-single-model-order.md
+++ b/.changeset/preserve-single-model-order.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Preserve configured model order on the single model tab in the Analysis Config dialog

--- a/public/js/components/AnalysisConfigModal.js
+++ b/public/js/components/AnalysisConfigModal.js
@@ -496,8 +496,7 @@ class AnalysisConfigModal {
     const container = this.modal.querySelector('#model-cards-container');
     if (!container) return;
 
-    const sortedModels = [...this.models].sort((a, b) => (a.name || a.id).localeCompare(b.name || b.id));
-    container.innerHTML = sortedModels.map(model => `
+    container.innerHTML = this.models.map(model => `
       <button class="model-card ${model.id === this.selectedModel ? 'selected' : ''}" data-model="${model.id}" data-tier="${model.tier}">
         <div class="model-badge ${model.badgeClass || ''}">${model.badge || ''}</div>
         <div class="model-icon">${this.getModelIcon(model.tier)}</div>


### PR DESCRIPTION
## Summary
- Removes alphabetical sorting from model cards on the single model tab so they appear in their configured order
- Provider buttons on the same tab remain sorted alphabetically
- No change to Review Council or Advanced tabs

## Test plan
- [ ] Open Analysis Config dialog, verify model cards on single model tab appear in configured order
- [ ] Verify provider buttons are still sorted alphabetically
- [ ] Verify Review Council and Advanced tabs still sort both providers and models

🤖 Generated with [Claude Code](https://claude.com/claude-code)