### PR TITLE
Fix --ai flag not triggering auto-analysis in local mode

### DIFF
--- a/.changeset/fix-local-ai-flag.md
+++ b/.changeset/fix-local-ai-flag.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Fix --ai flag not triggering auto-analysis in local mode

--- a/src/local-review.js
+++ b/src/local-review.js
@@ -876,7 +876,10 @@ async function handleLocalReview(targetPath, flags = {}) {
     const port = await startServer(db);
 
     // Open browser to local review view
-    const url = `http://localhost:${port}/local/${sessionId}`;
+    let url = `http://localhost:${port}/local/${sessionId}`;
+    if (flags.ai) {
+      url += '?analyze=true';
+    }
     console.log(`\nOpening browser to: ${url}`);
     await open(url);
 

--- a/tests/e2e/auto-analyze.spec.js
+++ b/tests/e2e/auto-analyze.spec.js
@@ -90,8 +90,8 @@ test.describe('Auto-Analyze Query Parameter', () => {
     await page.goto('/pr/test-owner/test-repo/1');
     await waitForDiffToRender(page);
 
-    // Give a moment for any async triggers
-    await page.waitForTimeout(1000);
+    // Wait for all network activity to settle before asserting the negative
+    await page.waitForLoadState('networkidle');
 
     expect(analyzeRequested).toBe(false);
   });
@@ -108,7 +108,59 @@ test.describe('Auto-Analyze Query Parameter', () => {
     await page.goto('/pr/test-owner/test-repo/1?analyze=false');
     await waitForDiffToRender(page);
 
-    await page.waitForTimeout(1000);
+    await page.waitForLoadState('networkidle');
+
+    expect(analyzeRequested).toBe(false);
+  });
+});
+
+test.describe('Auto-Analyze Query Parameter - Local Mode', () => {
+  test('should auto-trigger analysis when ?analyze=true is present in local mode', async ({ page }) => {
+    // Mock the local analysis endpoint so it returns immediately
+    await page.route('**/api/local/2/analyses', route => {
+      if (route.request().method() === 'POST') {
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            analysisId: 'test-local-analysis',
+            status: 'started',
+            message: 'AI analysis started in background'
+          })
+        });
+      } else {
+        route.continue();
+      }
+    });
+
+    // Intercept the analyze POST request to verify it fires
+    const analyzeRequest = page.waitForRequest(
+      request => request.url().includes('/api/local/2/analyses') &&
+                 request.method() === 'POST',
+      { timeout: 10000 }
+    );
+
+    await page.goto('/local/2?analyze=true');
+    await waitForDiffToRender(page);
+
+    // Verify the analysis POST was triggered
+    const analyze = await analyzeRequest;
+    expect(analyze.method()).toBe('POST');
+  });
+
+  test('should not auto-trigger analysis in local mode without query param', async ({ page }) => {
+    let analyzeRequested = false;
+
+    page.on('request', request => {
+      if (request.url().includes('/api/local/2/analyses') && request.method() === 'POST') {
+        analyzeRequested = true;
+      }
+    });
+
+    await page.goto('/local/2');
+    await waitForDiffToRender(page);
+
+    await page.waitForLoadState('networkidle');
 
     expect(analyzeRequested).toBe(false);
   });


### PR DESCRIPTION
## Summary
- `handleLocalReview()` was not appending `?analyze=true` to the browser URL when `flags.ai` was set, even though the frontend (`local.js`) already handled the parameter. PR mode had the wiring; local mode was missing it.
- Adds local mode E2E tests for the `?analyze=true` auto-analyze flow (positive and negative).
- Replaces brittle `waitForTimeout(1000)` with `waitForLoadState('networkidle')` in all negative auto-analyze tests (PR and local), making them faster and more reliable on slow CI.

## Test plan
- [x] All 5225 unit tests pass
- [x] All 6 auto-analyze E2E tests pass (4 existing PR + 2 new local)
- [x] Full E2E suite passes (266 passed)
- [ ] Manual: `npx pair-review --local --ai` opens browser and auto-triggers analysis

🤖 Generated with [Claude Code](https://claude.com/claude-code)