### PR TITLE
fix: include branch name in local session identity

### DIFF
--- a/.changeset/branch-session-identity.md
+++ b/.changeset/branch-session-identity.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Fix local mode session identity to include branch name. Previously, sessions were keyed by (path, HEAD SHA) only, so switching branches at the same commit would reuse the wrong session. Sessions are now keyed by (path, HEAD SHA, branch) and branch-scope sessions also match on branch name.

--- a/src/database.js
+++ b/src/database.js
@@ -20,7 +20,7 @@ function getDbPath() {
 /**
  * Current schema version - increment this when adding new migrations
  */
-const CURRENT_SCHEMA_VERSION = 29;
+const CURRENT_SCHEMA_VERSION = 30;
 
 /**
  * Database schema SQL statements
@@ -45,6 +45,7 @@ const SCHEMA_SQL = {
       name TEXT,
       local_mode TEXT DEFAULT 'uncommitted',
       local_base_branch TEXT,
+      local_head_branch TEXT,
       local_scope_start TEXT DEFAULT 'unstaged',
       local_scope_end TEXT DEFAULT 'untracked'
     )
@@ -287,7 +288,7 @@ const INDEX_SQL = [
   'CREATE INDEX IF NOT EXISTS idx_worktrees_last_accessed ON worktrees(last_accessed_at)',
   'CREATE INDEX IF NOT EXISTS idx_worktrees_repo ON worktrees(repository)',
   'CREATE UNIQUE INDEX IF NOT EXISTS idx_repo_settings_repository ON repo_settings(repository)',
-  'CREATE UNIQUE INDEX IF NOT EXISTS idx_reviews_local ON reviews(local_path, local_head_sha) WHERE review_type = \'local\'',
+  'CREATE UNIQUE INDEX IF NOT EXISTS idx_reviews_local ON reviews(local_path, local_head_sha, local_head_branch) WHERE review_type = \'local\'',
   // Partial unique index for PR reviews only (NULL pr_number values for local reviews should not conflict)
   'CREATE UNIQUE INDEX IF NOT EXISTS idx_reviews_pr_unique ON reviews(pr_number, repository) WHERE review_type = \'pr\'',
   // Analysis runs indexes
@@ -1356,6 +1357,30 @@ const MIGRATIONS = {
     }
 
     console.log('Migration to schema version 29 complete');
+  },
+
+  // Migration to version 30: adds head branch tracking for branch-aware session identity
+  30: (db) => {
+    console.log('Migrating to schema version 30: Add local_head_branch to reviews');
+
+    if (!columnExists(db, 'reviews', 'local_head_branch')) {
+      try {
+        db.prepare('ALTER TABLE reviews ADD COLUMN local_head_branch TEXT').run();
+        console.log('  Added local_head_branch column to reviews');
+      } catch (error) {
+        if (!error.message.includes('duplicate column name')) throw error;
+        console.log('  Column local_head_branch already exists (race condition)');
+      }
+    } else {
+      console.log('  Column local_head_branch already exists');
+    }
+
+    // Recreate unique index to include local_head_branch in session identity
+    db.prepare('DROP INDEX IF EXISTS idx_reviews_local').run();
+    db.prepare("CREATE UNIQUE INDEX IF NOT EXISTS idx_reviews_local ON reviews(local_path, local_head_sha, local_head_branch) WHERE review_type = 'local'").run();
+    console.log('  Recreated idx_reviews_local with local_head_branch');
+
+    console.log('Migration to schema version 30 complete');
   }
 };
 
@@ -2546,6 +2571,11 @@ class ReviewRepository {
       params.push(updates.name);
     }
 
+    if (updates.local_head_branch !== undefined) {
+      setClauses.push('local_head_branch = ?');
+      params.push(updates.local_head_branch);
+    }
+
     if (updates.submittedAt !== undefined) {
       setClauses.push('submitted_at = ?');
       const submittedAt = updates.submittedAt instanceof Date
@@ -2743,9 +2773,9 @@ class ReviewRepository {
    * @param {string} context.repository - Repository identifier (can be derived from path)
    * @returns {Promise<number>} The review ID
    */
-  async upsertLocalReview({ localPath, localHeadSha, repository, scopeStart, scopeEnd, localMode, localBaseBranch }) {
-    // Try to find existing local review by path and SHA
-    const existing = await this.getLocalReview(localPath, localHeadSha);
+  async upsertLocalReview({ localPath, localHeadSha, repository, scopeStart, scopeEnd, localMode, localBaseBranch, localHeadBranch }) {
+    // Try to find existing local review by path, SHA, and branch
+    const existing = await this.getLocalReview(localPath, localHeadSha, localHeadBranch);
 
     if (existing) {
       // Update the updated_at timestamp (and scope/base if provided)
@@ -2769,6 +2799,10 @@ class ReviewRepository {
         updates.push('local_base_branch = ?');
         params.push(localBaseBranch);
       }
+      if (localHeadBranch !== undefined) {
+        updates.push('local_head_branch = ?');
+        params.push(localHeadBranch);
+      }
       params.push(existing.id);
       await run(this.db, `
         UPDATE reviews
@@ -2785,27 +2819,60 @@ class ReviewRepository {
 
     // Create new local review
     const result = await run(this.db, `
-      INSERT INTO reviews (pr_number, repository, status, review_type, local_path, local_head_sha, local_mode, local_base_branch, local_scope_start, local_scope_end)
-      VALUES (NULL, ?, 'draft', 'local', ?, ?, ?, ?, ?, ?)
-    `, [repository, localPath, localHeadSha, effectiveMode, localBaseBranch || null, effectiveScopeStart, effectiveScopeEnd]);
+      INSERT INTO reviews (pr_number, repository, status, review_type, local_path, local_head_sha, local_mode, local_base_branch, local_head_branch, local_scope_start, local_scope_end)
+      VALUES (NULL, ?, 'draft', 'local', ?, ?, ?, ?, ?, ?, ?)
+    `, [repository, localPath, localHeadSha, effectiveMode, localBaseBranch || null, localHeadBranch || null, effectiveScopeStart, effectiveScopeEnd]);
 
     return result.lastID;
   }
 
   /**
-   * Get a local review by path and HEAD SHA
+   * Get a local review by path, HEAD SHA, and branch.
    * @param {string} localPath - Absolute path to the local repository
    * @param {string} localHeadSha - Current HEAD SHA of the repository
+   * @param {string} [headBranch] - Branch name; when falsy, matches only NULL-branch sessions
    * @returns {Promise<Object|null>} Review record or null if not found
    */
-  async getLocalReview(localPath, localHeadSha) {
+  async getLocalReview(localPath, localHeadSha, headBranch) {
+    const branchClause = headBranch
+      ? 'AND local_head_branch = ?'
+      : 'AND local_head_branch IS NULL';
+    const params = [localPath, localHeadSha];
+    if (headBranch) params.push(headBranch);
     const row = await queryOne(this.db, `
       SELECT id, pr_number, repository, status, review_id,
              created_at, updated_at, submitted_at, review_data, custom_instructions,
              review_type, local_path, local_head_sha, summary, name,
-             local_mode, local_base_branch, local_scope_start, local_scope_end
+             local_mode, local_base_branch, local_head_branch, local_scope_start, local_scope_end
+      FROM reviews
+      WHERE review_type = 'local' AND local_path = ? AND local_head_sha = ? ${branchClause}
+    `, params);
+
+    if (!row) return null;
+
+    return {
+      ...row,
+      review_data: row.review_data ? JSON.parse(row.review_data) : null
+    };
+  }
+
+  /**
+   * Get a local review by path and HEAD SHA only (ignoring branch).
+   * Used by external callers (MCP, analysis results) that may not have branch context.
+   * @param {string} localPath - Absolute path to the local repository
+   * @param {string} localHeadSha - Current HEAD SHA of the repository
+   * @returns {Promise<Object|null>} Review record or null if not found
+   */
+  async getLocalReviewByPathAndSha(localPath, localHeadSha) {
+    const row = await queryOne(this.db, `
+      SELECT id, pr_number, repository, status, review_id,
+             created_at, updated_at, submitted_at, review_data, custom_instructions,
+             review_type, local_path, local_head_sha, summary, name,
+             local_mode, local_base_branch, local_head_branch, local_scope_start, local_scope_end
       FROM reviews
       WHERE review_type = 'local' AND local_path = ? AND local_head_sha = ?
+      ORDER BY updated_at DESC
+      LIMIT 1
     `, [localPath, localHeadSha]);
 
     if (!row) return null;
@@ -2817,32 +2884,50 @@ class ReviewRepository {
   }
 
   /**
+   * Find a local review by path and SHA, trying branch-exact match first,
+   * then falling back to branch-agnostic lookup.
+   * @param {string} localPath - Absolute path to the local repository
+   * @param {string} localHeadSha - Current HEAD SHA of the repository
+   * @param {string} [headBranch] - Branch name for exact match
+   * @returns {Promise<Object|null>} Review record or null if not found
+   */
+  async findLocalReview(localPath, localHeadSha, headBranch) {
+    const review = await this.getLocalReview(localPath, localHeadSha, headBranch);
+    if (review) return review;
+    // Only adopt sessions that predate branch tracking (NULL branch)
+    const fallback = await this.getLocalReviewByPathAndSha(localPath, localHeadSha);
+    if (fallback && fallback.local_head_branch === null) return fallback;
+    return null;
+  }
+
+  /**
    * Get an existing branch-mode local review by path (ignoring HEAD SHA).
    * Branch-mode sessions persist across HEAD changes — only the path matters.
    * @param {string} localPath - Absolute path to the local repository
    * @returns {Promise<Object|null>} Most recent branch-mode review or null
    */
-  async getLocalBranchReview(localPath) {
-    return this.getLocalBranchScopeReview(localPath);
+  async getLocalBranchReview(localPath, headBranch) {
+    return this.getLocalBranchScopeReview(localPath, headBranch);
   }
 
   /**
-   * Get an existing branch-scope local review by path (ignoring HEAD SHA).
-   * Branch-scope sessions persist across HEAD changes — only the path matters.
+   * Get an existing branch-scope local review by path and head branch.
+   * Branch-scope sessions persist across HEAD changes but are scoped to a specific branch.
    * @param {string} localPath - Absolute path to the local repository
+   * @param {string} headBranch - Current branch name
    * @returns {Promise<Object|null>} Most recent branch-scope review or null
    */
-  async getLocalBranchScopeReview(localPath) {
+  async getLocalBranchScopeReview(localPath, headBranch) {
     const row = await queryOne(this.db, `
       SELECT id, pr_number, repository, status, review_id,
              created_at, updated_at, submitted_at, review_data, custom_instructions,
              review_type, local_path, local_head_sha, summary, name,
-             local_mode, local_base_branch, local_scope_start, local_scope_end
+             local_mode, local_base_branch, local_head_branch, local_scope_start, local_scope_end
       FROM reviews
-      WHERE review_type = 'local' AND local_path = ? AND local_scope_start = 'branch'
+      WHERE review_type = 'local' AND local_path = ? AND local_scope_start = 'branch' AND local_head_branch = ?
       ORDER BY updated_at DESC
       LIMIT 1
-    `, [localPath]);
+    `, [localPath, headBranch]);
     if (!row) return null;
     return { ...row, review_data: row.review_data ? JSON.parse(row.review_data) : null };
   }
@@ -2872,7 +2957,7 @@ class ReviewRepository {
    * @param {string} [baseBranch] - Base branch name (only relevant for branch scope)
    * @returns {Promise<boolean>} True if record was updated
    */
-  async updateLocalScope(id, scopeStart, scopeEnd, baseBranch) {
+  async updateLocalScope(id, scopeStart, scopeEnd, baseBranch, headBranch) {
     const updates = ['local_scope_start = ?', 'local_scope_end = ?', 'updated_at = CURRENT_TIMESTAMP'];
     const params = [scopeStart, scopeEnd];
     // Also write local_mode for backward compat
@@ -2882,6 +2967,9 @@ class ReviewRepository {
       updates.push('local_base_branch = ?');
       params.push(baseBranch);
     }
+    // Store head branch when entering branch scope, clear when leaving
+    updates.push('local_head_branch = ?');
+    params.push(scopeStart === 'branch' ? (headBranch || null) : null);
     params.push(id);
     const result = await run(this.db, `
       UPDATE reviews
@@ -2901,7 +2989,7 @@ class ReviewRepository {
       SELECT id, pr_number, repository, status, review_id,
              created_at, updated_at, submitted_at, review_data, custom_instructions,
              review_type, local_path, local_head_sha, summary, name,
-             local_mode, local_base_branch, local_scope_start, local_scope_end
+             local_mode, local_base_branch, local_head_branch, local_scope_start, local_scope_end
       FROM reviews
       WHERE id = ? AND review_type = 'local'
     `, [id]);

--- a/src/local-review.js
+++ b/src/local-review.js
@@ -761,12 +761,20 @@ async function handleLocalReview(targetPath, flags = {}) {
     }
 
     console.log('Checking for existing review session...');
-    let existingReview = await reviewRepo.getLocalReview(repoPath, headSha);
+    let existingReview = await reviewRepo.getLocalReview(repoPath, headSha, branch);
 
     if (!existingReview) {
-      // Check for existing branch-mode session on this path
-      // (branch mode sessions persist across HEAD changes)
-      const branchSession = await reviewRepo.getLocalBranchReview(repoPath);
+      // Adopt legacy sessions that predate branch tracking (local_head_branch is NULL)
+      const legacy = await reviewRepo.getLocalReviewByPathAndSha(repoPath, headSha);
+      if (legacy && legacy.local_head_branch === null) {
+        existingReview = legacy;
+      }
+    }
+
+    if (!existingReview) {
+      // Check for existing branch-scope session on this path
+      // (branch scope sessions persist across HEAD changes)
+      const branchSession = await reviewRepo.getLocalBranchReview(repoPath, branch);
       if (branchSession) {
         existingReview = branchSession;
       }
@@ -780,13 +788,19 @@ async function handleLocalReview(targetPath, flags = {}) {
         await reviewRepo.updateLocalHeadSha(sessionId, headSha);
         console.log(`Updated HEAD SHA on session ${sessionId}: ${existingReview.local_head_sha.substring(0, 7)} -> ${headSha.substring(0, 7)}`);
       }
+      // Backfill branch on legacy sessions
+      if (existingReview.local_head_branch === null) {
+        await reviewRepo.updateReview(sessionId, { local_head_branch: branch });
+        console.log(`Backfilled branch on session ${sessionId}: ${branch}`);
+      }
       console.log(`Resuming existing review session (ID: ${existingReview.id})`);
     } else {
       console.log('Creating new review session...');
       sessionId = await reviewRepo.upsertLocalReview({
         localPath: repoPath,
         localHeadSha: headSha,
-        repository
+        repository,
+        localHeadBranch: branch
       });
       console.log(`Created new review session (ID: ${sessionId})`);
     }

--- a/src/routes/analyses.js
+++ b/src/routes/analyses.js
@@ -31,7 +31,7 @@ const {
   killProcesses,
   createProgressCallback
 } = require('./shared');
-const { generateLocalDiff, computeLocalDiffDigest } = require('../local-review');
+const { generateLocalDiff, computeLocalDiffDigest, getCurrentBranch } = require('../local-review');
 const { validateCouncilConfig, normalizeCouncilConfig } = require('./councils');
 const { TIERS, TIER_ALIASES, VALID_TIERS, resolveTier } = require('../ai/prompts/config');
 
@@ -209,13 +209,21 @@ router.post('/api/analyses/results', async (req, res) => {
     // --- Resolve review ---
     let reviewId;
     if (hasLocal) {
-      // Local mode: derive repository name from the directory basename
-      const repository = path.basename(localPath) || 'local';
-      reviewId = await reviewRepo.upsertLocalReview({
-        localPath,
-        localHeadSha: headSha,
-        repository
-      });
+      // Local mode: find existing session or create a new one
+      let localHeadBranch;
+      try { localHeadBranch = await getCurrentBranch(localPath); } catch (_) { /* non-fatal */ }
+      const existingReview = await reviewRepo.findLocalReview(localPath, headSha, localHeadBranch);
+      if (existingReview) {
+        reviewId = existingReview.id;
+      } else {
+        const repository = path.basename(localPath) || 'local';
+        reviewId = await reviewRepo.upsertLocalReview({
+          localPath,
+          localHeadSha: headSha,
+          repository,
+          localHeadBranch
+        });
+      }
 
       // Generate and store diff so the web UI can display it
       try {

--- a/src/routes/local.js
+++ b/src/routes/local.js
@@ -23,7 +23,7 @@ const logger = require('../utils/logger');
 const { broadcastReviewEvent } = require('../events/review-events');
 const { mergeInstructions } = require('../utils/instructions');
 const { getGitHubToken } = require('../config');
-const { generateScopedDiff, computeScopedDigest, getBranchCommitCount, getFirstCommitSubject, detectAndBuildBranchInfo, findMergeBase } = require('../local-review');
+const { generateScopedDiff, computeScopedDigest, getBranchCommitCount, getFirstCommitSubject, detectAndBuildBranchInfo, findMergeBase, getCurrentBranch, getRepositoryName } = require('../local-review');
 const { isValidScope, scopeIncludes, includesBranch, DEFAULT_SCOPE } = require('../local-scope');
 const { getGeneratedFilePatterns } = require('../git/gitattributes');
 const { validateCouncilConfig, normalizeCouncilConfig } = require('./councils');
@@ -279,15 +279,31 @@ router.post('/api/local/start', async (req, res) => {
     const db = req.app.get('db');
     const reviewRepo = new ReviewRepository(db);
 
-    // First, check for an existing branch-scope session on this path
-    // (branch scope sessions persist across HEAD changes)
     let sessionId;
-    const branchSession = await reviewRepo.getLocalBranchScopeReview(repoPath);
-    if (branchSession) {
-      sessionId = branchSession.id;
-      // Update HEAD SHA if it changed
-      if (branchSession.local_head_sha !== headSha) {
+    // Try exact match (path + sha + branch)
+    let existing = await reviewRepo.getLocalReview(repoPath, headSha, branch);
+
+    // Adopt legacy sessions that predate branch tracking
+    if (!existing) {
+      const legacy = await reviewRepo.getLocalReviewByPathAndSha(repoPath, headSha);
+      if (legacy && legacy.local_head_branch === null) {
+        existing = legacy;
+      }
+    }
+
+    // Check for branch-scope session (persists across HEAD changes)
+    if (!existing) {
+      const branchSession = await reviewRepo.getLocalBranchScopeReview(repoPath, branch);
+      if (branchSession) existing = branchSession;
+    }
+
+    if (existing) {
+      sessionId = existing.id;
+      if (existing.local_head_sha !== headSha) {
         await reviewRepo.updateLocalHeadSha(sessionId, headSha);
+      }
+      if (existing.local_head_branch === null) {
+        await reviewRepo.updateReview(sessionId, { local_head_branch: branch });
       }
     } else {
       sessionId = await reviewRepo.upsertLocalReview({
@@ -295,15 +311,16 @@ router.post('/api/local/start', async (req, res) => {
         localHeadSha: headSha,
         repository,
         scopeStart: DEFAULT_SCOPE.start,
-        scopeEnd: DEFAULT_SCOPE.end
+        scopeEnd: DEFAULT_SCOPE.end,
+        localHeadBranch: branch
       });
     }
 
     // Generate diff using default scope
     logger.log('API', `Starting local review for ${repoPath}`, 'cyan');
-    const scopeStart = branchSession?.local_scope_start || DEFAULT_SCOPE.start;
-    const scopeEnd = branchSession?.local_scope_end || DEFAULT_SCOPE.end;
-    const baseBranch = branchSession?.local_base_branch || null;
+    const scopeStart = existing?.local_scope_start || DEFAULT_SCOPE.start;
+    const scopeEnd = existing?.local_scope_end || DEFAULT_SCOPE.end;
+    const baseBranch = existing?.local_base_branch || null;
     const { diff, stats } = await generateScopedDiff(repoPath, scopeStart, scopeEnd, baseBranch);
 
     // Compute digest for staleness detection
@@ -1136,20 +1153,21 @@ router.post('/api/local/:reviewId/refresh', async (req, res) => {
           sessionChanged = true;
 
           // Check if a session already exists for the new HEAD
-          const existingSession = await reviewRepo.getLocalReview(localPath, currentHeadSha);
+          let refreshBranch;
+          try { refreshBranch = await getCurrentBranch(localPath); } catch (_) { /* non-fatal */ }
+          const existingSession = await reviewRepo.findLocalReview(localPath, currentHeadSha, refreshBranch);
           if (existingSession) {
             newSessionId = existingSession.id;
             logger.log('API', `Existing session found for new HEAD: ${newSessionId}`, 'cyan');
           } else {
-            // Create a new session for the new HEAD
-            const { getRepositoryName } = require('../local-review');
             const repository = await getRepositoryName(localPath);
             newSessionId = await reviewRepo.upsertLocalReview({
               localPath: localPath,
               localHeadSha: currentHeadSha,
               repository,
               scopeStart,
-              scopeEnd
+              scopeEnd,
+              localHeadBranch: refreshBranch
             });
             logger.log('API', `Created new session for new HEAD: ${newSessionId}`, 'cyan');
           }
@@ -1235,12 +1253,12 @@ router.post('/api/local/:reviewId/set-scope', async (req, res) => {
       return res.status(400).json({ error: 'Local review is missing path information' });
     }
 
-    // When branch is in scope, resolve baseBranch
+    // When branch is in scope, resolve baseBranch and current branch
     let baseBranch = requestBaseBranch || null;
+    let currentBranch = null;
     if (includesBranch(scopeStart)) {
+      currentBranch = await getCurrentBranch(localPath);
       if (!baseBranch) {
-        const { getCurrentBranch } = require('../local-review');
-        const currentBranch = await getCurrentBranch(localPath);
         const { detectBaseBranch } = require('../git/base-branch');
         const config = req.app.get('config') || {};
         const token = getGitHubToken(config);
@@ -1270,8 +1288,8 @@ router.post('/api/local/:reviewId/set-scope', async (req, res) => {
     const { getHeadSha } = require('../local-review');
     const headSha = await getHeadSha(localPath);
 
-    // Update the review record with new scope
-    await reviewRepo.updateLocalScope(reviewId, scopeStart, scopeEnd, baseBranch);
+    // Update the review record with new scope (headBranch stored on branch scope, cleared otherwise)
+    await reviewRepo.updateLocalScope(reviewId, scopeStart, scopeEnd, baseBranch, currentBranch);
     await reviewRepo.updateLocalHeadSha(reviewId, headSha);
 
     // Auto-name review from first commit subject when branch is newly in scope

--- a/src/routes/mcp.js
+++ b/src/routes/mcp.js
@@ -11,6 +11,7 @@ const { getTierForModel } = require('../ai/provider');
 const { TIERS, TIER_ALIASES, resolveTier } = require('../ai/prompts/config');
 const { GitWorktreeManager } = require('../git/worktree');
 const path = require('path');
+const { getCurrentBranch } = require('../local-review');
 const { normalizeRepository } = require('../utils/paths');
 const logger = require('../utils/logger');
 const { broadcastReviewEvent } = require('../events/review-events');
@@ -118,7 +119,11 @@ async function resolveReview(args, db) {
   const reviewRepo = new ReviewRepository(db);
 
   if (args.path && args.headSha) {
-    const review = await reviewRepo.getLocalReview(args.path, args.headSha);
+    let headBranch = args.branch;
+    if (!headBranch) {
+      try { headBranch = await getCurrentBranch(args.path); } catch (_) { /* non-fatal */ }
+    }
+    const review = await reviewRepo.findLocalReview(args.path, args.headSha, headBranch);
     if (!review) {
       return { review: null, error: `No local review found for path "${args.path}" with HEAD SHA "${args.headSha}"` };
     }
@@ -507,21 +512,26 @@ function createMCPServer(db, options = {}) {
           const localPath = args.path;
           const localHeadSha = args.headSha;
 
+          // Resolve current branch for session identity
+          let localHeadBranch;
+          try { localHeadBranch = await getCurrentBranch(localPath); } catch (_) { /* non-fatal */ }
+
           // Look up or create local review record
-          // Try to get repository name from existing review, else use directory basename
+          let reviewId;
           let repository;
-          const existingReview = await reviewRepo.getLocalReview(localPath, localHeadSha);
+          const existingReview = await reviewRepo.findLocalReview(localPath, localHeadSha, localHeadBranch);
           if (existingReview) {
+            reviewId = existingReview.id;
             repository = existingReview.repository;
           } else {
             repository = path.basename(localPath);
+            reviewId = await reviewRepo.upsertLocalReview({
+              localPath,
+              localHeadSha,
+              repository,
+              localHeadBranch
+            });
           }
-
-          const reviewId = await reviewRepo.upsertLocalReview({
-            localPath,
-            localHeadSha,
-            repository
-          });
 
           // Concurrent analysis guard: check if one is already running
           const existingAnalysisId = reviewToAnalysisId.get(reviewId);

--- a/src/setup/local-setup.js
+++ b/src/setup/local-setup.js
@@ -56,7 +56,21 @@ async function setupLocalReview({ db, targetPath, onProgress }) {
     reviewId = generateLocalReviewId(repoPath, headSha);
 
     const reviewRepo = new ReviewRepository(db);
-    existingReview = await reviewRepo.getLocalReview(repoPath, headSha);
+    existingReview = await reviewRepo.getLocalReview(repoPath, headSha, branch);
+
+    // Adopt legacy sessions that predate branch tracking
+    if (!existingReview) {
+      const legacy = await reviewRepo.getLocalReviewByPathAndSha(repoPath, headSha);
+      if (legacy && legacy.local_head_branch === null) {
+        existingReview = legacy;
+      }
+    }
+
+    // Check for branch-scope session (persists across HEAD changes)
+    if (!existingReview) {
+      const branchSession = await reviewRepo.getLocalBranchReview(repoPath, branch);
+      if (branchSession) existingReview = branchSession;
+    }
 
     repository = await getRepositoryName(repoPath);
 
@@ -102,14 +116,21 @@ async function setupLocalReview({ db, targetPath, onProgress }) {
   try {
     progress({ step: 'store', status: 'running', message: 'Persisting review session...' });
 
+    const storeRepo = new ReviewRepository(db);
     if (existingReview) {
       sessionId = existingReview.id;
+      if (existingReview.local_head_sha !== headSha) {
+        await storeRepo.updateLocalHeadSha(sessionId, headSha);
+      }
+      if (existingReview.local_head_branch === null) {
+        await storeRepo.updateReview(sessionId, { local_head_branch: branch });
+      }
     } else {
-      const reviewRepo = new ReviewRepository(db);
-      sessionId = await reviewRepo.upsertLocalReview({
+      sessionId = await storeRepo.upsertLocalReview({
         localPath: repoPath,
         localHeadSha: headSha,
-        repository
+        repository,
+        localHeadBranch: branch
       });
     }
 

--- a/tests/integration/local-sessions.test.js
+++ b/tests/integration/local-sessions.test.js
@@ -930,4 +930,116 @@ describe('Local Sessions API', () => {
       expect(res.body.diff).toBe('');
     });
   });
+
+  describe('Branch-aware session identity', () => {
+    it('should create separate sessions for different branches at same path', async () => {
+      const reviewRepo = new ReviewRepository(db);
+
+      // Create two sessions, then set each to branch scope on different branches
+      const id1 = await reviewRepo.upsertLocalReview({
+        localPath: '/repo',
+        localHeadSha: 'sha-feature-a',
+        repository: 'owner/repo'
+      });
+      await reviewRepo.updateLocalScope(id1, 'branch', 'branch', 'main', 'feature-a');
+
+      const id2 = await reviewRepo.upsertLocalReview({
+        localPath: '/repo',
+        localHeadSha: 'sha-feature-b',
+        repository: 'owner/repo'
+      });
+      await reviewRepo.updateLocalScope(id2, 'branch', 'branch', 'main', 'feature-b');
+
+      expect(id1).not.toBe(id2);
+
+      // Each branch lookup returns the correct session
+      const foundA = await reviewRepo.getLocalBranchScopeReview('/repo', 'feature-a');
+      expect(foundA.id).toBe(id1);
+      const foundB = await reviewRepo.getLocalBranchScopeReview('/repo', 'feature-b');
+      expect(foundB.id).toBe(id2);
+    });
+
+    it('should reuse session for same branch with different HEAD SHA', async () => {
+      const reviewRepo = new ReviewRepository(db);
+
+      const id1 = await reviewRepo.upsertLocalReview({
+        localPath: '/repo',
+        localHeadSha: 'sha-old',
+        repository: 'owner/repo'
+      });
+      await reviewRepo.updateLocalScope(id1, 'branch', 'branch', 'main', 'feature-a');
+
+      // Simulate finding the session on the same branch with a new HEAD
+      const found = await reviewRepo.getLocalBranchScopeReview('/repo', 'feature-a');
+      expect(found).not.toBeNull();
+      expect(found.id).toBe(id1);
+    });
+
+    it('should not find branch session for a different branch at same path', async () => {
+      const reviewRepo = new ReviewRepository(db);
+
+      const id = await reviewRepo.upsertLocalReview({
+        localPath: '/repo',
+        localHeadSha: 'sha-1',
+        repository: 'owner/repo'
+      });
+      await reviewRepo.updateLocalScope(id, 'branch', 'branch', 'main', 'feature-a');
+
+      const found = await reviewRepo.getLocalBranchScopeReview('/repo', 'feature-b');
+      expect(found).toBeNull();
+    });
+
+    it('should store local_head_branch via updateLocalScope and retrieve it', async () => {
+      const reviewRepo = new ReviewRepository(db);
+
+      const id = await reviewRepo.upsertLocalReview({
+        localPath: '/repo',
+        localHeadSha: 'sha-1',
+        repository: 'owner/repo'
+      });
+
+      // head_branch is null at creation
+      let review = await reviewRepo.getLocalReviewById(id);
+      expect(review.local_head_branch).toBeNull();
+
+      // Set when entering branch scope
+      await reviewRepo.updateLocalScope(id, 'branch', 'branch', 'main', 'my-branch');
+      review = await reviewRepo.getLocalReviewById(id);
+      expect(review.local_head_branch).toBe('my-branch');
+
+      // Cleared when leaving branch scope
+      await reviewRepo.updateLocalScope(id, 'unstaged', 'untracked');
+      review = await reviewRepo.getLocalReviewById(id);
+      expect(review.local_head_branch).toBeNull();
+    });
+
+    it('POST /api/local/start should create separate sessions per branch after scope change', async () => {
+      // Start session on feature-a
+      localReviewModule.getCurrentBranch.mockResolvedValue('feature-a');
+      localReviewModule.getHeadSha.mockResolvedValue('sha-a');
+
+      const res1 = await request(app)
+        .post('/api/local/start')
+        .send({ path: '/tmp' });
+      expect(res1.status).toBe(200);
+      const sessionA = res1.body.sessionId;
+
+      // Switch scope to branch mode (stores headBranch via updateLocalScope)
+      const reviewRepo = new ReviewRepository(db);
+      await reviewRepo.updateLocalScope(sessionA, 'branch', 'branch', 'main', 'feature-a');
+
+      // Start session on feature-b (different branch)
+      localReviewModule.getCurrentBranch.mockResolvedValue('feature-b');
+      localReviewModule.getHeadSha.mockResolvedValue('sha-b');
+
+      const res2 = await request(app)
+        .post('/api/local/start')
+        .send({ path: '/tmp' });
+      expect(res2.status).toBe(200);
+      const sessionB = res2.body.sessionId;
+
+      // Should be different sessions
+      expect(sessionA).not.toBe(sessionB);
+    });
+  });
 });

--- a/tests/unit/mcp-tools.test.js
+++ b/tests/unit/mcp-tools.test.js
@@ -672,7 +672,7 @@ describe('start_analysis tool', () => {
 
     // Verify review was created
     const reviewRepo = new ReviewRepository(db);
-    const review = await reviewRepo.getLocalReview('/tmp/new-repo', 'def456');
+    const review = await reviewRepo.getLocalReviewByPathAndSha('/tmp/new-repo', 'def456');
     expect(review).not.toBeNull();
   });
 
@@ -881,13 +881,6 @@ describe('start_analysis tool', () => {
   });
 
   it('should persist customInstructions in local mode', async () => {
-    const reviewRepo = new ReviewRepository(db);
-    const reviewId = await reviewRepo.upsertLocalReview({
-      localPath: '/tmp/instructions-repo',
-      localHeadSha: 'inst123',
-      repository: 'instructions-repo',
-    });
-
     const result = await client.callTool({
       name: 'start_analysis',
       arguments: {
@@ -899,8 +892,9 @@ describe('start_analysis tool', () => {
     const content = JSON.parse(result.content[0].text);
     expect(content.status).toBe('started');
 
-    // Verify custom instructions were persisted
-    const review = await reviewRepo.getLocalReviewById(reviewId);
+    // Verify custom instructions were persisted on the review created by the tool
+    const reviewRepo = new ReviewRepository(db);
+    const review = await reviewRepo.getLocalReviewById(content.reviewId);
     expect(review.custom_instructions).toBe('Focus on performance');
   });
 

--- a/tests/utils/schema.js
+++ b/tests/utils/schema.js
@@ -35,6 +35,7 @@ const SCHEMA_SQL = {
       name TEXT,
       local_mode TEXT DEFAULT 'uncommitted',
       local_base_branch TEXT,
+      local_head_branch TEXT,
       local_scope_start TEXT DEFAULT 'unstaged',
       local_scope_end TEXT DEFAULT 'untracked'
     )
@@ -258,7 +259,7 @@ const INDEX_SQL = [
   'CREATE INDEX IF NOT EXISTS idx_worktrees_last_accessed ON worktrees(last_accessed_at)',
   'CREATE INDEX IF NOT EXISTS idx_worktrees_repo ON worktrees(repository)',
   'CREATE UNIQUE INDEX IF NOT EXISTS idx_repo_settings_repository ON repo_settings(repository)',
-  "CREATE UNIQUE INDEX IF NOT EXISTS idx_reviews_local ON reviews(local_path, local_head_sha) WHERE review_type = 'local'",
+  "CREATE UNIQUE INDEX IF NOT EXISTS idx_reviews_local ON reviews(local_path, local_head_sha, local_head_branch) WHERE review_type = 'local'",
   "CREATE UNIQUE INDEX IF NOT EXISTS idx_reviews_pr_unique ON reviews(pr_number, repository) WHERE review_type = 'pr'",
   'CREATE INDEX IF NOT EXISTS idx_analysis_runs_review_id ON analysis_runs(review_id, started_at DESC)',
   'CREATE INDEX IF NOT EXISTS idx_analysis_runs_status ON analysis_runs(status)',


### PR DESCRIPTION
## Summary
- Local mode sessions were keyed by `(path, HEAD SHA)` only — switching branches at the same commit reused the wrong session
- Session identity is now `(path, HEAD SHA, branch)` with a new `local_head_branch` column (migration v30) and updated unique index
- Branch-scope sessions (`local_scope_start = 'branch'`) also filter by head branch name
- Legacy sessions with NULL branch are adopted and backfilled on first access
- Extracted `findLocalReview` method on `ReviewRepository` for consistent fallback lookup across all entry points (MCP, analyses, refresh)

## Test plan
- [x] Unit/integration tests: 5054 passing across 108 files
- [ ] Manual: run `pair-review --local` on branch A, switch to branch B at same commit, verify new session created
- [ ] Manual: run `pair-review --local` on same branch + same commit, verify existing session reused
- [ ] Manual: verify legacy NULL-branch sessions are adopted on first access

🤖 Generated with [Claude Code](https://claude.com/claude-code)