### PR TITLE
fix: scroll collapsed files fully into view below sticky toolbar

### DIFF
--- a/.changeset/fix-collapsed-file-scroll.md
+++ b/.changeset/fix-collapsed-file-scroll.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Fix scrolling to collapsed files in file navigator so the file header is fully visible below the sticky toolbar

--- a/public/css/pr.css
+++ b/public/css/pr.css
@@ -1587,6 +1587,13 @@
   color: #f85149;
 }
 
+/* When collapsed, the wrapper is only as tall as the header, so the header's
+   sticky positioning can't push it below the toolbar.  Adding scroll-margin
+   ensures scrollIntoView() lands the header below the sticky toolbar. */
+.d2h-file-wrapper.collapsed {
+  scroll-margin-top: var(--toolbar-height, 0px);
+}
+
 /* Hide diff content when collapsed */
 .d2h-file-wrapper.collapsed .d2h-file-body,
 .d2h-file-wrapper.collapsed .d2h-diff-table {


### PR DESCRIPTION
## Summary
- Fixes #351
- Adds `scroll-margin-top: var(--toolbar-height)` to `.d2h-file-wrapper.collapsed` so that `scrollIntoView()` positions the collapsed file header below the sticky diff toolbar instead of behind it

## Root cause
When a file is collapsed, its wrapper is only as tall as the header. Non-collapsed files rely on `position: sticky; top: var(--toolbar-height)` on the header to slide below the toolbar, but collapsed wrappers are too short for that stickiness to take effect. `scroll-margin-top` tells the browser to offset the scroll target accordingly.

## Test plan
- [ ] Open a PR with enough changed files to fill the viewport
- [ ] Collapse the first file
- [ ] Scroll down so the collapsed header is out of view
- [ ] Click the collapsed file's name in the file navigator
- [ ] Verify the file header scrolls fully into view below the toolbar

🤖 Generated with [Claude Code](https://claude.com/claude-code)