### PR TITLE
Prevent tests from opening browser tabs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,6 +171,7 @@ Test structure:
   - `tests/integration/routes.test.js` (Integration test database)
   - Ensure index names match the production schema exactly
 - **Test coverage is mandatory for new functionality**: When adding new methods, parameters, or behavioral changes to existing code, add corresponding unit tests in the same task. Do not defer test writing to a separate task or leave it for later. Tests should cover: (1) the happy path, (2) edge cases like missing/null inputs, (3) error conditions. For bug fixes, add a regression test that would have caught the bug.
+- **Tests must NEVER open browser tabs or windows.** All calls to the `open` npm package in production code are gated behind `PAIR_REVIEW_NO_OPEN` env var. Vitest config sets this globally. Any test that spawns the CLI via `spawnSync`/`spawn` MUST include `PAIR_REVIEW_NO_OPEN: '1'` in its env. Playwright E2E tests must always run headless (`headless: true` in `playwright.config.js`). If you add a new code path that opens a browser, it must respect this env var.
 
 ### Skill Prompt Regeneration
 - When modifying prompt templates or line number guidance in `src/ai/prompts/`, run `node scripts/generate-skill-prompts.js` to regenerate the static reference files in `plugin-code-critic/skills/analyze/references/`

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -10,6 +10,7 @@ export default defineConfig({
   reporter: process.env.CI ? 'github' : 'list',
 
   use: {
+    headless: true,
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
   },

--- a/src/local-review.js
+++ b/src/local-review.js
@@ -15,7 +15,7 @@ const { initializeDatabase, ReviewRepository, RepoSettingsRepository } = require
 const { startServer } = require('./server');
 const { localReviewDiffs } = require('./routes/shared');
 const { getShaAbbrevLength } = require('./git/sha-abbrev');
-const open = (...args) => import('open').then(({ default: open }) => open(...args));
+const open = (...args) => process.env.PAIR_REVIEW_NO_OPEN ? Promise.resolve() : import('open').then(({ default: open }) => open(...args));
 
 // Design note: This module uses execSync for git commands despite async function signatures.
 // For a local CLI tool, synchronous execution is acceptable and simplifies error handling.

--- a/src/main.js
+++ b/src/main.js
@@ -16,7 +16,7 @@ const logger = require('./utils/logger');
 const simpleGit = require('simple-git');
 const { getGeneratedFilePatterns } = require('./git/gitattributes');
 const { getEmoji: getCategoryEmoji } = require('./utils/category-emoji');
-const open = (...args) => import('open').then(({default: open}) => open(...args));
+const open = (...args) => process.env.PAIR_REVIEW_NO_OPEN ? Promise.resolve() : import('open').then(({default: open}) => open(...args));
 const { registerProtocolHandler, unregisterProtocolHandler } = require('./protocol-handler');
 
 let db = null;

--- a/src/server.js
+++ b/src/server.js
@@ -210,7 +210,7 @@ async function startServer(sharedDb = null) {
     
     // Bulk-open — opens multiple local URLs in the OS browser via the `open` package.
     // Bypasses popup blockers since the server shells out directly.
-    const openUrl = (...args) => import('open').then(({ default: open }) => open(...args));
+    const openUrl = (...args) => process.env.PAIR_REVIEW_NO_OPEN ? Promise.resolve() : import('open').then(({ default: open }) => open(...args));
     app.post('/api/bulk-open', async (req, res) => {
       try {
         const { urls } = req.body || {};

--- a/tests/integration/first-run.test.js
+++ b/tests/integration/first-run.test.js
@@ -35,7 +35,8 @@ describe('First-run welcome message', () => {
         ...process.env,
         HOME: testHomeDir,
         // Prevent any GITHUB_TOKEN from being used
-        GITHUB_TOKEN: ''
+        GITHUB_TOKEN: '',
+        PAIR_REVIEW_NO_OPEN: '1'
       },
       timeout: 10000
     });
@@ -68,7 +69,8 @@ describe('First-run welcome message', () => {
       env: {
         ...process.env,
         HOME: testHomeDir,
-        GITHUB_TOKEN: ''
+        GITHUB_TOKEN: '',
+        PAIR_REVIEW_NO_OPEN: '1'
       },
       timeout: 10000
     });
@@ -86,7 +88,8 @@ describe('First-run welcome message', () => {
       cwd: path.join(__dirname, '../..'),
       env: {
         ...process.env,
-        HOME: testHomeDir
+        HOME: testHomeDir,
+        PAIR_REVIEW_NO_OPEN: '1'
       },
       timeout: 10000
     });
@@ -103,7 +106,8 @@ describe('First-run welcome message', () => {
       cwd: path.join(__dirname, '../..'),
       env: {
         ...process.env,
-        HOME: testHomeDir
+        HOME: testHomeDir,
+        PAIR_REVIEW_NO_OPEN: '1'
       },
       timeout: 10000
     });
@@ -120,7 +124,8 @@ describe('First-run welcome message', () => {
       cwd: path.join(__dirname, '../..'),
       env: {
         ...process.env,
-        HOME: testHomeDir
+        HOME: testHomeDir,
+        PAIR_REVIEW_NO_OPEN: '1'
       },
       timeout: 10000
     });
@@ -139,7 +144,8 @@ describe('First-run welcome message', () => {
       env: {
         ...process.env,
         HOME: testHomeDir,
-        GITHUB_TOKEN: ''
+        GITHUB_TOKEN: '',
+        PAIR_REVIEW_NO_OPEN: '1'
       },
       timeout: 10000
     });

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -5,6 +5,11 @@ export default defineConfig({
     // Use Node environment (not browser)
     environment: 'node',
 
+    // Suppress browser opening during tests
+    env: {
+      PAIR_REVIEW_NO_OPEN: '1',
+    },
+
     // Test file patterns
     include: ['tests/**/*.test.js'],
 


### PR DESCRIPTION
## Summary
- Gate all `open` npm package calls in `src/main.js`, `src/local-review.js`, and `src/server.js` behind `PAIR_REVIEW_NO_OPEN` env var — when set, browser opening is a no-op
- Set `PAIR_REVIEW_NO_OPEN=1` globally in `vitest.config.js` and in all `spawnSync` env blocks in `first-run.test.js`
- Add explicit `headless: true` to `playwright.config.js`
- Add CLAUDE.md testing practice rule to prevent regression

## Test plan
- [x] All 5197 vitest tests pass
- [x] All 266 E2E tests pass
- [x] No browser tabs opened during test execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)