### PR TITLE
fix: prevent context file header overflow with long paths

### DIFF
--- a/.changeset/fix-context-header-overflow.md
+++ b/.changeset/fix-context-header-overflow.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Fix context file header overflow when file paths are long. The header now truncates long paths from the left (showing the filename) instead of pushing badges and buttons outside the container.

--- a/public/css/pr.css
+++ b/public/css/pr.css
@@ -12277,9 +12277,12 @@ body.resizing * {
   font-size: 14px;
 }
 
-/* Override flex: 1 so the file name doesn't push the badge away */
+/* Don't grow (keeps badge next to text), shrink for long paths, clip from the left so the filename stays visible */
 .context-file-header .d2h-file-name {
-  flex: none;
+  flex: 0 1 auto;
+  direction: rtl;
+  unicode-bidi: plaintext;
+  text-overflow: ellipsis;
 }
 
 /* Push viewed checkbox (and everything after it) to the right */


### PR DESCRIPTION
## Summary
- Context file headers with long paths pushed badges and buttons outside the container
- Changed `flex: none` to `flex: 0 1 auto` so the file name shrinks when needed
- Added `direction: rtl` trick to truncate from the left, keeping the filename visible (e.g. `…nested/Thing.tsx` instead of `src/deeply/ne…`)

## Test plan
- [ ] Open a review with context files that have long paths
- [ ] Verify the header stays within bounds and truncates from the left
- [ ] Verify short paths still display normally with badge adjacent to text

🤖 Generated with [Claude Code](https://claude.com/claude-code)