### PR TITLE
Harden all git diff calls against user config

### DIFF
--- a/.changeset/harden-git-diff-flags.md
+++ b/.changeset/harden-git-diff-flags.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Harden all git diff calls against user git config that could alter output format (color.diff, diff.noprefix, diff.mnemonicPrefix, diff.relative)

--- a/src/ai/analyzer.js
+++ b/src/ai/analyzer.js
@@ -13,6 +13,7 @@ const { normalizePath, pathExistsInList, resolveRenamedFile } = require('../util
 const { buildFileLineCountMap, validateSuggestionLineNumbers } = require('../utils/line-validation');
 const { getPromptBuilder } = require('./prompts');
 const { formatValidFiles } = require('./prompts/shared/valid-files');
+const { GIT_DIFF_FLAGS } = require('../git/diff-flags');
 const {
   buildAnalysisLineNumberGuidance,
   buildOrchestrationLineNumberGuidance: buildOrchestrationGuidance,
@@ -27,13 +28,7 @@ const { buildSparseCheckoutGuidance } = require('./prompts/sparse-checkout-guida
 /** Minimum total suggestion count across all voices before consolidation is applied */
 const COUNCIL_CONSOLIDATION_THRESHOLD = 8;
 
-/**
- * Common git diff flags used across all diff operations.
- * - --no-color: Disable color output (guards against color.diff=always in user config)
- * - --no-ext-diff: Disable external diff drivers
- * - --src-prefix/--dst-prefix: Ensure consistent a/ b/ prefixes (overrides user's diff.noprefix)
- */
-const GIT_DIFF_COMMON_FLAGS = '--no-color --no-ext-diff --src-prefix=a/ --dst-prefix=b/';
+// GIT_DIFF_FLAGS imported from ../git/diff-flags
 
 /**
  * Build a human-readable display label for a council voice/reviewer.
@@ -667,7 +662,7 @@ Do NOT create suggestions for any files not in this list. If you cannot find iss
   async getChangedFilesList(worktreePath, prMetadata) {
     try {
       const { stdout } = await execPromise(
-        `git diff --no-ext-diff ${prMetadata.base_sha}...${prMetadata.head_sha} --name-only`,
+        `git diff ${GIT_DIFF_FLAGS} ${prMetadata.base_sha}...${prMetadata.head_sha} --name-only`,
         { cwd: worktreePath }
       );
       return stdout.trim().split('\n').filter(f => f.length > 0);
@@ -691,7 +686,7 @@ Do NOT create suggestions for any files not in this list. If you cannot find iss
     try {
       // Get modified tracked files (unstaged)
       const { stdout: unstaged } = await execPromise(
-        'git diff --no-ext-diff --name-only',
+        `git diff ${GIT_DIFF_FLAGS} --name-only`,
         { cwd: localPath }
       );
 
@@ -708,7 +703,7 @@ Do NOT create suggestions for any files not in this list. If you cannot find iss
       // Include staged files when scope includes staged
       if (options.includeStaged) {
         const { stdout: staged } = await execPromise(
-          'git diff --no-ext-diff --cached --name-only',
+          `git diff ${GIT_DIFF_FLAGS} --cached --name-only`,
           { cwd: localPath }
         );
         const stagedFiles = staged.trim().split('\n').filter(f => f.length > 0);
@@ -997,10 +992,10 @@ ${prMetadata.description || '(No description provided)'}
     const isLocal = prMetadata.reviewType === 'local';
     if (isLocal) {
       // For local mode, diff against HEAD to see working directory changes
-      return suffix ? `git diff ${GIT_DIFF_COMMON_FLAGS} HEAD ${suffix}` : `git diff ${GIT_DIFF_COMMON_FLAGS} HEAD`;
+      return suffix ? `git diff ${GIT_DIFF_FLAGS} HEAD ${suffix}` : `git diff ${GIT_DIFF_FLAGS} HEAD`;
     }
     // For PR mode, diff between base and head commits
-    const baseCmd = `git diff ${GIT_DIFF_COMMON_FLAGS} ${prMetadata.base_sha}...${prMetadata.head_sha}`;
+    const baseCmd = `git diff ${GIT_DIFF_FLAGS} ${prMetadata.base_sha}...${prMetadata.head_sha}`;
     return suffix ? `${baseCmd} ${suffix}` : baseCmd;
   }
 

--- a/src/git/diff-flags.js
+++ b/src/git/diff-flags.js
@@ -1,0 +1,43 @@
+// Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Shared git diff flags used across all diff operations.
+ *
+ * Rationale for each flag:
+ * - --no-color: Disable color output for consistent parsing (overrides color.diff / color.ui)
+ * - --no-ext-diff: Disable external diff drivers (overrides diff.external)
+ * - --src-prefix=a/ --dst-prefix=b/: Ensure consistent a/ b/ prefixes (overrides diff.noprefix / diff.mnemonicPrefix)
+ * - --no-relative: Ensure paths are repo-root-relative (overrides diff.relative)
+ */
+
+/**
+ * String form for execSync / exec shell calls (e.g. `git diff ${GIT_DIFF_FLAGS} ...`).
+ */
+const GIT_DIFF_FLAGS = '--no-color --no-ext-diff --src-prefix=a/ --dst-prefix=b/ --no-relative';
+
+/**
+ * Array form for simple-git .diff() calls (full diff output including file content).
+ */
+const GIT_DIFF_FLAGS_ARRAY = [
+  '--no-color',
+  '--no-ext-diff',
+  '--src-prefix=a/',
+  '--dst-prefix=b/',
+  '--no-relative'
+];
+
+/**
+ * Array form for simple-git .diffSummary() calls.
+ * Omits --src-prefix/--dst-prefix since diffSummary doesn't output file content with prefixes.
+ */
+const GIT_DIFF_SUMMARY_FLAGS_ARRAY = [
+  '--no-color',
+  '--no-ext-diff',
+  '--no-relative'
+];
+
+module.exports = {
+  GIT_DIFF_FLAGS,
+  GIT_DIFF_FLAGS_ARRAY,
+  GIT_DIFF_SUMMARY_FLAGS_ARRAY
+};

--- a/src/git/worktree.js
+++ b/src/git/worktree.js
@@ -7,6 +7,7 @@ const { getConfigDir, DEFAULT_CHECKOUT_TIMEOUT_MS } = require('../config');
 const { WorktreeRepository, generateWorktreeId } = require('../database');
 const { getGeneratedFilePatterns } = require('./gitattributes');
 const { normalizeRepository, resolveRenamedFile, resolveRenamedFileOld } = require('../utils/paths');
+const { GIT_DIFF_FLAGS_ARRAY, GIT_DIFF_SUMMARY_FLAGS_ARRAY } = require('./diff-flags');
 const { spawn, execSync } = require('child_process');
 
 /**
@@ -534,10 +535,12 @@ class GitWorktreeManager {
 
       // Generate diff between base SHA and head SHA (not branch names)
       // This ensures we compare the exact commits from the PR, even if the base branch has moved
+      // Defensive flags to normalize output regardless of user's git config
+      // (see src/git/diff-flags.js for rationale)
       const diff = await git.diff([
         `${prData.base_sha}...${prData.head_sha}`,
         '--unified=3',
-        '--no-ext-diff'
+        ...GIT_DIFF_FLAGS_ARRAY
       ]);
 
       return diff;
@@ -560,7 +563,10 @@ class GitWorktreeManager {
 
       // Get file changes with stats using base SHA and head SHA
       // This ensures we get the exact files changed in the PR, even if the base branch has moved
-      const diffSummary = await git.diffSummary([`${prData.base_sha}...${prData.head_sha}`, '--no-ext-diff']);
+      const diffSummary = await git.diffSummary([
+        `${prData.base_sha}...${prData.head_sha}`,
+        ...GIT_DIFF_SUMMARY_FLAGS_ARRAY
+      ]);
 
       // Parse .gitattributes to identify generated files
       const gitattributes = await getGeneratedFilePatterns(worktreePath);

--- a/src/local-review.js
+++ b/src/local-review.js
@@ -15,6 +15,7 @@ const { initializeDatabase, ReviewRepository, RepoSettingsRepository } = require
 const { startServer } = require('./server');
 const { localReviewDiffs } = require('./routes/shared');
 const { getShaAbbrevLength } = require('./git/sha-abbrev');
+const { GIT_DIFF_FLAGS } = require('./git/diff-flags');
 const open = (...args) => process.env.PAIR_REVIEW_NO_OPEN ? Promise.resolve() : import('open').then(({ default: open }) => open(...args));
 
 // Design note: This module uses execSync for git commands despite async function signatures.
@@ -33,13 +34,7 @@ const MAX_FILE_SIZE = 1024 * 1024;
  */
 const GIT_DIFF_HAS_DIFFERENCES = 1;
 
-/**
- * Common git diff flags used across all diff operations.
- * - --no-color: Disable color output for consistent parsing
- * - --no-ext-diff: Disable external diff drivers
- * - --src-prefix/--dst-prefix: Ensure consistent a/ b/ prefixes (overrides user's diff.noprefix)
- */
-const GIT_DIFF_COMMON_FLAGS = '--no-color --no-ext-diff --src-prefix=a/ --dst-prefix=b/';
+// GIT_DIFF_FLAGS imported from ./git/diff-flags
 
 /**
  * Find the main git repository root, resolving through worktrees.
@@ -409,7 +404,7 @@ function generateUntrackedDiffs(repoPath, untrackedFiles, wFlag) {
         const filePath = path.join(repoPath, untracked.file);
         let fileDiff;
         try {
-          fileDiff = execSync(`git diff --no-index ${GIT_DIFF_COMMON_FLAGS}${wFlag} -- /dev/null "${filePath}"`, {
+          fileDiff = execSync(`git diff --no-index ${GIT_DIFF_FLAGS}${wFlag} -- /dev/null "${filePath}"`, {
             cwd: repoPath,
             encoding: 'utf8',
             stdio: ['pipe', 'pipe', 'pipe'],
@@ -486,37 +481,37 @@ async function generateScopedDiff(repoPath, scopeStart, scopeEnd, baseBranch, op
   try {
     if (hasBranch && !hasStaged && !hasUnstaged) {
       // Branch only → committed changes since merge-base
-      diff = execSync(`git diff ${mergeBaseSha}..HEAD ${GIT_DIFF_COMMON_FLAGS} --unified=25${wFlag}`, {
+      diff = execSync(`git diff ${mergeBaseSha}..HEAD ${GIT_DIFF_FLAGS} --unified=25${wFlag}`, {
         cwd: repoPath, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'],
         maxBuffer: 50 * 1024 * 1024
       });
     } else if (hasBranch && hasStaged && !hasUnstaged) {
       // Branch–Staged → staged changes relative to merge-base
-      diff = execSync(`git diff --cached ${mergeBaseSha} ${GIT_DIFF_COMMON_FLAGS} --unified=25${wFlag}`, {
+      diff = execSync(`git diff --cached ${mergeBaseSha} ${GIT_DIFF_FLAGS} --unified=25${wFlag}`, {
         cwd: repoPath, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'],
         maxBuffer: 50 * 1024 * 1024
       });
     } else if (hasBranch && hasUnstaged) {
       // Branch–Unstaged (or Branch–Untracked) → working tree vs merge-base
-      diff = execSync(`git diff ${mergeBaseSha} ${GIT_DIFF_COMMON_FLAGS} --unified=25${wFlag}`, {
+      diff = execSync(`git diff ${mergeBaseSha} ${GIT_DIFF_FLAGS} --unified=25${wFlag}`, {
         cwd: repoPath, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'],
         maxBuffer: 50 * 1024 * 1024
       });
     } else if (hasStaged && !hasUnstaged) {
       // Staged only → cached changes
-      diff = execSync(`git diff --cached ${GIT_DIFF_COMMON_FLAGS} --unified=25${wFlag}`, {
+      diff = execSync(`git diff --cached ${GIT_DIFF_FLAGS} --unified=25${wFlag}`, {
         cwd: repoPath, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'],
         maxBuffer: 50 * 1024 * 1024
       });
     } else if (hasStaged && hasUnstaged) {
       // Staged–Unstaged (or Staged–Untracked) → all changes vs HEAD
-      diff = execSync(`git diff HEAD ${GIT_DIFF_COMMON_FLAGS} --unified=25${wFlag}`, {
+      diff = execSync(`git diff HEAD ${GIT_DIFF_FLAGS} --unified=25${wFlag}`, {
         cwd: repoPath, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'],
         maxBuffer: 50 * 1024 * 1024
       });
     } else if (hasUnstaged) {
       // Unstaged only or Unstaged–Untracked → working tree changes
-      diff = execSync(`git diff ${GIT_DIFF_COMMON_FLAGS} --unified=25${wFlag}`, {
+      diff = execSync(`git diff ${GIT_DIFF_FLAGS} --unified=25${wFlag}`, {
         cwd: repoPath, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'],
         maxBuffer: 50 * 1024 * 1024
       });
@@ -536,7 +531,7 @@ async function generateScopedDiff(repoPath, scopeStart, scopeEnd, baseBranch, op
   // Count staged/unstaged for stats when relevant
   if (hasStaged) {
     try {
-      const stagedDiff = execSync(`git diff --cached --stat --no-color --no-ext-diff`, {
+      const stagedDiff = execSync(`git diff --cached --stat ${GIT_DIFF_FLAGS}`, {
         cwd: repoPath, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe']
       });
       if (stagedDiff.trim()) {
@@ -546,7 +541,7 @@ async function generateScopedDiff(repoPath, scopeStart, scopeEnd, baseBranch, op
   }
   if (hasUnstaged) {
     try {
-      const unstagedDiff = execSync(`git diff --stat --no-color --no-ext-diff`, {
+      const unstagedDiff = execSync(`git diff --stat ${GIT_DIFF_FLAGS}`, {
         cwd: repoPath, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe']
       });
       if (unstagedDiff.trim()) {
@@ -598,7 +593,7 @@ async function computeScopedDigest(repoPath, scopeStart, scopeEnd) {
   // Staged in scope → cached diff content
   if (scopeIncludes(scopeStart, scopeEnd, 'staged')) {
     try {
-      const result = await execAsync(`git diff --cached ${GIT_DIFF_COMMON_FLAGS}`, {
+      const result = await execAsync(`git diff --cached ${GIT_DIFF_FLAGS}`, {
         cwd: repoPath, encoding: 'utf8', maxBuffer: 50 * 1024 * 1024
       });
       parts.push('STAGED:' + result.stdout);
@@ -610,7 +605,7 @@ async function computeScopedDigest(repoPath, scopeStart, scopeEnd) {
   // Unstaged in scope → working tree diff
   if (scopeIncludes(scopeStart, scopeEnd, 'unstaged')) {
     try {
-      const result = await execAsync(`git diff ${GIT_DIFF_COMMON_FLAGS}`, {
+      const result = await execAsync(`git diff ${GIT_DIFF_FLAGS}`, {
         cwd: repoPath, encoding: 'utf8', maxBuffer: 50 * 1024 * 1024
       });
       parts.push('UNSTAGED:' + result.stdout);
@@ -665,7 +660,7 @@ async function generateLocalDiff(repoPath, options = {}) {
   // Always count staged changes for CLI info message, even when staged is out of scope
   if (!result.stats.stagedChanges) {
     try {
-      const stagedStat = execSync('git diff --cached --stat --no-color --no-ext-diff', {
+      const stagedStat = execSync(`git diff --cached --stat ${GIT_DIFF_FLAGS}`, {
         cwd: repoPath, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe']
       });
       if (stagedStat.trim()) {

--- a/src/main.js
+++ b/src/main.js
@@ -15,6 +15,7 @@ const { normalizeRepository, resolveRenamedFile, resolveRenamedFileOld } = requi
 const logger = require('./utils/logger');
 const simpleGit = require('simple-git');
 const { getGeneratedFilePatterns } = require('./git/gitattributes');
+const { GIT_DIFF_FLAGS_ARRAY, GIT_DIFF_SUMMARY_FLAGS_ARRAY } = require('./git/diff-flags');
 const { getEmoji: getCategoryEmoji } = require('./utils/category-emoji');
 const open = (...args) => process.env.PAIR_REVIEW_NO_OPEN ? Promise.resolve() : import('open').then(({default: open}) => open(...args));
 const { registerProtocolHandler, unregisterProtocolHandler } = require('./protocol-handler');
@@ -705,10 +706,17 @@ async function performHeadlessReview(args, config, db, flags, options) {
         }
       }
 
-      diff = await git.diff([`${prData.base_sha}...${prData.head_sha}`, '--unified=3', '--no-ext-diff']);
+      diff = await git.diff([
+        `${prData.base_sha}...${prData.head_sha}`,
+        '--unified=3',
+        ...GIT_DIFF_FLAGS_ARRAY
+      ]);
 
       // Get changed files
-      const diffSummary = await git.diffSummary([`${prData.base_sha}...${prData.head_sha}`, '--no-ext-diff']);
+      const diffSummary = await git.diffSummary([
+        `${prData.base_sha}...${prData.head_sha}`,
+        ...GIT_DIFF_SUMMARY_FLAGS_ARRAY
+      ]);
       const gitattributes = await getGeneratedFilePatterns(worktreePath);
 
       changedFiles = diffSummary.files.map(file => {

--- a/src/routes/pr.js
+++ b/src/routes/pr.js
@@ -32,6 +32,7 @@ const { broadcastReviewEvent } = require('../events/review-events');
 const { fireHooks, hasHooks } = require('../hooks/hook-runner');
 const { buildReviewStartedPayload, buildReviewLoadedPayload, buildAnalysisStartedPayload, buildAnalysisCompletedPayload, getCachedUser } = require('../hooks/payloads');
 const simpleGit = require('simple-git');
+const { GIT_DIFF_FLAGS_ARRAY, GIT_DIFF_SUMMARY_FLAGS_ARRAY } = require('../git/diff-flags');
 const {
   activeAnalyses,
   reviewToAnalysisId,
@@ -706,10 +707,19 @@ router.get('/api/pr/:owner/:repo/:number/diff', async (req, res) => {
 
         if (baseSha && headSha) {
           // Regenerate diff with -w flag to ignore whitespace changes
-          diffContent = await git.diff([`${baseSha}...${headSha}`, '--unified=3', '-w', '--no-ext-diff']);
+          diffContent = await git.diff([
+            `${baseSha}...${headSha}`,
+            '--unified=3',
+            '-w',
+            ...GIT_DIFF_FLAGS_ARRAY
+          ]);
 
           // Regenerate changed files stats with -w flag
-          const diffSummary = await git.diffSummary([`${baseSha}...${headSha}`, '-w', '--no-ext-diff']);
+          const diffSummary = await git.diffSummary([
+            `${baseSha}...${headSha}`,
+            '-w',
+            ...GIT_DIFF_SUMMARY_FLAGS_ARRAY
+          ]);
           const gitattributes = await getGeneratedFilePatterns(worktreePath);
           changedFiles = diffSummary.files.map(file => {
             const resolvedFile = resolveRenamedFile(file.file);

--- a/src/utils/diff-file-list.js
+++ b/src/utils/diff-file-list.js
@@ -2,6 +2,7 @@
 const { promisify } = require('util');
 const { exec } = require('child_process');
 const { queryOne } = require('../database');
+const { GIT_DIFF_FLAGS } = require('../git/diff-flags');
 
 const execPromise = promisify(exec);
 
@@ -37,7 +38,7 @@ async function getDiffFileList(db, review) {
     try {
       const opts = { cwd: review.local_path };
       const [{ stdout: unstaged }, { stdout: untracked }] = await Promise.all([
-        execPromise('git diff --no-ext-diff --name-only', opts),
+        execPromise(`git diff ${GIT_DIFF_FLAGS} --name-only`, opts),
         execPromise('git ls-files --others --exclude-standard', opts),
       ]);
       const combined = `${unstaged}\n${untracked}`


### PR DESCRIPTION
## Summary
- Extracts shared `GIT_DIFF_FLAGS` constants into `src/git/diff-flags.js` (string form for `execSync`, array form for `simple-git`)
- Applies defensive flags (`--no-color`, `--no-ext-diff`, `--src-prefix=a/`, `--dst-prefix=b/`, `--no-relative`) to **all** git diff calls across the codebase
- Fixes gaps where `worktree.js`, `main.js`, `pr.js`, `analyzer.js`, and `diff-file-list.js` were missing some or all of these flags
- Fixes `--stat` calls in `local-review.js` that were missing `--no-relative`

Guards against these user git config options silently corrupting diff output:
| Config | Effect without guard |
|---|---|
| `color.diff` / `color.ui` | ANSI codes in output break parsing |
| `diff.noprefix` | Removes `a/` `b/` prefixes parsers depend on |
| `diff.mnemonicPrefix` | Changes prefixes to `c/` `i/` `w/` `o/` |
| `diff.external` | External tool produces different format |
| `diff.relative` | Paths become CWD-relative instead of repo-root-relative |

## Test plan
- [x] All 5220 unit/integration tests pass
- [ ] Manual: set `diff.noprefix=true` in git config, verify local review diff renders correctly
- [ ] Manual: set `color.diff=always` in git config, verify PR diff renders correctly
- [ ] Manual: set `diff.relative=true`, verify file paths resolve correctly in both modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)