### PR TITLE
Gracefully handle failed inline comments instead of nuking entire review

### DIFF
--- a/src/github/client.js
+++ b/src/github/client.js
@@ -397,13 +397,14 @@ class GitHubClient {
    */
   async addCommentsInBatches(prNodeId, reviewId, comments, batchSize = 10) {
     if (comments.length === 0) {
-      return { successCount: 0, failed: false, failedDetails: [] };
+      return { successCount: 0, failed: false, failedDetails: [], failedComments: [] };
     }
 
     let currentBatchSize = batchSize;
     let remaining = comments.slice();
     let totalSuccessful = 0;
     const failedDetails = [];
+    const failedComments = [];
     let batchNumber = 0;
 
     console.log(`Adding ${comments.length} comments in batches of up to ${currentBatchSize}`);
@@ -535,16 +536,15 @@ class GitHubClient {
               const location = `${batch[i].path}:${batch[i].line || 'file-level'}`;
               console.warn(`Comment ${i} in batch ${batchNumber} failed to add: ${location} - ${ghError}`);
               failedDetails.push(`${location} - ${ghError}`);
+              failedComments.push(batch[i]);
             }
           }
-          // If not all comments in batch succeeded, it's a failure
           if (batchSuccessful < batch.length) {
-            console.error(`CRITICAL: Batch ${batchNumber} had ${batch.length - batchSuccessful} failures`);
-            return { successCount: totalSuccessful + batchSuccessful, failed: true, failedDetails };
+            console.warn(`Batch ${batchNumber} had ${batch.length - batchSuccessful} failures, continuing with remaining batches`);
           }
-          // All comments succeeded despite the error being thrown (recovered from partial error)
-          console.log(`Batch ${batchNumber} complete (recovered from partial error): ${batchSuccessful} comments added`);
+          // Continue processing — don't return early on partial failure
           totalSuccessful += batchSuccessful;
+          console.log(`Batch ${batchNumber} complete (partial): ${batchSuccessful}/${batch.length} comments added`);
         } else {
           // Total failure of the batch
           const totalError = batchError.message || 'Unknown error';
@@ -554,8 +554,9 @@ class GitHubClient {
             const ghError = perCommentErrors[`comment${i}`] || totalError;
             const location = `${batch[i].path}:${batch[i].line || 'file-level'}`;
             failedDetails.push(`${location} - ${ghError}`);
+            failedComments.push(batch[i]);
           }
-          return { successCount: totalSuccessful, failed: true, failedDetails };
+          console.warn(`Batch ${batchNumber} failed completely, continuing with remaining batches`);
         }
       } else if (batchResult) {
         // Verify each comment was successfully added
@@ -568,24 +569,59 @@ class GitHubClient {
             const location = `${batch[i].path}:${batch[i].line || 'file-level'}`;
             console.warn(`Comment ${i} in batch ${batchNumber} failed to add: ${location} - No error details available`);
             failedDetails.push(`${location} - No error details available`);
+            failedComments.push(batch[i]);
           }
         }
 
         if (batchSuccessful < batch.length) {
-          console.error(`CRITICAL: Batch ${batchNumber} had ${batch.length - batchSuccessful} failures`);
-          return { successCount: totalSuccessful + batchSuccessful, failed: true, failedDetails };
+          console.warn(`Batch ${batchNumber} had ${batch.length - batchSuccessful} failures, continuing with remaining batches`);
         }
 
         totalSuccessful += batchSuccessful;
-        console.log(`Batch ${batchNumber} complete: ${batchSuccessful} comments added`);
+        console.log(`Batch ${batchNumber} complete: ${batchSuccessful}/${batch.length} comments added`);
       }
 
       // Advance past the successfully processed batch
       remaining = remaining.slice(batch.length);
     }
 
