### PR TITLE
Fix local mode header overlap with long branch names

### DIFF
--- a/.changeset/fix-local-header-overlap.md
+++ b/.changeset/fix-local-header-overlap.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Fix local mode header elements overlapping right-side actions when branch names are long

--- a/public/css/pr.css
+++ b/public/css/pr.css
@@ -5968,6 +5968,7 @@ body::before {
 .header-center {
   flex: 1;
   min-width: 0;
+  overflow: hidden;
   text-align: center;
 }
 

--- a/public/local.html
+++ b/public/local.html
@@ -112,10 +112,24 @@
             font-family: 'JetBrains Mono', monospace;
             font-size: 11px;
             color: var(--color-text-primary);
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            max-width: 260px;
         }
 
         .local-branch-badge svg {
             color: var(--color-text-tertiary);
+            flex-shrink: 0;
+        }
+
+        .local-branch-badge span {
+            overflow: hidden;
+            text-overflow: ellipsis;
+        }
+
+        .local-branch-vs {
+            flex-shrink: 0;
         }
 
         /* Dark mode improvements for header icon buttons */
@@ -139,18 +153,25 @@
             gap: 16px;
             font-size: 13px;
             color: var(--color-text-secondary);
+            min-width: 0;
+            overflow: hidden;
         }
 
         .local-header-info .info-item {
             display: flex;
             align-items: center;
             gap: 6px;
+            min-width: 0;
+            overflow: hidden;
         }
 
         .local-header-info .info-value {
             color: var(--color-text-primary);
             font-weight: 600;
             font-size: 14px;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
         }
 
         /* Path display in toolbar-meta (with left truncation) */
@@ -193,11 +214,12 @@
             border-radius: 4px;
             border: 1px dashed var(--color-border-primary);
             transition: all 0.15s ease;
-            max-width: 360px;
+            max-width: 100%;
             overflow: hidden;
             text-overflow: ellipsis;
             white-space: nowrap;
             position: relative;
+            display: inline-block;
         }
 
         .local-review-name:hover {


### PR DESCRIPTION
## Summary
- Add overflow/truncation constraints to local mode header elements (branch badges, review name) so long text truncates with ellipsis instead of overflowing into neighboring header sections
- Add `overflow: hidden` to shared `.header-center` rule so flex shrinking actually clips content
- Change `.local-review-name` from fixed `max-width: 360px` to `max-width: 100%` so it respects container width

## Test plan
- [ ] Open a local review with long branch names — verify badges truncate with ellipsis
- [ ] Set a long review name — verify it truncates and doesn't overlap the right-side actions
- [ ] Resize the browser window narrower — verify center section disappears at 900px breakpoint
- [ ] All 5220 unit tests pass
- [ ] All 266 E2E tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)