### PR TITLE
Auto-refresh GitHub PR tabs on activation

### DIFF
--- a/.changeset/auto-refresh-github-tabs.md
+++ b/.changeset/auto-refresh-github-tabs.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Auto-refresh GitHub PR lists when switching to "My Review Requests" or "My PRs" tabs on the index page

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -402,11 +402,6 @@
       state.fetchedAt = data.fetched_at;
 
       renderCollectionTable(container, state, collection);
-
-      // Auto-refresh on first load if cache is empty
-      if (state.prs.length === 0 && !state.fetchedAt) {
-        refreshCollectionPrs(collection, containerId, state);
-      }
     } catch (error) {
       console.error('Error loading ' + collection + ':', error);
       container.innerHTML =
@@ -1204,19 +1199,25 @@
     const unifiedTabBtn = event.target.closest('#unified-tab-bar .tab-btn');
     if (unifiedTabBtn) {
       const tabBar = document.getElementById('unified-tab-bar');
-      switchTab(tabBar, unifiedTabBtn, function (tabId) {
+      switchTab(tabBar, unifiedTabBtn, async function (tabId) {
         // Persist tab choice
         localStorage.setItem(TAB_STORAGE_KEY, tabId);
         // Lazy-load local reviews on first switch
         if (tabId === 'local-tab' && !localReviewsPagination.loaded) {
           loadLocalReviews();
         }
-        // Lazy-load GitHub collection tabs on first switch
-        if (tabId === 'review-requests-tab' && !reviewRequestsState.loaded) {
-          loadCollectionPrs('review-requests', 'review-requests-container', reviewRequestsState);
+        // Load cached data on first switch, then always refresh from GitHub
+        if (tabId === 'review-requests-tab') {
+          if (!reviewRequestsState.loaded) {
+            await loadCollectionPrs('review-requests', 'review-requests-container', reviewRequestsState);
+          }
+          refreshCollectionPrs('review-requests', 'review-requests-container', reviewRequestsState);
         }
-        if (tabId === 'my-prs-tab' && !myPrsState.loaded) {
-          loadCollectionPrs('my-prs', 'my-prs-container', myPrsState);
+        if (tabId === 'my-prs-tab') {
+          if (!myPrsState.loaded) {
+            await loadCollectionPrs('my-prs', 'my-prs-container', myPrsState);
+          }
+          refreshCollectionPrs('my-prs', 'my-prs-container', myPrsState);
         }
       });
       return;
@@ -1248,12 +1249,14 @@
       loadLocalReviews();
     }
 
-    // If a GitHub collection tab is active, load it immediately
+    // If a GitHub collection tab is active, load cached data then refresh from GitHub
     if (savedTab === 'review-requests-tab') {
-      loadCollectionPrs('review-requests', 'review-requests-container', reviewRequestsState);
+      loadCollectionPrs('review-requests', 'review-requests-container', reviewRequestsState)
+        .then(function () { refreshCollectionPrs('review-requests', 'review-requests-container', reviewRequestsState); });
     }
     if (savedTab === 'my-prs-tab') {
-      loadCollectionPrs('my-prs', 'my-prs-container', myPrsState);
+      loadCollectionPrs('my-prs', 'my-prs-container', myPrsState)
+        .then(function () { refreshCollectionPrs('my-prs', 'my-prs-container', myPrsState); });
     }
 
     // Set up start review form handler

--- a/tests/e2e/ai-analysis.spec.js
+++ b/tests/e2e/ai-analysis.spec.js
@@ -131,6 +131,11 @@ async function seedAISuggestions(page) {
 
   // Wait for at least one AI suggestion to render
   await page.waitForSelector('.ai-suggestion, [data-suggestion-id]', { timeout: 5000 });
+
+  // Dismiss the progress modal if it appeared (the POST triggers the modal via
+  // the running-analysis check on the frontend, and it can linger long enough to
+  // intercept pointer events on suggestion action buttons).
+  await dismissProgressModalIfVisible(page);
 }
 
 test.describe('AI Analysis Button', () => {


### PR DESCRIPTION
## Summary
- Automatically refresh the PR list from GitHub whenever the "My Review Requests" or "My PRs" tab becomes active (on switch or page load)
- Cached data renders instantly while the refresh runs in the background, preventing stale-data races by awaiting cache load before refresh
- Fixes flaky E2E test where `council-progress-modal` intercepted clicks on suggestion action buttons

## Test plan
- [x] Unit/integration tests pass (4,867 tests)
- [x] E2E tests pass (245 tests, previously failing test now fixed)
- [ ] Manual: open index page, switch to "My Review Requests" tab — verify refresh spinner appears and list updates
- [ ] Manual: set "My PRs" as default tab, reload page — verify list refreshes on load

🤖 Generated with [Claude Code](https://claude.com/claude-code)