### PR TITLE
fix: descriptive browser tab titles with flash on review completion

### DIFF
--- a/.changeset/large-steaks-hide.md
+++ b/.changeset/large-steaks-hide.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Improve browser tab titles to show context (PR number or branch name) instead of generic text. Flash tab title on review completion or failure when the tab is in the background, reverting when the tab regains focus.

--- a/public/js/components/CouncilProgressModal.js
+++ b/public/js/components/CouncilProgressModal.js
@@ -806,6 +806,11 @@ class CouncilProgressModal {
       window.prManager.setButtonComplete();
     }
 
+    // Flash tab title
+    if (window.tabTitle) {
+      window.tabTitle.flashComplete();
+    }
+
     // Reload suggestions
     const manager = window.prManager || window.localManager;
     if (manager && typeof manager.loadAISuggestions === 'function') {
@@ -884,6 +889,11 @@ class CouncilProgressModal {
     if (window.prManager) {
       window.prManager.resetButton();
     }
+
+    // Flash tab title
+    if (window.tabTitle) {
+      window.tabTitle.flashFailed();
+    }
   }
 
   _handleCancellation(_status) {
@@ -924,6 +934,9 @@ class CouncilProgressModal {
     if (window.prManager) {
       window.prManager.resetButton();
     }
+
+    // No tab-title flash for cancellation — the user initiated it, so no notification needed.
+
     if (window.aiPanel?.setAnalysisState) {
       window.aiPanel.setAnalysisState('unknown');
     }

--- a/public/js/components/TabTitle.js
+++ b/public/js/components/TabTitle.js
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/**
+ * TabTitle — manages the browser tab title with flash-on-completion support.
+ *
+ * Usage:
+ *   window.tabTitle = new TabTitle();
+ *   window.tabTitle.setBase('PR #123');        // → "pair-review - PR #123"
+ *   window.tabTitle.flashComplete();           // flashes "✓ Review Complete" until tab gains focus
+ *   window.tabTitle.flashFailed();             // flashes "✗ Review Failed" until tab gains focus
+ */
+class TabTitle {
+  constructor() {
+    this._base = '';
+    this._flashInterval = null;
+    this._flashTimeout = null;
+    this._onVisibility = this._onVisibilityChange.bind(this);
+  }
+
+  /**
+   * Set the base identifier shown in the tab title.
+   * @param {string} identifier - e.g. "PR #123" or "feature/dark-mode"
+   */
+  setBase(identifier) {
+    this._base = identifier;
+    this._apply();
+  }
+
+  /** Flash "✓ Review Complete" until the tab gains focus. */
+  flashComplete() {
+    this._flash('✓ Review Complete');
+  }
+
+  /** Flash "✗ Review Failed" until the tab gains focus. */
+  flashFailed() {
+    this._flash('✗ Review Failed');
+  }
+
+  // ---------------------------------------------------------------------------
+  // Internal
+  // ---------------------------------------------------------------------------
+
+  _format(suffix) {
+    return suffix ? `pair-review - ${suffix}` : 'pair-review';
+  }
+
+  _apply() {
+    document.title = this._format(this._base);
+  }
+
+  _flash(message) {
+    this._stopFlash();
+
+    // If the tab is already visible, just show the message briefly then revert.
+    if (!document.hidden) {
+      document.title = this._format(message);
+      this._flashTimeout = setTimeout(() => this._apply(), 3000);
+      return;
+    }
+
+    // Tab is hidden — alternate between message and base title.
+    let showMessage = true;
+    document.title = this._format(message);
+
+    this._flashInterval = setInterval(() => {
+      showMessage = !showMessage;
+      document.title = showMessage
+        ? this._format(message)
+        : this._format(this._base);
+    }, 1000);
+
+    document.addEventListener('visibilitychange', this._onVisibility);
+  }
+
+  _onVisibilityChange() {
+    if (!document.hidden) {
+      this._stopFlash();
+    }
+  }
+
+  _stopFlash() {
+    if (this._flashTimeout) {
+      clearTimeout(this._flashTimeout);
+      this._flashTimeout = null;
+    }
+    if (this._flashInterval) {
+      clearInterval(this._flashInterval);
+      this._flashInterval = null;
+    }
+    document.removeEventListener('visibilitychange', this._onVisibility);
+    this._apply();
+  }
+}
+
+if (typeof module !== 'undefined') {
+  module.exports = { TabTitle };
+}

--- a/public/js/local.js
+++ b/public/js/local.js
@@ -977,6 +977,11 @@ class LocalManager {
       branchText.textContent = reviewData.branch || 'unknown';
     }
 
+    // Set descriptive tab title
+    if (window.tabTitle && reviewData.branch) {
+      window.tabTitle.setBase(reviewData.branch);
+    }
+
     // Show base branch badge when branch is in scope
     const LS = window.LocalScope;
     const scopeStart = this.scopeStart || (LS ? LS.DEFAULT_SCOPE.start : 'unstaged');

--- a/public/js/pr.js
+++ b/public/js/pr.js
@@ -464,6 +464,11 @@ class PRManager {
       // Render PR header with metadata
       this.renderPRHeader(prData);
 
+      // Set descriptive tab title
+      if (window.tabTitle) {
+        window.tabTitle.setBase(`PR #${number}`);
+      }
+
       // Fetch diff and file list from diff endpoint
       await this.loadAndDisplayFiles(owner, repo, number);
 
@@ -5191,6 +5196,11 @@ if (typeof document !== 'undefined') {
     // Initialize panel resizer for drag-to-resize functionality
     if (typeof window.PanelResizer !== 'undefined') {
       window.PanelResizer.init();
+    }
+
+    // Initialize tab title manager
+    if (typeof TabTitle !== 'undefined') {
+      window.tabTitle = new TabTitle();
     }
 
     prManager = new PRManager();

--- a/public/local.html
+++ b/public/local.html
@@ -535,6 +535,7 @@
     <script src="/js/ws-client.js"></script>
 
     <!-- Components -->
+    <script src="/js/components/TabTitle.js"></script>
     <script src="/js/components/Toast.js"></script>
     <script src="/js/components/ConfirmDialog.js"></script>
     <script src="/js/components/TextInputDialog.js"></script>

--- a/public/pr.html
+++ b/public/pr.html
@@ -375,6 +375,7 @@
     <script src="/js/ws-client.js"></script>
 
     <!-- Components -->
+    <script src="/js/components/TabTitle.js"></script>
     <script src="/js/components/Toast.js"></script>
     <script src="/js/components/ConfirmDialog.js"></script>
     <script src="/js/components/TextInputDialog.js"></script>

--- a/tests/unit/tab-title.test.js
+++ b/tests/unit/tab-title.test.js
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/**
+ * Unit tests for TabTitle component
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+let TabTitle;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+
+  global.document = {
+    title: '',
+    hidden: false,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn()
+  };
+
+  // Fresh import each test
+  vi.resetModules();
+  return import('../../public/js/components/TabTitle.js').then(mod => {
+    TabTitle = mod.TabTitle;
+  });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  delete global.document;
+});
+
+describe('TabTitle', () => {
+  describe('setBase', () => {
+    it('should set document.title with prefix', () => {
+      const tt = new TabTitle();
+      tt.setBase('PR #42');
+      expect(document.title).toBe('pair-review - PR #42');
+    });
+
+    it('should handle empty identifier', () => {
+      const tt = new TabTitle();
+      tt.setBase('');
+      expect(document.title).toBe('pair-review');
+    });
+  });
+
+  describe('flashComplete (tab visible)', () => {
+    it('should show message then revert after 3s', () => {
+      const tt = new TabTitle();
+      tt.setBase('PR #42');
+      tt.flashComplete();
+
+      expect(document.title).toBe('pair-review - ✓ Review Complete');
+
+      vi.advanceTimersByTime(3000);
+      expect(document.title).toBe('pair-review - PR #42');
+    });
+
+    it('should not start an interval or add visibilitychange listener', () => {
+      const tt = new TabTitle();
+      tt.setBase('PR #42');
+      tt.flashComplete();
+
+      // No visibilitychange listener added (only added for hidden tabs)
+      expect(document.addEventListener).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('flashComplete (tab hidden)', () => {
+    it('should alternate title on interval', () => {
+      document.hidden = true;
+      const tt = new TabTitle();
+      tt.setBase('my-branch');
+      tt.flashComplete();
+
+      expect(document.title).toBe('pair-review - ✓ Review Complete');
+
+      vi.advanceTimersByTime(1000);
+      expect(document.title).toBe('pair-review - my-branch');
+
+      vi.advanceTimersByTime(1000);
+      expect(document.title).toBe('pair-review - ✓ Review Complete');
+    });
+
+    it('should register visibilitychange listener', () => {
+      document.hidden = true;
+      const tt = new TabTitle();
+      tt.setBase('PR #1');
+      tt.flashComplete();
+
+      expect(document.addEventListener).toHaveBeenCalledWith(
+        'visibilitychange',
+        expect.any(Function)
+      );
+    });
+
+    it('should stop flashing and revert when tab becomes visible', () => {
+      document.hidden = true;
+      const tt = new TabTitle();
+      tt.setBase('PR #1');
+      tt.flashComplete();
+
+      // Simulate tab becoming visible
+      document.hidden = false;
+      const handler = document.addEventListener.mock.calls[0][1];
+      handler();
+
+      expect(document.title).toBe('pair-review - PR #1');
+      expect(document.removeEventListener).toHaveBeenCalledWith(
+        'visibilitychange',
+        handler
+      );
+    });
+  });
+
+  describe('flashFailed', () => {
+    it('should show failure message', () => {
+      const tt = new TabTitle();
+      tt.setBase('PR #99');
+      tt.flashFailed();
+
+      expect(document.title).toBe('pair-review - ✗ Review Failed');
+    });
+
+    it('should alternate when tab hidden', () => {
+      document.hidden = true;
+      const tt = new TabTitle();
+      tt.setBase('PR #99');
+      tt.flashFailed();
+
+      vi.advanceTimersByTime(1000);
+      expect(document.title).toBe('pair-review - PR #99');
+
+      vi.advanceTimersByTime(1000);
+      expect(document.title).toBe('pair-review - ✗ Review Failed');
+    });
+  });
+
+  describe('successive flashes', () => {
+    it('should stop previous flash before starting new one', () => {
+      document.hidden = true;
+      const tt = new TabTitle();
+      tt.setBase('PR #1');
+      tt.flashComplete();
+
+      // Start a new flash — should clean up the first
+      tt.flashFailed();
+      expect(document.title).toBe('pair-review - ✗ Review Failed');
+
+      vi.advanceTimersByTime(1000);
+      // Should alternate with base, not with complete message
+      expect(document.title).toBe('pair-review - PR #1');
+    });
+
+    it('should not let first visible-tab timeout revert a second flash', () => {
+      // Tab is visible for both flashes
+      document.hidden = false;
+      const tt = new TabTitle();
+      tt.setBase('PR #7');
+
+      // First flash — starts a 3s timeout to revert
+      tt.flashComplete();
+      expect(document.title).toBe('pair-review - ✓ Review Complete');
+
+      // 500ms later, a second flash arrives before the first timeout fires
+      vi.advanceTimersByTime(500);
+      tt.flashFailed();
+      expect(document.title).toBe('pair-review - ✗ Review Failed');
+
+      // Advance past the original 3s mark — the old timeout must have been cancelled
+      vi.advanceTimersByTime(2500);
+      expect(document.title).toBe('pair-review - ✗ Review Failed');
+
+      // After the second timeout's full 3s, title reverts to base
+      vi.advanceTimersByTime(500);
+      expect(document.title).toBe('pair-review - PR #7');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Set tab title to `pair-review - PR #<number>` (PR mode) or `pair-review - <branch>` (local mode) instead of generic static text
- Flash `✓ Review Complete` / `✗ Review Failed` in the tab title when analysis finishes while the tab is in the background, reverting when the tab regains focus
- New `TabTitle` component with 11 unit tests covering visible/hidden flash, successive flash cleanup, and the visible-tab timeout race condition

## Test plan
- [x] Unit tests pass (`npx vitest run tests/unit/tab-title.test.js` — 11 tests)
- [x] Full test suite passes (`npm test` — 5054 tests)
- [ ] Manual: open a PR review, verify tab shows `pair-review - PR #<number>`
- [ ] Manual: open a local review, verify tab shows `pair-review - <branch>`
- [ ] Manual: start analysis, switch to another tab, verify title flashes on completion
- [ ] Manual: verify flash stops and title reverts when switching back to the tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)