### PR TITLE
Support gh CLI as GitHub token source

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -2,6 +2,8 @@
   "_comment": "Example configuration file for pair-review. Copy to ~/.pair-review/config.json and modify as needed.",
 
   "github_token": "ghp_your_github_personal_access_token_here",
+  "_github_token_source_comment": "Set github_token_source to 'gh' to use the token from 'gh auth token' instead of a static github_token. Requires the GitHub CLI to be installed and authenticated.",
+  "github_token_source": "",
   "port": 7247,
   "theme": "light",
   "default_provider": "claude",

--- a/src/config.js
+++ b/src/config.js
@@ -2,6 +2,7 @@
 const fs = require('fs').promises;
 const path = require('path');
 const os = require('os');
+const childProcess = require('child_process');
 const logger = require('./utils/logger');
 
 const CONFIG_DIR = path.join(os.homedir(), '.pair-review');
@@ -247,6 +248,7 @@ function getConfigDir() {
  * Priority:
  *   1. GITHUB_TOKEN environment variable (highest priority)
  *   2. config.github_token from ~/.pair-review/config.json
+ *   3. `gh auth token` when config.github_token_source is "gh"
  *
  * @param {Object} config - Configuration object from loadConfig()
  * @returns {string} - GitHub token or empty string if not configured
@@ -257,7 +259,18 @@ function getGitHubToken(config) {
     return process.env.GITHUB_TOKEN;
   }
   // Fall back to config file
-  return config.github_token || '';
+  if (config.github_token) {
+    return config.github_token;
+  }
+  // Fall back to gh CLI when configured as token source
+  if (config.github_token_source === 'gh') {
+    try {
+      return childProcess.execSync('gh auth token', { encoding: 'utf8' }).trim();
+    } catch {
+      return '';
+    }
+  }
+  return '';
 }
 
 /**

--- a/src/main.js
+++ b/src/main.js
@@ -337,6 +337,8 @@ GITHUB TOKEN:
     You can provide the token via:
       1. GITHUB_TOKEN environment variable (takes precedence)
       2. github_token field in config file
+      3. github_token_source set to "gh" in config file
+         (uses 'gh auth token' from GitHub CLI)
 
 ENVIRONMENT VARIABLES:
     GITHUB_TOKEN            GitHub Personal Access Token (takes precedence over config file)
@@ -504,7 +506,7 @@ async function handlePullRequest(args, config, db, flags = {}) {
     // Get GitHub token (env var takes precedence over config)
     const githubToken = getGitHubToken(config);
     if (!githubToken) {
-      throw new Error('GitHub token not found. Set GITHUB_TOKEN environment variable or run: npx pair-review --configure');
+      throw new Error('GitHub token not found. Set GITHUB_TOKEN env var, add github_token to config, or set github_token_source to "gh". Run: npx pair-review --configure');
     }
 
     // Parse PR arguments
@@ -600,7 +602,7 @@ async function performHeadlessReview(args, config, db, flags, options) {
     // Get GitHub token (env var takes precedence over config)
     const githubToken = getGitHubToken(config);
     if (!githubToken) {
-      throw new Error('GitHub token not found. Set GITHUB_TOKEN environment variable or run: npx pair-review --configure');
+      throw new Error('GitHub token not found. Set GITHUB_TOKEN env var, add github_token to config, or set github_token_source to "gh". Run: npx pair-review --configure');
     }
 
     // Parse PR arguments

--- a/tests/unit/config.test.js
+++ b/tests/unit/config.test.js
@@ -92,6 +92,69 @@ describe('config.js', () => {
 
       expect(result).toBe('env_token');
     });
+
+    describe('github_token_source: "gh"', () => {
+      let execSyncSpy;
+
+      beforeEach(() => {
+        const childProcess = require('child_process');
+        execSyncSpy = vi.spyOn(childProcess, 'execSync');
+      });
+
+      afterEach(() => {
+        execSyncSpy.mockRestore();
+      });
+
+      it('should resolve token via gh auth token when github_token_source is "gh" and no token/env set', () => {
+        execSyncSpy.mockReturnValue('gh_token_from_cli\n');
+        const config = { github_token_source: 'gh' };
+
+        const result = getGitHubToken(config);
+
+        expect(result).toBe('gh_token_from_cli');
+        expect(execSyncSpy).toHaveBeenCalledWith('gh auth token', { encoding: 'utf8' });
+      });
+
+      it('should return empty string when github_token_source is "gh" but gh CLI fails', () => {
+        execSyncSpy.mockImplementation(() => { throw new Error('command not found: gh'); });
+        const config = { github_token_source: 'gh' };
+
+        const result = getGitHubToken(config);
+
+        expect(result).toBe('');
+      });
+
+      it('should prefer env var over github_token_source', () => {
+        execSyncSpy.mockReturnValue('gh_token\n');
+        process.env.GITHUB_TOKEN = 'env_token';
+        const config = { github_token_source: 'gh' };
+
+        const result = getGitHubToken(config);
+
+        expect(result).toBe('env_token');
+        expect(execSyncSpy).not.toHaveBeenCalled();
+      });
+
+      it('should prefer config.github_token over github_token_source', () => {
+        execSyncSpy.mockReturnValue('gh_token\n');
+        const config = { github_token: 'literal_token', github_token_source: 'gh' };
+
+        const result = getGitHubToken(config);
+
+        expect(result).toBe('literal_token');
+        expect(execSyncSpy).not.toHaveBeenCalled();
+      });
+
+      it('should ignore github_token_source when value is not "gh"', () => {
+        execSyncSpy.mockReturnValue('should_not_be_called\n');
+        const config = { github_token_source: 'unsupported' };
+
+        const result = getGitHubToken(config);
+
+        expect(result).toBe('');
+        expect(execSyncSpy).not.toHaveBeenCalled();
+      });
+    });
   });
 
   describe('expandPath', () => {


### PR DESCRIPTION
## 💡 What it is

Add a new `github_token_source` config option that resolves the GitHub token at runtime via `gh auth token`. Users who already have the GitHub CLI installed and authenticated can set `"github_token_source": "gh"` in their config instead of storing a static token.

## ❓ Why

Avoids storing GitHub tokens in plaintext config files. Users who already have `gh` authenticated can leverage that directly. The option is opt-in to avoid surprising users with multiple GitHub accounts.

## 🔧 How

- `getGitHubToken()` gains a third priority level: after env var and literal token, check `config.github_token_source === 'gh'` and shell out to `gh auth token` via `execSync`
- Gracefully returns empty string if `gh` is not installed or not authenticated (try/catch around execSync)
- Update `--configure` help text and error messages to mention the new option
- Add `github_token_source` to `config.example.json`