### PR TITLE
Display app version in header on index page

### DIFF
--- a/.changeset/display-version.md
+++ b/.changeset/display-version.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Display app version in the header on the index page

--- a/public/index.html
+++ b/public/index.html
@@ -1089,6 +1089,7 @@
                         <path transform="rotate(-50 12 12)" d="M18.178 8c5.096 0 5.096 8 0 8-5.095 0-7.133-8-12.356-8-5.096 0-5.096 8 0 8 5.223 0 7.26-8 12.356-8z"/>
                     </svg>
                     <span class="logo-text">pair<span class="logo-accent">review</span></span>
+                    <span id="app-version" style="color: var(--color-fg-muted, #656d76); font-size: 12px; font-weight: 400; margin-left: 6px; opacity: 0.7;"></span>
                 </a>
             </div>
             <div class="header-right">

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -1092,6 +1092,12 @@
         const config = await response.json();
         updateCommandExamples(config.is_running_via_npx);
 
+        // Display version in header
+        if (config.version) {
+          const versionEl = document.getElementById('app-version');
+          if (versionEl) versionEl.textContent = 'v' + config.version;
+        }
+
         // Expose chat provider config to components (ChatPanel reads these)
         window.__pairReview = window.__pairReview || {};
         window.__pairReview.chatProvider = config.chat_provider || 'pi';

--- a/src/routes/config.js
+++ b/src/routes/config.js
@@ -21,6 +21,7 @@ const {
 } = require('../ai');
 const { normalizeRepository } = require('../utils/paths');
 const { isRunningViaNpx, saveConfig } = require('../config');
+const { version } = require('../../package.json');
 const { getAllChatProviders, getAllCachedChatAvailability } = require('../chat/chat-providers');
 const { PRESETS } = require('../utils/comment-formatter');
 const logger = require('../utils/logger');
@@ -42,6 +43,7 @@ router.get('/api/config', (req, res) => {
 
   // Only return safe configuration values (not secrets like github_token)
   res.json({
+    version,
     theme: config.theme || 'light',
     comment_button_action: config.comment_button_action || 'submit',
     comment_format: config.comment_format || 'legacy',


### PR DESCRIPTION
## Summary
- Add package version (e.g. "v2.5.0") in gray text next to the "pairreview" logo in the header on the index page
- Version is served from `package.json` via the existing `/api/config` endpoint and populated client-side on load

## Test plan
- [ ] Open the index page and verify the version appears in gray next to the logo
- [ ] Confirm the version matches `package.json`
- [ ] Verify existing `/api/config` integration tests pass (`npx vitest run tests/integration/routes.test.js -t "GET /api/config"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)