### PR TITLE
feat: display app version on PR setup page

### DIFF
--- a/.changeset/setup-page-version.md
+++ b/.changeset/setup-page-version.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Display app version on PR setup page and extract shared .app-version CSS class

--- a/public/index.html
+++ b/public/index.html
@@ -177,6 +177,14 @@
             color: var(--color-text-primary);
         }
 
+        .app-version {
+            color: var(--color-fg-muted, #656d76);
+            font-size: 12px;
+            font-weight: 400;
+            margin-left: 6px;
+            opacity: 0.7;
+        }
+
         .header-right {
             display: flex;
             align-items: center;
@@ -1089,7 +1097,7 @@
                         <path transform="rotate(-50 12 12)" d="M18.178 8c5.096 0 5.096 8 0 8-5.095 0-7.133-8-12.356-8-5.096 0-5.096 8 0 8 5.223 0 7.26-8 12.356-8z"/>
                     </svg>
                     <span class="logo-text">pair<span class="logo-accent">review</span></span>
-                    <span id="app-version" style="color: var(--color-fg-muted, #656d76); font-size: 12px; font-weight: 400; margin-left: 6px; opacity: 0.7;"></span>
+                    <span id="app-version" class="app-version"></span>
                 </a>
             </div>
             <div class="header-right">

--- a/public/setup.html
+++ b/public/setup.html
@@ -137,6 +137,14 @@
             color: var(--color-text-primary);
         }
 
+        .app-version {
+            color: var(--color-fg-muted, #656d76);
+            font-size: 12px;
+            font-weight: 400;
+            margin-left: 6px;
+            opacity: 0.7;
+        }
+
         .setup-target {
             font-family: var(--font-mono);
             font-size: 15px;
@@ -463,6 +471,7 @@
                         <path transform="rotate(-50 12 12)" d="M18.178 8c5.096 0 5.096 8 0 8-5.095 0-7.133-8-12.356-8-5.096 0-5.096 8 0 8 5.223 0 7.26-8 12.356-8z"/>
                     </svg>
                     <span class="logo-text">pair<span class="logo-accent">review</span></span>
+                    <span id="app-version" class="app-version"></span>
                 </a>
                 <div class="setup-target" id="setup-target"></div>
                 <div class="setup-subtitle">Setting up review</div>
@@ -838,6 +847,16 @@
                     }
                 });
             }
+
+            /* ── Display Version ── */
+            fetch('/api/config').then(function(r) {
+                return r.ok ? r.json() : null;
+            }).then(function(config) {
+                if (config && config.version) {
+                    var versionEl = document.getElementById('app-version');
+                    if (versionEl) versionEl.textContent = 'v' + config.version;
+                }
+            }).catch(function() { /* non-critical */ });
 
             /* ── Kick Off ── */
             startSetup();


### PR DESCRIPTION
## Summary
- Display the app version next to the "pairreview" logo on the PR setup page, fetched from `/api/config`
- Extract the inline version styles into a shared `.app-version` CSS class on both index and setup pages

## Test plan
- [ ] Open the setup page (start a PR review) and verify the version appears next to "pairreview"
- [ ] Verify the index page still shows the version correctly
- [ ] Verify styling matches between both pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)