### PR TITLE
fix: exclude PRs from archived repos in review requests

### DIFF
--- a/.changeset/ignore-archived-repos.md
+++ b/.changeset/ignore-archived-repos.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Exclude PRs from archived repositories in review requests and my PRs lists

--- a/src/routes/github-collections.js
+++ b/src/routes/github-collections.js
@@ -45,7 +45,7 @@ router.post('/api/github/review-requests/refresh', async (req, res) => {
     const db = req.app.get('db');
     const client = new GitHubClient(githubToken);
     const user = await client.getAuthenticatedUser();
-    const prs = await client.searchPullRequests(`is:pr is:open user-review-requested:${user.login}`);
+    const prs = await client.searchPullRequests(`is:pr is:open archived:false user-review-requested:${user.login}`);
 
     await withTransaction(db, async () => {
       await run(db, 'DELETE FROM github_pr_cache WHERE collection = ?', ['review-requests']);
@@ -99,7 +99,7 @@ router.post('/api/github/my-prs/refresh', async (req, res) => {
     const db = req.app.get('db');
     const client = new GitHubClient(githubToken);
     const user = await client.getAuthenticatedUser();
-    const prs = await client.searchPullRequests(`is:pr is:open author:${user.login}`);
+    const prs = await client.searchPullRequests(`is:pr is:open archived:false author:${user.login}`);
 
     await withTransaction(db, async () => {
       await run(db, 'DELETE FROM github_pr_cache WHERE collection = ?', ['my-prs']);

--- a/tests/integration/github-collections.test.js
+++ b/tests/integration/github-collections.test.js
@@ -201,7 +201,7 @@ describe('GitHub Collections Routes', () => {
 
       // Verify the search query includes the authenticated user's login
       expect(GitHubClient.prototype.searchPullRequests).toHaveBeenCalledWith(
-        'is:pr is:open user-review-requested:testuser'
+        'is:pr is:open archived:false user-review-requested:testuser'
       );
     });
 
@@ -425,7 +425,7 @@ describe('GitHub Collections Routes', () => {
 
       // Verify the search query includes the authenticated user's login with author:
       expect(GitHubClient.prototype.searchPullRequests).toHaveBeenCalledWith(
-        'is:pr is:open author:myuser'
+        'is:pr is:open archived:false author:myuser'
       );
     });
 


### PR DESCRIPTION
## Summary
- Adds `archived:false` to GitHub search queries for both review requests and my PRs collections
- PRs from archived repositories no longer appear in the lists

Closes #329

## Test plan
- [x] Integration tests updated and passing (22/22)

🤖 Generated with [Claude Code](https://claude.com/claude-code)