### PR TITLE
fix: skip user config creation when managed config has keys

### DIFF
--- a/.changeset/skip-user-config-when-managed.md
+++ b/.changeset/skip-user-config-when-managed.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Skip creating ~/.pair-review/config.json on first run when config.managed.json contains configuration keys

--- a/src/config.js
+++ b/src/config.js
@@ -185,22 +185,26 @@ async function loadConfig() {
 
   let mergedConfig = { ...DEFAULT_CONFIG };
   let isFirstRun = false;
+  let hasManagedConfig = false;
 
   for (const source of sources) {
     try {
       const data = await fs.readFile(source.path, 'utf8');
       const parsed = JSON.parse(data);
+      if (source.label === 'managed config' && Object.keys(parsed).length > 0) {
+        hasManagedConfig = true;
+      }
       mergedConfig = deepMerge(mergedConfig, parsed);
     } catch (error) {
       if (error.code === 'ENOENT') {
-        if (source.required) {
+        if (source.required && !hasManagedConfig) {
           // Global config doesn't exist — create it with defaults
           const config = { ...DEFAULT_CONFIG };
           await saveConfig(config);
           logger.debug(`Created default config file: ${CONFIG_FILE}`);
           isFirstRun = true;
         }
-        // Optional files: skip silently
+        // Optional files or managed-config-present: skip silently
       } else if (error instanceof SyntaxError) {
         if (source.required) {
           console.error(`Invalid configuration file at ~/.pair-review/config.json`);

--- a/tests/unit/config.test.js
+++ b/tests/unit/config.test.js
@@ -1095,6 +1095,44 @@ describe('config.js', () => {
       expect(config.port).toBe(7247);
     });
 
+    it('should skip creating global config when managed config has keys', async () => {
+      mockReadFile({
+        managed: { default_provider: 'gemini', theme: 'dark' },
+        global: null,  // ENOENT — would normally trigger creation
+      });
+
+      const { config, isFirstRun } = await loadConfig();
+
+      expect(writeFileSpy).not.toHaveBeenCalled();
+      expect(isFirstRun).toBe(false);
+      expect(config.default_provider).toBe('gemini');
+      expect(config.theme).toBe('dark');
+    });
+
+    it('should still create global config when managed config is empty object', async () => {
+      mockReadFile({
+        managed: {},
+        global: null,  // ENOENT
+      });
+
+      const { isFirstRun } = await loadConfig();
+
+      expect(writeFileSpy).toHaveBeenCalled();
+      expect(isFirstRun).toBe(true);
+    });
+
+    it('should still create global config when managed config is missing', async () => {
+      mockReadFile({
+        // managed defaults to null (ENOENT)
+        global: null,
+      });
+
+      const { isFirstRun } = await loadConfig();
+
+      expect(writeFileSpy).toHaveBeenCalled();
+      expect(isFirstRun).toBe(true);
+    });
+
     it('should warn and skip malformed local config files', async () => {
       const logger = require('../../src/utils/logger');
       const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});


### PR DESCRIPTION
## Summary
- When `config.managed.json` contains actual configuration keys, skip creating `~/.pair-review/config.json` on first startup
- An empty `{}` managed config (the default shipping state) still triggers normal first-run behavior
- Prevents corporate/packaged environments from getting an unnecessary user config file that could override managed settings

## Test plan
- [x] Added test: managed config with keys → no user config created, `isFirstRun` false
- [x] Added test: empty `{}` managed config → user config still created, `isFirstRun` true
- [x] Added test: missing managed config → user config still created, `isFirstRun` true
- [x] All 98 config unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)