### PR TITLE
Fix logger.error/warn silently dropping error objects

### DIFF
--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -129,28 +129,38 @@ class AILogger {
 
   /**
    * Log AI analysis error
+   * @param {string} message - Error message
+   * @param {Error} [error] - Optional error object to include
    */
-  error(message) {
+  error(message, error) {
     if (!this.enabled) return;
     const timestamp = new Date().toISOString().split('T')[1].split('.')[0];
-    process.stderr.write(
-      `${COLORS.cyan}[${timestamp}]${COLORS.reset} ` +
+    let output = `${COLORS.cyan}[${timestamp}]${COLORS.reset} ` +
       `${COLORS.bright}${COLORS.red}[AI ✗]${COLORS.reset} ` +
-      `${COLORS.red}${message}${COLORS.reset}\n`
-    );
+      `${COLORS.red}${message}${COLORS.reset}`;
+    if (error) {
+      const errorMsg = error.message || String(error);
+      output += ` ${COLORS.red}${errorMsg}${COLORS.reset}`;
+    }
+    process.stderr.write(output + '\n');
   }
 
   /**
    * Log AI analysis warning
+   * @param {string} message - Warning message
+   * @param {Error} [error] - Optional error object to include
    */
-  warn(message) {
+  warn(message, error) {
     if (!this.enabled) return;
     const timestamp = new Date().toISOString().split('T')[1].split('.')[0];
-    this._stdout.write(
-      `${COLORS.cyan}[${timestamp}]${COLORS.reset} ` +
+    let output = `${COLORS.cyan}[${timestamp}]${COLORS.reset} ` +
       `${COLORS.bright}${COLORS.yellow}[AI ⚠]${COLORS.reset} ` +
-      `${COLORS.yellow}${message}${COLORS.reset}\n`
-    );
+      `${COLORS.yellow}${message}${COLORS.reset}`;
+    if (error) {
+      const errorMsg = error.message || String(error);
+      output += ` ${COLORS.yellow}${errorMsg}${COLORS.reset}`;
+    }
+    this._stdout.write(output + '\n');
   }
 
   /**


### PR DESCRIPTION
## Summary
- The `logger.error()` and `logger.warn()` methods only accepted a single string argument
- Error objects passed as the second argument were silently ignored
- This made debugging difficult when routes logged errors like `logger.error('Failed:', error)`

Now both methods accept an optional second argument and append its message to the output with proper spacing.

## Test plan
- [x] Verified output renders correctly: `Bulk open failed: connection refused`
- [x] All unit tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)