### PR TITLE
feat: bulk actions (selection mode) for index page

### DIFF
--- a/.changeset/bulk-actions-selection-mode.md
+++ b/.changeset/bulk-actions-selection-mode.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": minor
+---
+
+Add bulk actions with selection mode on the index page: bulk delete for Pull Requests and Local Reviews tabs, bulk open and analyze for My Review Requests and My PRs tabs

--- a/plans/bulk-actions.md
+++ b/plans/bulk-actions.md
@@ -1,0 +1,181 @@
+# Bulk Actions (Selection Mode) on Index Page
+
+## Context
+
+The index page has four tabs (Pull Requests, My Review Requests, My PRs, Local Reviews) each listing items with only single-item actions. Users with many reviews accumulate stale entries with no efficient way to clean up. The Review Requests and My PRs tabs also lack a way to batch-open or batch-analyze multiple PRs. This plan adds a generic selection mode system that supports per-tab bulk actions.
+
+## Tab-Action Matrix
+
+| Tab                  | Bulk Actions       |
+|----------------------|--------------------|
+| Pull Requests        | Delete             |
+| Local Reviews        | Delete             |
+| My Review Requests   | Open, Analyze      |
+| My PRs               | Open, Analyze      |
+
+## UX Design
+
+### Entering Selection Mode
+- Each tab gets a small **"Select"** button in the header area:
+  - PR tab & Local tab: between the input form and the table container
+  - Collection tabs: in the existing `.tab-pane-header` alongside the refresh button
+- Clicking "Select" enters selection mode for that tab; button text changes to **"Cancel"**
+- Switching tabs or pressing Escape exits selection mode
+
+### Selection Mode Active
+- A checkbox column appears as the first column in the table (header + all rows)
+- Select All checkbox in the table header
+- Individual row checkboxes toggle selection
+- Selected rows get a subtle highlight
+- Per-row delete buttons are hidden (replaced by bulk delete)
+- Collection row click-to-open behavior is suppressed (clicks toggle checkbox instead)
+
+### Bulk Action Bar
+- Sticky bar at the bottom of the tab pane container
+- Shows: `"N selected"` + action buttons + Cancel
+- Appears when 1+ items are selected
+- For Delete: clicking triggers inline confirmation in the bar itself ("Delete N items? [Confirm] [Cancel]") — no modal, consistent with existing inline-confirm pattern
+
+### Exiting Selection Mode
+- Cancel button (in action bar or the Select toggle)
+- Escape key
+- Tab switch
+- After completing a bulk action (delete reloads table, open/analyze finishes)
+
+## Implementation
+
+### Phase 1: Selection Infrastructure + Bulk Delete
+
+#### 1. Backend — Bulk Delete Endpoints
+
+**`src/routes/worktrees.js`** — `POST /api/worktrees/bulk-delete`
+
+- Extract core delete logic from existing `DELETE /api/worktrees/:id` into a reusable `deleteReviewById(db, metadataId)` helper
+- Existing single-delete endpoint calls this helper (no behavior change)
+- New endpoint validates `{ ids: number[] }` (non-empty, max 50, positive integers)
+- Loops calling `deleteReviewById` for each ID, collecting results
+- Response: `{ success: true, deleted: N, failed: N, errors: [{ id, error }] }`
+
+**`src/routes/local.js`** — `POST /api/local/sessions/bulk-delete`
+
+- Register BEFORE `/:reviewId` param routes
+- Validates `{ ids: number[] }` same as above
+- Loops calling `reviewRepo.deleteLocalSession(id)` + `deleteLocalReviewDiff(id)` for each
+- Same response shape
+
+#### 2. Frontend — `SelectionMode` Class
+
+**`public/js/index.js`** — New class inside the IIFE:
+
+```js
+SelectionMode({
+  tabId,          // e.g. 'pr-tab'
+  containerId,    // e.g. 'recent-reviews-container'
+  tbodyId,        // e.g. 'recent-reviews-tbody'
+  getRowId(tr),   // extracts unique ID from a row element
+  actions: [{ label, className, handler(selectedIds) }]
+})
+```
+
+Key methods:
+- `enter()` — inject checkbox column into thead + all tbody rows, show action bar, add `.selection-mode` class
+- `exit()` — remove checkboxes, hide action bar, clear selection, remove class
+- `onRowsAdded(rows)` — inject unchecked checkboxes into newly-paginated rows
+- `_updateActionBar()` — update count, toggle visibility
+
+Checkbox injection is done via DOM manipulation (prepend `<th>`/`<td>` cells), NOT by modifying the HTML-string render functions. This keeps the render functions clean and handles pagination naturally.
+
+#### 3. Row Data Attributes
+
+- `renderRecentReviewRow`: add `data-review-id="${review.id}"` to the `<tr>`
+- `renderCollectionPrRow` (Phase 2): add `data-owner`, `data-repo`, `data-number` to the `<tr>`
+
+#### 4. Pagination Integration
+
+After `insertAdjacentHTML` in `loadMoreReviews` / `loadMoreLocalReviews`, if the corresponding SelectionMode is active, call `onRowsAdded()` for the newly added rows. New rows are NOT pre-selected.
+
+#### 5. Full Table Reload
+
+`loadRecentReviews` and `loadLocalReviews` call `selectionInstance.exit()` at the top if active. Since `exit()` is a no-op when not active, this is safe for all existing callers.
+
+#### 6. Event Delegation
+
+- Action bar buttons use direct `addEventListener` (scoped to the SelectionMode instance), not global delegation
+- Global click handler: add early check — if selection mode is active for the current tab and click is on a row, toggle checkbox instead of existing row behavior
+- Suppress `.btn-delete-review` / `.btn-delete-session` clicks while in selection mode (or hide via CSS)
+
+#### 7. Module-Level State
+
+Track the currently active SelectionMode instance:
+```js
+var activeSelection = null;
+```
+Tab switch callback calls `activeSelection.exit()` before switching. Escape handler checks `activeSelection`.
+
+### Phase 2: Bulk Open / Analyze (Collection Tabs)
+
+#### 1. Open Action
+
+Handler reads `data-pr-url` from selected rows, calls `window.open(url, '_blank')` for each, exits selection mode.
+
+Note: browsers may block multiple `window.open` calls as popups. Mitigation: the first `window.open` is in direct response to user click (allowed); subsequent ones may be blocked. Alternative: open first tab directly, use `fetch` to pre-create worktrees for others, then open. Simplest first approach: try `window.open` and let the browser's popup blocker handle it — users can allow popups for localhost.
+
+#### 2. Analyze Action
+
+Same as Open but appends `?analyze=true` to each URL. Leverages existing auto-analyze support in `pr.js` (line 412) and `local.js` (line 73).
+
+```js
+var url = '/pr/' + owner + '/' + repo + '/' + number + '?analyze=true';
+window.open(url, '_blank');
+```
+
+### CSS
+
+All new styles added to the inline `<style>` in `public/index.html`:
+
+- `.selection-mode .col-select` — narrow checkbox column (32px)
+- `.selection-mode tbody tr.selected` — subtle highlight using existing CSS vars
+- `.btn-select-toggle` — styled like `.btn-refresh` (small, bordered, icon+text)
+- `.btn-select-toggle.active` — highlighted state
+- `.bulk-action-bar` — sticky bottom, flex layout, border + shadow
+- `.bulk-action-bar.confirming` — toggles between action buttons and confirm buttons
+- `.selection-mode .btn-delete-review, .selection-mode .btn-delete-session` — `display: none`
+- Dark theme variants via `[data-theme="dark"]` selectors where needed
+
+## Hazards
+
+- **`loadRecentReviews` / `loadLocalReviews` called from multiple sites**: initial load, after single delete, after bfcache restore. Adding `exit()` at the top is safe — it's a no-op when selection mode is not active.
+
+- **`renderRecentReviewRow` callers**: `loadRecentReviews` (initial) and `loadMoreReviews` (pagination). Both use the return value as HTML string. Adding `data-review-id` to `<tr>` is safe for both.
+
+- **`renderCollectionPrRow` callers**: only `renderCollectionTable`. Adding data attributes is safe.
+
+- **Per-row delete vs selection mode**: Inline single-delete replaces row innerHTML (removing checkbox). Rather than managing re-injection, hide per-row delete buttons via CSS while in selection mode.
+
+- **Collection row click-to-open**: Existing delegation handler catches `.collection-pr-row` clicks and navigates. Must suppress this when selection mode is active — check `activeSelection?.active` before navigating, toggle checkbox instead.
+
+- **Popup blocker (Phase 2)**: Multiple `window.open` calls may be blocked. Accept this limitation initially; users can whitelist localhost.
+
+## Files to Modify
+
+| File | Changes |
+|------|---------|
+| `public/js/index.js` | SelectionMode class, 4 instances, event wiring, pagination hooks, row data attributes |
+| `public/index.html` | CSS for selection mode, action bar, checkbox column |
+| `src/routes/worktrees.js` | Extract `deleteReviewById` helper, add `POST /api/worktrees/bulk-delete` |
+| `src/routes/local.js` | Add `POST /api/local/sessions/bulk-delete` |
+| `tests/integration/routes.test.js` | Integration tests for both bulk endpoints |
+| `tests/e2e/bulk-actions.spec.js` | E2E tests for selection mode UI |
+
+## Verification
+
+1. **Unit/Integration tests**: `npm test` — new bulk delete endpoint tests pass
+2. **Manual testing**:
+   - PR tab: enter select mode, select items, bulk delete with confirmation, verify table reloads
+   - Local tab: same flow
+   - Pagination: enter select mode, load more, verify new rows get unchecked checkboxes
+   - Tab switch: verify selection mode exits
+   - Escape: verify selection mode exits
+   - Select All: verify toggles all rows
+3. **E2E tests**: `npm run test:e2e` — new bulk-actions spec passes
+4. **Phase 2**: Open/Analyze on collection tabs — verify tabs open with correct URLs, `?analyze=true` triggers auto-analysis

--- a/public/index.html
+++ b/public/index.html
@@ -61,6 +61,7 @@
 
             --color-accent-primary: #0969da;
             --color-accent-hover: #0860ca;
+            --color-accent-subtle: rgba(9, 105, 218, 0.04);
             --color-accent-emphasis: #238636;
             --color-accent-emphasis-hover: #2ea043;
 
@@ -94,6 +95,7 @@
 
             --color-accent-primary: #58a6ff;
             --color-accent-hover: #1f6feb;
+            --color-accent-subtle: rgba(56, 139, 253, 0.06);
             --color-accent-emphasis: #238636;
             --color-accent-emphasis-hover: #2ea043;
 
@@ -1053,6 +1055,168 @@
             color: var(--color-text-primary);
         }
 
