### PR TITLE
fix: center context file line window around target line

### DIFF
--- a/.changeset/center-context-file-lines.md
+++ b/.changeset/center-context-file-lines.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Center context file line window around the target line (±10 lines) instead of starting from it. Near the beginning or end of a file, the window shifts to show ~20 lines of content.

--- a/public/js/pr.js
+++ b/public/js/pr.js
@@ -4480,7 +4480,16 @@ class PRManager {
     const tbody = document.createElement('tbody');
     tbody.className = 'd2h-diff-tbody context-chunk';
     tbody.dataset.contextId = contextFile.id;
-    tbody.dataset.lineStart = contextFile.line_start;
+
+    // Compute effective display range, shifting for end-of-file
+    const clampedEnd = Math.min(contextFile.line_end, data.lines.length);
+    const intendedSize = contextFile.line_end - contextFile.line_start + 1;
+    let effectiveStart = contextFile.line_start;
+    const actualSize = clampedEnd - effectiveStart + 1;
+    if (actualSize < intendedSize && effectiveStart > 1) {
+      effectiveStart = Math.max(1, effectiveStart - (intendedSize - actualSize));
+    }
+    tbody.dataset.lineStart = effectiveStart;
 
     // Chunk header row with range label and per-chunk dismiss button
     const headerRow = document.createElement('tr');
@@ -4493,8 +4502,7 @@ class PRManager {
     contentTd.colSpan = 3;
     const rangeLabel = document.createElement('span');
     rangeLabel.className = 'context-range-label';
-    const lineEnd = Math.min(contextFile.line_end, data.lines.length);
-    rangeLabel.textContent = `Lines ${contextFile.line_start}\u2013${lineEnd}`;
+    rangeLabel.textContent = `Lines ${effectiveStart}\u2013${clampedEnd}`;
     contentTd.appendChild(rangeLabel);
     const chunkDismiss = document.createElement('button');
     chunkDismiss.className = 'context-chunk-dismiss';
@@ -4508,25 +4516,22 @@ class PRManager {
     headerRow.appendChild(contentTd);
     tbody.appendChild(headerRow);
 
-    const lineStart = contextFile.line_start;
-    const clampedEnd = Math.min(contextFile.line_end, data.lines.length);
-
     // Add expand-up gap row if there are lines above the context range
-    if (lineStart > 1) {
-      const gapAboveSize = lineStart - 1;
+    if (effectiveStart > 1) {
+      const gapAboveSize = effectiveStart - 1;
       const gapAbove = window.HunkParser.createGapRowElement(
         contextFile.file,
-        1,              // startLine (old coords)
-        lineStart - 1,  // endLine (old coords)
+        1,                  // startLine (old coords)
+        effectiveStart - 1, // endLine (old coords)
         gapAboveSize,
         'above',
         this.expandGapContext.bind(this),
-        1               // startLineNew (same as old for context files — no diff offset)
+        1                   // startLineNew (same as old for context files — no diff offset)
       );
       tbody.appendChild(gapAbove);
     }
 
-    for (let i = lineStart; i <= clampedEnd; i++) {
+    for (let i = effectiveStart; i <= clampedEnd; i++) {
       const lineData = {
         type: 'context',
         oldNumber: i,
@@ -4874,8 +4879,9 @@ class PRManager {
       lineStartVal = 1;
       lineEndVal = 100;
     } else if (lineEnd == null) {
-      lineStartVal = lineStart;
-      lineEndVal = lineStart + 49;
+      // Center a ~21-line window around the target line (±10 lines)
+      lineStartVal = Math.max(1, lineStart - 10);
+      lineEndVal = lineStartVal + 20;
     } else {
       lineStartVal = lineStart;
       lineEndVal = Math.min(lineEnd, lineStart + 499);

--- a/tests/unit/chat-panel.test.js
+++ b/tests/unit/chat-panel.test.js
@@ -4817,15 +4817,26 @@ describe('ChatPanel', () => {
       expect(callBody.line_end).toBe(100);
     });
 
-    it('should set line_end = lineStart + 49 when only lineStart provided', async () => {
+    it('should center ±10 lines around lineStart when only lineStart provided', async () => {
       const mgr = createMockPRManager();
       global.fetch.mockResolvedValue({ status: 201 });
 
-      await mgr.ensureContextFile('src/foo.js', 10);
+      await mgr.ensureContextFile('src/foo.js', 50);
 
       const callBody = JSON.parse(global.fetch.mock.calls[0][1].body);
-      expect(callBody.line_start).toBe(10);
-      expect(callBody.line_end).toBe(59);
+      expect(callBody.line_start).toBe(40);
+      expect(callBody.line_end).toBe(60);
+    });
+
+    it('should clamp lineStart to 1 when target line is near beginning of file', async () => {
+      const mgr = createMockPRManager();
+      global.fetch.mockResolvedValue({ status: 201 });
+
+      await mgr.ensureContextFile('src/foo.js', 3);
+
+      const callBody = JSON.parse(global.fetch.mock.calls[0][1].body);
+      expect(callBody.line_start).toBe(1);
+      expect(callBody.line_end).toBe(21);
     });
 
     it('should clamp range > 500 lines (line_end capped at lineStart + 499)', async () => {


### PR DESCRIPTION
## Summary
- When a context file is added focused on a specific line (e.g., from chat), the displayed lines now center ±10 around the target instead of showing 50 lines starting from it
- Near the beginning of a file, the window clamps to line 1 and shifts forward
- Near the end of a file, the rendering shifts the window start back to maintain ~20 lines of visible content

## Test plan
- [x] Unit tests updated and passing (367/367)
- [ ] Manual: click a file link with a line number in the chat panel — verify the target line appears in the middle of the context chunk, not at the top
- [ ] Manual: click a link targeting line 3 of a file — verify lines 1–21 are shown
- [ ] Manual: click a link targeting the last line of a short file — verify the window shifts back to show ~20 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)