-    console.log(`All batches complete: ${totalSuccessful} total comments added`);
-    return { successCount: totalSuccessful, failed: false, failedDetails };
+    const hasFailed = failedComments.length > 0;
+    if (hasFailed) {
+      console.warn(`All batches complete: ${totalSuccessful} comments added, ${failedComments.length} failed`);
+    } else {
+      console.log(`All batches complete: ${totalSuccessful} total comments added`);
+    }
+    return { successCount: totalSuccessful, failed: hasFailed, failedDetails, failedComments };
+  }
+
+  /**
+   * Format failed comments as text to append to the review body.
+   * When inline comments fail (e.g., invalid line positions outside diff hunks),
+   * we include them in the review body so the feedback is not lost.
+   *
+   * @param {Array} failedComments - Array of comment objects that failed to post inline
+   * @returns {string} Formatted text to append to review body
+   */
+  formatFailedCommentsForBody(failedComments) {
+    if (!failedComments || failedComments.length === 0) return '';
+
+    const lines = [
+      '',
+      '---',
+      `⚠️ **${failedComments.length} comment${failedComments.length === 1 ? '' : 's'} could not be posted inline** (invalid position in diff):`,
+      ''
+    ];
+
+    for (const comment of failedComments) {
+      const location = comment.line
+        ? `**${comment.path}:${comment.line}**`
+        : `**${comment.path}** (file-level)`;
+      lines.push(`### ${location}`);
+      lines.push(comment.body);
+      lines.push('');
+    }
+
+    return lines.join('\n');
   }
 
   /**
@@ -807,30 +843,29 @@ class GitHubClient {
 
       // Step 2: Add comments in batches
       let successfulComments = 0;
+      let failedCommentsList = [];
       if (comments.length > 0) {
         console.log(`Step 2: Adding ${comments.length} comments in batches...`);
         const batchResult = await this.addCommentsInBatches(prNodeId, reviewId, comments);
         successfulComments = batchResult.successCount;
+        failedCommentsList = batchResult.failedComments || [];
 
         if (batchResult.failed) {
           const failedCount = comments.length - successfulComments;
-          const details = batchResult.failedDetails || [];
-          console.error(`CRITICAL: ${failedCount} of ${comments.length} comments failed to add to GitHub`);
-          // Only clean up the pending review if we created it (not if it was pre-existing)
-          if (!usedExistingReview) {
-            const cleaned = await this.deletePendingReview(reviewId);
-            if (!cleaned) {
-              console.warn('Warning: Failed to clean up pending review - manual cleanup may be required');
-            }
-          } else {
-            console.warn('Skipping cleanup of pre-existing pending review - comments may be partially added');
-          }
-          const detailSuffix = details.length > 0 ? ` Failures:\n${details.join('\n')}` : '';
-          throw new Error(`Failed to add ${failedCount} of ${comments.length} comments to GitHub.${detailSuffix}`);
+          console.warn(
+            `${failedCount} of ${comments.length} comments failed to add inline. ` +
+            `${successfulComments} posted inline, ${failedCount} will be added to review body.`
+          );
         }
       }
 
       // Step 3: Submit the review
+      // If some comments failed, append them to the body so feedback is not lost
+      let finalBody = body || '';
+      if (failedCommentsList.length > 0) {
+        finalBody += this.formatFailedCommentsForBody(failedCommentsList);
+      }
+
       console.log(`Step 3: Submitting review with event ${event}...`);
       const submitResult = await this.octokit.graphql(`
         mutation SubmitReview($reviewId: ID!, $event: PullRequestReviewEvent!, $body: String) {
@@ -850,18 +885,23 @@ class GitHubClient {
       `, {
         reviewId: reviewId,
         event: event,
-        body: body || null
+        body: finalBody || null
       });
 
       const result = submitResult.submitPullRequestReview.pullRequestReview;
-      console.log(`Review submitted successfully: ${result.url}`);
+      if (failedCommentsList.length > 0) {
+        console.warn(`Review submitted with ${successfulComments} inline comments, ${failedCommentsList.length} added to review body: ${result.url}`);
+      } else {
+        console.log(`Review submitted successfully: ${result.url}`);
+      }
 
       return {
         id: result.id,
         databaseId: result.databaseId,
         html_url: result.url,
         state: result.state,
-        comments_count: successfulComments
+        comments_count: successfulComments,
+        failed_comments_count: failedCommentsList.length
       };
 
     } catch (error) {
@@ -934,42 +974,66 @@ class GitHubClient {
 
       // Step 2: Add comments in batches
       let successfulComments = 0;
+      let failedCommentsList = [];
       if (comments.length > 0) {
         console.log(`Step 2: Adding ${comments.length} comments in batches...`);
         const batchResult = await this.addCommentsInBatches(prNodeId, reviewId, comments);
         successfulComments = batchResult.successCount;
+        failedCommentsList = batchResult.failedComments || [];
 
         if (batchResult.failed) {
           const failedCount = comments.length - successfulComments;
-          const details = batchResult.failedDetails || [];
-          const detailSuffix = details.length > 0 ? ` Failures:\n${details.join('\n')}` : '';
-          console.error(`CRITICAL: ${failedCount} of ${comments.length} comments failed to add to draft review`);
-          // Only clean up the pending review if we created it (not if it was pre-existing)
-          if (!usedExistingReview) {
-            const cleaned = await this.deletePendingReview(reviewId);
-            if (!cleaned) {
-              console.warn('Warning: Failed to clean up pending review - manual cleanup may be required');
+          console.warn(
+            `${failedCount} of ${comments.length} comments failed to add inline to draft review. ` +
+            `${successfulComments} posted inline, ${failedCount} will be added to review body.`
+          );
+
+          // If all comments failed and we created the review, there's nothing
+          // to keep — but we still don't delete. We'll update the body with all
+          // comments as top-level text so nothing is lost.
+        }
+      }
+
+      // If some comments failed, update the review body to include them
+      if (failedCommentsList.length > 0) {
+        const failedBodyText = this.formatFailedCommentsForBody(failedCommentsList);
+        const updatedBody = (body || '') + failedBodyText;
+        try {
+          await this.octokit.graphql(`
+            mutation UpdateReviewBody($reviewId: ID!, $body: String!) {
+              updatePullRequestReview(input: {
+                pullRequestReviewId: $reviewId
+                body: $body
+              }) {
+                pullRequestReview {
+                  id
+                }
+              }
             }
-            throw new Error(
-              `Failed to add ${failedCount} of ${comments.length} comments to draft review. ` +
-              `The draft review has been deleted.${detailSuffix}`
-            );
-          } else {
-            console.warn('Skipping cleanup of pre-existing pending review - comments may be partially added');
-            throw new Error(`Failed to add ${failedCount} of ${comments.length} comments to existing draft review. ${successfulComments} comments were added to the GitHub draft.${detailSuffix}`);
-          }
+          `, {
+            reviewId: reviewId,
+            body: updatedBody
+          });
+          console.log(`Updated draft review body with ${failedCommentsList.length} failed comment(s)`);
+        } catch (updateError) {
+          console.warn(`Failed to update review body with failed comments: ${updateError.message}`);
         }
       }
 
       // Note: We do NOT submit the review - it stays as PENDING (draft)
-      console.log(`Draft review created successfully (pending): ${reviewUrl || reviewId}`);
+      if (failedCommentsList.length > 0) {
+        console.warn(`Draft review created with ${successfulComments} inline comments, ${failedCommentsList.length} added to review body (pending): ${reviewUrl || reviewId}`);
+      } else {
+        console.log(`Draft review created successfully (pending): ${reviewUrl || reviewId}`);
+      }
 
       return {
         id: reviewId,
         databaseId: reviewDatabaseId,
         html_url: reviewUrl,
         state: 'PENDING',
-        comments_count: successfulComments
+        comments_count: successfulComments,
+        failed_comments_count: failedCommentsList.length
       };
 
     } catch (error) {

--- a/tests/unit/github-client.test.js
+++ b/tests/unit/github-client.test.js
@@ -391,12 +391,18 @@ describe('GitHubClient', () => {
       expect(firstCallMutation).toContain('addPullRequestReview');
     });
 
-    it('should NOT delete pre-existing review on batch failure', async () => {
+    it('should NOT delete pre-existing review on batch failure and submit with failed comments in body', async () => {
       const client = new GitHubClient('test-token');
       const mockGraphql = vi.fn()
         // Add comments batch fails completely
         .mockRejectedValueOnce(new Error('Batch failed'))
-        .mockRejectedValueOnce(new Error('Batch failed retry'));
+        .mockRejectedValueOnce(new Error('Batch failed retry'))
+        // Step 3: Submit review succeeds (with failed comments appended to body)
+        .mockResolvedValueOnce({
+          submitPullRequestReview: {
+            pullRequestReview: { id: 'existing-review-id', databaseId: 789, url: 'https://github.com/owner/repo/pull/1#pullrequestreview-789', state: 'COMMENTED' }
+          }
+        });
       client.octokit.graphql = mockGraphql;
 
       // Spy on deletePendingReview to ensure it's NOT called
@@ -410,15 +416,21 @@ describe('GitHubClient', () => {
         isFileLevel: false
       }];
 
-      await expect(
-        client.createReviewGraphQL('PR_node123', 'COMMENT', 'Body', comments, 'existing-review-id')
-      ).rejects.toThrow('Failed to add');
+      const result = await client.createReviewGraphQL('PR_node123', 'COMMENT', 'Body', comments, 'existing-review-id');
 
-      // deletePendingReview should NOT be called for pre-existing reviews
+      // deletePendingReview should NOT be called — review is kept with failed comments in body
       expect(deleteSpy).not.toHaveBeenCalled();
+      // Review should be submitted
+      expect(result.state).toBe('COMMENTED');
+      expect(result.comments_count).toBe(0);
+      expect(result.failed_comments_count).toBe(1);
+      // Body should include the failed comment text
+      const submitCall = mockGraphql.mock.calls[2];
+      expect(submitCall[1].body).toContain('could not be posted inline');
+      expect(submitCall[1].body).toContain('src/file.js:1');
     });
 
-    it('should delete newly-created review on batch failure', async () => {
+    it('should NOT delete newly-created review on batch failure and submit with failed comments in body', async () => {
       const client = new GitHubClient('test-token');
       const mockGraphql = vi.fn()
         // Step 1: Create review succeeds
@@ -429,10 +441,16 @@ describe('GitHubClient', () => {
         })
         // Step 2: Add comments fails
         .mockRejectedValueOnce(new Error('Batch failed'))
-        .mockRejectedValueOnce(new Error('Batch failed retry'));
+        .mockRejectedValueOnce(new Error('Batch failed retry'))
+        // Step 3: Submit review succeeds (with failed comments appended to body)
+        .mockResolvedValueOnce({
+          submitPullRequestReview: {
+            pullRequestReview: { id: 'new-review-456', databaseId: 456, url: 'https://github.com/owner/repo/pull/1#pullrequestreview-456', state: 'COMMENTED' }
+          }
+        });
       client.octokit.graphql = mockGraphql;
 
-      // Spy on deletePendingReview
+      // Spy on deletePendingReview to ensure it's NOT called
       const deleteSpy = vi.spyOn(client, 'deletePendingReview').mockResolvedValue(true);
 
       const comments = [{
@@ -443,12 +461,17 @@ describe('GitHubClient', () => {
         isFileLevel: false
       }];
 
-      await expect(
-        client.createReviewGraphQL('PR_node123', 'COMMENT', 'Body', comments)
-      ).rejects.toThrow('Failed to add');
+      const result = await client.createReviewGraphQL('PR_node123', 'COMMENT', 'Body', comments);
 
-      // deletePendingReview SHOULD be called for reviews we created
-      expect(deleteSpy).toHaveBeenCalledWith('new-review-456');
+      // deletePendingReview should NOT be called — review is kept
+      expect(deleteSpy).not.toHaveBeenCalled();
+      // Review should be submitted
+      expect(result.state).toBe('COMMENTED');
+      expect(result.comments_count).toBe(0);
+      expect(result.failed_comments_count).toBe(1);
+      // Body should include the failed comment text
+      const submitCall = mockGraphql.mock.calls[3];
+      expect(submitCall[1].body).toContain('could not be posted inline');
     });
   });
 
@@ -603,6 +626,160 @@ describe('GitHubClient', () => {
       expect(mutationString).not.toContain('startLine');
       expect(mutationString).toContain('line: 50');
     });
+
+    it('should keep review and update body when some comments fail (partial failure)', async () => {
+      const client = new GitHubClient('test-token');
+      const mockGraphql = vi.fn()
+        // Step 1: Create pending review
+        .mockResolvedValueOnce({
+          addPullRequestReview: {
+            pullRequestReview: { id: 'review-789', databaseId: 789, url: 'https://github.com/owner/repo/pull/1#pullrequestreview-789' }
+          }
+        })
+        // Step 2: Batch with partial success (comment0 succeeds, comment1 fails)
+        .mockRejectedValueOnce(Object.assign(new Error('GraphQL partial failure'), {
+          data: {
+            comment0: { thread: { id: 'thread-0' } },
+            comment1: null
+          },
+          errors: [{ path: ['comment1'], message: 'line is not part of the diff' }]
+        }))
+        .mockRejectedValueOnce(Object.assign(new Error('GraphQL partial failure retry'), {
+          data: {
+            comment0: { thread: { id: 'thread-0' } },
+            comment1: null
+          },
+          errors: [{ path: ['comment1'], message: 'line is not part of the diff' }]
+        }))
+        // Step 3: updatePullRequestReview to add failed comments to body
+        .mockResolvedValueOnce({
+          updatePullRequestReview: { pullRequestReview: { id: 'review-789' } }
+        });
+      client.octokit.graphql = mockGraphql;
+
+      const deleteSpy = vi.spyOn(client, 'deletePendingReview').mockResolvedValue(true);
+
+      const comments = [
+        { path: 'src/good.js', line: 10, side: 'RIGHT', body: 'Good comment', isFileLevel: false },
+        { path: 'src/bad.js', line: 999, side: 'RIGHT', body: 'Bad line comment', isFileLevel: false }
+      ];
+
+      const result = await client.createDraftReviewGraphQL('PR_node123', 'Draft body', comments);
+
+      // Review should NOT be deleted
+      expect(deleteSpy).not.toHaveBeenCalled();
+      // Review should be kept as PENDING
+      expect(result.state).toBe('PENDING');
+      expect(result.comments_count).toBe(1);
+      expect(result.failed_comments_count).toBe(1);
+      // Should have called updatePullRequestReview to update body
+      const updateCall = mockGraphql.mock.calls[3];
+      expect(updateCall[0]).toContain('updatePullRequestReview');
+      expect(updateCall[1].body).toContain('could not be posted inline');
+      expect(updateCall[1].body).toContain('src/bad.js:999');
+    });
+
+    it('should keep review and update body when ALL comments fail', async () => {
+      const client = new GitHubClient('test-token');
+      const mockGraphql = vi.fn()
+        // Step 1: Create pending review
+        .mockResolvedValueOnce({
+          addPullRequestReview: {
+            pullRequestReview: { id: 'review-all-fail', databaseId: 100, url: 'https://github.com/owner/repo/pull/1#pullrequestreview-100' }
+          }
+        })
+        // Step 2: All comments fail
+        .mockRejectedValueOnce(new Error('All comments invalid'))
+        .mockRejectedValueOnce(new Error('All comments invalid retry'))
+        // Step 3: updatePullRequestReview to add all failed comments to body
+        .mockResolvedValueOnce({
+          updatePullRequestReview: { pullRequestReview: { id: 'review-all-fail' } }
+        });
+      client.octokit.graphql = mockGraphql;
+
+      const deleteSpy = vi.spyOn(client, 'deletePendingReview').mockResolvedValue(true);
+
+      const comments = [
+        { path: 'src/a.js', line: 999, side: 'RIGHT', body: 'Comment A', isFileLevel: false },
+        { path: 'src/b.js', line: 888, side: 'RIGHT', body: 'Comment B', isFileLevel: false }
+      ];
+
+      const result = await client.createDraftReviewGraphQL('PR_node123', 'Draft body', comments);
+
+      // Review should NOT be deleted — body updated with all comments
+      expect(deleteSpy).not.toHaveBeenCalled();
+      expect(result.state).toBe('PENDING');
+      expect(result.comments_count).toBe(0);
+      expect(result.failed_comments_count).toBe(2);
+      // Should update body with both failed comments
+      const updateCall = mockGraphql.mock.calls[3];
+      expect(updateCall[1].body).toContain('src/a.js:999');
+      expect(updateCall[1].body).toContain('src/b.js:888');
+    });
+
+    it('should return normally when all comments succeed (no regression)', async () => {
+      const client = new GitHubClient('test-token');
+      const mockGraphql = vi.fn()
+        .mockResolvedValueOnce({
+          addPullRequestReview: {
+            pullRequestReview: { id: 'review-ok', databaseId: 200, url: 'https://github.com/owner/repo/pull/1#pullrequestreview-200' }
+          }
+        })
+        .mockResolvedValueOnce({
+          comment0: { thread: { id: 'thread-0' } },
+          comment1: { thread: { id: 'thread-1' } }
+        });
+      client.octokit.graphql = mockGraphql;
+
+      const comments = [
+        { path: 'src/a.js', line: 10, side: 'RIGHT', body: 'Good A', isFileLevel: false },
+        { path: 'src/b.js', line: 20, side: 'RIGHT', body: 'Good B', isFileLevel: false }
+      ];
+
+      const result = await client.createDraftReviewGraphQL('PR_node123', 'Draft body', comments);
+
+      expect(result.state).toBe('PENDING');
+      expect(result.comments_count).toBe(2);
+      expect(result.failed_comments_count).toBe(0);
+      // Only 2 calls: create review + add comments (no updatePullRequestReview)
+      expect(mockGraphql).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('formatFailedCommentsForBody', () => {
+    it('should format failed comments with file and line info', () => {
+      const client = new GitHubClient('test-token');
+      const failedComments = [
+        { path: 'src/foo.js', line: 42, body: 'This needs refactoring' },
+        { path: 'src/bar.js', line: 100, body: 'Consider using a constant' }
+      ];
+
+      const result = client.formatFailedCommentsForBody(failedComments);
+
+      expect(result).toContain('2 comments could not be posted inline');
+      expect(result).toContain('**src/foo.js:42**');
+      expect(result).toContain('This needs refactoring');
+      expect(result).toContain('**src/bar.js:100**');
+      expect(result).toContain('Consider using a constant');
+    });
+
+    it('should handle file-level comments without line numbers', () => {
+      const client = new GitHubClient('test-token');
+      const failedComments = [
+        { path: 'README.md', body: 'File comment' }
+      ];
+
+      const result = client.formatFailedCommentsForBody(failedComments);
+
+      expect(result).toContain('1 comment could not be posted inline');
+      expect(result).toContain('**README.md** (file-level)');
+    });
+
+    it('should return empty string for no failed comments', () => {
+      const client = new GitHubClient('test-token');
+      expect(client.formatFailedCommentsForBody([])).toBe('');
+      expect(client.formatFailedCommentsForBody(null)).toBe('');
+    });
   });
 
   describe('addCommentsInBatches', () => {
@@ -704,7 +881,7 @@ describe('GitHubClient', () => {
       expect(mockGraphql).toHaveBeenCalledTimes(2);
     });
 
-    it('should return failed: true on partial failure', async () => {
+    it('should return failed: true on partial failure and include failedComments', async () => {
       const client = new GitHubClient('test-token');
       const mockGraphql = vi.fn().mockResolvedValue({
         comment0: { thread: { id: 'thread-0' } },
@@ -721,6 +898,9 @@ describe('GitHubClient', () => {
 
       expect(result.successCount).toBe(1);
       expect(result.failed).toBe(true);
+      expect(result.failedComments).toHaveLength(1);
+      expect(result.failedComments[0].path).toBe('file2.js');
+      expect(result.failedComments[0].body).toBe('Comment 2');
     });
 
     it('should return failed: true when batch completely fails after retry', async () => {


### PR DESCRIPTION
## Summary

When `pair-review --ai-draft` posts a pending review with inline comments, if ANY comment fails to add (e.g., invalid line number outside a diff hunk), the entire pending review is deleted — including all successfully added comments. This fix preserves successful inline comments and adds failed ones to the review body instead.

## Approach

- **`addCommentsInBatches`**: Continue processing remaining batches after a failure instead of returning early. Return a new `failedComments` array alongside `failedDetails` so callers have the full comment objects for embedding in the review body.
- **`createReviewGraphQL`**: Instead of deleting the review and throwing on partial failure, append failed comments to the review body text via `formatFailedCommentsForBody()` and submit the review normally. The reviewer sees inline comments where possible and body-level comments for the rest.
- **`createDraftReviewGraphQL`**: Same approach — instead of deleting the pending review, call `updatePullRequestReview` to update the body with failed comments. The draft review is preserved with all successful inline comments.
- **`formatFailedCommentsForBody`** (new): Formats failed comments as markdown sections with file path, line number, and the original comment body, preceded by a warning banner.

## Test coverage

- 6 new tests covering: partial failure (some comments fail), total failure (all comments fail), no regression (all succeed), `formatFailedCommentsForBody` formatting, and `failedComments` array in batch results.
- 2 existing tests updated to match new behavior (no longer expects throw on failure).
- All 89 tests pass.

Co-authored-by: Claude <noreply@anthropic.com>