### PR TITLE
feat: enable user skills/extensions in provider subprocesses

### DIFF
--- a/.changeset/provider-subprocess-flags.md
+++ b/.changeset/provider-subprocess-flags.md
@@ -1,0 +1,9 @@
+---
+"@in-the-loop-labs/pair-review": minor
+---
+
+Enable user skills and extensions in AI provider subprocesses
+
+AI analysis and chat subprocesses no longer suppress the user's configured skills and extensions (`--no-skills`, `--no-extensions` removed from Pi provider, Pi chat bridge, and task extension). This lets the user's environment flow through to subprocesses by default. To opt out, add the corresponding flags to `extra_args` in provider/model config.
+
+Also adds hook suppression (`disableAllHooks`) to the Claude analysis provider, preventing user hooks from firing during review analysis — consistent with the existing chat bridge behavior.

--- a/.pi/extensions/task/index.ts
+++ b/.pi/extensions/task/index.ts
@@ -205,10 +205,13 @@ async function runTask(
 	onUpdate: OnUpdate | undefined,
 	makeDetails: (results: TaskResult[]) => TaskDetails,
 ): Promise<TaskResult> {
-	// Build args: full tool access, JSON output, no session persistence
+	// Build args: full tool access, JSON output, no session persistence.
+	// Skills and extensions are left enabled so subtasks have access to the
+	// user's configured environment. --no-prompt-templates is kept because
+	// prompt templates can't be triggered in -p mode.
 	const args: string[] = [
 		"--mode", "json", "-p", "--no-session",
-		"--no-extensions", "--no-skills", "--no-prompt-templates",
+		"--no-prompt-templates",
 		"-e", EXTENSION_DIR,
 	];
 	if (model) {

--- a/src/ai/claude-provider.js
+++ b/src/ai/claude-provider.js
@@ -174,7 +174,14 @@ class ClaudeProvider extends AIProvider {
       ].join(',');
       permissionArgs = ['--allowedTools', allowedTools];
     }
-    const baseArgs = ['-p', '--verbose', ...cliModelArgs, '--output-format', 'stream-json', ...permissionArgs];
+    // Suppress user hooks in analysis subprocesses to avoid side-effects
+    // (notifications, confirmations, etc.) firing on every tool call during review.
+    // Uses --settings '{"disableAllHooks":true}' since Claude has no --no-hooks flag.
+    // Skills and extensions are left enabled so the subprocess has access to the
+    // user's configured environment. To disable skills, add --disable-slash-commands
+    // to extra_args in provider/model config.
+    const hooksArgs = ['--settings', '{"disableAllHooks":true}'];
+    const baseArgs = ['-p', '--verbose', ...cliModelArgs, '--output-format', 'stream-json', ...hooksArgs, ...permissionArgs];
     if (maxBudget) {
       const budgetNum = parseFloat(maxBudget);
       if (isNaN(budgetNum) || budgetNum <= 0) {

--- a/src/ai/pi-provider.js
+++ b/src/ai/pi-provider.js
@@ -189,24 +189,23 @@ class PiProvider extends AIProvider {
     // --no-session: Each pi invocation is an ephemeral analysis — there's no need to
     //               persist session state between runs. Set PAIR_REVIEW_PI_SESSION=1
     //               to enable session saving for debugging (sessions saved to ~/.pi/sessions/).
-    // --no-skills: Skills are disabled by default to keep runs deterministic. A skill can
-    //              still be loaded via `--skill` in model-specific `extra_args` if needed.
-
     // Build args: base args + built-in extra_args + provider extra_args + model extra_args
     // In yolo mode, omit --tools entirely to allow all tools (including edit, write)
     // The task extension is loaded to give the model a subagent tool for delegating
     // work to isolated subprocesses, preserving the main context window.
-    // --no-extensions prevents auto-discovery of other extensions.
-    // --no-skills and --no-prompt-templates keep the subprocess focused.
+    // --no-prompt-templates: prompt templates can't be triggered in -p mode, so suppress
+    // them to avoid wasting context. Skills and extensions are left enabled so the
+    // subprocess has access to the user's configured environment. To disable them,
+    // add --no-skills or --no-extensions to extra_args in provider/model config.
     const sessionArgs = process.env.PAIR_REVIEW_PI_SESSION ? [] : ['--no-session'];
     let baseArgs;
     if (configOverrides.yolo) {
       baseArgs = ['-p', '--mode', 'json', ...cliModelArgs, ...sessionArgs,
-        '--no-extensions', '--no-skills', '--no-prompt-templates',
+        '--no-prompt-templates',
         '-e', TASK_EXTENSION_DIR];
     } else {
       baseArgs = ['-p', '--mode', 'json', ...cliModelArgs, '--tools', 'read,bash,grep,find,ls', ...sessionArgs,
-        '--no-extensions', '--no-skills', '--no-prompt-templates',
+        '--no-prompt-templates',
         '-e', TASK_EXTENSION_DIR];
     }
     const builtInArgs = builtIn?.extra_args || [];

--- a/src/chat/pi-bridge.js
+++ b/src/chat/pi-bridge.js
@@ -273,12 +273,9 @@ class PiBridge extends EventEmitter {
     }
 
     // Load extensions via -e (e.g., task extension for subagent delegation).
-    // --no-extensions prevents auto-discovery; only explicitly listed ones load.
-    if (this.extensions.length > 0) {
-      args.push('--no-extensions');
-      for (const ext of this.extensions) {
-        args.push('-e', ext);
-      }
+    // These are additive — the user's auto-discovered extensions remain available.
+    for (const ext of this.extensions) {
+      args.push('-e', ext);
     }
 
     return args;

--- a/tests/unit/claude-provider.test.js
+++ b/tests/unit/claude-provider.test.js
@@ -155,6 +155,9 @@ describe('ClaudeProvider', () => {
       expect(provider.args).toContain('--output-format');
       expect(provider.args).toContain('stream-json');
       expect(provider.args).toContain('--allowedTools');
+      // Hooks are suppressed in analysis subprocesses to avoid side-effects
+      expect(provider.args).toContain('--settings');
+      expect(provider.args).toContain('{"disableAllHooks":true}');
     });
 
     it('should merge provider extra_args from config', () => {

--- a/tests/unit/pi-provider.test.js
+++ b/tests/unit/pi-provider.test.js
@@ -150,11 +150,12 @@ describe('PiProvider', () => {
       expect(provider.baseArgs).toContain('--tools');
       expect(provider.baseArgs).toContain('read,bash,grep,find,ls');
       expect(provider.baseArgs).toContain('--no-session');
-      // Task extension loaded, auto-discovery disabled
+      // Task extension loaded, prompt templates suppressed (not useful in -p mode)
       expect(provider.baseArgs).toContain('-e');
-      expect(provider.baseArgs).toContain('--no-extensions');
-      expect(provider.baseArgs).toContain('--no-skills');
       expect(provider.baseArgs).toContain('--no-prompt-templates');
+      // Skills and extensions are left enabled for the user's environment
+      expect(provider.baseArgs).not.toContain('--no-extensions');
+      expect(provider.baseArgs).not.toContain('--no-skills');
     });
 
     it('should merge provider extra_args from config', () => {
@@ -240,9 +241,9 @@ describe('PiProvider', () => {
       expect(provider.baseArgs).not.toContain('--tools');
       expect(provider.baseArgs).not.toContain('read,bash,grep,find,ls');
       expect(provider.baseArgs).toContain('-e');
-      expect(provider.baseArgs).toContain('--no-extensions');
-      expect(provider.baseArgs).toContain('--no-skills');
       expect(provider.baseArgs).toContain('--no-prompt-templates');
+      expect(provider.baseArgs).not.toContain('--no-extensions');
+      expect(provider.baseArgs).not.toContain('--no-skills');
     });
 
     it('should include --tools in non-yolo mode (default)', () => {


### PR DESCRIPTION
## Summary
- **Remove `--no-skills` and `--no-extensions`** from Pi analysis provider, Pi chat bridge, and task extension — the agent should work in the user's configured environment by default
- **Add hook suppression** (`disableAllHooks`) to Claude analysis provider, preventing user hooks from firing during review analysis (consistent with existing chat bridge behavior)
- **Keep `--no-prompt-templates`** — prompt templates can't be triggered in `-p` mode and just waste context

Users who want the old locked-down behavior can add `--no-skills` / `--no-extensions` (Pi) or `--disable-slash-commands` (Claude) to `extra_args` in their provider/model config.

## Test plan
- [x] Pi provider unit tests pass (106 tests)
- [x] Claude provider unit tests pass (116 tests)
- [x] Pi bridge chat tests pass (47 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)