### PR TITLE
feat: dynamic SHA abbreviation length from Git

### DIFF
--- a/.changeset/dynamic-sha-length.md
+++ b/.changeset/dynamic-sha-length.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Use Git's dynamic SHA abbreviation length instead of hardcoded 7-char truncation. Calls `git rev-parse --short HEAD` to respect the repository's `core.abbrev` setting and Git's auto-scaling for large monorepos.

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -235,8 +235,9 @@
     const link = '/local/' + session.id;
     const relativeTime = formatRelativeTime(session.updated_at);
     const pathDisplay = session.local_path || '';
+    const abbrevLen = session.sha_abbrev_length || 7;
     const sha = session.local_head_sha
-      ? session.local_head_sha.substring(0, 7)
+      ? session.local_head_sha.substring(0, abbrevLen)
       : '';
     const hasName = !!session.name;
     const nameDisplay = hasName ? escapeHtml(session.name) : '<em>Untitled</em>';

--- a/public/js/local.js
+++ b/public/js/local.js
@@ -663,8 +663,9 @@ class LocalManager {
       let userDeclinedSwitch = false;
       if (result.sessionChanged && result.newSessionId) {
         // Show confirmation dialog to user
-        const originalSha = result.previousHeadSha ? result.previousHeadSha.substring(0, 7) : 'unknown';
-        const newSha = result.currentHeadSha ? result.currentHeadSha.substring(0, 7) : 'unknown';
+        const abbrevLen = this.localData?.shaAbbrevLength || 7;
+        const originalSha = result.previousHeadSha ? result.previousHeadSha.substring(0, abbrevLen) : 'unknown';
+        const newSha = result.currentHeadSha ? result.currentHeadSha.substring(0, abbrevLen) : 'unknown';
 
         if (window.confirmDialog) {
           const dialogResult = await window.confirmDialog.show({
@@ -709,8 +710,9 @@ class LocalManager {
       if (!userDeclinedSwitch && window.chatPanel) {
         if (result.headShaChanged) {
           const prev = result.previousHeadSha;
+          const abbrevLen = this.localData?.shaAbbrevLength || 7;
           window.chatPanel.queueDiffStateNotification(
-            `HEAD SHA changed: ${prev ? prev.substring(0, 7) : 'unknown'} → ${result.currentHeadSha ? result.currentHeadSha.substring(0, 7) : 'unknown'}.`
+            `HEAD SHA changed: ${prev ? prev.substring(0, abbrevLen) : 'unknown'} → ${result.currentHeadSha ? result.currentHeadSha.substring(0, abbrevLen) : 'unknown'}.`
           );
         }
         window.chatPanel.queueDiffStateNotification(
@@ -773,9 +775,10 @@ class LocalManager {
 
       // Notify chat of HEAD SHA change even when diff digest is unchanged
       // (e.g. git commit --amend with identical content, or rebase)
+      const abbrevLen = this.localData?.shaAbbrevLength || 7;
       if (result.headShaChanged && window.chatPanel) {
         window.chatPanel.queueDiffStateNotification(
-          `HEAD SHA changed (${result.previousHeadSha ? result.previousHeadSha.substring(0, 7) : 'unknown'} → ${result.currentHeadSha ? result.currentHeadSha.substring(0, 7) : 'unknown'}). The branch may have been rebased.`
+          `HEAD SHA changed (${result.previousHeadSha ? result.previousHeadSha.substring(0, abbrevLen) : 'unknown'} → ${result.currentHeadSha ? result.currentHeadSha.substring(0, abbrevLen) : 'unknown'}). The branch may have been rebased.`
         );
       }
       if (result.isStale !== true) return result;
@@ -791,7 +794,7 @@ class LocalManager {
           // (the !hasData path calls refreshDiff() which queues its own notification)
           if (result.headShaChanged) {
             window.chatPanel.queueDiffStateNotification(
-              `HEAD SHA changed (${result.previousHeadSha ? result.previousHeadSha.substring(0, 7) : 'unknown'} → ${result.currentHeadSha ? result.currentHeadSha.substring(0, 7) : 'unknown'}). The branch may have been rebased.`
+              `HEAD SHA changed (${result.previousHeadSha ? result.previousHeadSha.substring(0, abbrevLen) : 'unknown'} → ${result.currentHeadSha ? result.currentHeadSha.substring(0, abbrevLen) : 'unknown'}). The branch may have been rebased.`
             );
           }
           window.chatPanel.queueDiffStateNotification(
@@ -875,6 +878,7 @@ class LocalManager {
         head_branch: reviewData.branch,
         base_branch: hasBranch ? reviewData.baseBranch : reviewData.branch,
         head_sha: reviewData.localHeadSha,
+        shaAbbrevLength: reviewData.shaAbbrevLength || 7,
         reviewType: 'local',
         localPath: reviewData.localPath
       };
@@ -924,6 +928,7 @@ class LocalManager {
         manager.analysisHistoryManager = new window.AnalysisHistoryManager({
           reviewId: this.reviewId,
           mode: 'local',
+          shaAbbrevLength: reviewData.shaAbbrevLength || 7,
           onSelectionChange: (runId, _run) => {
             manager.selectedRunId = runId;
             manager.loadAISuggestions(null, runId);
@@ -1121,7 +1126,8 @@ class LocalManager {
     // Update commit SHA and wire up copy button
     const commitSha = document.getElementById('pr-commit-sha');
     if (commitSha && reviewData.localHeadSha) {
-      commitSha.textContent = reviewData.localHeadSha.substring(0, 7);
+      const abbrevLen = reviewData.shaAbbrevLength || 7;
+      commitSha.textContent = reviewData.localHeadSha.substring(0, abbrevLen);
       commitSha.dataset.fullSha = reviewData.localHeadSha;
     }
 

--- a/public/js/modules/analysis-history.js
+++ b/public/js/modules/analysis-history.js
@@ -20,11 +20,12 @@ class AnalysisHistoryManager {
    * @param {Function} options.onSelectionChange - Callback when a run is selected, receives (runId, run)
    * @param {string} options.containerPrefix - Prefix for DOM element IDs (default: 'analysis-context')
    */
-  constructor({ reviewId, mode, onSelectionChange, containerPrefix = 'analysis-context' }) {
+  constructor({ reviewId, mode, onSelectionChange, containerPrefix = 'analysis-context', shaAbbrevLength = 7 }) {
     this.reviewId = reviewId;
     this.mode = mode;
     this.onSelectionChange = onSelectionChange;
     this.containerPrefix = containerPrefix;
+    this.shaAbbrevLength = shaAbbrevLength;
 
     // State
     this.runs = [];
@@ -421,7 +422,7 @@ class AnalysisHistoryManager {
 
     // Format HEAD SHA - show abbreviated version with full SHA in title
     const headSha = run.head_sha;
-    const headShaDisplay = headSha ? headSha.substring(0, 7) : null;
+    const headShaDisplay = headSha ? headSha.substring(0, this.shaAbbrevLength) : null;
 
     // Format status
     const statusInfo = this.formatStatus(run.status);

--- a/public/js/pr.js
+++ b/public/js/pr.js
@@ -499,6 +499,7 @@ class PRManager {
         this.analysisHistoryManager = new window.AnalysisHistoryManager({
           reviewId: this.currentPR.id,
           mode: 'pr',
+          shaAbbrevLength: this.currentPR.shaAbbrevLength || 7,
           onSelectionChange: (runId, _run) => {
             this.selectedRunId = runId;
             this.loadAISuggestions(null, runId);
@@ -899,7 +900,8 @@ class PRManager {
     const commitSha = document.getElementById('pr-commit-sha');
     const commitCopy = document.getElementById('pr-commit-copy');
     if (commitSha && pr.head_sha) {
-      commitSha.textContent = pr.head_sha.substring(0, 7);
+      const abbrevLen = pr.shaAbbrevLength || 7;
+      commitSha.textContent = pr.head_sha.substring(0, abbrevLen);
       // Store full SHA for copying (updates on refresh)
       commitSha.dataset.fullSha = pr.head_sha;
 
@@ -4415,8 +4417,9 @@ class PRManager {
       if (hasData) {
         this._showStaleBadge('stale');
         if (window.chatPanel) {
-          const oldSha = result.localHeadSha ? result.localHeadSha.substring(0, 7) : 'unknown';
-          const newSha = result.remoteHeadSha ? result.remoteHeadSha.substring(0, 7) : 'unknown';
+          const abbrevLen = this.currentPR?.shaAbbrevLength || 7;
+          const oldSha = result.localHeadSha ? result.localHeadSha.substring(0, abbrevLen) : 'unknown';
+          const newSha = result.remoteHeadSha ? result.remoteHeadSha.substring(0, abbrevLen) : 'unknown';
           window.chatPanel.queueDiffStateNotification(
             `PR HEAD has changed (${oldSha} → ${newSha}). The diff has not been refreshed yet.`
           );
@@ -4561,8 +4564,9 @@ class PRManager {
         // Notify chat agent if HEAD SHA changed
         const newHeadSha = data.data?.head_sha;
         if (window.chatPanel && oldHeadSha && newHeadSha && oldHeadSha !== newHeadSha) {
+          const abbrevLen = this.currentPR?.shaAbbrevLength || 7;
           window.chatPanel.queueDiffStateNotification(
-            `PR refreshed. HEAD changed: ${oldHeadSha.substring(0, 7)} → ${newHeadSha.substring(0, 7)}.`
+            `PR refreshed. HEAD changed: ${oldHeadSha.substring(0, abbrevLen)} → ${newHeadSha.substring(0, abbrevLen)}.`
           );
         }
 

--- a/src/git/sha-abbrev.js
+++ b/src/git/sha-abbrev.js
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+const { execSync } = require('child_process');
+
+const DEFAULT_SHA_ABBREV_LENGTH = 7;
+
+const defaults = {
+  execSync,
+};
+
+/**
+ * Get the SHA abbreviation length that Git uses for a given repository.
+ *
+ * Calls `git rev-parse --short HEAD` and measures the output length.
+ * This respects the repository's `core.abbrev` setting and Git's
+ * auto-scaling logic (larger repos get longer abbreviations).
+ *
+ * @param {string} repoPath - Absolute path to the repository
+ * @param {Object} [_deps] - Dependency overrides for testing
+ * @returns {number} The abbreviation length Git uses for this repo
+ */
+function getShaAbbrevLength(repoPath, _deps) {
+  const deps = { ...defaults, ..._deps };
+  try {
+    const shortSha = deps.execSync('git rev-parse --short HEAD', {
+      cwd: repoPath,
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+    return shortSha.length || DEFAULT_SHA_ABBREV_LENGTH;
+  } catch {
+    return DEFAULT_SHA_ABBREV_LENGTH;
+  }
+}
+
+module.exports = { getShaAbbrevLength, DEFAULT_SHA_ABBREV_LENGTH };

--- a/src/github/client.js
+++ b/src/github/client.js
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 const { Octokit } = require('@octokit/rest');
 const logger = require('../utils/logger');
+const { DEFAULT_SHA_ABBREV_LENGTH } = require('../git/sha-abbrev');
 
 /**
  * Custom error class for GitHub API errors that preserves the HTTP status code.
@@ -332,7 +333,7 @@ class GitHubClient {
       // Extract commit_id from first comment (all comments should have the same one)
       const commitId = comments.length > 0 ? comments[0].commit_id : null;
       if (commitId) {
-        console.log(`Using commit_id for review: ${commitId.substring(0, 7)}`);
+        console.log(`Using commit_id for review: ${commitId.substring(0, DEFAULT_SHA_ABBREV_LENGTH)}`);
       } else {
         console.warn('No commit_id available - review may fail for lines outside diff');
       }

--- a/src/local-review.js
+++ b/src/local-review.js
@@ -14,6 +14,7 @@ const { STOPS, scopeIncludes, includesBranch, DEFAULT_SCOPE, scopeLabel } = requ
 const { initializeDatabase, ReviewRepository, RepoSettingsRepository } = require('./database');
 const { startServer } = require('./server');
 const { localReviewDiffs } = require('./routes/shared');
+const { getShaAbbrevLength } = require('./git/sha-abbrev');
 const open = (...args) => import('open').then(({ default: open }) => open(...args));
 
 // Design note: This module uses execSync for git commands despite async function signatures.
@@ -767,7 +768,8 @@ async function handleLocalReview(targetPath, flags = {}) {
       // Update HEAD SHA if it changed (branch mode: new commits on same branch)
       if (existingReview.local_head_sha !== headSha) {
         await reviewRepo.updateLocalHeadSha(sessionId, headSha);
-        console.log(`Updated HEAD SHA on session ${sessionId}: ${existingReview.local_head_sha.substring(0, 7)} -> ${headSha.substring(0, 7)}`);
+        const abbrevLen = getShaAbbrevLength(repoPath);
+        console.log(`Updated HEAD SHA on session ${sessionId}: ${existingReview.local_head_sha.substring(0, abbrevLen)} -> ${headSha.substring(0, abbrevLen)}`);
       }
       // Backfill branch on legacy sessions
       if (existingReview.local_head_branch === null) {

--- a/src/routes/local.js
+++ b/src/routes/local.js
@@ -28,6 +28,7 @@ const { getGitHubToken } = require('../config');
 const { generateScopedDiff, computeScopedDigest, getBranchCommitCount, getFirstCommitSubject, detectAndBuildBranchInfo, findMergeBase, getCurrentBranch, getRepositoryName } = require('../local-review');
 const { STOPS, isValidScope, scopeIncludes, includesBranch, DEFAULT_SCOPE } = require('../local-scope');
 const { getGeneratedFilePatterns } = require('../git/gitattributes');
+const { getShaAbbrevLength } = require('../git/sha-abbrev');
 const { validateCouncilConfig, normalizeCouncilConfig } = require('./councils');
 const { TIERS, TIER_ALIASES, VALID_TIERS, resolveTier } = require('../ai/prompts/config');
 const {
@@ -186,9 +187,19 @@ router.get('/api/local/sessions', async (req, res) => {
     const reviewRepo = new ReviewRepository(db);
     const { sessions, hasMore } = await reviewRepo.listLocalSessions({ limit, before });
 
+    // Compute SHA abbreviation length per unique repo path
+    const abbrevCache = new Map();
+    const enrichedSessions = sessions.map(session => {
+      if (!session.local_path) return session;
+      if (!abbrevCache.has(session.local_path)) {
+        abbrevCache.set(session.local_path, getShaAbbrevLength(session.local_path));
+      }
+      return { ...session, sha_abbrev_length: abbrevCache.get(session.local_path) };
+    });
+
     res.json({
       success: true,
-      sessions,
+      sessions: enrichedSessions,
       hasMore
     });
 
@@ -583,6 +594,9 @@ router.get('/api/local/:reviewId', async (req, res) => {
       }
     }
 
+    // Compute SHA abbreviation length from the repo's git config
+    const shaAbbrevLength = getShaAbbrevLength(review.local_path);
+
     res.json({
       id: review.id,
       localPath: review.local_path,
@@ -598,6 +612,7 @@ router.get('/api/local/:reviewId', async (req, res) => {
       baseBranch,
       branchInfo,
       branchAvailable,
+      shaAbbrevLength,
       createdAt: review.created_at,
       updatedAt: review.updated_at
     });
@@ -1322,7 +1337,8 @@ router.post('/api/local/:reviewId/refresh', async (req, res) => {
       currentHeadSha = await getHeadSha(localPath);
 
       if (originalHeadSha && currentHeadSha !== originalHeadSha) {
-        logger.log('API', `HEAD changed: ${originalHeadSha.substring(0, 7)} -> ${currentHeadSha.substring(0, 7)}`, 'yellow');
+        const abbrevLen = getShaAbbrevLength(localPath);
+        logger.log('API', `HEAD changed: ${originalHeadSha.substring(0, abbrevLen)} -> ${currentHeadSha.substring(0, abbrevLen)}`, 'yellow');
 
         if (hasBranch) {
           // Branch scope: session persists across HEAD changes — just update the SHA

--- a/src/routes/pr.js
+++ b/src/routes/pr.js
@@ -18,6 +18,7 @@ const { query, queryOne, run, withTransaction, WorktreeRepository, ReviewReposit
 const { GitWorktreeManager } = require('../git/worktree');
 const { GitHubClient } = require('../github/client');
 const { getGeneratedFilePatterns } = require('../git/gitattributes');
+const { getShaAbbrevLength, DEFAULT_SHA_ABBREV_LENGTH } = require('../git/sha-abbrev');
 const { normalizeRepository, resolveRenamedFile, resolveRenamedFileOld } = require('../utils/paths');
 const { mergeInstructions } = require('../utils/instructions');
 const Analyzer = require('../ai/analyzer');
@@ -222,6 +223,11 @@ router.get('/api/pr/:owner/:repo/:number', async (req, res) => {
       }
     }
 
+    // Compute SHA abbreviation length from the worktree's git config
+    const shaAbbrevLength = extendedData.worktree_path
+      ? getShaAbbrevLength(extendedData.worktree_path)
+      : DEFAULT_SHA_ABBREV_LENGTH;
+
     // Prepare response
     // Use review.id instead of prMetadata.id to avoid ID collision with local mode
     const response = {
@@ -239,6 +245,7 @@ router.get('/api/pr/:owner/:repo/:number', async (req, res) => {
         head_branch: prMetadata.head_branch,
         head_sha: extendedData.head_sha || null,  // Head commit SHA for GitHub API comments
         node_id: extendedData.node_id || null,  // GraphQL node ID for review submission
+        shaAbbrevLength,
         created_at: prMetadata.created_at,
         updated_at: prMetadata.updated_at,
         file_changes: extendedData.changed_files ? extendedData.changed_files.length : 0,

--- a/tests/unit/sha-abbrev.test.js
+++ b/tests/unit/sha-abbrev.test.js
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+import { describe, it, expect, vi } from 'vitest';
+const { getShaAbbrevLength, DEFAULT_SHA_ABBREV_LENGTH } = require('../../src/git/sha-abbrev');
+
+function createMockDeps(overrides = {}) {
+  return {
+    execSync: vi.fn(() => { throw new Error('not mocked'); }),
+    ...overrides
+  };
+}
+
+describe('getShaAbbrevLength', () => {
+  it('returns length of git rev-parse --short HEAD output', () => {
+    const deps = createMockDeps({
+      execSync: vi.fn(() => 'abc1234\n')
+    });
+    expect(getShaAbbrevLength('/repo', deps)).toBe(7);
+  });
+
+  it('returns longer length for large repos (e.g. 11 chars)', () => {
+    const deps = createMockDeps({
+      execSync: vi.fn(() => 'abc12345678\n')
+    });
+    expect(getShaAbbrevLength('/repo', deps)).toBe(11);
+  });
+
+  it('returns shorter length when core.abbrev is set low', () => {
+    const deps = createMockDeps({
+      execSync: vi.fn(() => 'abcd\n')
+    });
+    expect(getShaAbbrevLength('/repo', deps)).toBe(4);
+  });
+
+  it('passes repo path as cwd to execSync', () => {
+    const execSync = vi.fn(() => 'abc1234\n');
+    getShaAbbrevLength('/my/repo/path', { execSync });
+    expect(execSync).toHaveBeenCalledWith('git rev-parse --short HEAD', {
+      cwd: '/my/repo/path',
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+  });
+
+  it('returns default length when git command fails', () => {
+    const deps = createMockDeps({
+      execSync: vi.fn(() => { throw new Error('not a git repo'); })
+    });
+    expect(getShaAbbrevLength('/not-a-repo', deps)).toBe(DEFAULT_SHA_ABBREV_LENGTH);
+  });
+
+  it('returns default length when output is empty', () => {
+    const deps = createMockDeps({
+      execSync: vi.fn(() => '\n')
+    });
+    expect(getShaAbbrevLength('/repo', deps)).toBe(DEFAULT_SHA_ABBREV_LENGTH);
+  });
+
+  it('exports DEFAULT_SHA_ABBREV_LENGTH as 7', () => {
+    expect(DEFAULT_SHA_ABBREV_LENGTH).toBe(7);
+  });
+});


### PR DESCRIPTION
## Summary
- Replaces all 14 hardcoded `substring(0, 7)` SHA truncations across 7 files with a dynamic length from `git rev-parse --short HEAD`
- Respects the repository's `core.abbrev` setting and Git's auto-scaling for large monorepos (7 chars for small repos, 11+ for monorepos)
- Zero new config surface — just uses what Git already knows about the repo

## Changes
- **New**: `src/git/sha-abbrev.js` — utility calling `git rev-parse --short HEAD` with `_deps` pattern for testability
- **Backend**: `shaAbbrevLength` included in local review, PR, and sessions list API responses
- **Frontend**: All SHA display sites in `pr.js`, `local.js`, `index.js`, and `analysis-history.js` use the dynamic length
- **Tests**: 7 unit tests covering normal, long/short, error, and empty output cases

## Test plan
- [x] Unit tests pass (5158 tests, 114 files)
- [x] E2E tests pass (266 tests)
- [ ] Manual: verify SHA display in local mode header
- [ ] Manual: verify SHA display in PR mode header
- [ ] Manual: verify SHA display on index page session list
- [ ] Manual: verify analysis history SHA display

Closes #378

🤖 Generated with [Claude Code](https://claude.com/claude-code)