### PR TITLE
fix: inject paragraph separation between Claude text content blocks

### DIFF
--- a/.changeset/fix-claude-text-block-spacing.md
+++ b/.changeset/fix-claude-text-block-spacing.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Fix Claude chat sentences running together when multiple text content blocks are sent in a single response

--- a/src/chat/claude-code-bridge.js
+++ b/src/chat/claude-code-bridge.js
@@ -465,6 +465,14 @@ class ClaudeCodeBridge extends EventEmitter {
             toolName: name,
             status: 'start',
           });
+        } else if (event.content_block && event.content_block.type === 'text') {
+          // When a new text block starts and we already have accumulated text
+          // from a previous block, inject paragraph separation so the markdown
+          // renderer doesn't smash the blocks together (e.g., "diff.The").
+          if (this._accumulatedText) {
+            this._accumulatedText += '\n\n';
+            this.emit('delta', { text: '\n\n' });
+          }
         }
         break;
 

--- a/tests/unit/chat/claude-code-bridge.test.js
+++ b/tests/unit/chat/claude-code-bridge.test.js
@@ -440,6 +440,85 @@ describe('ClaudeCodeBridge', () => {
       expect(bridge._accumulatedText).toBe('Hello world');
     });
 
+    it('should inject paragraph separation between text content blocks', async () => {
+      const { mockDeps, rlEmitter } = createMockDeps();
+      const bridge = new ClaudeCodeBridge({ _deps: mockDeps });
+      await startBridge(bridge, rlEmitter);
+
+      bridge._inMessage = true;
+
+      const deltaHandler = vi.fn();
+      bridge.on('delta', deltaHandler);
+
+      // First text block
+      simulateLine(rlEmitter, {
+        type: 'stream_event',
+        event: {
+          type: 'content_block_start',
+          content_block: { type: 'text' },
+        },
+      });
+      simulateLine(rlEmitter, {
+        type: 'stream_event',
+        event: {
+          type: 'content_block_delta',
+          delta: { type: 'text_delta', text: 'Let me look at the actual diff.' },
+        },
+      });
+
+      // Second text block starts — should inject paragraph separation
+      simulateLine(rlEmitter, {
+        type: 'stream_event',
+        event: {
+          type: 'content_block_start',
+          content_block: { type: 'text' },
+        },
+      });
+      simulateLine(rlEmitter, {
+        type: 'stream_event',
+        event: {
+          type: 'content_block_delta',
+          delta: { type: 'text_delta', text: 'The changes look good.' },
+        },
+      });
+
+      expect(bridge._accumulatedText).toBe(
+        'Let me look at the actual diff.\n\nThe changes look good.'
+      );
+      // Separator emitted as a delta
+      expect(deltaHandler).toHaveBeenCalledWith({ text: '\n\n' });
+    });
+
+    it('should not inject separator before the first text content block', async () => {
+      const { mockDeps, rlEmitter } = createMockDeps();
+      const bridge = new ClaudeCodeBridge({ _deps: mockDeps });
+      await startBridge(bridge, rlEmitter);
+
+      bridge._inMessage = true;
+
+      const deltaHandler = vi.fn();
+      bridge.on('delta', deltaHandler);
+
+      // First text block — no prior text, so no separator
+      simulateLine(rlEmitter, {
+        type: 'stream_event',
+        event: {
+          type: 'content_block_start',
+          content_block: { type: 'text' },
+        },
+      });
+      simulateLine(rlEmitter, {
+        type: 'stream_event',
+        event: {
+          type: 'content_block_delta',
+          delta: { type: 'text_delta', text: 'Hello' },
+        },
+      });
+
+      expect(bridge._accumulatedText).toBe('Hello');
+      expect(deltaHandler).not.toHaveBeenCalledWith({ text: '\n\n' });
+    });
+
     it('should emit tool_use start on stream_event content_block_start tool_use', async () => {
       const { mockDeps, rlEmitter } = createMockDeps();
       const bridge = new ClaudeCodeBridge({ _deps: mockDeps });


### PR DESCRIPTION
## Summary
- Fix Claude chat output where sentences run together without spacing (e.g., "diff.The changes") when multiple text content blocks are sent in a single response
- Apply the same `content_block_start` paragraph separation fix already used in the Pi bridge
- ACP and Codex providers don't need this — they use continuous stream fragments without block boundaries

## Test plan
- [x] Added unit test for paragraph separation between text blocks
- [x] Added unit test verifying no separator before first text block
- [x] All 64 Claude Code bridge tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)