### PR TITLE
Fix diff panel scroll trapping on file boundaries

### DIFF
--- a/.changeset/fix-diff-scroll-trap.md
+++ b/.changeset/fix-diff-scroll-trap.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Fix diff panel scroll getting stuck on file boundaries

--- a/public/css/pr.css
+++ b/public/css/pr.css
@@ -1616,9 +1616,13 @@
 }
 
 /* Scrollable wrapper for diff tables — provides per-file horizontal scroll
-   now that .d2h-file-wrapper and .diff-container use overflow:visible for sticky headers */
+   now that .d2h-file-wrapper and .diff-container use overflow:visible for sticky headers.
+   overflow-y must be explicitly hidden: CSS spec coerces it to 'auto' when overflow-x
+   is non-visible, which creates an accidental vertical scroll trap that eats wheel events
+   at the boundary instead of propagating them to .diff-view. */
 .d2h-file-body {
   overflow-x: auto;
+  overflow-y: hidden;
 }
 
 .d2h-diff-table {


### PR DESCRIPTION
## Summary
- `.d2h-file-body` (per-file horizontal scroll wrapper) was silently becoming a vertical scroll container due to CSS spec: setting `overflow-x: auto` coerces `overflow-y` from `visible` to `auto`
- This trapped wheel events at each file's scroll boundary, causing scroll to "stick" and requiring repeated scroll gestures to continue
- Fix: explicitly set `overflow-y: hidden` on `.d2h-file-body`

## Test plan
- [ ] Open a PR with multiple changed files
- [ ] Scroll vertically through the diff — should be smooth with no sticking at file boundaries
- [ ] Verify horizontal scroll still works for long code lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)