### PR TITLE
Sticky file headers in diff panel

### DIFF
--- a/.changeset/sticky-file-headers.md
+++ b/.changeset/sticky-file-headers.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Sticky file headers in diff panel so the current file's header stays visible while scrolling

--- a/public/css/pr.css
+++ b/public/css/pr.css
@@ -1188,8 +1188,7 @@
   background: var(--color-bg-primary);
   border: 1px solid var(--color-border-primary);
   border-radius: 8px;
-  overflow-x: auto;
-  overflow-y: visible;
+  overflow: visible; /* Must be visible so sticky file headers work relative to .diff-view */
   position: relative;
   min-width: 0;
   padding-bottom: 1px;
@@ -1335,7 +1334,7 @@
 /* Diff styling improvements */
 .d2h-file-wrapper[data-file-name] {
   margin-bottom: 24px;
-  overflow-x: auto; /* Allow horizontal scroll for long code lines */
+  overflow-x: visible; /* Must be visible for sticky file headers to work */
   max-width: 100%;
 }
 
@@ -1348,6 +1347,9 @@
   border-bottom: 1px solid var(--color-border-primary);
   font-weight: 600;
   font-size: 14px;
+  position: sticky;
+  top: var(--toolbar-height, 0px);
+  z-index: 4;
 }
 
 .d2h-file-name {
@@ -1540,7 +1542,8 @@
   color: #f85149;
 }
 
-/* Hide diff table when collapsed */
+/* Hide diff content when collapsed */
+.d2h-file-wrapper.collapsed .d2h-file-body,
 .d2h-file-wrapper.collapsed .d2h-diff-table {
   display: none;
 }
@@ -1558,6 +1561,12 @@
 /* Make header clickable for collapse toggle */
 .d2h-file-wrapper .d2h-file-header {
   cursor: pointer;
+}
+
+/* Scrollable wrapper for diff tables — provides per-file horizontal scroll
+   now that .d2h-file-wrapper and .diff-container use overflow:visible for sticky headers */
+.d2h-file-body {
+  overflow-x: auto;
 }
 
 .d2h-diff-table {
@@ -6288,6 +6297,9 @@ body:not([data-theme="dark"]) .theme-icon-light {
   background: var(--color-bg-primary);
   border-bottom: 1px solid var(--color-border-primary);
   flex-shrink: 0;
+  position: sticky;
+  top: 0;
+  z-index: 5;
 }
 
 .diff-toolbar .sidebar-toggle-collapsed {
@@ -6759,11 +6771,10 @@ body:not([data-theme="dark"]) .theme-icon-light {
 }
 
 .main-layout .diff-container {
-  flex: 1;
+  flex: 1 0 auto; /* Grow to fill, but don't shrink below content so .diff-view scrolls */
   min-width: 0; /* Prevent flex item from expanding beyond container */
   padding: 16px;
-  overflow-y: auto;
-  overflow-x: auto; /* Allow scroll as fallback for unbreakable content */
+  overflow: visible; /* Must be visible so sticky file headers work relative to .diff-view */
 }
 
 /* --------------------------------------------------------------------------

--- a/public/js/pr.js
+++ b/public/js/pr.js
@@ -180,6 +180,9 @@ class PRManager {
     this.initAnalysisConfigModal();
     this.initKeyboardShortcuts();
 
+    // Track toolbar height for sticky file headers (they sit below the sticky toolbar)
+    this._initToolbarHeightTracking();
+
     // Initialize diff options dropdown (gear icon for whitespace toggle).
     // Must happen before init() so the persisted hideWhitespace state is
     // applied before the first loadAndDisplayFiles() call.
@@ -236,6 +239,27 @@ class PRManager {
       }
       return originalFetch.call(this, input, init);
     };
+  }
+
+  /**
+   * Keep --toolbar-height CSS variable in sync with the actual toolbar size
+   * so sticky file headers can position themselves below the sticky toolbar.
+   */
+  _initToolbarHeightTracking() {
+    const toolbar = document.querySelector('.diff-toolbar');
+    if (!toolbar) return;
+
+    const update = () => {
+      document.documentElement.style.setProperty(
+        '--toolbar-height', toolbar.offsetHeight + 'px'
+      );
+    };
+    update();
+
+    // Re-measure when toolbar resizes (e.g. analysis dots appear/disappear)
+    if (typeof ResizeObserver !== 'undefined') {
+      new ResizeObserver(update).observe(toolbar);
+    }
   }
 
   /**
@@ -1182,7 +1206,13 @@ class PRManager {
     }
 
     table.appendChild(tbody);
-    wrapper.appendChild(table);
+
+    // Wrap table in a scrollable container for horizontal scroll of long code lines
+    // (parent elements use overflow:visible to support sticky file headers)
+    const fileBody = document.createElement('div');
+    fileBody.className = 'd2h-file-body';
+    fileBody.appendChild(table);
+    wrapper.appendChild(fileBody);
 
     return wrapper;
   }
@@ -4784,7 +4814,11 @@ class PRManager {
     table.className = 'd2h-diff-table';
     const tbody = this._buildContextChunkTbody(data, contextFile);
     table.appendChild(tbody);
-    wrapper.appendChild(table);
+
+    const fileBody = document.createElement('div');
+    fileBody.className = 'd2h-file-body';
+    fileBody.appendChild(table);
+    wrapper.appendChild(fileBody);
 
     // Insert in sorted path order among existing file wrappers
     const allWrappers = [...diffContainer.querySelectorAll('.d2h-file-wrapper')];


### PR DESCRIPTION
## Summary
- File headers now stick to the top of the diff panel while scrolling, matching GitHub's behavior
- Toolbar also sticks at the top; file headers position themselves below it via a `--toolbar-height` CSS variable tracked by `ResizeObserver`
- Horizontal scroll for long code lines moved to a new `.d2h-file-body` wrapper so parent elements can use `overflow: visible` (required for sticky positioning)

## Test plan
- [x] Unit tests pass (102/103, 1 pre-existing failure)
- [x] E2E tests pass (246/246)
- [ ] Manual: scroll through a multi-file diff — each file's header should stick below the toolbar until you scroll past that file
- [ ] Manual: verify horizontal scroll still works on files with long lines
- [ ] Manual: verify collapsed files, context files, and generated files render correctly
- [ ] Manual: verify header buttons (viewed, comment, chat) are clickable while sticky

🤖 Generated with [Claude Code](https://claude.com/claude-code)