### PR TITLE
feat: add GPT-5.4 models to Codex and Cursor Agent providers

### DIFF
--- a/.changeset/add-gpt-5.4-models.md
+++ b/.changeset/add-gpt-5.4-models.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Add GPT-5.4 models to Codex and Cursor Agent providers

--- a/src/ai/codex-provider.js
+++ b/src/ai/codex-provider.js
@@ -23,7 +23,8 @@ const BIN_DIR = path.join(__dirname, '..', '..', 'bin');
  * Based on OpenAI Codex Models guide (developers.openai.com/codex/models)
  * - gpt-5.1-codex-mini: Smaller, cost-effective variant for quick scans
  * - gpt-5.2-codex: Advanced coding model for everyday reviews, good reasoning/cost balance
- * - gpt-5.3-codex: Most capable agentic coding model with frontier performance and reasoning
+ * - gpt-5.3-codex: Capable agentic coding model with frontier performance and reasoning
+ * - gpt-5.4: Latest generation with enhanced reasoning depth
  */
 const CODEX_MODELS = [
   {
@@ -50,7 +51,16 @@ const CODEX_MODELS = [
     name: 'GPT-5.3 Codex',
     tier: 'thorough',
     tagline: 'Deep Review',
-    description: 'Most capable agentic coding model—combines frontier coding performance with stronger reasoning for deep cross-file analysis.',
+    description: 'Capable agentic coding model—combines frontier coding performance with strong reasoning for cross-file analysis.',
+    badge: 'Thorough',
+    badgeClass: 'badge-power'
+  },
+  {
+    id: 'gpt-5.4',
+    name: 'GPT-5.4',
+    tier: 'thorough',
+    tagline: 'Latest Gen',
+    description: 'Latest generation model with enhanced reasoning depth for complex architectural reviews.',
     badge: 'Most Thorough',
     badgeClass: 'badge-power'
   }

--- a/src/ai/cursor-agent-provider.js
+++ b/src/ai/cursor-agent-provider.js
@@ -143,6 +143,24 @@ const CURSOR_AGENT_MODELS = [
     description: 'Deep analysis with extended thinking—Cursor default for maximum review quality',
     badge: 'Most Thorough',
     badgeClass: 'badge-power'
+  },
+  {
+    id: 'gpt-5.4-high',
+    name: 'GPT-5.4 High',
+    tier: 'thorough',
+    tagline: 'Latest OpenAI',
+    description: 'Latest generation with high reasoning effort—strong for complex architectural reviews',
+    badge: 'Latest Gen',
+    badgeClass: 'badge-power'
+  },
+  {
+    id: 'gpt-5.4-medium',
+    name: 'GPT-5.4',
+    tier: 'thorough',
+    tagline: 'Latest Gen',
+    description: 'Latest generation at medium reasoning depth',
+    badge: 'Latest',
+    badgeClass: 'badge-power'
   }
 ];
 

--- a/tests/unit/codex-provider.test.js
+++ b/tests/unit/codex-provider.test.js
@@ -60,13 +60,14 @@ describe('CodexProvider', () => {
     it('should return array of models with expected structure', () => {
       const models = CodexProvider.getModels();
       expect(Array.isArray(models)).toBe(true);
-      expect(models.length).toBe(3);
+      expect(models.length).toBe(4);
 
       // Check that we have the expected model IDs
       const modelIds = models.map(m => m.id);
       expect(modelIds).toContain('gpt-5.1-codex-mini');
       expect(modelIds).toContain('gpt-5.2-codex');
       expect(modelIds).toContain('gpt-5.3-codex');
+      expect(modelIds).toContain('gpt-5.4');
 
       // Check model structure
       const defaultModel = models.find(m => m.id === 'gpt-5.2-codex');

--- a/tests/unit/cursor-agent-provider.test.js
+++ b/tests/unit/cursor-agent-provider.test.js
@@ -63,7 +63,7 @@ describe('CursorAgentProvider', () => {
     it('should return array of models with expected structure', () => {
       const models = CursorAgentProvider.getModels();
       expect(Array.isArray(models)).toBe(true);
-      expect(models.length).toBe(12);
+      expect(models.length).toBe(14);
 
       // Check that we have the expected model IDs
       const modelIds = models.map(m => m.id);
@@ -79,6 +79,8 @@ describe('CursorAgentProvider', () => {
       expect(modelIds).toContain('gpt-5.3-codex-xhigh');
       expect(modelIds).toContain('opus-4.5-thinking');
       expect(modelIds).toContain('opus-4.6-thinking');
+      expect(modelIds).toContain('gpt-5.4-high');
+      expect(modelIds).toContain('gpt-5.4-medium');
 
       // Check model structure for the default model
       const defaultModel = models.find(m => m.id === 'sonnet-4.6-thinking');


### PR DESCRIPTION
## Summary
- Add GPT-5.4 to Codex provider (thorough tier)
- Add GPT-5.4 High and GPT-5.4 Medium to Cursor Agent provider (both thorough tier)
- Update corresponding tests

## Test plan
- [x] Unit tests pass for codex-provider and cursor-agent-provider

🤖 Generated with [Claude Code](https://claude.com/claude-code)