### PR TITLE
feat: loop logo spinner easter egg for chat

### DIFF
--- a/public/css/pr.css
+++ b/public/css/pr.css
@@ -11970,6 +11970,25 @@ body.resizing * {
   30% { opacity: 1; transform: scale(1); }
 }
 
+/* Loop logo spinner (easter egg: chat_spinner = "loop") */
+.chat-panel__loop-spinner {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 0;
+}
+
+.chat-panel__loop-spinner svg {
+  width: 20px;
+  height: 20px;
+  color: var(--color-accent-ai, #8b5cf6);
+  animation: loop-spin 1.4s linear infinite;
+}
+
+@keyframes loop-spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}
+
 /* Blinking cursor during streaming */
 .chat-panel__cursor {
   display: inline-block;

--- a/public/js/components/ChatPanel.js
+++ b/public/js/components/ChatPanel.js
@@ -10,6 +10,13 @@ const DISMISS_ICON = `<svg viewBox="0 0 16 16" fill="currentColor" width="12" he
 /** Pixel threshold for considering the user "near the bottom" of the messages container. */
 const NEAR_BOTTOM_THRESHOLD = 80;
 
+const LOOP_SPINNER_HTML = `<span class="chat-panel__loop-spinner"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" width="20" height="20"><path transform="rotate(-50 12 12)" d="M18.178 8c5.096 0 5.096 8 0 8-5.095 0-7.133-8-12.356-8-5.096 0-5.096 8 0 8 5.223 0 7.26-8 12.356-8z"/></svg></span>`;
+const DOTS_SPINNER_HTML = '<span class="chat-panel__typing-indicator"><span></span><span></span><span></span></span>';
+
+function getChatSpinnerHTML() {
+  return window.__pairReview?.chatSpinner === 'loop' ? LOOP_SPINNER_HTML : DOTS_SPINNER_HTML;
+}
+
 class ChatPanel {
   constructor(containerId) {
     this.containerId = containerId;
@@ -2409,7 +2416,7 @@ class ChatPanel {
 
     const bubble = document.createElement('div');
     bubble.className = 'chat-panel__bubble';
-    bubble.innerHTML = '<span class="chat-panel__typing-indicator"><span></span><span></span><span></span></span>';
+    bubble.innerHTML = getChatSpinnerHTML();
 
     msgEl.appendChild(bubble);
     this.messagesEl.appendChild(msgEl);
@@ -2641,10 +2648,10 @@ class ChatPanel {
     // Don't add duplicate
     if (streamingMsg.querySelector('.chat-panel__thinking')) return;
 
-    // Don't add if the bubble still has its initial typing indicator (no content yet).
-    // The bubble's own dots are sufficient — adding a second set would show two pulsing indicators.
+    // Don't add if the bubble still has its initial spinner (no content yet).
+    // The bubble's own indicator is sufficient — adding a second would show two.
     const bubble = streamingMsg.querySelector('.chat-panel__bubble');
-    if (bubble && bubble.querySelector('.chat-panel__typing-indicator')) return;
+    if (bubble && (bubble.querySelector('.chat-panel__typing-indicator') || bubble.querySelector('.chat-panel__loop-spinner'))) return;
 
     // Remove the cursor — the thinking indicator replaces it as the "working" signal.
     // When new text arrives, updateStreamingMessage() will re-add the cursor naturally.
@@ -2653,7 +2660,7 @@ class ChatPanel {
 
     const indicator = document.createElement('div');
     indicator.className = 'chat-panel__thinking';
-    indicator.innerHTML = '<span class="chat-panel__typing-indicator"><span></span><span></span><span></span></span>';
+    indicator.innerHTML = getChatSpinnerHTML();
     streamingMsg.appendChild(indicator);
     this.scrollToBottom();
   }

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -1119,6 +1119,7 @@
         const chatProviders = config.chat_providers || [];
         window.__pairReview.chatProviders = chatProviders;
         window.__pairReview.enableGraphite = config.enable_graphite === true;
+        window.__pairReview.chatSpinner = config.chat_spinner || 'dots';
 
         // Set chat feature state based on config and provider availability
         let chatState = 'disabled';

--- a/public/local.html
+++ b/public/local.html
@@ -19,6 +19,7 @@
             window.__pairReview = window.__pairReview || {};
             window.__pairReview.chatProvider = config.chat_provider || 'pi';
             window.__pairReview.chatProviders = chatProviders;
+            window.__pairReview.chatSpinner = config.chat_spinner || 'dots';
             document.documentElement.setAttribute('data-chat', state);
             const shortcutsState = config.chat_enable_shortcuts === false ? 'disabled' : 'enabled';
             document.documentElement.setAttribute('data-chat-shortcuts', shortcutsState);

--- a/public/pr.html
+++ b/public/pr.html
@@ -27,6 +27,7 @@
             window.__pairReview.chatProviders = chatProviders;
             window.__pairReview.share = config.share || null;
             window.__pairReview.enableGraphite = config.enable_graphite === true;
+            window.__pairReview.chatSpinner = config.chat_spinner || 'dots';
             document.documentElement.setAttribute('data-chat', state);
             const shortcutsState = config.chat_enable_shortcuts === false ? 'disabled' : 'enabled';
             document.documentElement.setAttribute('data-chat-shortcuts', shortcutsState);

--- a/src/routes/config.js
+++ b/src/routes/config.js
@@ -56,6 +56,7 @@ router.get('/api/config', (req, res) => {
     pi_available: getCachedAvailability('pi')?.available || false,
     assisted_by_url: config.assisted_by_url || 'https://github.com/in-the-loop-labs/pair-review',
     enable_graphite: config.enable_graphite === true,
+    chat_spinner: config.chat_spinner || 'dots',
     // Share configuration for external review viewers.
     // - url: The base URL of the external share site
     // - method: Plumbed through for future use (e.g., POST-based share flows).


### PR DESCRIPTION
## Summary
- Adds undocumented `chat_spinner` config option (default `"dots"`)
- When set to `"loop"` in `~/.pair-review/config.json`, replaces the bouncing dots typing indicator in chat with a spinning loop logo SVG
- Plumbed through backend config API → both HTML early-load scripts → `index.js` late-load → `ChatPanel.js` spinner selection

## Test plan
- [ ] Open chat, send a message — confirm default bouncing dots still appear
- [ ] Set `"chat_spinner": "loop"` in config, reload — confirm spinning loop logo appears instead
- [ ] Verify both PR mode and Local mode pick up the config
- [ ] Run `npm test` — all 5049 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)