### PR TITLE
Add spinner animation to local mode refresh button

### DIFF
--- a/.changeset/local-refresh-animation.md
+++ b/.changeset/local-refresh-animation.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Add spinner animation to the local mode refresh button, matching the existing PR mode behavior.

--- a/public/css/pr.css
+++ b/public/css/pr.css
@@ -501,16 +501,19 @@
 }
 
 /* Refresh button spinner animation */
-#refresh-pr .spinner-icon {
+#refresh-pr .spinner-icon,
+#local-refresh-btn .spinner-icon {
   display: none;
   animation: spin 1s linear infinite;
 }
 
-#refresh-pr.refreshing .refresh-icon {
+#refresh-pr.refreshing .refresh-icon,
+#local-refresh-btn.refreshing .refresh-icon {
   display: none !important;
 }
 
-#refresh-pr.refreshing .spinner-icon {
+#refresh-pr.refreshing .spinner-icon,
+#local-refresh-btn.refreshing .spinner-icon {
   display: inline-block !important;
 }
 

--- a/public/js/local.js
+++ b/public/js/local.js
@@ -657,7 +657,7 @@ class LocalManager {
     try {
       // Show loading state
       refreshBtn.disabled = true;
-      refreshBtn.classList.add('btn-loading');
+      refreshBtn.classList.add('refreshing');
 
       const response = await fetch(`/api/local/${this.reviewId}/refresh`, {
         method: 'POST'
@@ -708,7 +708,7 @@ class LocalManager {
       // Reset button state
       if (refreshBtn) {
         refreshBtn.disabled = false;
-        refreshBtn.classList.remove('btn-loading');
+        refreshBtn.classList.remove('refreshing');
       }
     }
   }

--- a/public/local.html
+++ b/public/local.html
@@ -309,8 +309,12 @@
             <div class="header-right">
                 <div class="header-icon-group">
                     <button class="btn btn-icon" id="local-refresh-btn" title="Refresh diff from directory">
-                        <svg viewBox="0 0 16 16" fill="currentColor" width="16" height="16">
+                        <svg class="refresh-icon" viewBox="0 0 16 16" fill="currentColor" width="16" height="16">
                             <path d="M1.705 8.005a.75.75 0 0 1 .834.656 5.5 5.5 0 0 0 9.592 2.97l-1.204-1.204a.25.25 0 0 1 .177-.427h3.646a.25.25 0 0 1 .25.25v3.646a.25.25 0 0 1-.427.177l-1.38-1.38A7.002 7.002 0 0 1 1.05 8.84a.75.75 0 0 1 .656-.834ZM8 2.5a5.487 5.487 0 0 0-4.131 1.869l1.204 1.204A.25.25 0 0 1 4.896 6H1.25A.25.25 0 0 1 1 5.75V2.104a.25.25 0 0 1 .427-.177l1.38 1.38A7.002 7.002 0 0 1 14.95 7.16a.75.75 0 1 1-1.49.178A5.5 5.5 0 0 0 8 2.5Z"/>
+                        </svg>
+                        <svg class="spinner-icon" viewBox="0 0 16 16" fill="currentColor" width="16" height="16">
+                            <path d="M8 0a8 8 0 1 1 0 16A8 8 0 0 1 8 0ZM1.5 8a6.5 6.5 0 1 0 13 0 6.5 6.5 0 0 0-13 0Z" opacity="0.25"/>
+                            <path d="M8 0a8 8 0 0 1 8 8h-2A6 6 0 0 0 8 2V0Z"/>
                         </svg>
                     </button>
                     <button class="btn btn-icon" id="theme-toggle" title="Toggle theme">

--- a/tests/unit/local-refresh-animation.test.js
+++ b/tests/unit/local-refresh-animation.test.js
@@ -1,0 +1,161 @@
+// Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+/**
+ * Unit tests for local mode refresh button animation.
+ *
+ * When refreshDiff is called, the refresh button should:
+ *   - Add the 'refreshing' class on start (which swaps in the spinner icon)
+ *   - Remove the 'refreshing' class on completion (success or error)
+ */
+
+global.STALE_TIMEOUT = 2000;
+
+const { PRManager } = require('../../public/js/pr.js');
+
+const mockFetch = vi.fn();
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.useFakeTimers();
+
+  global.fetch = mockFetch;
+
+  global.window = {
+    prManager: null,
+    location: { pathname: '/local/42' },
+    PAIR_REVIEW_LOCAL_MODE: true,
+    scrollTo: vi.fn(),
+    aiPanel: { showDismissedComments: false, setFileOrder: vi.fn(), setComments: vi.fn(), setAnalysisState: vi.fn(), setSummaryData: vi.fn() },
+    FileOrderUtils: { sortFilesByPath: vi.fn((f) => f), createFileOrderMap: vi.fn(() => new Map()) },
+    toast: { showSuccess: vi.fn(), showWarning: vi.fn(), showError: vi.fn(), showInfo: vi.fn() },
+    confirmDialog: null
+  };
+
+  global.document = {
+    getElementById: vi.fn(() => null),
+    querySelector: vi.fn(() => null),
+    querySelectorAll: vi.fn(() => []),
+    addEventListener: vi.fn()
+  };
+
+  global.alert = vi.fn();
+  global.AbortController = AbortController;
+  global.performance = { now: () => Date.now() };
+
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+  vi.spyOn(console, 'debug').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+const { LocalManager } = require('../../public/js/local.js');
+
+function createTestLocalManager() {
+  const lm = Object.create(LocalManager.prototype);
+  lm.reviewId = 42;
+  lm.localData = null;
+  lm.isInitialized = false;
+  return lm;
+}
+
+function createTestPRManager() {
+  const pm = Object.create(PRManager.prototype);
+  pm.currentPR = { id: 42, owner: 'local', repo: 'my-repo', number: 42, reviewType: 'local' };
+  pm.renderDiff = vi.fn();
+  pm._hideStaleBadge = vi.fn();
+  pm._stalenessPromise = null;
+  pm.loadUserComments = vi.fn().mockResolvedValue(undefined);
+  pm.loadAISuggestions = vi.fn().mockResolvedValue(undefined);
+  return pm;
+}
+
+function createMockRefreshBtn() {
+  const classes = new Set();
+  return {
+    disabled: false,
+    classList: {
+      add: vi.fn((cls) => classes.add(cls)),
+      remove: vi.fn((cls) => classes.delete(cls)),
+      contains: (cls) => classes.has(cls),
+      _classes: classes
+    }
+  };
+}
+
+describe('local refresh button animation', () => {
+  let lm, pm, mockBtn;
+
+  beforeEach(() => {
+    lm = createTestLocalManager();
+    pm = createTestPRManager();
+    mockBtn = createMockRefreshBtn();
+
+    global.window.prManager = pm;
+    global.document.getElementById = vi.fn((id) => {
+      if (id === 'local-refresh-btn') return mockBtn;
+      return null;
+    });
+  });
+
+  it('adds refreshing class before the fetch begins', async () => {
+    // Capture the button's class state at the moment fetch is called
+    let hadRefreshingDuringFetch = false;
+    mockFetch.mockImplementation(() => {
+      hadRefreshingDuringFetch = mockBtn.classList._classes.has('refreshing');
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ stats: {}, sessionChanged: false })
+      });
+    });
+    lm.loadLocalDiff = vi.fn().mockResolvedValue(undefined);
+
+    await lm.refreshDiff();
+
+    expect(hadRefreshingDuringFetch).toBe(true);
+  });
+
+  it('removes refreshing class after successful refresh', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ stats: {}, sessionChanged: false })
+    });
+    lm.loadLocalDiff = vi.fn().mockResolvedValue(undefined);
+
+    await lm.refreshDiff();
+
+    expect(mockBtn.classList.remove).toHaveBeenCalledWith('refreshing');
+    expect(mockBtn.classList._classes.has('refreshing')).toBe(false);
+  });
+
+  it('removes refreshing class after failed refresh', async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      json: () => Promise.resolve({ error: 'Server error' })
+    });
+
+    await lm.refreshDiff();
+
+    expect(mockBtn.classList.add).toHaveBeenCalledWith('refreshing');
+    expect(mockBtn.classList.remove).toHaveBeenCalledWith('refreshing');
+    expect(mockBtn.classList._classes.has('refreshing')).toBe(false);
+  });
+
+  it('does not use btn-loading class', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ stats: {}, sessionChanged: false })
+    });
+    lm.loadLocalDiff = vi.fn().mockResolvedValue(undefined);
+
+    await lm.refreshDiff();
+
+    expect(mockBtn.classList.add).not.toHaveBeenCalledWith('btn-loading');
+    expect(mockBtn.classList.remove).not.toHaveBeenCalledWith('btn-loading');
+  });
+});


### PR DESCRIPTION
## Summary

The local mode refresh button was missing the spinner animation that the PR mode refresh button has. Users clicking refresh in local mode had no visual feedback that the operation was in progress.

## Approach

- Added the spinner SVG icon (with `spinner-icon` class) to the `#local-refresh-btn` button in `local.html`, matching the markup pattern used by `#refresh-pr` in `pr.html`
- Extended the existing CSS spinner rules in `pr.css` to also target `#local-refresh-btn`, keeping the selectors grouped with the PR refresh button rules
- Changed the CSS class toggled in `local.js` from the non-functional `btn-loading` to `refreshing`, which is the class the CSS selectors actually use to swap between the refresh icon and the spinner icon

Co-authored-by: Claude <noreply@anthropic.com>
Orchestrated-by: ae <noreply@shopify.com>
