### PR TITLE
Fix local review page load perf for web UI sessions

### DIFF
--- a/.changeset/fix-local-web-ui-perf.md
+++ b/.changeset/fix-local-web-ui-perf.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Fix slow local review page load for web UI-started sessions by removing blocking GitHub API calls from the metadata endpoint

--- a/src/git/base-branch.js
+++ b/src/git/base-branch.js
@@ -171,46 +171,43 @@ function tryDefaultBranch(repoPath, currentBranch, deps) {
 }
 
 /**
- * Synchronously detect the default branch for a repository.
+ * Synchronously detect the default branch for a repository using only
+ * local refs (no network I/O).
  *
- * Uses the same logic as tryDefaultBranch but returns just the branch name
- * (or null). Suitable for call sites that need a quick, synchronous answer
- * without the full detectBaseBranch priority chain.
+ * Priority:
+ *   1. `git symbolic-ref refs/remotes/origin/HEAD` — reads the local ref
+ *      that `git clone` sets automatically.
+ *   2. Check whether `refs/heads/main` or `refs/heads/master` exist locally.
  *
- * @param {string} repoPath - Absolute path to the repository
+ * @param {string} localPath - Absolute path to the repository
  * @param {Object} [_deps] - Dependency overrides for testing
  * @returns {string|null} Default branch name, or null if it cannot be determined
  */