+        /* ─── Selection Mode ─────────────────────────────────────── */
+
+        /* Select toggle button — matches .btn-refresh sizing */
+        .btn-select-toggle {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            padding: 4px 12px;
+            font-family: var(--font-sans);
+            font-size: 12px;
+            font-weight: 500;
+            color: var(--color-text-secondary);
+            background: transparent;
+            border: 1px solid var(--color-border-primary);
+            border-radius: var(--radius-md);
+            cursor: pointer;
+            transition: all var(--transition-fast);
+        }
+
+        .btn-select-toggle:hover {
+            background: var(--color-bg-secondary);
+            color: var(--color-text-primary);
+        }
+
+        .btn-select-toggle.active {
+            background: var(--color-accent-subtle);
+            border-color: var(--color-accent-primary);
+            color: var(--color-accent-primary);
+        }
+
+        /* Checkbox column */
+        .col-select {
+            width: 32px;
+            text-align: center;
+            padding: 6px 8px !important;
+        }
+
+        .col-select input[type="checkbox"] {
+            width: 15px;
+            height: 15px;
+            cursor: pointer;
+            accent-color: var(--color-accent-primary);
+            vertical-align: middle;
+        }
+
+        /* Selected row highlight */
+        .recent-reviews-table tbody tr.bulk-selected td {
+            background-color: var(--color-accent-subtle);
+        }
+
+        /* Hide per-row delete buttons in selection mode */
+        .selection-mode .btn-delete-review,
+        .selection-mode .btn-delete-session {
+            display: none;
+        }
+
+        /* Inline bulk action controls — appear next to Select button */
+        .bulk-inline-actions {
+            display: inline-flex;
+            align-items: center;
+            gap: 8px;
+        }
+
+        .bulk-action-count {
+            font-size: 12px;
+            font-weight: 500;
+            color: var(--color-text-secondary);
+        }
+
+        .bulk-action-buttons {
+            display: inline-flex;
+            gap: 6px;
+        }
+
+        .btn-bulk-delete {
+            padding: 4px 12px;
+            font-size: 12px;
+            font-weight: 500;
+            background: var(--color-danger);
+            color: #ffffff;
+            border: none;
+            border-radius: var(--radius-sm);
+            cursor: pointer;
+        }
+
+        .btn-bulk-delete:hover:not(:disabled) {
+            background: var(--color-danger-hover);
+        }
+
+        .btn-bulk-delete:disabled {
+            opacity: 0.4;
+            cursor: default;
+        }
+
+        .btn-bulk-open,
+        .btn-bulk-analyze {
+            padding: 4px 12px;
+            font-size: 12px;
+            font-weight: 500;
+            background: var(--color-accent-primary);
+            color: #ffffff;
+            border: none;
+            border-radius: var(--radius-sm);
+            cursor: pointer;
+        }
+
+        .btn-bulk-open:hover:not(:disabled),
+        .btn-bulk-analyze:hover:not(:disabled) {
+            opacity: 0.9;
+        }
+
+        .btn-bulk-open:disabled,
+        .btn-bulk-analyze:disabled {
+            opacity: 0.4;
+            cursor: default;
+        }
+
+        .btn-bulk-cancel {
+            padding: 4px 12px;
+            font-size: 12px;
+            font-weight: 500;
+            background: transparent;
+            color: var(--color-text-secondary);
+            border: 1px solid var(--color-border-primary);
+            border-radius: var(--radius-sm);
+            cursor: pointer;
+        }
+
+        .btn-bulk-cancel:hover {
+            background: var(--color-bg-secondary);
+            color: var(--color-text-primary);
+        }
+
+        /* Confirmation state — hide normal action buttons, show confirm buttons */
+        .bulk-inline-actions .bulk-confirm-buttons {
+            display: none;
+            gap: 6px;
+        }
+
+        .bulk-inline-actions.confirming .bulk-action-buttons {
+            display: none;
+        }
+
+        .bulk-inline-actions.confirming .bulk-confirm-buttons {
+            display: inline-flex;
+        }
+
+        .bulk-inline-actions.confirming > .btn-bulk-cancel {
+            display: none;
+        }
+
+        /* Select mode header row (between form and table, for PR/Local tabs) */
+        .select-mode-header {
+            display: none;
+            justify-content: flex-end;
+            padding: 0 0 8px 0;
+        }
+
+        .select-mode-header.visible {
+            display: flex;
+        }
+
         /* Start review section spacing inside unified tabs */
         .tab-pane .start-review-section {
             max-width: 100%;
@@ -1266,6 +1430,7 @@
         </div>
     </div>
 
+    <script src="/js/components/Toast.js"></script>
     <script src="/js/index.js"></script>
 </body>
 </html>

--- a/public/js/components/Toast.js
+++ b/public/js/components/Toast.js
@@ -8,6 +8,12 @@ class Toast {
     this.toastContainer = null;
     this.activeToasts = [];
     this.createContainer();
+
+    // Convenience aliases — matches the conventional toast API (toast.error(), toast.success(), etc.)
+    this.error = this.showError.bind(this);
+    this.success = this.showSuccess.bind(this);
+    this.warning = this.showWarning.bind(this);
+    this.info = this.showInfo.bind(this);
   }
 
   /**

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -66,6 +66,12 @@
   // Close on Escape key
   document.addEventListener('keydown', function (e) {
     if (e.key === 'Escape') {
+      // Exit selection mode first (higher priority)
+      if (activeSelection && activeSelection.active) {
+        activeSelection.exit();
+        return;
+      }
+      // Then try closing help modal
       const overlay = document.getElementById('help-modal-overlay');
       if (overlay.classList.contains('visible')) {
         closeHelpModal();
@@ -328,7 +334,7 @@
       : '<td class="col-author">' + authorDisplay + '</td>';
 
     return '' +
-      '<tr class="collection-pr-row" data-pr-url="' + escapeHtml(prUrl) + '">' +
+      '<tr class="collection-pr-row" data-pr-url="' + escapeHtml(prUrl) + '" data-owner="' + escapeHtml(pr.owner) + '" data-repo="' + escapeHtml(pr.repo) + '" data-number="' + pr.number + '">' +
         '<td class="col-repo">' + escapeHtml(repoFull) + '</td>' +
         '<td class="col-pr"><span class="collection-pr-number">#' + pr.number + '</span></td>' +
         '<td class="col-title" title="' + escapeHtml(pr.title || '') + '">' + escapeHtml(pr.title || '') + '</td>' +
@@ -345,6 +351,9 @@
    * @param {string} collection - The collection name ('review-requests' or 'my-prs')
    */
   function renderCollectionTable(container, state, collection) {
+    var sel = collection === 'review-requests' ? reviewRequestsSelection : myPrsSelection;
+    sel.exit();
+
     var fetchedAtId = collection === 'review-requests' ? 'review-requests-fetched-at' : 'my-prs-fetched-at';
     var fetchedAtEl = document.getElementById(fetchedAtId);
     if (fetchedAtEl) {
@@ -374,6 +383,8 @@
 
     var authorTh = collection === 'my-prs' ? '' : '<th>Author</th>';
 
+    var tbodyId = collection === 'review-requests' ? 'review-requests-tbody' : 'my-prs-tbody';
+
     container.innerHTML =
       '<table class="recent-reviews-table">' +
         '<thead>' +
@@ -386,7 +397,7 @@
             '<th>Actions</th>' +
           '</tr>' +
         '</thead>' +
-        '<tbody>' +
+        '<tbody id="' + tbodyId + '">' +
           state.prs.map(function (pr) { return renderCollectionPrRow(pr, collection); }).join('') +
         '</tbody>' +
       '</table>';
@@ -486,6 +497,8 @@
    * Fetch and display local review sessions (initial load).
    */
   async function loadLocalReviews() {
+    localSelection.exit();
+
     const container = document.getElementById('local-reviews-container');
     if (!container) return;
 
@@ -577,6 +590,7 @@
       }
 
       tbody.insertAdjacentHTML('beforeend', data.sessions.map(renderLocalReviewRow).join(''));
+      if (localSelection.active) localSelection.onRowsAdded();
 
       localReviewsPagination.lastTimestamp = data.sessions[data.sessions.length - 1].updated_at;
       localReviewsPagination.hasMore = !!data.hasMore;
@@ -750,7 +764,7 @@
       : '';
 
     return '' +
-      '<tr>' +
+      '<tr data-review-id="' + review.id + '">' +
         '<td class="col-repo">' + escapeHtml(review.repository) + '</td>' +
         '<td class="col-pr"><a href="' + link + '">#' + review.pr_number + '</a></td>' +
         '<td class="col-title" title="' + escapeHtml(review.pr_title) + '">' + escapeHtml(review.pr_title) + '</td>' +
@@ -858,6 +872,8 @@
    * Resets pagination state and renders the full table from scratch.
    */
   async function loadRecentReviews() {
+    prSelection.exit();
+
     const container = document.getElementById('recent-reviews-container');
     const section = document.getElementById('recent-reviews-section');
     // Reset pagination state
@@ -973,6 +989,7 @@
 
       // Append new rows to the existing table body
       tbody.insertAdjacentHTML('beforeend', data.reviews.map(renderRecentReviewRow).join(''));
+      if (prSelection.active) prSelection.onRowsAdded();
 
       // Update pagination state - advance the cursor
       recentReviewsPagination.lastTimestamp = data.reviews[data.reviews.length - 1].last_accessed_at;
@@ -1140,6 +1157,518 @@
     }
   }
 
+  // ─── Selection Mode ──────────────────────────────────────────────────────
+
+  /** Currently active SelectionMode instance (only one tab at a time) */
+  var activeSelection = null;
+
+  /**
+   * SelectionMode manages checkbox-based selection for a single tab's table.
+   *
+   * @param {Object} config
+   * @param {string} config.tabId - Tab pane element ID (e.g. 'pr-tab')
+   * @param {string} config.containerId - Table container ID (e.g. 'recent-reviews-container')
+   * @param {string} config.tbodyId - Table body ID (e.g. 'recent-reviews-tbody')
+   * @param {string} config.rowIdAttr - data attribute name on <tr> for the row's ID (e.g. 'reviewId' reads tr.dataset.reviewId)
+   * @param {Array} config.actions - [{ label: string, className: string, handler: function(selectedIds, selectionInstance) }]
+   */
+  function SelectionMode(config) {
+    this.config = config;
+    this.active = false;
+    this.selectedIds = new Set();
+    this._actionBar = null;
+    this._toggleBtn = null;
+    this._confirming = false;
+  }
+
+  SelectionMode.prototype.enter = function () {
+    if (this.active) return;
+    this.active = true;
+    this.selectedIds.clear();
+    this._confirming = false;
+
+    // Deactivate any other active selection
+    if (activeSelection && activeSelection !== this) {
+      activeSelection.exit();
+    }
+    activeSelection = this;
+
+    var container = document.getElementById(this.config.containerId);
+    if (container) container.classList.add('selection-mode');
+
+    // Hide the Select button, show inline action controls
+    if (this._toggleBtn) {
+      this._toggleBtn.style.display = 'none';
+    }
+    this._ensureInlineActions();
+    this._showInlineActions();
+
+    this._injectCheckboxes();
+    this._updateInlineActions();
+  };
+
+  SelectionMode.prototype.exit = function () {
+    if (!this.active) return;
+    this.active = false;
+    this.selectedIds.clear();
+    this._confirming = false;
+
+    if (activeSelection === this) activeSelection = null;
+
+    var container = document.getElementById(this.config.containerId);
+    if (container) container.classList.remove('selection-mode');
+
+    // Show Select button, hide inline action controls
+    if (this._toggleBtn) {
+      this._toggleBtn.style.display = '';
+    }
+    this._hideInlineActions();
+
+    this._removeCheckboxes();
+  };
+
+  SelectionMode.prototype.toggle = function () {
+    if (this.active) {
+      this.exit();
+    } else {
+      this.enter();
+    }
+  };
+
+  SelectionMode.prototype._getTable = function () {
+    var container = document.getElementById(this.config.containerId);
+    return container ? container.querySelector('table') : null;
+  };
+
+  SelectionMode.prototype._getTbody = function () {
+    return document.getElementById(this.config.tbodyId);
+  };
+
+  SelectionMode.prototype._injectCheckboxes = function () {
+    var table = this._getTable();
+    if (!table) return;
+
+    // Add select-all checkbox to thead
+    var thead = table.querySelector('thead tr');
+    if (thead) {
+      var th = document.createElement('th');
+      th.className = 'col-select';
+      th.innerHTML = '<input type="checkbox" class="select-all-checkbox" title="Select all">';
+      thead.insertBefore(th, thead.firstChild);
+
+      var self = this;
+      th.querySelector('input').addEventListener('change', function () {
+        self._handleSelectAll(this.checked);
+      });
+    }
+
+    // Add checkboxes to all existing rows
+    var tbody = this._getTbody();
+    if (tbody) {
+      var rows = tbody.querySelectorAll('tr');
+      for (var i = 0; i < rows.length; i++) {
+        this._injectCheckboxIntoRow(rows[i]);
+      }
+    }
+  };
+
+  SelectionMode.prototype._injectCheckboxIntoRow = function (tr) {
+    // Skip rows that already have a checkbox (e.g. delete-confirm rows)
+    if (tr.querySelector('.col-select')) return;
+    // Skip delete confirmation rows
+    if (tr.classList.contains('delete-confirm-row')) return;
+
+    var rowId = tr.dataset[this.config.rowIdAttr];
+    var td = document.createElement('td');
+    td.className = 'col-select';
+    td.innerHTML = '<input type="checkbox" data-select-id="' + (rowId || '') + '">';
+    tr.insertBefore(td, tr.firstChild);
+
+    var self = this;
+    td.querySelector('input').addEventListener('change', function () {
+      self._handleRowCheckbox(this.dataset.selectId, this.checked, tr);
+    });
+  };
+
+  SelectionMode.prototype._removeCheckboxes = function () {
+    var table = this._getTable();
+    if (!table) return;
+
+    // Remove all .col-select cells
+    var cells = table.querySelectorAll('.col-select');
+    for (var i = 0; i < cells.length; i++) {
+      cells[i].remove();
+    }
+
+    // Remove selected class from all rows
+    var rows = table.querySelectorAll('tr.bulk-selected');
+    for (var j = 0; j < rows.length; j++) {
+      rows[j].classList.remove('bulk-selected');
+    }
+  };
+
+  SelectionMode.prototype._handleSelectAll = function (checked) {
+    var tbody = this._getTbody();
+    if (!tbody) return;
+
+    var checkboxes = tbody.querySelectorAll('.col-select input[type="checkbox"]');
+    for (var i = 0; i < checkboxes.length; i++) {
+      var cb = checkboxes[i];
+      cb.checked = checked;
+      var id = cb.dataset.selectId;
+      var row = cb.closest('tr');
+      if (checked) {
+        if (id) this.selectedIds.add(id);
+        if (row) row.classList.add('bulk-selected');
+      } else {
+        this.selectedIds.delete(id);
+        if (row) row.classList.remove('bulk-selected');
+      }
+    }
+    this._updateInlineActions();
+  };
+
+  SelectionMode.prototype._handleRowCheckbox = function (id, checked, tr) {
+    if (checked) {
+      if (id) this.selectedIds.add(id);
+      tr.classList.add('bulk-selected');
+    } else {
+      this.selectedIds.delete(id);
+      tr.classList.remove('bulk-selected');
+    }
+
+    // Update select-all checkbox state
+    var table = this._getTable();
+    if (table) {
+      var selectAllCb = table.querySelector('.select-all-checkbox');
+      if (selectAllCb) {
+        var tbody = this._getTbody();
+        var total = tbody ? tbody.querySelectorAll('.col-select input[type="checkbox"]').length : 0;
+        selectAllCb.checked = total > 0 && this.selectedIds.size === total;
+        selectAllCb.indeterminate = !selectAllCb.checked && this.selectedIds.size > 0;
+      }
+    }
+
+    this._updateInlineActions();
+  };
+
+  SelectionMode.prototype.onRowsAdded = function () {
+    if (!this.active) return;
+    var tbody = this._getTbody();
+    if (!tbody) return;
+
+    var rows = tbody.querySelectorAll('tr');
+    for (var i = 0; i < rows.length; i++) {
+      if (!rows[i].querySelector('.col-select')) {
+        this._injectCheckboxIntoRow(rows[i]);
+      }
+    }
+
+    // Uncheck select-all since new rows are not selected
+    var table = this._getTable();
+    if (table) {
+      var selectAllCb = table.querySelector('.select-all-checkbox');
+      if (selectAllCb) {
+        selectAllCb.checked = false;
+        selectAllCb.indeterminate = this.selectedIds.size > 0;
+      }
+    }
+  };
+
+  /**
+   * Build the inline action controls (action buttons + count + cancel) and
+   * insert them next to the Select toggle button. Created once, then
+   * shown/hidden on enter/exit.
+   */
+  SelectionMode.prototype._ensureInlineActions = function () {
+    if (this._inlineEl) return;
+    if (!this._toggleBtn) return;
+
+    var wrapper = document.createElement('span');
+    wrapper.className = 'bulk-inline-actions';
+
+    // Count label
+    var countSpan = document.createElement('span');
+    countSpan.className = 'bulk-action-count';
+    wrapper.appendChild(countSpan);
+
+    // Action buttons (disabled by default — enabled when selection count > 0)
+    var buttonsSpan = document.createElement('span');
+    buttonsSpan.className = 'bulk-action-buttons';
+    var self = this;
+    this._actionBtns = [];
+    for (var i = 0; i < this.config.actions.length; i++) {
+      var action = this.config.actions[i];
+      var btn = document.createElement('button');
+      btn.className = action.className;
+      btn.textContent = action.label;
+      btn.disabled = true;
+      btn.addEventListener('click', (function (act) {
+        return function () {
+          act.handler(new Set(self.selectedIds), self);
+        };
+      })(action));
+      buttonsSpan.appendChild(btn);
+      this._actionBtns.push(btn);
+    }
+    wrapper.appendChild(buttonsSpan);
+
+    // Confirm buttons (hidden by default, shown when confirming)
+    var confirmSpan = document.createElement('span');
+    confirmSpan.className = 'bulk-confirm-buttons';
+    var confirmYes = document.createElement('button');
+    confirmYes.className = 'btn-bulk-delete';
+    confirmYes.textContent = 'Confirm';
+    var confirmNo = document.createElement('button');
+    confirmNo.className = 'btn-bulk-cancel';
+    confirmNo.textContent = 'Cancel';
+    confirmSpan.appendChild(confirmYes);
+    confirmSpan.appendChild(confirmNo);
+    wrapper.appendChild(confirmSpan);
+
+    // Cancel button (exits selection mode)
+    var cancelBtn = document.createElement('button');
+    cancelBtn.className = 'btn-bulk-cancel';
+    cancelBtn.textContent = 'Cancel';
+    cancelBtn.addEventListener('click', function () {
+      self.exit();
+    });
+    wrapper.appendChild(cancelBtn);
+
+    // Insert after the toggle button
+    this._toggleBtn.parentNode.insertBefore(wrapper, this._toggleBtn.nextSibling);
+    this._inlineEl = wrapper;
+    this._countEl = countSpan;
+    this._confirmYes = confirmYes;
+    this._confirmNo = confirmNo;
+  };
+
+  SelectionMode.prototype._showInlineActions = function () {
+    if (this._inlineEl) this._inlineEl.style.display = '';
+  };
+
+  SelectionMode.prototype._hideInlineActions = function () {
+    if (this._inlineEl) {
+      this._inlineEl.style.display = 'none';
+      this._inlineEl.classList.remove('confirming');
+      this._confirming = false;
+    }
+  };
+
+  SelectionMode.prototype._updateInlineActions = function () {
+    if (!this._inlineEl) return;
+
+    var count = this.selectedIds.size;
+
+    // Update count label
+    // Clear count text when not confirming (only used for confirm message)
+    if (this._countEl && !this._confirming) {
+      this._countEl.textContent = '';
+    }
+
+    // Enable/disable action buttons
+    for (var i = 0; i < this._actionBtns.length; i++) {
+      this._actionBtns[i].disabled = count === 0;
+    }
+
+    // Exit confirming state if count drops to 0
+    if (count === 0 && this._confirming) {
+      this._inlineEl.classList.remove('confirming');
+      this._confirming = false;
+    }
+  };
+
+  /**
+   * Show confirmation state in the inline action controls.
+   * @param {string} message - Confirmation message (e.g. "Delete 3 reviews?")
+   * @param {Function} onConfirm - Called when user confirms
+   */
+  SelectionMode.prototype.showConfirm = function (message, onConfirm) {
+    if (!this._inlineEl) return;
+
+    this._confirming = true;
+    if (this._countEl) this._countEl.textContent = message;
+    this._inlineEl.classList.add('confirming');
+
+    var self = this;
+
+    // Wire up confirm/cancel buttons (replace nodes to avoid stacking listeners)
+    var newConfirmYes = this._confirmYes.cloneNode(true);
+    this._confirmYes.parentNode.replaceChild(newConfirmYes, this._confirmYes);
+    this._confirmYes = newConfirmYes;
+
+    var newConfirmNo = this._confirmNo.cloneNode(true);
+    this._confirmNo.parentNode.replaceChild(newConfirmNo, this._confirmNo);
+    this._confirmNo = newConfirmNo;
+
+    newConfirmYes.addEventListener('click', function () {
+      self._inlineEl.classList.remove('confirming');
+      self._confirming = false;
+      onConfirm();
+    });
+
+    newConfirmNo.addEventListener('click', function () {
+      self._inlineEl.classList.remove('confirming');
+      self._confirming = false;
+      self._updateInlineActions();
+    });
+  };
+
+  // ─── Selection Mode Instances & Handlers ────────────────────────────────────
+
+  var prSelection = new SelectionMode({
+    tabId: 'pr-tab',
+    containerId: 'recent-reviews-container',
+    tbodyId: 'recent-reviews-tbody',
+    rowIdAttr: 'reviewId',
+    actions: [
+      { label: 'Delete', className: 'btn-bulk-delete', handler: handleBulkDeletePR }
+    ]
+  });
+
+  var localSelection = new SelectionMode({
+    tabId: 'local-tab',
+    containerId: 'local-reviews-container',
+    tbodyId: 'local-reviews-tbody',
+    rowIdAttr: 'sessionId',
+    actions: [
+      { label: 'Delete', className: 'btn-bulk-delete', handler: handleBulkDeleteLocal }
+    ]
+  });
+
+  var reviewRequestsSelection = new SelectionMode({
+    tabId: 'review-requests-tab',
+    containerId: 'review-requests-container',
+    tbodyId: 'review-requests-tbody',
+    rowIdAttr: 'prUrl',
+    actions: [
+      { label: 'Open', className: 'btn-bulk-open', handler: handleBulkOpen },
+      { label: 'Analyze', className: 'btn-bulk-analyze', handler: handleBulkAnalyze }
+    ]
+  });
+
+  var myPrsSelection = new SelectionMode({
+    tabId: 'my-prs-tab',
+    containerId: 'my-prs-container',
+    tbodyId: 'my-prs-tbody',
+    rowIdAttr: 'prUrl',
+    actions: [
+      { label: 'Open', className: 'btn-bulk-open', handler: handleBulkOpen },
+      { label: 'Analyze', className: 'btn-bulk-analyze', handler: handleBulkAnalyze }
+    ]
+  });
+
+  async function handleBulkDeletePR(selectedIds, selectionInstance) {
+    var count = selectedIds.size;
+    selectionInstance.showConfirm('Delete ' + count + ' review' + (count === 1 ? '' : 's') + '?', async function () {
+      try {
+        var response = await fetch('/api/worktrees/bulk-delete', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ ids: Array.from(selectedIds).map(Number) })
+        });
+        var data = await response.json();
+        if (!response.ok) throw new Error(data.error || 'Bulk delete failed');
+
+        if (data.failed > 0) {
+          if (window.toast) window.toast.error(data.failed + ' of ' + count + ' failed to delete');
+        } else {
+          if (window.toast) window.toast.success('Deleted ' + data.deleted + ' review' + (data.deleted === 1 ? '' : 's'));
+        }
+
+        selectionInstance.exit();
+        await loadRecentReviews();
+      } catch (error) {
+        console.error('Bulk delete PR error:', error);
+        if (window.toast) window.toast.error('Bulk delete failed: ' + error.message);
+        selectionInstance.exit();
+        await loadRecentReviews();
+      }
+    });
+  }
+
+  async function handleBulkDeleteLocal(selectedIds, selectionInstance) {
+    var count = selectedIds.size;
+    selectionInstance.showConfirm('Delete ' + count + ' session' + (count === 1 ? '' : 's') + '?', async function () {
+      try {
+        var response = await fetch('/api/local/sessions/bulk-delete', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ ids: Array.from(selectedIds).map(Number) })
+        });
+        var data = await response.json();
+        if (!response.ok) throw new Error(data.error || 'Bulk delete failed');
+
+        if (data.failed > 0) {
+          if (window.toast) window.toast.error(data.failed + ' of ' + count + ' failed to delete');
+        } else {
+          if (window.toast) window.toast.success('Deleted ' + data.deleted + ' session' + (data.deleted === 1 ? '' : 's'));
+        }
+
+        selectionInstance.exit();
+        await loadLocalReviews();
+      } catch (error) {
+        console.error('Bulk delete local error:', error);
+        if (window.toast) window.toast.error('Bulk delete failed: ' + error.message);
+        selectionInstance.exit();
+        await loadLocalReviews();
+      }
+    });
+  }
+
+  /**
+   * Build pair-review URLs from selected collection rows.
+   * @param {Set} selectedIds - PR URLs (data-pr-url values)
+   * @param {string} tbodyId - tbody element ID
+   * @param {string} [query] - optional query string (e.g. '?analyze=true')
+   * @returns {string[]} array of pair-review URLs
+   */
+  function buildReviewUrls(selectedIds, tbodyId, query) {
+    var tbody = document.getElementById(tbodyId);
+    if (!tbody) return [];
+    var urls = [];
+    selectedIds.forEach(function (prUrl) {
+      var row = tbody.querySelector('tr[data-pr-url="' + CSS.escape(prUrl) + '"]');
+      if (!row) return;
+      var owner = row.dataset.owner;
+      var repo = row.dataset.repo;
+      var number = row.dataset.number;
+      if (owner && repo && number) {
+        urls.push('/pr/' + encodeURIComponent(owner) + '/' + encodeURIComponent(repo) + '/' + number + (query || ''));
+      }
+    });
+    return urls;
+  }
+
+  /**
+   * Open multiple review URLs via the server-side /api/bulk-open endpoint.
+   * The server uses the OS `open` command to launch each URL in the default
+   * browser, bypassing popup blockers entirely.
+   */
+  function bulkOpenUrls(urls) {
+    if (urls.length === 0) return;
+    fetch('/api/bulk-open', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ urls: urls })
+    }).catch(function (err) {
+      console.error('Bulk open failed:', err);
+      if (window.toast) window.toast.error('Failed to open reviews');
+    });
+  }
+
+  function handleBulkOpen(selectedIds, selectionInstance) {
+    var urls = buildReviewUrls(selectedIds, selectionInstance.config.tbodyId);
+    selectionInstance.exit();
+    bulkOpenUrls(urls);
+  }
+
+  function handleBulkAnalyze(selectedIds, selectionInstance) {
+    var urls = buildReviewUrls(selectedIds, selectionInstance.config.tbodyId, '?analyze=true');
+    selectionInstance.exit();
+    bulkOpenUrls(urls);
+  }
+
   // ─── Event Delegation ───────────────────────────────────────────────────────
 
   // Event delegation for buttons, show-more, tab switching
