### PR TITLE
feat: stale badge indicator for local reviews

### DIFF
--- a/.changeset/local-stale-badge.md
+++ b/.changeset/local-stale-badge.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": minor
+---
+
+Add stale badge indicator for local reviews on page load, matching PR mode behavior

--- a/public/js/local.js
+++ b/public/js/local.js
@@ -230,10 +230,6 @@ class LocalManager {
 
     // Override triggerAIAnalysis for local mode
     manager.triggerAIAnalysis = async function() {
-      // Timeout (ms) for stale check — git commands can hang on locked repos.
-      // Defined locally to avoid relying on cross-script const from pr.js.
-      const STALE_TIMEOUT = 2000;
-
       if (manager.isAnalyzing) {
         manager.reopenModal();
         return;
@@ -257,19 +253,13 @@ class LocalManager {
           return;
         }
 
-        // Run stale check and settings fetch in parallel to minimize dialog delay
-        // Use AbortController so the fetch is truly cancelled on timeout,
-        // freeing the HTTP connection for subsequent requests.
+        // Run stale check and settings fetch in parallel to minimize dialog delay.
+        // Reuse the on-load staleness promise if still available, otherwise fetch fresh.
         const _tParallel0 = performance.now();
-        const staleAbort = new AbortController();
-        const staleTimer = setTimeout(() => {
-          console.debug(`[Analyze] stale-check timed out after ${STALE_TIMEOUT}ms, aborting`);
-          staleAbort.abort();
-        }, STALE_TIMEOUT);
-        const staleCheckWithTimeout = fetch(`/api/local/${reviewId}/check-stale`, { signal: staleAbort.signal })
-          .then(r => r.ok ? r.json() : null)
-          .then(result => { clearTimeout(staleTimer); return result; })
-          .catch(() => { clearTimeout(staleTimer); return null; });
+        const staleCheckWithTimeout = manager._stalenessPromise
+          ? manager._stalenessPromise
+          : self._fetchLocalStaleness();
+        manager._stalenessPromise = null; // consume it
         const [staleResult, repoSettings, reviewSettings] = await Promise.all([
           staleCheckWithTimeout,
           manager.fetchRepoSettings().catch(() => null),
@@ -721,6 +711,10 @@ class LocalManager {
       // refresh must call unconditionally since the manager won't re-fire its callback.
       await manager.loadAISuggestions(null, manager.selectedRunId);
 
+      // Clear stale state after successful refresh
+      manager._hideStaleBadge();
+      manager._stalenessPromise = null;
+
       // Show success toast
       if (window.toast) {
         window.toast.showSuccess('Diff refreshed successfully');
@@ -743,6 +737,59 @@ class LocalManager {
         refreshBtn.disabled = false;
         refreshBtn.classList.remove('btn-loading');
       }
+    }
+  }
+
+  /**
+   * Check staleness on page load and show badge or auto-refresh.
+   *
+   * Logic mirrors PRManager._checkStalenessOnLoad but uses the local
+   * GET endpoint and only supports the 'stale' badge type (no merged/closed).
+   * @returns {Promise<Object|null>} The staleness result, or null on failure.
+   */
+  async _checkLocalStalenessOnLoad() {
+    try {
+      const result = await this._fetchLocalStaleness();
+      if (!result) return null;
+
+      if (result.isStale !== true) return result;
+
+      // Stale — decide: silent refresh or show badge
+      const manager = window.prManager;
+      const hasData = await manager._hasActiveSessionData();
+      if (hasData) {
+        console.debug('[Local] working directory stale, session has data — showing badge');
+        manager._showStaleBadge('stale', 'Working directory has changed');
+      } else {
+        // No user work to protect — refresh silently
+        console.debug('[Local] working directory stale, no session data — auto-refreshing');
+        await this.refreshDiff();
+      }
+      return result;
+    } catch {
+      // Fail silently — staleness badge is best-effort
+      return null;
+    }
+  }
+
+  /**
+   * Fetch staleness data from the local review endpoint with a timeout.
+   * Uses GET to check the local review staleness endpoint.
+   * @returns {Promise<Object|null>} The parsed staleness result, or null on failure/timeout.
+   */
+  async _fetchLocalStaleness() {
+    try {
+      const staleAbort = new AbortController();
+      const staleTimer = setTimeout(() => staleAbort.abort(), STALE_TIMEOUT);
+      const response = await fetch(
+        `/api/local/${this.reviewId}/check-stale`,
+        { signal: staleAbort.signal }
+      );
+      clearTimeout(staleTimer);
+      if (!response.ok) return null;
+      return await response.json();
+    } catch {
+      return null;
     }
   }
 
@@ -862,6 +909,9 @@ class LocalManager {
       if (window.prManager?._initReviewEventListeners) {
         window.prManager._initReviewEventListeners();
       }
+
+      // Fire-and-forget staleness check — shows badge or auto-refreshes
+      manager._stalenessPromise = this._checkLocalStalenessOnLoad();
 
     } catch (error) {
       console.error('Error loading local review:', error);
@@ -1577,6 +1627,11 @@ class LocalManager {
 }
 
 // Initialize LocalManager when in local mode
-if (window.PAIR_REVIEW_LOCAL_MODE) {
+if (typeof window !== 'undefined' && window.PAIR_REVIEW_LOCAL_MODE) {
   window.localManager = new LocalManager();
+}
+
+// Export for testing (Node.js environment)
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { LocalManager };
 }

--- a/public/js/pr.js
+++ b/public/js/pr.js
@@ -4476,8 +4476,9 @@ class PRManager {
   /**
    * Show the stale badge with an optional variant class.
    * @param {'stale'|'closed'|'merged'} type
+   * @param {string} [title] - Optional custom tooltip text. Falls back to type-specific defaults.
    */
-  _showStaleBadge(type) {
+  _showStaleBadge(type, title) {
     const badge = document.getElementById('stale-badge');
     if (!badge) return;
 
@@ -4488,14 +4489,14 @@ class PRManager {
     if (type === 'merged') {
       badge.classList.add('pr-merged');
       if (textEl) textEl.textContent = 'MERGED';
-      badge.title = 'This PR has been merged';
+      badge.title = title || 'This PR has been merged';
     } else if (type === 'closed') {
       badge.classList.add('pr-closed');
       if (textEl) textEl.textContent = 'CLOSED';
-      badge.title = 'This PR has been closed';
+      badge.title = title || 'This PR has been closed';
     } else {
       if (textEl) textEl.textContent = 'STALE';
-      badge.title = 'PR data is outdated';
+      badge.title = title || 'PR data is outdated';
     }
     badge.style.display = '';
   }

--- a/public/local.html
+++ b/public/local.html
@@ -276,6 +276,9 @@
                         </span>
                     </div>
                 </div>
+                <span id="stale-badge" class="stale-badge" style="display: none" title="Working directory has changed">
+                    <span class="stale-badge-text">STALE</span>
+                </span>
             </div>
             <div class="header-center">
                 <!-- Editable review name/title -->

--- a/tests/unit/local-stale-badge.test.js
+++ b/tests/unit/local-stale-badge.test.js
@@ -1,0 +1,295 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+/**
+ * Unit tests for local mode staleness-on-load badge behaviour.
+ *
+ * LocalManager._checkLocalStalenessOnLoad fires on page load and either:
+ *   - shows a STALE badge when the session has active data, or
+ *   - silently refreshes when the session has no user work.
+ *
+ * triggerAIAnalysis reuses the on-load staleness promise when still pending.
+ */
+
+// We need STALE_TIMEOUT to be defined before importing LocalManager
+global.STALE_TIMEOUT = 2000;
+
+// Provide a minimal PRManager class so LocalManager can reference it
+const { PRManager } = require('../../public/js/pr.js');
+
+const mockFetch = vi.fn();
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.useFakeTimers();
+
+  global.fetch = mockFetch;
+
+  global.window = {
+    prManager: null, // set per-test
+    location: { pathname: '/local/42' },
+    PAIR_REVIEW_LOCAL_MODE: true,
+    scrollTo: vi.fn(),
+    aiPanel: { showDismissedComments: false, setFileOrder: vi.fn(), setComments: vi.fn(), setAnalysisState: vi.fn(), setSummaryData: vi.fn() },
+    FileOrderUtils: { sortFilesByPath: vi.fn((f) => f), createFileOrderMap: vi.fn(() => new Map()) },
+    toast: { showSuccess: vi.fn(), showWarning: vi.fn(), showError: vi.fn(), showInfo: vi.fn() },
+    confirmDialog: null
+  };
+
+  global.document = {
+    getElementById: vi.fn(() => null),
+    querySelector: vi.fn(() => null),
+    querySelectorAll: vi.fn(() => []),
+    addEventListener: vi.fn()
+  };
+
+  global.alert = vi.fn();
+  global.AbortController = AbortController;
+  global.performance = { now: () => Date.now() };
+
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+  vi.spyOn(console, 'debug').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+// Import LocalManager after globals are set up
+const { LocalManager } = require('../../public/js/local.js');
+
+/**
+ * Create a minimal LocalManager for testing without triggering the full init().
+ */
+function createTestLocalManager() {
+  const lm = Object.create(LocalManager.prototype);
+  lm.reviewId = 42;
+  lm.localData = null;
+  lm.isInitialized = false;
+  return lm;
+}
+
+/**
+ * Create a minimal PRManager mock with the methods LocalManager depends on.
+ */
+function createTestPRManager() {
+  const pm = Object.create(PRManager.prototype);
+  pm.currentPR = { id: 42, owner: 'local', repo: 'my-repo', number: 42, reviewType: 'local' };
+  pm._stalenessPromise = null;
+  pm._showStaleBadge = vi.fn();
+  pm._hideStaleBadge = vi.fn();
+  pm._hasActiveSessionData = vi.fn().mockResolvedValue(false);
+  pm.loadUserComments = vi.fn().mockResolvedValue(undefined);
+  pm.loadAISuggestions = vi.fn().mockResolvedValue(undefined);
+  pm.showError = vi.fn();
+  return pm;
+}
+
+describe('LocalManager._checkLocalStalenessOnLoad', () => {
+  it('shows STALE badge when stale and session has data', async () => {
+    const lm = createTestLocalManager();
+    const pm = createTestPRManager();
+    pm._hasActiveSessionData.mockResolvedValue(true);
+    global.window.prManager = pm;
+
+    // Mock _fetchLocalStaleness to return stale
+    lm._fetchLocalStaleness = vi.fn().mockResolvedValue({ isStale: true });
+
+    const result = await lm._checkLocalStalenessOnLoad();
+
+    expect(result).toEqual({ isStale: true });
+    expect(pm._showStaleBadge).toHaveBeenCalledWith('stale', 'Working directory has changed');
+    expect(pm._hasActiveSessionData).toHaveBeenCalled();
+  });
+
+  it('silently refreshes when stale and no session data', async () => {
+    const lm = createTestLocalManager();
+    const pm = createTestPRManager();
+    pm._hasActiveSessionData.mockResolvedValue(false);
+    global.window.prManager = pm;
+
+    lm._fetchLocalStaleness = vi.fn().mockResolvedValue({ isStale: true });
+    lm.refreshDiff = vi.fn().mockResolvedValue(undefined);
+
+    const result = await lm._checkLocalStalenessOnLoad();
+
+    expect(result).toEqual({ isStale: true });
+    expect(lm.refreshDiff).toHaveBeenCalled();
+    expect(pm._showStaleBadge).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when not stale', async () => {
+    const lm = createTestLocalManager();
+    const pm = createTestPRManager();
+    global.window.prManager = pm;
+
+    lm._fetchLocalStaleness = vi.fn().mockResolvedValue({ isStale: false });
+    lm.refreshDiff = vi.fn();
+
+    const result = await lm._checkLocalStalenessOnLoad();
+
+    expect(result).toEqual({ isStale: false });
+    expect(pm._showStaleBadge).not.toHaveBeenCalled();
+    expect(lm.refreshDiff).not.toHaveBeenCalled();
+    expect(pm._hasActiveSessionData).not.toHaveBeenCalled();
+  });
+
+  it('returns null silently on fetch failure', async () => {
+    const lm = createTestLocalManager();
+    const pm = createTestPRManager();
+    global.window.prManager = pm;
+
+    lm._fetchLocalStaleness = vi.fn().mockResolvedValue(null);
+
+    const result = await lm._checkLocalStalenessOnLoad();
+
+    expect(result).toBeNull();
+    expect(pm._showStaleBadge).not.toHaveBeenCalled();
+  });
+
+  it('returns null silently on thrown error', async () => {
+    const lm = createTestLocalManager();
+    const pm = createTestPRManager();
+    global.window.prManager = pm;
+
+    lm._fetchLocalStaleness = vi.fn().mockRejectedValue(new Error('network'));
+
+    const result = await lm._checkLocalStalenessOnLoad();
+
+    expect(result).toBeNull();
+    expect(pm._showStaleBadge).not.toHaveBeenCalled();
+  });
+});
+
+describe('LocalManager._fetchLocalStaleness', () => {
+  it('fetches from GET /api/local/:reviewId/check-stale', async () => {
+    const lm = createTestLocalManager();
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ isStale: false })
+    });
+
+    const result = await lm._fetchLocalStaleness();
+
+    expect(result).toEqual({ isStale: false });
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/api/local/42/check-stale',
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
+    );
+    // Should NOT use POST — the endpoint is GET
+    const callArgs = mockFetch.mock.calls[0][1];
+    expect(callArgs.method).toBeUndefined();
+  });
+
+  it('returns null on non-ok response', async () => {
+    const lm = createTestLocalManager();
+    mockFetch.mockResolvedValue({ ok: false, status: 500 });
+
+    const result = await lm._fetchLocalStaleness();
+    expect(result).toBeNull();
+  });
+
+  it('returns null on fetch error', async () => {
+    const lm = createTestLocalManager();
+    mockFetch.mockRejectedValue(new Error('network error'));
+
+    const result = await lm._fetchLocalStaleness();
+    expect(result).toBeNull();
+  });
+});
+
+describe('staleness promise reuse in triggerAIAnalysis', () => {
+  /**
+   * Helper: set up a LocalManager + PRManager pair with patchPRManager applied,
+   * mocking enough of the environment so triggerAIAnalysis reaches the
+   * consume-or-fetch branching logic (lines 259-262 in local.js) and then
+   * bails out cleanly via analysisConfigModal.show() returning null.
+   */
+  function setupTriggerEnv() {
+    const lm = createTestLocalManager();
+    const pm = createTestPRManager();
+    pm.isAnalyzing = false;
+    pm.getAnalyzeButton = vi.fn(() => null);
+    pm.fetchRepoSettings = vi.fn().mockResolvedValue(null);
+    pm.fetchLastReviewSettings = vi.fn().mockResolvedValue({ custom_instructions: '', last_council_id: null });
+    pm.analysisConfigModal = { show: vi.fn().mockResolvedValue(null), onTabChange: null };
+    pm.collapsedFiles = new Set();
+    pm.viewedFiles = new Set();
+    pm.resetButton = vi.fn();
+    global.window.prManager = pm;
+    global.localStorage = { getItem: vi.fn(() => null), setItem: vi.fn(), removeItem: vi.fn() };
+
+    // Patch triggerAIAnalysis onto pm via the real patchPRManager
+    lm.patchPRManager();
+
+    return { lm, pm };
+  }
+
+  it('consumes _stalenessPromise when available instead of fetching fresh', async () => {
+    const { lm, pm } = setupTriggerEnv();
+
+    // Pre-set a resolved staleness promise on the manager
+    const stalenessResult = { isStale: false };
+    pm._stalenessPromise = Promise.resolve(stalenessResult);
+
+    // Spy on _fetchLocalStaleness to verify it is NOT called
+    const fetchSpy = vi.spyOn(lm, '_fetchLocalStaleness');
+
+    await pm.triggerAIAnalysis();
+
+    // The reuse path was taken — _fetchLocalStaleness should NOT have been called
+    expect(fetchSpy).not.toHaveBeenCalled();
+    // The promise should be consumed (set to null)
+    expect(pm._stalenessPromise).toBeNull();
+  });
+
+  it('calls _fetchLocalStaleness when no pre-set promise exists', async () => {
+    const { lm, pm } = setupTriggerEnv();
+
+    // No pre-set promise
+    pm._stalenessPromise = null;
+
+    // Spy on _fetchLocalStaleness to verify it IS called
+    const fetchSpy = vi.spyOn(lm, '_fetchLocalStaleness').mockResolvedValue({ isStale: false });
+
+    await pm.triggerAIAnalysis();
+
+    // The fresh-fetch path was taken
+    expect(fetchSpy).toHaveBeenCalledOnce();
+    // _stalenessPromise is still null (was consumed/never set)
+    expect(pm._stalenessPromise).toBeNull();
+  });
+});
+
+describe('refreshDiff hides stale badge', () => {
+  it('calls _hideStaleBadge and clears _stalenessPromise on success', async () => {
+    const lm = createTestLocalManager();
+    const pm = createTestPRManager();
+    pm._stalenessPromise = Promise.resolve({ isStale: true });
+    global.window.prManager = pm;
+
+    // Mock the refresh API
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ stats: {}, sessionChanged: false })
+    });
+
+    // Mock loadLocalDiff (called by refreshDiff)
+    lm.loadLocalDiff = vi.fn().mockResolvedValue(undefined);
+
+    // Set up required DOM element for button check
+    const mockBtn = { disabled: false, classList: { add: vi.fn(), remove: vi.fn() } };
+    global.document.getElementById = vi.fn((id) => {
+      if (id === 'local-refresh-btn') return mockBtn;
+      return null;
+    });
+
+    await lm.refreshDiff();
+
+    expect(pm._hideStaleBadge).toHaveBeenCalled();
+    expect(pm._stalenessPromise).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds on-page-load staleness detection for local review mode, matching existing PR mode behavior
- Shows a "STALE" badge when the working directory has changed and the session has user work (analysis results or comments); silently auto-refreshes when no user work exists
- Reuses the existing `check-stale` backend endpoint (digest-based detection) and the `triggerAIAnalysis` staleness promise pattern
- Fixes `_showStaleBadge` to accept an optional title parameter so local mode shows "Working directory has changed" instead of "PR data is outdated"

## Test plan
- [x] Unit tests for on-load staleness check (badge shown, silent refresh, fetch failure, promise reuse/consumption)
- [x] All 5127 unit tests pass
- [x] All 251 E2E tests pass
- [ ] Manual: open a local review, edit a file, reload — verify STALE badge appears
- [ ] Manual: open a local review with no analysis/comments, edit a file, reload — verify silent refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)