### PR TITLE
Add skip_update_notifier config setting

### DIFF
--- a/.changeset/skip-update-notifier.md
+++ b/.changeset/skip-update-notifier.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Add `skip_update_notifier` config setting to suppress the "update available" notification on exit. Useful for managed deployments where users cannot update directly.

--- a/bin/pair-review.js
+++ b/bin/pair-review.js
@@ -8,10 +8,13 @@ const pkg = require('../package.json');
 const args = process.argv.slice(2);
 const isMCP = args.includes('--mcp');
 
-// Check for updates and notify user (skip in MCP mode to avoid stdout pollution)
+// Check for updates and notify user (skip in MCP mode and when config suppresses it)
 if (!isMCP) {
-  const updateNotifier = require('update-notifier');
-  updateNotifier({ pkg }).notify();
+  const { shouldSkipUpdateNotifier } = require('../src/config');
+  if (!shouldSkipUpdateNotifier()) {
+    const updateNotifier = require('update-notifier');
+    updateNotifier({ pkg }).notify();
+  }
 }
 
 async function main() {

--- a/config.example.json
+++ b/config.example.json
@@ -12,6 +12,7 @@
   "dev_mode": false,
   "debug_stream": false,
   "yolo": false,
+  "skip_update_notifier": false,
   "chat": {
     "enable_shortcuts": true
   },

--- a/src/config.js
+++ b/src/config.js
@@ -37,7 +37,8 @@ const DEFAULT_CONFIG = {
   monorepos: {},  // Monorepo configurations: { "owner/repo": { path: "~/path/to/clone" } }
   assisted_by_url: "https://github.com/in-the-loop-labs/pair-review",  // URL for "Review assisted by" footer link
   hooks: {},  // Hook commands per event: { "review.started": { "my_hook": { "command": "..." } } }
-  enable_graphite: false  // When true, shows Graphite links alongside GitHub links
+  enable_graphite: false,  // When true, shows Graphite links alongside GitHub links
+  skip_update_notifier: false  // When true, suppresses the "update available" notification on exit
 };
 
 /**
@@ -495,6 +496,42 @@ function warnIfDevModeWithoutDbName(config) {
   }
 }
 
+/**
+ * Synchronously checks whether the update notifier should be skipped.
+ * Reads config files in the standard merge order (managed → global → global.local
+ * → project → project.local) and returns the resolved boolean value of
+ * `skip_update_notifier`. Designed for use in bin/pair-review.js which runs
+ * before the async main process.
+ *
+ * @returns {boolean} True if the update notifier should be suppressed
+ */
+function shouldSkipUpdateNotifier() {
+  const fsSync = require('fs');
+  const localDir = path.join(process.cwd(), '.pair-review');
+  // Keep in sync with the sources list in loadConfig()
+  const sources = [
+    MANAGED_CONFIG_FILE,
+    CONFIG_FILE,
+    CONFIG_LOCAL_FILE,
+    path.join(localDir, 'config.json'),
+    path.join(localDir, 'config.local.json'),
+  ];
+
+  let skip = false;
+  for (const filePath of sources) {
+    try {
+      const data = fsSync.readFileSync(filePath, 'utf8');
+      const parsed = JSON.parse(data);
+      if ('skip_update_notifier' in parsed) {
+        skip = Boolean(parsed.skip_update_notifier);
+      }
+    } catch {
+      // File missing or malformed — skip silently
+    }
+  }
+  return skip;
+}
+
 module.exports = {
   deepMerge,
   loadConfig,
@@ -515,6 +552,7 @@ module.exports = {
   resolveMonorepoOptions,
   resolveDbName,
   warnIfDevModeWithoutDbName,
+  shouldSkipUpdateNotifier,
   _resetTokenCache,
   DEFAULT_CHECKOUT_TIMEOUT_MS
 };

--- a/tests/unit/config.test.js
+++ b/tests/unit/config.test.js
@@ -5,7 +5,7 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 const childProcess = require('child_process');
-const { deepMerge, getGitHubToken, expandPath, getMonorepoPath, getMonorepoCheckoutScript, getMonorepoWorktreeDirectory, getMonorepoWorktreeNameTemplate, getMonorepoCheckoutTimeout, resolveMonorepoOptions, resolveDbName, warnIfDevModeWithoutDbName, loadConfig, _resetTokenCache } = require('../../src/config');
+const { deepMerge, getGitHubToken, expandPath, getMonorepoPath, getMonorepoCheckoutScript, getMonorepoWorktreeDirectory, getMonorepoWorktreeNameTemplate, getMonorepoCheckoutTimeout, resolveMonorepoOptions, resolveDbName, warnIfDevModeWithoutDbName, loadConfig, shouldSkipUpdateNotifier, _resetTokenCache } = require('../../src/config');
 
 describe('config.js', () => {
   describe('getGitHubToken', () => {
@@ -1151,6 +1151,104 @@ describe('config.js', () => {
       expect(config.port).toBe(7247);
       expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Malformed config'));
       warnSpy.mockRestore();
+    });
+  });
+
+  describe('shouldSkipUpdateNotifier', () => {
+    const MANAGED_CONFIG_PATH = path.join(__dirname, '..', '..', 'config.managed.json');
+    const GLOBAL_CONFIG_PATH = path.join(os.homedir(), '.pair-review', 'config.json');
+    const GLOBAL_LOCAL_CONFIG_PATH = path.join(os.homedir(), '.pair-review', 'config.local.json');
+    const PROJECT_CONFIG_PATH = path.join(process.cwd(), '.pair-review', 'config.json');
+    const PROJECT_LOCAL_CONFIG_PATH = path.join(process.cwd(), '.pair-review', 'config.local.json');
+
+    let readFileSyncSpy;
+
+    beforeEach(() => {
+      readFileSyncSpy = vi.spyOn(fs, 'readFileSync');
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    function mockReadFileSync(fileMap) {
+      readFileSyncSpy.mockImplementation((filePath) => {
+        if (filePath in fileMap && fileMap[filePath] !== null) {
+          return JSON.stringify(fileMap[filePath]);
+        }
+        const err = new Error('ENOENT');
+        err.code = 'ENOENT';
+        throw err;
+      });
+    }
+
+    it('should return false when no config files exist', () => {
+      mockReadFileSync({});
+      expect(shouldSkipUpdateNotifier()).toBe(false);
+    });
+
+    it('should return false when config files do not set the flag', () => {
+      mockReadFileSync({
+        [GLOBAL_CONFIG_PATH]: { port: 7247 },
+      });
+      expect(shouldSkipUpdateNotifier()).toBe(false);
+    });
+
+    it('should return true when global config sets skip_update_notifier', () => {
+      mockReadFileSync({
+        [GLOBAL_CONFIG_PATH]: { skip_update_notifier: true },
+      });
+      expect(shouldSkipUpdateNotifier()).toBe(true);
+    });
+
+    it('should return true when managed config sets skip_update_notifier', () => {
+      mockReadFileSync({
+        [MANAGED_CONFIG_PATH]: { skip_update_notifier: true },
+      });
+      expect(shouldSkipUpdateNotifier()).toBe(true);
+    });
+
+    it('should let later config files override earlier ones', () => {
+      mockReadFileSync({
+        [MANAGED_CONFIG_PATH]: { skip_update_notifier: true },
+        [GLOBAL_CONFIG_PATH]: { skip_update_notifier: false },
+      });
+      expect(shouldSkipUpdateNotifier()).toBe(false);
+    });
+
+    it('should let project config override global config', () => {
+      mockReadFileSync({
+        [GLOBAL_CONFIG_PATH]: { skip_update_notifier: false },
+        [PROJECT_CONFIG_PATH]: { skip_update_notifier: true },
+      });
+      expect(shouldSkipUpdateNotifier()).toBe(true);
+    });
+
+    it('should let project local config have final say', () => {
+      mockReadFileSync({
+        [MANAGED_CONFIG_PATH]: { skip_update_notifier: true },
+        [GLOBAL_CONFIG_PATH]: { skip_update_notifier: true },
+        [PROJECT_LOCAL_CONFIG_PATH]: { skip_update_notifier: false },
+      });
+      expect(shouldSkipUpdateNotifier()).toBe(false);
+    });
+
+    it('should skip malformed config files silently', () => {
+      readFileSyncSpy.mockImplementation((filePath) => {
+        if (filePath === GLOBAL_CONFIG_PATH) return '{ bad json';
+        if (filePath === GLOBAL_LOCAL_CONFIG_PATH) return JSON.stringify({ skip_update_notifier: true });
+        const err = new Error('ENOENT');
+        err.code = 'ENOENT';
+        throw err;
+      });
+      expect(shouldSkipUpdateNotifier()).toBe(true);
+    });
+
+    it('should coerce truthy values to boolean', () => {
+      mockReadFileSync({
+        [GLOBAL_CONFIG_PATH]: { skip_update_notifier: 1 },
+      });
+      expect(shouldSkipUpdateNotifier()).toBe(true);
     });
   });
 });


### PR DESCRIPTION
## Summary
- Adds `skip_update_notifier` boolean config option (default: `false`) that suppresses the "update available" notification on process exit
- Designed for managed deployments where users cannot update directly — set it in `config.managed.json` to suppress org-wide
- Respects the full 5-layer config merge order (managed → global → global.local → project → project.local), so individual users can still override

## Test plan
- [x] Unit tests for `shouldSkipUpdateNotifier()` covering all config layers, override precedence, malformed files, and truthy coercion (8 new tests, all passing)
- [ ] Manual: set `"skip_update_notifier": true` in `~/.pair-review/config.json`, run `npx pair-review --help`, verify no update notification on exit
- [ ] Manual: set in `config.managed.json`, verify it suppresses without user config

🤖 Generated with [Claude Code](https://claude.com/claude-code)