@@ -1177,9 +1706,30 @@
       return;
     }
 
-    // Click on a collection PR row to start review
+    // Select toggle button
+    var selectToggle = event.target.closest('.btn-select-toggle');
+    if (selectToggle) {
+      event.preventDefault();
+      var tabId = selectToggle.dataset.selectionTab;
+      var instances = { 'pr-tab': prSelection, 'local-tab': localSelection, 'review-requests-tab': reviewRequestsSelection, 'my-prs-tab': myPrsSelection };
+      var instance = instances[tabId];
+      if (instance) instance.toggle();
+      return;
+    }
+
+    // Click on a collection PR row — toggle checkbox in selection mode, else start review
     var collectionRow = event.target.closest('.collection-pr-row');
-    if (collectionRow && !event.target.closest('a')) {
+    if (collectionRow && !event.target.closest('a') && !event.target.closest('.col-select')) {
+      // If in selection mode, toggle the row's checkbox
+      if (activeSelection && activeSelection.active && collectionRow.closest('.selection-mode')) {
+        var cb = collectionRow.querySelector('.col-select input[type="checkbox"]');
+        if (cb) {
+          cb.checked = !cb.checked;
+          cb.dispatchEvent(new Event('change'));
+        }
+        return;
+      }
+
       var prUrl = collectionRow.dataset.prUrl;
       if (prUrl) {
         // Switch to PR tab to show loading state (do NOT persist to
@@ -1223,6 +1773,8 @@
     if (unifiedTabBtn) {
       const tabBar = document.getElementById('unified-tab-bar');
       switchTab(tabBar, unifiedTabBtn, async function (tabId) {
+        // Exit any active selection mode when switching tabs
+        if (activeSelection) activeSelection.exit();
         // Persist tab choice
         localStorage.setItem(TAB_STORAGE_KEY, tabId);
         // Lazy-load local reviews on first switch
@@ -1305,6 +1857,57 @@
     // Note: No explicit Enter keypress handlers are needed here.
     // Both inputs are inside <form> elements, so pressing Enter
     // natively triggers form submission.
+
+    // ─── Create Select toggle buttons for each tab ──────────────────────────
+
+    function createSelectButton(tabId) {
+      var btn = document.createElement('button');
+      btn.className = 'btn-select-toggle';
+      btn.type = 'button';
+      btn.textContent = 'Select';
+      btn.dataset.selectionTab = tabId;
+      return btn;
+    }
+
+    // PR tab: insert header between form and container
+    var prTab = document.getElementById('pr-tab');
+    if (prTab) {
+      var prContainer = document.getElementById('recent-reviews-container');
+      var prHeader = document.createElement('div');
+      prHeader.className = 'select-mode-header visible';
+      var prBtn = createSelectButton('pr-tab');
+      prSelection._toggleBtn = prBtn;
+      prHeader.appendChild(prBtn);
+      prTab.insertBefore(prHeader, prContainer);
+    }
+
+    // Local tab: insert header between form and container
+    var localTab = document.getElementById('local-tab');
+    if (localTab) {
+      var localContainer = document.getElementById('local-reviews-container');
+      var localHeader = document.createElement('div');
+      localHeader.className = 'select-mode-header visible';
+      var localBtn = createSelectButton('local-tab');
+      localSelection._toggleBtn = localBtn;
+      localHeader.appendChild(localBtn);
+      localTab.insertBefore(localHeader, localContainer);
+    }
+
+    // Review Requests tab: add to existing header
+    var rrHeader = document.querySelector('#review-requests-tab .tab-pane-header');
+    if (rrHeader) {
+      var rrBtn = createSelectButton('review-requests-tab');
+      reviewRequestsSelection._toggleBtn = rrBtn;
+      rrHeader.insertBefore(rrBtn, rrHeader.firstChild);
+    }
+
+    // My PRs tab: add to existing header
+    var mpHeader = document.querySelector('#my-prs-tab .tab-pane-header');
+    if (mpHeader) {
+      var mpBtn = createSelectButton('my-prs-tab');
+      myPrsSelection._toggleBtn = mpBtn;
+      mpHeader.insertBefore(mpBtn, mpHeader.firstChild);
+    }
   });
 
   // ─── bfcache Restoration ───────────────────────────────────────────────────

--- a/src/routes/local.js
+++ b/src/routes/local.js
@@ -66,6 +66,22 @@ function deleteLocalReviewDiff(reviewId) {
 }
 
 /**
+ * Delete a local review session and its in-memory diff cache.
+ * Shared by both single-delete and bulk-delete routes.
+ *
+ * @param {ReviewRepository} reviewRepo - Repository instance
+ * @param {number} id - Review ID
+ * @returns {boolean} true if deleted, false if not found
+ */
+async function deleteLocalReviewFull(reviewRepo, id) {
+  const deleted = await reviewRepo.deleteLocalSession(id);
+  if (deleted) {
+    deleteLocalReviewDiff(id);
+  }
+  return deleted;
+}
+
+/**
  * Open native OS directory picker dialog and return the selected path.
  * Uses osascript on macOS, zenity/kdialog on Linux, PowerShell on Windows.
  * Must be registered BEFORE /:reviewId param routes.
@@ -185,6 +201,74 @@ router.get('/api/local/sessions', async (req, res) => {
 });
 
 /**
+ * Bulk delete local review sessions.
+ * Accepts { ids: number[] } in request body. Max 50 IDs per request.
+ * Must be registered BEFORE /:reviewId param routes.
+ * Only deletes DB records — does NOT remove files on disk.
+ */
+router.post('/api/local/sessions/bulk-delete', async (req, res) => {
+  try {
+    const { ids } = req.body || {};
+
+    if (!Array.isArray(ids) || ids.length === 0) {
+      return res.status(400).json({
+        success: false,
+        error: 'Request body must contain a non-empty "ids" array'
+      });
+    }
+
+    if (ids.length > 50) {
+      return res.status(400).json({
+        success: false,
+        error: 'Maximum 50 IDs per request'
+      });
+    }
+
+    const parsedIds = ids.map(id => parseInt(id, 10));
+    if (parsedIds.some(id => isNaN(id) || id <= 0)) {
+      return res.status(400).json({
+        success: false,
+        error: 'All IDs must be positive integers'
+      });
+    }
+
+    const db = req.app.get('db');
+    const reviewRepo = new ReviewRepository(db);
+    let deleted = 0;
+    const errors = [];
+
+    for (const id of parsedIds) {
+      try {
+        const result = await deleteLocalReviewFull(reviewRepo, id);
+        if (result) {
+          deleted++;
+        } else {
+          errors.push({ id, error: `Local review #${id} not found` });
+        }
+      } catch (err) {
+        errors.push({ id, error: err.message });
+      }
+    }
+
+    if (deleted > 0) logger.success(`Bulk deleted ${deleted} local review session(s)`);
+
+    res.json({
+      success: deleted > 0 || errors.length === 0,
+      deleted,
+      failed: errors.length,
+      errors
+    });
+
+  } catch (error) {
+    logger.error(`Error in bulk delete local sessions: ${error.message}`);
+    res.status(500).json({
+      success: false,
+      error: 'Failed to process bulk delete'
+    });
+  }
+});
+
+/**
  * Delete a local review session
  * Must be registered BEFORE /:reviewId param routes
  * Only deletes DB records — does NOT remove files on disk.
@@ -201,16 +285,13 @@ router.delete('/api/local/sessions/:reviewId', async (req, res) => {
 
     const db = req.app.get('db');
     const reviewRepo = new ReviewRepository(db);
-    const deleted = await reviewRepo.deleteLocalSession(reviewId);
+    const deleted = await deleteLocalReviewFull(reviewRepo, reviewId);
 
     if (!deleted) {
       return res.status(404).json({
         error: `Local review #${reviewId} not found`
       });
     }
-
-    // Clean up in-memory diff cache to avoid stale data
-    deleteLocalReviewDiff(reviewId);
 
     logger.success(`Deleted local review session #${reviewId}`);
 

--- a/src/routes/worktrees.js
+++ b/src/routes/worktrees.js
@@ -12,6 +12,7 @@ const express = require('express');
 const { query, queryOne, run, ReviewRepository } = require('../database');
 const { setupPRReview } = require('../setup/pr-setup');
 const { GitHubApiError } = require('../github/client');
+const { GitWorktreeManager } = require('../git/worktree');
 const fs = require('fs').promises;
 const logger = require('../utils/logger');
 
@@ -218,6 +219,70 @@ router.get('/api/worktrees/recent', async (req, res) => {
 });
 
 /**
+ * Delete a single review by pr_metadata ID.
+ * Cleans up: worktree directory, worktree record, comments, reviews, and pr_metadata.
+ *
+ * @param {object} db - Database handle
+ * @param {number} metadataId - pr_metadata.id
+ * @returns {{ success: boolean, message: string }}
+ * @throws {Error} if deletion fails
+ */
+async function deleteReviewById(db, metadataId) {
+  const metadata = await queryOne(db, `
+    SELECT id, pr_number, repository FROM pr_metadata WHERE id = ?
+  `, [metadataId]);
+
+  if (!metadata) {
+    return { success: false, message: 'Review not found' };
+  }
+
+  const { pr_number: prNumber, repository } = metadata;
+  logger.info(`Deleting review for ${repository} #${prNumber} (metadata ID ${metadataId})`);
+
+  // Look up associated worktree path for cleanup after DB commit
+  const worktree = await queryOne(db, `
+    SELECT id, path FROM worktrees WHERE pr_number = ? AND repository = ? COLLATE NOCASE
+  `, [prNumber, repository]);
+
+  // Delete all associated database records in a transaction
+  await run(db, 'BEGIN TRANSACTION');
+  try {
+    await run(db, 'DELETE FROM worktrees WHERE pr_number = ? AND repository = ? COLLATE NOCASE', [prNumber, repository]);
+    await run(db, 'DELETE FROM chat_sessions WHERE review_id IN (SELECT id FROM reviews WHERE pr_number = ? AND repository = ? COLLATE NOCASE)', [prNumber, repository]);
+    await run(db, `
+      DELETE FROM comments WHERE review_id IN (
+        SELECT id FROM reviews WHERE pr_number = ? AND repository = ? COLLATE NOCASE
+      )
+    `, [prNumber, repository]);
+    await run(db, 'DELETE FROM reviews WHERE pr_number = ? AND repository = ? COLLATE NOCASE', [prNumber, repository]);
+    await run(db, 'DELETE FROM pr_metadata WHERE id = ?', [metadataId]);
+    // Clean up cached GitHub PR data
+    const parts = repository.split('/');
+    if (parts.length === 2) {
+      await run(db, 'DELETE FROM github_pr_cache WHERE owner = ? AND repo = ? AND number = ?', [parts[0], parts[1], prNumber]);
+    }
+    await run(db, 'COMMIT');
+  } catch (txError) {
+    await run(db, 'ROLLBACK');
+    throw txError;
+  }
+
+  // Clean up worktree AFTER successful DB commit so rollback doesn't orphan data
+  if (worktree && worktree.path) {
+    try {
+      const worktreeManager = new GitWorktreeManager(db);
+      await worktreeManager.cleanupWorktree(worktree.path);
+      logger.info(`Cleaned up worktree: ${worktree.path}`);
+    } catch {
+      logger.warn(`Could not clean up worktree (may not exist): ${worktree.path}`);
+    }
+  }
+
+  logger.success(`Deleted review for ${repository} #${prNumber}`);
+  return { success: true, message: `Review for ${repository} #${prNumber} deleted` };
+}
+
+/**
  * Delete a review and all associated data.
  * Cleans up: worktree directory, worktree record, comments, reviews, and pr_metadata.
  *
@@ -235,62 +300,18 @@ router.delete('/api/worktrees/:id', async (req, res) => {
     }
 
     const db = req.app.get('db');
+    const result = await deleteReviewById(db, metadataId);
 
-    // Look up pr_metadata to get the composite key
-    const metadata = await queryOne(db, `
-      SELECT id, pr_number, repository FROM pr_metadata WHERE id = ?
-    `, [metadataId]);
-
-    if (!metadata) {
+    if (!result.success) {
       return res.status(404).json({
         success: false,
-        error: 'Review not found'
+        error: result.message
       });
     }
 
-    const { pr_number: prNumber, repository } = metadata;
-    logger.info(`Deleting review for ${repository} #${prNumber} (metadata ID ${metadataId})`);
-
-    // Look up associated worktree for filesystem cleanup
-    const worktree = await queryOne(db, `
-      SELECT id, path FROM worktrees WHERE pr_number = ? AND repository = ? COLLATE NOCASE
-    `, [prNumber, repository]);
-
-    // Delete the worktree directory if it exists
-    if (worktree && worktree.path) {
-      try {
-        await fs.access(worktree.path);
-        await fs.rm(worktree.path, { recursive: true, force: true });
-        logger.info(`Deleted worktree directory: ${worktree.path}`);
-      } catch {
-        logger.warn(`Could not delete worktree directory (may not exist): ${worktree.path}`);
-      }
-    }
-
-    // Delete all associated database records
-    // First delete the worktree record, then use shared review cleanup
-    await run(db, 'DELETE FROM worktrees WHERE pr_number = ? AND repository = ? COLLATE NOCASE', [prNumber, repository]);
-
-    // Find all reviews for this PR and delete them with cascading cleanup
-    const reviews = await query(db, `
-      SELECT id FROM reviews WHERE pr_number = ? AND repository = ? COLLATE NOCASE
-    `, [prNumber, repository]);
-
-    const reviewRepo = new ReviewRepository(db);
-    for (const review of reviews) {
-      await reviewRepo.deleteWithRelatedData(review.id, { prNumber, repository });
-    }
-
-    // If no reviews existed, still clean up pr_metadata directly
-    if (reviews.length === 0) {
-      await run(db, 'DELETE FROM pr_metadata WHERE id = ?', [metadataId]);
-    }
-
-    logger.success(`Deleted review for ${repository} #${prNumber}`);
-
     res.json({
       success: true,
-      message: `Review for ${repository} #${prNumber} deleted`
+      message: result.message
     });
 
   } catch (error) {
@@ -298,6 +319,72 @@ router.delete('/api/worktrees/:id', async (req, res) => {
     res.status(500).json({
       success: false,
       error: 'Failed to delete review: ' + error.message
+    });
+  }
+});
+
+/**
+ * Bulk delete reviews by pr_metadata IDs.
+ * Accepts { ids: number[] } in request body. Max 50 IDs per request.
+ * Each deletion is independent — partial failures are reported per-ID.
+ */
+router.post('/api/worktrees/bulk-delete', async (req, res) => {
+  try {
+    const { ids } = req.body || {};
+
+    if (!Array.isArray(ids) || ids.length === 0) {
+      return res.status(400).json({
+        success: false,
+        error: 'Request body must contain a non-empty "ids" array'
+      });
+    }
+
+    if (ids.length > 50) {
+      return res.status(400).json({
+        success: false,
+        error: 'Maximum 50 IDs per request'
+      });
+    }
+
+    const parsedIds = ids.map(id => parseInt(id, 10));
+    if (parsedIds.some(id => isNaN(id) || id <= 0)) {
+      return res.status(400).json({
+        success: false,
+        error: 'All IDs must be positive integers'
+      });
+    }
+
+    const db = req.app.get('db');
+    let deleted = 0;
+    const errors = [];
+
+    for (const id of parsedIds) {
+      try {
+        const result = await deleteReviewById(db, id);
+        if (result.success) {
+          deleted++;
+        } else {
+          errors.push({ id, error: result.message });
+        }
+      } catch (err) {
+        errors.push({ id, error: err.message });
+      }
+    }
+
+    if (deleted > 0) logger.success(`Bulk deleted ${deleted} review(s)`);
+
+    res.json({
+      success: deleted > 0 || errors.length === 0,
+      deleted,
+      failed: errors.length,
+      errors
+    });
+
+  } catch (error) {
+    logger.error('Error in bulk delete:', error);
+    res.status(500).json({
+      success: false,
+      error: 'Failed to process bulk delete: ' + error.message
     });
   }
 });

--- a/src/server.js
+++ b/src/server.js
@@ -208,6 +208,34 @@ async function startServer(sharedDb = null) {
       res.sendFile(path.join(__dirname, '..', 'public', 'index.html'));
     });
     
+    // Bulk-open — opens multiple local URLs in the OS browser via the `open` package.
+    // Bypasses popup blockers since the server shells out directly.
+    const openUrl = (...args) => import('open').then(({ default: open }) => open(...args));
+    app.post('/api/bulk-open', async (req, res) => {
+      try {
+        const { urls } = req.body || {};
+        if (!Array.isArray(urls) || urls.length === 0) {
+          return res.status(400).json({ error: 'urls array required' });
+        }
+        if (urls.length > 20) {
+          return res.status(400).json({ error: 'Maximum 20 URLs per request' });
+        }
+        // Only allow local paths starting with / (prevent open-redirect)
+        const validUrls = urls.filter(u => typeof u === 'string' && u.startsWith('/'));
+        if (validUrls.length === 0) {
+          return res.status(400).json({ error: 'All URLs must be local paths starting with /' });
+        }
+        const port = req.socket.localPort;
+        for (const url of validUrls) {
+          await openUrl(`http://localhost:${port}${url}`);
+        }
+        res.json({ success: true, opened: validUrls.length });
+      } catch (error) {
+        logger.error('Bulk open failed:', error);
+        res.status(500).json({ error: 'Failed to open URLs' });
+      }
+    });
+
     // PR display route - serves pr.html if review data exists, setup.html otherwise
     app.get('/pr/:owner/:repo/:number', async (req, res) => {
       const { owner, repo, number } = req.params;

--- a/tests/e2e/bulk-actions.spec.js
+++ b/tests/e2e/bulk-actions.spec.js
@@ -1,0 +1,457 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/**
+ * E2E Tests: Bulk Actions / Selection Mode
+ *
+ * Tests the selection mode UI on the index page:
+ * - Entering/exiting selection mode via Select toggle button
+ * - Checkbox injection and row selection
+ * - Select All functionality
+ * - Bulk action bar with count display
+ * - Bulk delete with confirmation flow (PR and Local tabs)
+ * - Escape key exits selection mode
+ * - Tab switch exits selection mode
+ */
+
+import { test, expect } from './fixtures.js';
+
+/**
+ * Seed additional PR reviews into the test database so the PR table has
+ * multiple rows for bulk selection tests.
+ *
+ * The default test data from test-server.js inserts 1 pr_metadata row
+ * (pr_number=1, repo='test-owner/test-repo'). We add 2 more here.
+ */
+function seedExtraPRReviews(db) {
+  const now = new Date().toISOString();
+  const prData2 = JSON.stringify({
+    state: 'open',
+    diff: '',
+    changed_files: [],
+    additions: 5,
+    deletions: 2,
+    html_url: 'https://github.com/test-owner/test-repo/pull/2',
+    base_sha: 'aaa111',
+    head_sha: 'bbb222',
+    node_id: 'PR_test_node_2'
+  });
+  const prData3 = JSON.stringify({
+    state: 'open',
+    diff: '',
+    changed_files: [],
+    additions: 10,
+    deletions: 3,
+    html_url: 'https://github.com/test-owner/test-repo/pull/3',
+    base_sha: 'ccc333',
+    head_sha: 'ddd444',
+    node_id: 'PR_test_node_3'
+  });
+
+  db.prepare(`
+    INSERT OR IGNORE INTO pr_metadata (pr_number, repository, title, description, author, base_branch, head_branch, pr_data, last_accessed_at)
+    VALUES (2, 'test-owner/test-repo', 'Second test PR', 'Description 2', 'user2', 'main', 'feature-2', ?, ?)
+  `).run(prData2, now);
+
+  db.prepare(`
+    INSERT OR IGNORE INTO pr_metadata (pr_number, repository, title, description, author, base_branch, head_branch, pr_data, last_accessed_at)
+    VALUES (3, 'test-owner/test-repo', 'Third test PR', 'Description 3', 'user3', 'main', 'feature-3', ?, ?)
+  `).run(prData3, now);
+}
+
+/**
+ * Seed additional local review sessions so the Local tab has multiple rows.
+ *
+ * The default test data inserts 1 local review (review_type='local', id=2).
+ * We add 2 more here.
+ */
+function seedExtraLocalSessions(db) {
+  const now = new Date().toISOString();
+
+  db.prepare(`
+    INSERT INTO reviews (repository, status, review_type, local_path, local_head_sha, created_at, updated_at)
+    VALUES ('test-repo-extra-1', 'draft', 'local', '/tmp/test-local-extra-1', 'sha_extra_1', ?, ?)
+  `).run(now, now);
+
+  db.prepare(`
+    INSERT INTO reviews (repository, status, review_type, local_path, local_head_sha, created_at, updated_at)
+    VALUES ('test-repo-extra-2', 'draft', 'local', '/tmp/test-local-extra-2', 'sha_extra_2', ?, ?)
+  `).run(now, now);
+}
+
+/**
+ * Wait for the PR tab's table to render with at least `minRows` data rows.
+ */
+async function waitForPRTable(page, minRows = 1) {
+  await page.waitForSelector('#recent-reviews-tbody', { timeout: 10000 });
+  await page.waitForFunction(
+    (min) => {
+      const tbody = document.getElementById('recent-reviews-tbody');
+      return tbody && tbody.querySelectorAll('tr[data-review-id]').length >= min;
+    },
+    minRows,
+    { timeout: 10000 }
+  );
+}
+
+/**
+ * Wait for the Local tab's table to render with at least `minRows` data rows.
+ */
+async function waitForLocalTable(page, minRows = 1) {
+  await page.waitForSelector('#local-reviews-tbody', { timeout: 10000 });
+  await page.waitForFunction(
+    (min) => {
+      const tbody = document.getElementById('local-reviews-tbody');
+      return tbody && tbody.querySelectorAll('tr[data-session-id]').length >= min;
+    },
+    minRows,
+    { timeout: 10000 }
+  );
+}
+
+// ─── PR Tab: Selection Mode ──────────────────────────────────────────────────
+
+test.describe('Bulk Actions - PR Tab', () => {
+  test.beforeEach(async ({ page, testServer }) => {
+    seedExtraPRReviews(testServer.db);
+    await page.goto('/');
+    await page.waitForLoadState('domcontentloaded');
+    await waitForPRTable(page, 3);
+  });
+
+  test('Select button appears on PR tab', async ({ page }) => {
+    const selectBtn = page.locator('.btn-select-toggle[data-selection-tab="pr-tab"]');
+    await expect(selectBtn).toBeVisible();
+    await expect(selectBtn).toHaveText('Select');
+  });
+
+  test('clicking Select enters selection mode with checkboxes', async ({ page }) => {
+    const selectBtn = page.locator('.btn-select-toggle[data-selection-tab="pr-tab"]');
+    await selectBtn.click();
+
+    // Button text should change to Cancel
+    await expect(selectBtn).toBeHidden();
+
+    // Checkboxes should appear on rows
+    const checkboxes = page.locator('#recent-reviews-tbody .col-select input[type="checkbox"]');
+    const count = await checkboxes.count();
+    expect(count).toBeGreaterThanOrEqual(3);
+
+    // Select-all checkbox should appear in thead
+    const selectAll = page.locator('#recent-reviews-container .select-all-checkbox');
+    await expect(selectAll).toBeVisible();
+  });
+
+  test('clicking Cancel exits selection mode', async ({ page }) => {
+    const selectBtn = page.locator('.btn-select-toggle[data-selection-tab="pr-tab"]');
+
+    // Enter selection mode
+    await selectBtn.click();
+    await expect(selectBtn).toBeHidden();
+
+    // Exit selection mode via inline Cancel button
+    const cancelBtn = page.locator('#pr-tab .bulk-inline-actions > .btn-bulk-cancel');
+    await cancelBtn.click();
+    await expect(selectBtn).toHaveText('Select');
+    await expect(selectBtn).toBeVisible();
+
+    // Checkboxes should be gone
+    const checkboxes = page.locator('#recent-reviews-tbody .col-select');
+    await expect(checkboxes).toHaveCount(0);
+  });
+
+  test('selecting items enables action buttons', async ({ page }) => {
+    const selectBtn = page.locator('.btn-select-toggle[data-selection-tab="pr-tab"]');
+    await selectBtn.click();
+
+    // Delete button starts disabled
+    const deleteBtn = page.locator('#pr-tab .bulk-action-buttons .btn-bulk-delete');
+    await expect(deleteBtn).toBeDisabled();
+
+    // Click the first row's checkbox
+    const firstCheckbox = page.locator('#recent-reviews-tbody .col-select input[type="checkbox"]').first();
+    await firstCheckbox.check();
+
+    // Delete button should now be enabled
+    await expect(deleteBtn).toBeEnabled();
+
+    // Row should have bulk-selected class
+    const selectedRows = page.locator('#recent-reviews-tbody tr.bulk-selected');
+    await expect(selectedRows).toHaveCount(1);
+  });
+
+  test('Select All checkbox selects all rows', async ({ page }) => {
+    const selectBtn = page.locator('.btn-select-toggle[data-selection-tab="pr-tab"]');
+    await selectBtn.click();
+
+    // Count total rows
+    const totalRows = await page.locator('#recent-reviews-tbody tr[data-review-id]').count();
+    expect(totalRows).toBeGreaterThanOrEqual(3);
+
+    // Click select-all
+    const selectAll = page.locator('#recent-reviews-container .select-all-checkbox');
+    await selectAll.check();
+
+    // All rows should be selected
+    const selectedRows = page.locator('#recent-reviews-tbody tr.bulk-selected');
+    await expect(selectedRows).toHaveCount(totalRows);
+
+    // Delete button should be enabled
+    const deleteBtn = page.locator('#pr-tab .bulk-action-buttons .btn-bulk-delete');
+    await expect(deleteBtn).toBeEnabled();
+  });
+
+  test('unchecking a row after Select All updates select-all state', async ({ page }) => {
+    const selectBtn = page.locator('.btn-select-toggle[data-selection-tab="pr-tab"]');
+    await selectBtn.click();
+
+    // Select all
+    const selectAll = page.locator('#recent-reviews-container .select-all-checkbox');
+    await selectAll.check();
+
+    // Uncheck the first row
+    const firstCheckbox = page.locator('#recent-reviews-tbody .col-select input[type="checkbox"]').first();
+    await firstCheckbox.uncheck();
+
+    // Select-all should be unchecked (indeterminate)
+    await expect(selectAll).not.toBeChecked();
+  });
+
+  test('bulk delete with confirmation deletes selected items', async ({ page }) => {
+    const selectBtn = page.locator('.btn-select-toggle[data-selection-tab="pr-tab"]');
+    await selectBtn.click();
+
+    // Count rows before delete
+    const rowsBefore = await page.locator('#recent-reviews-tbody tr[data-review-id]').count();
+    expect(rowsBefore).toBeGreaterThanOrEqual(3);
+
+    // Select 2 rows
+    const checkboxes = page.locator('#recent-reviews-tbody .col-select input[type="checkbox"]');
+    await checkboxes.nth(0).check();
+    await checkboxes.nth(1).check();
+
+    // Click Delete button in action bar
+    const deleteBtn = page.locator('#pr-tab .bulk-action-buttons .btn-bulk-delete');
+    await deleteBtn.click();
+
+    // Action bar should enter confirming state
+    const actionBar = page.locator('#pr-tab .bulk-inline-actions.confirming');
+    await expect(actionBar).toBeVisible();
+
+    // Confirmation message should mention count
+    const countEl = page.locator('#pr-tab .bulk-action-count');
+    await expect(countEl).toContainText('Delete 2 review');
+
+    // Click Confirm
+    const confirmBtn = page.locator('#pr-tab .bulk-confirm-buttons .btn-bulk-delete');
+    await confirmBtn.click();
+
+    // Wait for table to reload with fewer rows
+    const expectedMax = rowsBefore - 2;
+    await page.waitForFunction(
+      (max) => {
+        const tbody = document.getElementById('recent-reviews-tbody');
+        return tbody && tbody.querySelectorAll('tr[data-review-id]').length <= max;
+      },
+      expectedMax,
+      { timeout: 10000 }
+    );
+
+    // Should have exactly rowsBefore - 2 rows
+    const rowsAfter = await page.locator('#recent-reviews-tbody tr[data-review-id]').count();
+    expect(rowsAfter).toBe(rowsBefore - 2);
+  });
+
+  test('bulk delete cancel returns to selection state', async ({ page }) => {
+    const selectBtn = page.locator('.btn-select-toggle[data-selection-tab="pr-tab"]');
+    await selectBtn.click();
+
+    // Select a row
+    const firstCheckbox = page.locator('#recent-reviews-tbody .col-select input[type="checkbox"]').first();
+    await firstCheckbox.check();
+
+    // Click Delete
+    const deleteBtn = page.locator('#pr-tab .bulk-action-buttons .btn-bulk-delete');
+    await deleteBtn.click();
+
+    // Confirming state should be active
+    const actionBar = page.locator('#pr-tab .bulk-inline-actions.confirming');
+    await expect(actionBar).toBeVisible();
+
+    // Click Cancel in confirm mode
+    const cancelConfirmBtn = page.locator('#pr-tab .bulk-confirm-buttons .btn-bulk-cancel');
+    await cancelConfirmBtn.click();
+
+    // Should exit confirming state but remain in selection mode
+    await expect(page.locator('#pr-tab .bulk-inline-actions.confirming')).not.toBeVisible();
+
+    // Selection mode should still be active (checkboxes still present)
+    const checkboxes = page.locator('#recent-reviews-tbody .col-select input[type="checkbox"]');
+    const count = await checkboxes.count();
+    expect(count).toBeGreaterThan(0);
+  });
+});
+
+// ─── Local Tab: Selection Mode ───────────────────────────────────────────────
+
+test.describe('Bulk Actions - Local Tab', () => {
+  test.beforeEach(async ({ page, testServer }) => {
+    seedExtraLocalSessions(testServer.db);
+    await page.goto('/');
+    await page.waitForLoadState('domcontentloaded');
+
+    // Switch to Local tab
+    await page.click('#unified-tab-bar [data-tab="local-tab"]');
+    await waitForLocalTable(page, 3);
+  });
+
+  test('Select button appears on Local tab', async ({ page }) => {
+    const selectBtn = page.locator('.btn-select-toggle[data-selection-tab="local-tab"]');
+    await expect(selectBtn).toBeVisible();
+    await expect(selectBtn).toHaveText('Select');
+  });
+
+  test('selection mode works on Local tab', async ({ page }) => {
+    const selectBtn = page.locator('.btn-select-toggle[data-selection-tab="local-tab"]');
+    await selectBtn.click();
+
+    // Button text changes
+    await expect(selectBtn).toBeHidden();
+
+    // Checkboxes appear
+    const checkboxes = page.locator('#local-reviews-tbody .col-select input[type="checkbox"]');
+    const count = await checkboxes.count();
+    expect(count).toBeGreaterThanOrEqual(3);
+
+    // Delete button starts disabled
+    const deleteBtn = page.locator('#local-tab .bulk-action-buttons .btn-bulk-delete');
+    await expect(deleteBtn).toBeDisabled();
+
+    // Select a row
+    await checkboxes.first().check();
+
+    // Delete button should now be enabled
+    await expect(deleteBtn).toBeEnabled();
+  });
+
+  test('bulk delete works on Local tab', async ({ page }) => {
+    const selectBtn = page.locator('.btn-select-toggle[data-selection-tab="local-tab"]');
+    await selectBtn.click();
+
+    // Count rows before delete
+    const rowsBefore = await page.locator('#local-reviews-tbody tr[data-session-id]').count();
+    expect(rowsBefore).toBeGreaterThanOrEqual(3);
+
+    // Select 2 rows
+    const checkboxes = page.locator('#local-reviews-tbody .col-select input[type="checkbox"]');
+    await checkboxes.nth(0).check();
+    await checkboxes.nth(1).check();
+
+    // Click Delete
+    const deleteBtn = page.locator('#local-tab .bulk-action-buttons .btn-bulk-delete');
+    await deleteBtn.click();
+
+    // Confirm
+    const confirmBtn = page.locator('#local-tab .bulk-confirm-buttons .btn-bulk-delete');
+    await confirmBtn.click();
+
+    // Wait for table to reload with fewer rows
+    const expectedMax = rowsBefore - 2;
+    await page.waitForFunction(
+      (max) => {
+        const tbody = document.getElementById('local-reviews-tbody');
+        return tbody && tbody.querySelectorAll('tr[data-session-id]').length <= max;
+      },
+      expectedMax,
+      { timeout: 10000 }
+    );
+
+    // Should have exactly rowsBefore - 2 rows
+    const rowsAfter = await page.locator('#local-reviews-tbody tr[data-session-id]').count();
+    expect(rowsAfter).toBe(rowsBefore - 2);
+  });
+});
+
+// ─── Cross-Tab Behaviors ─────────────────────────────────────────────────────
+
+test.describe('Bulk Actions - Cross-Tab Behaviors', () => {
+  test.beforeEach(async ({ page, testServer }) => {
+    seedExtraPRReviews(testServer.db);
+    seedExtraLocalSessions(testServer.db);
+    await page.goto('/');
+    await page.waitForLoadState('domcontentloaded');
+    await waitForPRTable(page, 3);
+  });
+
+  test('Escape key exits selection mode', async ({ page }) => {
+    const selectBtn = page.locator('.btn-select-toggle[data-selection-tab="pr-tab"]');
+    await selectBtn.click();
+
+    // Verify selection mode is active
+    await expect(selectBtn).toBeHidden();
+    const checkboxes = page.locator('#recent-reviews-tbody .col-select input[type="checkbox"]');
+    const count = await checkboxes.count();
+    expect(count).toBeGreaterThan(0);
+
+    // Press Escape
+    await page.keyboard.press('Escape');
+
+    // Selection mode should be exited
+    await expect(selectBtn).toHaveText('Select');
+    await expect(page.locator('#recent-reviews-tbody .col-select')).toHaveCount(0);
+  });
+
+  test('tab switch exits selection mode', async ({ page }) => {
+    // Enter selection mode on PR tab
+    const prSelectBtn = page.locator('.btn-select-toggle[data-selection-tab="pr-tab"]');
+    await prSelectBtn.click();
+    await expect(prSelectBtn).toBeHidden();
+
+    // Switch to Local tab
+    await page.click('#unified-tab-bar [data-tab="local-tab"]');
+    await waitForLocalTable(page, 3);
+
+    // PR tab selection mode should be exited
+    await expect(prSelectBtn).toHaveText('Select');
+
+    // Switch back to PR tab to verify checkboxes are gone
+    await page.click('#unified-tab-bar [data-tab="pr-tab"]');
+    await expect(page.locator('#recent-reviews-tbody .col-select')).toHaveCount(0);
+  });
+
+  test('deselecting all items disables action buttons', async ({ page }) => {
+    const selectBtn = page.locator('.btn-select-toggle[data-selection-tab="pr-tab"]');
+    await selectBtn.click();
+
+    // Select a row
+    const firstCheckbox = page.locator('#recent-reviews-tbody .col-select input[type="checkbox"]').first();
+    await firstCheckbox.check();
+
+    // Delete button should be enabled
+    const deleteBtn = page.locator('#pr-tab .bulk-action-buttons .btn-bulk-delete');
+    await expect(deleteBtn).toBeEnabled();
+
+    // Deselect the row
+    await firstCheckbox.uncheck();
+
+    // Delete button should be disabled
+    await expect(deleteBtn).toBeDisabled();
+  });
+
+  test('clicking row in selection mode toggles checkbox (collection tab pattern)', async ({ page }) => {
+    // This test verifies the PR tab checkbox toggle via direct checkbox click
+    const selectBtn = page.locator('.btn-select-toggle[data-selection-tab="pr-tab"]');
+    await selectBtn.click();
+
+    // Click a checkbox to select
+    const firstCheckbox = page.locator('#recent-reviews-tbody .col-select input[type="checkbox"]').first();
+    await firstCheckbox.check();
+    await expect(firstCheckbox).toBeChecked();
+
+    // Verify row is marked selected
+    const firstRow = page.locator('#recent-reviews-tbody tr[data-review-id]').first();
+    await expect(firstRow).toHaveClass(/bulk-selected/);
+
+    // Uncheck
+    await firstCheckbox.uncheck();
+    await expect(firstRow).not.toHaveClass(/bulk-selected/);
+  });
+});

--- a/tests/integration/routes.test.js
+++ b/tests/integration/routes.test.js
@@ -6818,3 +6818,306 @@ describe('Share Endpoint', () => {
     });
   });
 });
+
+// ============================================================================
+// Bulk Delete Endpoint Tests
+// ============================================================================
+
+describe('POST /api/worktrees/bulk-delete', () => {
+  let db;
+  let app;
+
+  beforeEach(async () => {
+    db = await createTestDatabase();
+    app = createTestApp(db);
+  });
+
+  afterEach(async () => {
+    if (db) {
+      await closeTestDatabase(db);
+    }
+  });
+
+  /**
+   * Helper: insert a PR and return the pr_metadata.id
+   */
+  async function insertPRAndGetMetadataId(prNumber, repository = 'owner/repo') {
+    await insertTestPR(db, prNumber, repository);
+    const row = await queryOne(db, `
+      SELECT id FROM pr_metadata WHERE pr_number = ? AND repository = ?
+    `, [prNumber, repository]);
+    return row.id;
+  }
+
+  it('should bulk delete multiple reviews and return correct counts', async () => {
+    const id1 = await insertPRAndGetMetadataId(10);
+    const id2 = await insertPRAndGetMetadataId(20);
+    const id3 = await insertPRAndGetMetadataId(30);
+
+    const response = await request(app)
+      .post('/api/worktrees/bulk-delete')
+      .send({ ids: [id1, id3] });
+
+    expect(response.status).toBe(200);
+    expect(response.body.success).toBe(true);
+    expect(response.body.deleted).toBe(2);
+    expect(response.body.failed).toBe(0);
+    expect(response.body.errors).toEqual([]);
+
+    // Verify deleted rows are gone
+    const deleted1 = await queryOne(db, 'SELECT id FROM pr_metadata WHERE id = ?', [id1]);
+    const deleted3 = await queryOne(db, 'SELECT id FROM pr_metadata WHERE id = ?', [id3]);
+    expect(deleted1).toBeUndefined();
+    expect(deleted3).toBeUndefined();
+
+    // Verify the untouched row still exists
+    const kept = await queryOne(db, 'SELECT id FROM pr_metadata WHERE id = ?', [id2]);
+    expect(kept).toBeDefined();
+  });
+
+  it('should return 400 when ids array is empty', async () => {
+    const response = await request(app)
+      .post('/api/worktrees/bulk-delete')
+      .send({ ids: [] });
+
+    expect(response.status).toBe(400);
+    expect(response.body.success).toBe(false);
+    expect(response.body.error).toMatch(/non-empty/);
+  });
+
+  it('should return 400 when ids field is missing', async () => {
+    const response = await request(app)
+      .post('/api/worktrees/bulk-delete')
+      .send({});
+
+    expect(response.status).toBe(400);
+    expect(response.body.success).toBe(false);
+    expect(response.body.error).toMatch(/non-empty/);
+  });
+
+  it('should return 400 when body is empty', async () => {
+    const response = await request(app)
+      .post('/api/worktrees/bulk-delete')
+      .send();
+
+    expect(response.status).toBe(400);
+    expect(response.body.success).toBe(false);
+  });
+
+  it('should return 400 when ids contain non-integer values', async () => {
+    const response = await request(app)
+      .post('/api/worktrees/bulk-delete')
+      .send({ ids: [1, 'abc', 3] });
+
+    expect(response.status).toBe(400);
+    expect(response.body.success).toBe(false);
+    expect(response.body.error).toMatch(/positive integers/);
+  });
+
+  it('should return 400 when ids contain zero or negative values', async () => {
+    const response = await request(app)
+      .post('/api/worktrees/bulk-delete')
+      .send({ ids: [0, -1] });
+
+    expect(response.status).toBe(400);
+    expect(response.body.success).toBe(false);
+    expect(response.body.error).toMatch(/positive integers/);
+  });
+
+  it('should return 400 when more than 50 ids are provided', async () => {
+    const ids = Array.from({ length: 51 }, (_, i) => i + 1);
+    const response = await request(app)
+      .post('/api/worktrees/bulk-delete')
+      .send({ ids });
+
+    expect(response.status).toBe(400);
+    expect(response.body.success).toBe(false);
+    expect(response.body.error).toMatch(/Maximum 50/);
+  });
+
+  it('should report partial failure when some ids do not exist', async () => {
+    const id1 = await insertPRAndGetMetadataId(10);
+
+    const response = await request(app)
+      .post('/api/worktrees/bulk-delete')
+      .send({ ids: [id1, 99999] });
+
+    expect(response.status).toBe(200);
+    expect(response.body.success).toBe(true);
+    expect(response.body.deleted).toBe(1);
+    expect(response.body.failed).toBe(1);
+    expect(response.body.errors).toHaveLength(1);
+    expect(response.body.errors[0].id).toBe(99999);
+    expect(response.body.errors[0].error).toMatch(/not found/i);
+  });
+
+  it('should report all failures when no ids exist', async () => {
+    const response = await request(app)
+      .post('/api/worktrees/bulk-delete')
+      .send({ ids: [88888, 99999] });
+
+    expect(response.status).toBe(200);
+    expect(response.body.success).toBe(false);
+    expect(response.body.deleted).toBe(0);
+    expect(response.body.failed).toBe(2);
+    expect(response.body.errors).toHaveLength(2);
+  });
+});
+
+describe('POST /api/local/sessions/bulk-delete', () => {
+  let db;
+  let app;
+
+  beforeEach(async () => {
+    db = await createTestDatabase();
+    app = createTestApp(db);
+  });
+
+  afterEach(async () => {
+    if (db) {
+      await closeTestDatabase(db);
+    }
+  });
+
+  /**
+   * Helper: insert a local review session and return its reviews.id
+   */
+  async function insertLocalSession(name = 'test-session') {
+    const result = await run(db, `
+      INSERT INTO reviews (repository, status, review_type, local_path, local_head_sha, name)
+      VALUES ('test-repo', 'draft', 'local', '/tmp/test-repo', 'abc123def', ?)
+    `, [name]);
+    return result.lastID;
+  }
+
+  it('should bulk delete multiple local sessions and return correct counts', async () => {
+    const id1 = await insertLocalSession('session-1');
+    const id2 = await insertLocalSession('session-2');
+    const id3 = await insertLocalSession('session-3');
+
+    const response = await request(app)
+      .post('/api/local/sessions/bulk-delete')
+      .send({ ids: [id1, id3] });
+
+    expect(response.status).toBe(200);
+    expect(response.body.success).toBe(true);
+    expect(response.body.deleted).toBe(2);
+    expect(response.body.failed).toBe(0);
+    expect(response.body.errors).toEqual([]);
+
+    // Verify deleted rows are gone
+    const deleted1 = await queryOne(db, 'SELECT id FROM reviews WHERE id = ?', [id1]);
+    const deleted3 = await queryOne(db, 'SELECT id FROM reviews WHERE id = ?', [id3]);
+    expect(deleted1).toBeUndefined();
+    expect(deleted3).toBeUndefined();
+
+    // Verify the untouched row still exists
+    const kept = await queryOne(db, 'SELECT id FROM reviews WHERE id = ?', [id2]);
+    expect(kept).toBeDefined();
+  });
+
+  it('should return 400 when ids array is empty', async () => {
+    const response = await request(app)
+      .post('/api/local/sessions/bulk-delete')
+      .send({ ids: [] });
+
+    expect(response.status).toBe(400);
+    expect(response.body.success).toBe(false);
+    expect(response.body.error).toMatch(/non-empty/);
+  });
+
+  it('should return 400 when ids field is missing', async () => {
+    const response = await request(app)
+      .post('/api/local/sessions/bulk-delete')
+      .send({});
+
+    expect(response.status).toBe(400);
+    expect(response.body.success).toBe(false);
+    expect(response.body.error).toMatch(/non-empty/);
+  });
+
+  it('should return 400 when body is empty', async () => {
+    const response = await request(app)
+      .post('/api/local/sessions/bulk-delete')
+      .send();
+
+    expect(response.status).toBe(400);
+    expect(response.body.success).toBe(false);
+  });
+
+  it('should return 400 when ids contain non-integer values', async () => {
+    const response = await request(app)
+      .post('/api/local/sessions/bulk-delete')
+      .send({ ids: [1, 'abc', 3] });
+
+    expect(response.status).toBe(400);
+    expect(response.body.success).toBe(false);
+    expect(response.body.error).toMatch(/positive integers/);
+  });
+
+  it('should return 400 when ids contain zero or negative values', async () => {
+    const response = await request(app)
+      .post('/api/local/sessions/bulk-delete')
+      .send({ ids: [0, -1] });
+
+    expect(response.status).toBe(400);
+    expect(response.body.success).toBe(false);
+    expect(response.body.error).toMatch(/positive integers/);
+  });
+
+  it('should return 400 when more than 50 ids are provided', async () => {
+    const ids = Array.from({ length: 51 }, (_, i) => i + 1);
+    const response = await request(app)
+      .post('/api/local/sessions/bulk-delete')
+      .send({ ids });
+
+    expect(response.status).toBe(400);
+    expect(response.body.success).toBe(false);
+    expect(response.body.error).toMatch(/Maximum 50/);
+  });
+
+  it('should report partial failure when some ids do not exist', async () => {
+    const id1 = await insertLocalSession('session-1');
+
+    const response = await request(app)
+      .post('/api/local/sessions/bulk-delete')
+      .send({ ids: [id1, 99999] });
+
+    expect(response.status).toBe(200);
+    expect(response.body.success).toBe(true);
+    expect(response.body.deleted).toBe(1);
+    expect(response.body.failed).toBe(1);
+    expect(response.body.errors).toHaveLength(1);
+    expect(response.body.errors[0].id).toBe(99999);
+    expect(response.body.errors[0].error).toMatch(/not found/i);
+  });
+
+  it('should report all failures when no ids exist', async () => {
+    const response = await request(app)
+      .post('/api/local/sessions/bulk-delete')
+      .send({ ids: [88888, 99999] });
+
+    expect(response.status).toBe(200);
+    expect(response.body.success).toBe(false);
+    expect(response.body.deleted).toBe(0);
+    expect(response.body.failed).toBe(2);
+    expect(response.body.errors).toHaveLength(2);
+  });
+
+  it('should not delete PR-mode reviews even if id matches', async () => {
+    // Insert a PR review (not local)
+    const reviewId = await insertTestPR(db, 42, 'owner/repo');
+
+    const response = await request(app)
+      .post('/api/local/sessions/bulk-delete')
+      .send({ ids: [reviewId] });
+
+    expect(response.status).toBe(200);
+    expect(response.body.deleted).toBe(0);
+    expect(response.body.failed).toBe(1);
+
+    // Verify the PR review still exists
+    const kept = await queryOne(db, 'SELECT id FROM reviews WHERE id = ?', [reviewId]);
+    expect(kept).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds selection mode to all four index page tabs with per-tab bulk actions: **Delete** for PR/Local tabs, **Open/Analyze** for collection tabs
- New `SelectionMode` class handles checkbox injection, select-all toggle, sticky action bar with inline confirmation
- Backend endpoints: `POST /api/worktrees/bulk-delete`, `POST /api/local/sessions/bulk-delete`, `POST /api/bulk-open`
- Fixes: Toast.js now loaded on index page, added `.error()`/`.success()` convenience aliases, bulk-open has try/catch + 20-URL limit

## Test plan
- [ ] Integration tests for both bulk-delete endpoints (`npm test`)
- [ ] E2E tests for selection mode UI (`npm run test:e2e`)
- [ ] Manual: enter selection mode, select items, bulk delete with confirmation, verify table reloads
- [ ] Manual: pagination — enter select mode, load more, verify new rows get unchecked checkboxes
- [ ] Manual: tab switch and Escape both exit selection mode
- [ ] Manual: collection tabs — bulk Open and Analyze open correct URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)