-function getDefaultBranch(repoPath, _deps) {
+function getDefaultBranch(localPath, _deps) {
+  if (!localPath) return null;
   const deps = { ...defaults, ..._deps };
 
-  // Try `git remote show origin`
+  // Try symbolic-ref (set by git clone)
   try {
-    const output = deps.execSync('git remote show origin', {
-      cwd: repoPath,
+    const ref = deps.execSync('git symbolic-ref refs/remotes/origin/HEAD', {
+      cwd: localPath,
       encoding: 'utf8',
       stdio: ['pipe', 'pipe', 'pipe'],
-      timeout: 5000
-    });
-
-    const match = output.match(/HEAD branch:\s*(.+)/);
-    if (match) {
-      const branch = match[1].trim();
-      if (branch && branch !== '(unknown)') {
-        return branch;
-      }
-    }
+    }).trim();
+    // ref looks like "refs/remotes/origin/main"
+    const branch = ref.replace(/^refs\/remotes\/origin\//, '');
+    if (branch && branch !== ref) return branch;
   } catch {
-    // No remote or network issue — try local refs
+    // origin/HEAD not set — fall through to local check
   }
 
   // Fallback: check if main or master exists locally
   for (const candidate of ['main', 'master']) {
     try {
-      deps.execSync(`git rev-parse --verify ${candidate}`, {
-        cwd: repoPath,
+      deps.execSync(`git rev-parse --verify refs/heads/${candidate}`, {
+        cwd: localPath,
         encoding: 'utf8',
-        stdio: ['pipe', 'pipe', 'pipe']
+        stdio: ['pipe', 'pipe', 'pipe'],
       });
       return candidate;
     } catch {

--- a/src/routes/local.js
+++ b/src/routes/local.js
@@ -32,6 +32,7 @@ const { getShaAbbrevLength } = require('../git/sha-abbrev');
 const { validateCouncilConfig, normalizeCouncilConfig } = require('./councils');
 const { TIERS, TIER_ALIASES, VALID_TIERS, resolveTier } = require('../ai/prompts/config');
 const { getProviderClass, createProvider } = require('../ai/provider');
+const { getDefaultBranch } = require('../git/base-branch');
 const { CommentRepository } = require('../database');
 const { runExecutableAnalysis } = require('./executable-analysis');
 const {
@@ -83,9 +84,8 @@ function isBranchAvailable(branchName, scopeStart, localPath) {
   if (includesBranch(scopeStart)) return true;
   if (!branchName || branchName === 'HEAD' || branchName === 'unknown') return false;
 
-  const { getDefaultBranch } = require('../git/base-branch');
-  const defaultBranch = localPath ? getDefaultBranch(localPath) : null;
-  // If detection fails, fall back to checking main/master
+  // Detect the default branch using only local refs (no network).
+  const defaultBranch = getDefaultBranch(localPath);
   if (defaultBranch) {
     return branchName !== defaultBranch;
   }
@@ -565,19 +565,14 @@ router.get('/api/local/:reviewId', async (req, res) => {
     const baseBranch = review.local_base_branch || null;
 
     // When scope does NOT include branch, check for branch detection info
-    // Frontend uses this to suggest expanding scope to include branch
+    // Frontend uses this to suggest expanding scope to include branch.
+    // Only use already-cached results here — never block the response on
+    // GitHub API calls.  Background detection (after res.json) will populate
+    // the cache for subsequent requests.
     let branchInfo = null;
     const cachedDiff = getLocalReviewDiff(reviewId);
     if (!includesBranch(scopeStart) && cachedDiff?.branchInfo) {
       branchInfo = cachedDiff.branchInfo;
-    } else if (!includesBranch(scopeStart) && !cachedDiff && review.local_path) {
-      // No cache (web UI started session) — run detection on-demand
-      const config = req.app.get('config') || {};
-      branchInfo = await detectAndBuildBranchInfo(review.local_path, branchName, {
-        repository: repositoryName,
-        githubToken: getGitHubToken(config),
-        enableGraphite: config.enable_graphite === true
-      });
     }
 
     // Check repo settings for auto_branch_review preference

--- a/tests/unit/base-branch.test.js
+++ b/tests/unit/base-branch.test.js
@@ -1,6 +1,6 @@
 // Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, vi } from 'vitest';
-const { detectBaseBranch } = require('../../src/git/base-branch');
+const { detectBaseBranch, getDefaultBranch } = require('../../src/git/base-branch');
 
 /**
  * Create mock deps for detectBaseBranch testing.
@@ -221,5 +221,73 @@ describe('detectBaseBranch', () => {
     });
     // Should skip the PR result (base === current) and fall back to default branch
     expect(result).toEqual({ baseBranch: 'main', source: 'default-branch' });
+  });
+});
+
+describe('getDefaultBranch', () => {
+  it('returns branch name from symbolic-ref', () => {
+    const execSync = vi.fn((cmd) => {
+      if (cmd === 'git symbolic-ref refs/remotes/origin/HEAD') {
+        return 'refs/remotes/origin/main\n';
+      }
+      throw new Error(`unexpected: ${cmd}`);
+    });
+
+    const result = getDefaultBranch('/repo', { execSync });
+    expect(result).toBe('main');
+    expect(execSync).toHaveBeenCalledWith(
+      'git symbolic-ref refs/remotes/origin/HEAD',
+      expect.objectContaining({ cwd: '/repo' })
+    );
+  });
+
+  it('falls back to main when symbolic-ref fails', () => {
+    const execSync = vi.fn((cmd) => {
+      if (cmd === 'git symbolic-ref refs/remotes/origin/HEAD') {
+        throw new Error('not a symbolic ref');
+      }
+      if (cmd === 'git rev-parse --verify refs/heads/main') {
+        return 'abc123\n';
+      }
+      throw new Error(`unexpected: ${cmd}`);
+    });
+
+    const result = getDefaultBranch('/repo', { execSync });
+    expect(result).toBe('main');
+  });
+
+  it('falls back to master when symbolic-ref fails and main does not exist', () => {
+    const execSync = vi.fn((cmd) => {
+      if (cmd === 'git symbolic-ref refs/remotes/origin/HEAD') {
+        throw new Error('not a symbolic ref');
+      }
+      if (cmd === 'git rev-parse --verify refs/heads/main') {
+        throw new Error('not found');
+      }
+      if (cmd === 'git rev-parse --verify refs/heads/master') {
+        return 'abc123\n';
+      }
+      throw new Error(`unexpected: ${cmd}`);
+    });
+
+    const result = getDefaultBranch('/repo', { execSync });
+    expect(result).toBe('master');
+  });
+
+  it('returns null when no default branch can be determined', () => {
+    const execSync = vi.fn(() => { throw new Error('fail'); });
+
+    const result = getDefaultBranch('/repo', { execSync });
+    expect(result).toBeNull();
+  });
+
+  it('returns null when no localPath is provided', () => {
+    const execSync = vi.fn();
+
+    expect(getDefaultBranch(null, { execSync })).toBeNull();
+    expect(getDefaultBranch(undefined, { execSync })).toBeNull();
+    expect(getDefaultBranch('', { execSync })).toBeNull();
+    // execSync should never have been called
+    expect(execSync).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- Remove blocking `await detectAndBuildBranchInfo()` from the metadata endpoint for web UI-started sessions (background detection already covers this path)
- Replace `getDefaultBranch()` implementation with local-only ref reading (`git symbolic-ref refs/remotes/origin/HEAD`) instead of `git remote show origin` which contacts the remote (~1s)
- Consolidate `getDefaultBranchLocal()` into `src/git/base-branch.js` using the `_deps` injection pattern
- Add 5 unit tests for the updated `getDefaultBranch()`

## Test plan
- [x] All existing unit/integration tests pass (117/118 files, pre-existing flake in first-run.test.js)
- [x] 5 new unit tests covering all `getDefaultBranch()` code paths
- [ ] Manual: start a local review from the web UI and verify metadata endpoint responds in <200ms
- [ ] Manual: verify branch scope suggestion still appears after background detection completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)