### PR TITLE
Add analysis-in-progress spinners to index page

### DIFF
--- a/.changeset/index-page-analysis-spinners.md
+++ b/.changeset/index-page-analysis-spinners.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": minor
+---
+
+Show analysis-in-progress spinners on the index page. Entries on the Pull Requests and Local Reviews tabs now display a rotating indicator when an AI analysis is running in the background, with real-time updates via WebSocket.

--- a/plans/index-page-analysis-spinners.md
+++ b/plans/index-page-analysis-spinners.md
@@ -1,0 +1,152 @@
+# Index Page Analysis Spinners
+
+## Context
+
+Users want to see when an AI analysis is running in the background for a review, directly from the index page. Currently, analysis status is only visible on the individual review page. This adds a pulsing indicator dot to entries on the Pull Requests and Local Reviews tabs when analysis is active.
+
+## Approach
+
+**Visual**: A small pulsing 8px amber dot (matching the existing `pulse-dot` animation style) prepended inside the title/name cell of each row. No extra table column.
+
+**Data flow**: New REST endpoint returns currently-active analyses from the in-memory `activeAnalyses` map. A new `index:analyses` WebSocket topic pushes start/end events for real-time updates. The frontend fetches on page load, subscribes to WS, and decorates matching rows.
+
+**Matching**: Use `reviewId` (from the `reviews` table) universally for both modes. For local rows, `data-session-id` already equals `reviews.id`. For PR rows, add a LEFT JOIN to the recent reviews query to include `reviews.id`, and expose it as a new `data-analysis-review-id` attribute. The active analyses endpoint returns `reviewId` which is `reviews.id` — one lookup works for both.
+
+---
+
+## Changes
+
+### 1. Backend: New `GET /api/analyses/active` endpoint
+
+**File**: `src/routes/analyses.js` (add before the parameterized `:id` routes at line ~305)
+
+Iterate `activeAnalyses` values, filter to `status === 'running'`, return lightweight projections:
+
+```json
+{
+  "active": [
+    { "analysisId": "uuid", "reviewId": 42, "reviewType": "pr", "repository": "owner/repo", "prNumber": 123 },
+    { "analysisId": "uuid2", "reviewId": 55, "reviewType": "local", "repository": "my-project" }
+  ]
+}
+```
+
+No DB access — purely from in-memory maps. Only include entries with `status === 'running'`.
+
+### 2. Backend: Broadcast on `index:analyses` topic
+
+**File**: `src/routes/shared.js`
+
+Add a `broadcastIndexAnalysisEvent(data)` helper that calls `ws.broadcast('index:analyses', data)`.
+
+**Where to call it** — centralize in `broadcastProgress`:
+- When broadcasting a status with `status === 'running'` for the first time for an analysisId, also emit `{ type: 'analysis_started', analysisId, reviewId, reviewType, repository, prNumber }` on the index topic. Track which analysisIds have been announced with a module-level Set.
+- When broadcasting a terminal status (`completed`/`failed`/`cancelled`), emit `{ type: 'analysis_ended', analysisId, reviewId, reviewType, repository, prNumber }` and remove from the tracking Set.
+
+This covers all analysis paths (single-model PR/local, council, executable, MCP) without modifying each individually.
+
+Export `broadcastIndexAnalysisEvent` from `shared.js`.
+
+### 3. Frontend: Load `ws-client.js` on index page
+
+**File**: `public/index.html` (before existing scripts at line 1433)
+
+Add: `<script src="/js/ws-client.js"></script>`
+
+### 4. Frontend: Spinner CSS
+
+**File**: `public/index.html` (inside existing `<style>` block)
+
+```css
+.index-analysis-spinner {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border: 2px solid var(--ai-primary);
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: index-spin 0.8s linear infinite;
+  margin-right: 6px;
+  vertical-align: middle;
+}
+@keyframes index-spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}
+```
+
+Matches the `.council-spinner` pattern from `pr.css` (rotating circle with amber border, transparent top). Uses existing `--ai-primary` CSS variable (already defined for both light/dark themes on index page). 12px size fits cleanly inline with row text.
+
+### 5. Backend: Add `reviews.id` to PR recent reviews query
+
+**File**: `src/routes/worktrees.js` — `GET /api/worktrees/recent` (line ~144)
+
+Add a LEFT JOIN to the `reviews` table to include the `reviews.id` for each PR entry:
+```sql
+LEFT JOIN reviews r ON r.pr_number = pm.pr_number
+  AND r.repository = pm.repository COLLATE NOCASE
+```
+Add `r.id as review_id` to the SELECT. Include `review_id` in the response objects (nullable — PR rows without a review record will have `null`).
+
+### 6. Frontend: Add `data-analysis-review-id` to PR rows
+
+**File**: `public/js/index.js` — `renderRecentReviewRow()` (line ~768)
+
+Add `data-analysis-review-id` to the `<tr>` tag using the new `review_id` field:
+```html
+<tr data-review-id="..." data-analysis-review-id="42">
+```
+Only render the attribute when `review.review_id` is non-null.
+
+### 7. Frontend: Analysis spinner logic
+
+**File**: `public/js/index.js` — new section at end of IIFE
+
+**7a.** `fetchAndApplyActiveAnalyses()`:
+- `GET /api/analyses/active`
+- For each active entry, find the matching row and add spinner
+- Remove spinners from rows no longer in the active set
+
+**7b.** Row finder — unified by `reviewId`:
+- Find `tr[data-analysis-review-id="${reviewId}"]` (PR rows)
+- OR `tr[data-session-id="${reviewId}"]` (local rows)
+- One selector covers both: `tr[data-analysis-review-id="${reviewId}"], tr[data-session-id="${reviewId}"]`
+
+**7c.** `addSpinnerToRow(row)` / `removeSpinnerFromRow(row)`:
+- Prepend/remove a `<span class="index-analysis-spinner">` in the title/name cell (`.col-title` for PR, `.col-local-name a` for local)
+- No-op if already present/absent
+
+**7d.** WebSocket subscription:
+- `window.wsClient.connect()` + `subscribe('index:analyses', handler)`
+- On `analysis_started`: find row, add spinner
+- On `analysis_ended`: find row, remove spinner
+
+**7e.** Hook into existing load functions:
+- Call `fetchAndApplyActiveAnalyses()` after `loadRecentReviews()` and `loadLocalReviews()` complete (and after pagination loads), since those rebuild the DOM
+- Also on `wsReconnected` event
+
+---
+
+## Hazards
+
+- **`broadcastProgress` has many callers**: All analysis paths call it. Centralizing the index broadcast inside it covers all paths, but verify each path calls `broadcastProgress` at least once with the initial `running` status and once with a terminal status. Confirmed: executable-analysis.js:195, pr.js:1700, local.js (equivalent), analyses.js:543 all call `broadcastProgress` on start, and their `.then()`/`.catch()` handlers all call it on completion.
+- **Row rebuilds destroy spinners**: `loadRecentReviews()` replaces container innerHTML. The re-fetch after each load handles this. WS events during the brief rebuild window gracefully no-op (row not found).
+- **`activeAnalyses` entries linger after completion**: Completed entries stay in the map with terminal status. The endpoint and WS logic must filter to `status === 'running'` only.
+- **PR row matching**: Uses `reviews.id` via LEFT JOIN in the worktrees query. If a PR has no `reviews` record, `review_id` is NULL and no spinner can appear — which is correct, since no analysis can run without a review record.
+- **Multiple reviews per PR**: The LEFT JOIN could match multiple `reviews` records if the same pr_number+repository combination exists in `reviews` more than once. Use a correlated subquery or `MAX(r.id)` to ensure at most one result row per `pr_metadata` entry.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `src/routes/analyses.js` | New `GET /api/analyses/active` endpoint |
+| `src/routes/shared.js` | `broadcastIndexAnalysisEvent()` + hook in `broadcastProgress()` |
+| `src/routes/worktrees.js` | LEFT JOIN `reviews` to include `review_id` in recent reviews response |
+| `public/index.html` | Add `ws-client.js` script tag + spinner CSS |
+| `public/js/index.js` | `data-analysis-review-id` on PR rows + spinner fetch/subscribe/decorate logic |
+
+## Testing
+
+- **Unit tests**: New `/api/analyses/active` endpoint with mocked `activeAnalyses` map (mixed running/completed statuses). Index broadcast emission from `broadcastProgress`.
+- **E2E test**: Start analysis, navigate to index, verify spinner appears; wait for completion, verify spinner disappears.
+- **Manual**: Open index page, trigger analysis from another tab, confirm spinner appears in real-time.

--- a/public/index.html
+++ b/public/index.html
@@ -685,6 +685,25 @@
             text-align: right;
         }
 
+        /* Analysis-in-progress spinner for index page rows */
+        .index-analysis-spinner {
+            display: inline-block;
+            width: 12px;
+            height: 12px;
+            border: 2px solid var(--ai-primary);
+            border-top-color: transparent;
+            border-radius: 50%;
+            animation: index-spin 0.8s linear infinite;
+            margin-right: 6px;
+            vertical-align: middle;
+            flex-shrink: 0;
+        }
+
+        @keyframes index-spin {
+            0% { transform: rotate(0deg); }
+            100% { transform: rotate(360deg); }
+        }
+
         .local-table .btn-repo-settings {
             margin-right: 4px;
         }
@@ -1430,6 +1449,7 @@
         </div>
     </div>
 
+    <script src="/js/ws-client.js"></script>
     <script src="/js/components/Toast.js"></script>
     <script src="/js/index.js"></script>
 </body>

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -553,6 +553,9 @@
       container.classList.remove('recent-reviews-loading');
       localReviewsPagination.loaded = true;
 
+      // Apply analysis-in-progress spinners to any rows with active analyses
+      fetchAndApplyActiveAnalyses();
+
     } catch (error) {
       console.error('Error loading local reviews:', error);
       container.innerHTML =
@@ -592,6 +595,9 @@
 
       tbody.insertAdjacentHTML('beforeend', data.sessions.map(renderLocalReviewRow).join(''));
       if (localSelection.active) localSelection.onRowsAdded();
+
+      // Apply analysis spinners to newly added rows
+      fetchAndApplyActiveAnalyses();
 
       localReviewsPagination.lastTimestamp = data.sessions[data.sessions.length - 1].updated_at;
       localReviewsPagination.hasMore = !!data.hasMore;
@@ -764,8 +770,10 @@
       ? '<a href="https://github.com/' + encodeURIComponent(review.author) + '" target="_blank" rel="noopener">' + escapeHtml(review.author) + '</a>'
       : '';
 
+    var reviewIdAttr = review.review_id ? ' data-analysis-review-id="' + review.review_id + '"' : '';
+
     return '' +
-      '<tr data-review-id="' + review.id + '">' +
+      '<tr data-review-id="' + review.id + '"' + reviewIdAttr + '>' +
         '<td class="col-repo">' + escapeHtml(review.repository) + '</td>' +
         '<td class="col-pr"><a href="' + link + '">#' + review.pr_number + '</a></td>' +
         '<td class="col-title" title="' + escapeHtml(review.pr_title) + '">' + escapeHtml(review.pr_title) + '</td>' +
@@ -927,6 +935,9 @@
       container.innerHTML = html;
       container.classList.remove('recent-reviews-loading');
 
+      // Apply analysis-in-progress spinners to any rows with active analyses
+      fetchAndApplyActiveAnalyses();
+
     } catch (error) {
       console.error('Error loading recent reviews:', error);
       container.innerHTML =
@@ -991,6 +1002,9 @@
       // Append new rows to the existing table body
       tbody.insertAdjacentHTML('beforeend', data.reviews.map(renderRecentReviewRow).join(''));
       if (prSelection.active) prSelection.onRowsAdded();
+
+      // Apply analysis spinners to newly added rows
+      fetchAndApplyActiveAnalyses();
 
       // Update pagination state - advance the cursor
       recentReviewsPagination.lastTimestamp = data.reviews[data.reviews.length - 1].last_accessed_at;
@@ -1923,5 +1937,108 @@
       setFormLoading('local', false);
     }
   });
+
+  // ─── Analysis-in-progress Spinners ──────────────────────────────────────────
+
+  /** Set of reviewIds (integers) that currently have a spinner on the page */
+  var activeSpinnerReviewIds = new Set();
+
+  /**
+   * Find a table row matching the given reviewId.
+   * Checks both PR rows (data-analysis-review-id) and local rows (data-session-id).
+   * @param {number} reviewId - The reviews.id to find
+   * @returns {HTMLElement|null}
+   */
+  function findRowByReviewId(reviewId) {
+    return document.querySelector(
+      'tr[data-analysis-review-id="' + reviewId + '"], tr[data-session-id="' + reviewId + '"]'
+    );
+  }
+
+  /**
+   * Add a spinner to the title/name cell of a row.
+   * @param {HTMLElement} row - The <tr> element
+   * @param {number} reviewId - The reviewId to track
+   */
+  function addSpinnerToRow(row, reviewId) {
+    if (row.querySelector('.index-analysis-spinner')) return;
+
+    var spinner = document.createElement('span');
+    spinner.className = 'index-analysis-spinner';
+    spinner.title = 'Analysis in progress';
+
+    // PR rows: prepend in .col-title; local rows: prepend in .col-local-name
+    var cell = row.querySelector('.col-title') || row.querySelector('.col-local-name');
+    if (cell) {
+      cell.insertBefore(spinner, cell.firstChild);
+    }
+    activeSpinnerReviewIds.add(reviewId);
+  }
+
+  /**
+   * Remove a spinner from a row.
+   * @param {HTMLElement} row - The <tr> element
+   * @param {number} reviewId - The reviewId to untrack
+   */
+  function removeSpinnerFromRow(row, reviewId) {
+    var spinner = row.querySelector('.index-analysis-spinner');
+    if (spinner) spinner.remove();
+    activeSpinnerReviewIds.delete(reviewId);
+  }
+
+  /**
+   * Fetch active analyses and apply/remove spinners to matching rows.
+   */
+  function fetchAndApplyActiveAnalyses() {
+    fetch('/api/analyses/active')
+      .then(function (res) { return res.json(); })
+      .then(function (data) {
+        if (!data.active) return;
+
+        var activeReviewIds = new Set();
+        data.active.forEach(function (entry) {
+          var rid = entry.reviewId;
+          if (rid == null) return;
+          activeReviewIds.add(rid);
+          var row = findRowByReviewId(rid);
+          if (row) addSpinnerToRow(row, rid);
+        });
+
+        // Remove spinners for analyses that are no longer active
+        activeSpinnerReviewIds.forEach(function (rid) {
+          if (!activeReviewIds.has(rid)) {
+            var row = findRowByReviewId(rid);
+            if (row) removeSpinnerFromRow(row, rid);
+            else activeSpinnerReviewIds.delete(rid);
+          }
+        });
+      })
+      .catch(function () { /* ignore — spinners are best-effort */ });
+  }
+
+  // Subscribe to real-time analysis events via WebSocket
+  if (window.wsClient) {
+    window.wsClient.connect();
+    window.wsClient.subscribe('index:analyses', function (msg) {
+      var reviewId = msg.reviewId;
+      if (reviewId == null) return;
+
+      if (msg.type === 'analysis_started') {
+        var row = findRowByReviewId(reviewId);
+        if (row) addSpinnerToRow(row, reviewId);
+      } else if (msg.type === 'analysis_ended') {
+        var endRow = findRowByReviewId(reviewId);
+        if (endRow) removeSpinnerFromRow(endRow, reviewId);
+        else activeSpinnerReviewIds.delete(reviewId);
+      }
+    });
+
+    // On reconnect, re-fetch active analyses to catch anything missed
+    window.addEventListener('wsReconnected', fetchAndApplyActiveAnalyses);
+  }
+
+  // Expose for use after data loads (loadRecentReviews / loadLocalReviews)
+  window.__pairReview = window.__pairReview || {};
+  window.__pairReview.refreshAnalysisSpinners = fetchAndApplyActiveAnalyses;
 
 })();

--- a/src/routes/analyses.js
+++ b/src/routes/analyses.js
@@ -300,6 +300,25 @@ router.post('/api/analyses/results', async (req, res) => {
   }
 });
 
+/**
+ * List currently active (running) analyses across all reviews.
+ * Returns lightweight projections from the in-memory activeAnalyses map.
+ */
+router.get('/api/analyses/active', (req, res) => {
+  const active = [];
+  for (const status of activeAnalyses.values()) {
+    if (status.status !== 'running') continue;
+    active.push({
+      analysisId: status.id,
+      reviewId: status.reviewId,
+      reviewType: status.reviewType || null,
+      repository: status.repository || null,
+      prNumber: status.prNumber || null
+    });
+  }
+  res.json({ active });
+});
+
 // ==========================================================================
 // Parameterised :id routes — registered AFTER static paths
 // ==========================================================================

--- a/src/routes/shared.js
+++ b/src/routes/shared.js
@@ -108,13 +108,50 @@ function determineCompletionInfo(result) {
   };
 }
 
+// Track which analysisIds have been announced on the index topic
+const _indexAnnouncedIds = new Set();
+
+/**
+ * Broadcast an analysis status change on the `index:analyses` topic
+ * so the index page can show/hide spinners in real time.
+ * @param {Object} data - Event data (type, analysisId, reviewId, etc.)
+ */
+function broadcastIndexAnalysisEvent(data) {
+  ws.broadcast('index:analyses', data);
+}
+
 /**
  * Broadcast progress update to all WebSocket clients subscribed to `analysis:{analysisId}`.
+ * Also emits index-level start/end events for the index page spinners.
  * @param {string} analysisId - Analysis ID
  * @param {Object} progressData - Progress data to broadcast
  */
 function broadcastProgress(analysisId, progressData) {
   ws.broadcast('analysis:' + analysisId, { type: 'progress', ...progressData });
+
+  // Emit index-level events for analysis lifecycle transitions
+  const status = progressData.status;
+  if (status === 'running' && !_indexAnnouncedIds.has(analysisId)) {
+    _indexAnnouncedIds.add(analysisId);
+    broadcastIndexAnalysisEvent({
+      type: 'analysis_started',
+      analysisId,
+      reviewId: progressData.reviewId,
+      reviewType: progressData.reviewType || null,
+      repository: progressData.repository || null,
+      prNumber: progressData.prNumber || null
+    });
+  } else if (['completed', 'failed', 'cancelled'].includes(status) && _indexAnnouncedIds.has(analysisId)) {
+    _indexAnnouncedIds.delete(analysisId);
+    broadcastIndexAnalysisEvent({
+      type: 'analysis_ended',
+      analysisId,
+      reviewId: progressData.reviewId,
+      reviewType: progressData.reviewType || null,
+      repository: progressData.repository || null,
+      prNumber: progressData.prNumber || null
+    });
+  }
 }
 
 /**
@@ -439,6 +476,8 @@ module.exports = {
   getModel,
   determineCompletionInfo,
   broadcastProgress,
+  broadcastIndexAnalysisEvent,
+  _indexAnnouncedIds,
   broadcastSetupProgress,
   registerProcess,
   killProcesses,

--- a/src/routes/worktrees.js
+++ b/src/routes/worktrees.js
@@ -154,7 +154,8 @@ router.get('/api/worktrees/recent', async (req, res) => {
         json_extract(pm.pr_data, '$.html_url') as html_url,
         w.id as worktree_id,
         w.path as worktree_path,
-        w.branch
+        w.branch,
+        (SELECT r.id FROM reviews r WHERE r.pr_number = pm.pr_number AND r.repository = pm.repository COLLATE NOCASE ORDER BY r.updated_at DESC LIMIT 1) as review_id
       FROM pr_metadata pm
       LEFT JOIN worktrees w ON pm.pr_number = w.pr_number AND pm.repository = w.repository COLLATE NOCASE
       WHERE pm.title IS NOT NULL AND pm.title != ''
@@ -195,7 +196,8 @@ router.get('/api/worktrees/recent', async (req, res) => {
         last_accessed_at: row.last_accessed_at,
         created_at: row.created_at,
         storage_status: storageStatus,
-        html_url: row.html_url || null
+        html_url: row.html_url || null,
+        review_id: row.review_id || null
       });
     }
 

--- a/tests/integration/analysis-results.test.js
+++ b/tests/integration/analysis-results.test.js
@@ -723,3 +723,101 @@ describe('POST /api/analyses/results', () => {
     expect(prPayload.type).toBe('review:analysis_completed');
   });
 });
+
+describe('GET /api/analyses/active', () => {
+  const { activeAnalyses } = require('../../src/routes/shared');
+  let db;
+  let app;
+
+  beforeEach(() => {
+    activeAnalyses.clear();
+    db = createTestDatabase();
+    app = createTestApp(db);
+  });
+
+  afterEach(() => {
+    activeAnalyses.clear();
+    if (db) closeTestDatabase(db);
+  });
+
+  it('should return empty array when no active analyses', async () => {
+    const res = await request(app).get('/api/analyses/active').expect(200);
+    expect(res.body.active).toEqual([]);
+  });
+
+  it('should return only running analyses', async () => {
+    activeAnalyses.set('running-1', {
+      id: 'running-1',
+      reviewId: 10,
+      reviewType: 'pr',
+      repository: 'owner/repo',
+      prNumber: 42,
+      status: 'running'
+    });
+    activeAnalyses.set('completed-1', {
+      id: 'completed-1',
+      reviewId: 20,
+      status: 'completed'
+    });
+    activeAnalyses.set('failed-1', {
+      id: 'failed-1',
+      reviewId: 30,
+      status: 'failed'
+    });
+
+    const res = await request(app).get('/api/analyses/active').expect(200);
+    expect(res.body.active).toHaveLength(1);
+    expect(res.body.active[0]).toEqual({
+      analysisId: 'running-1',
+      reviewId: 10,
+      reviewType: 'pr',
+      repository: 'owner/repo',
+      prNumber: 42
+    });
+  });
+
+  it('should return multiple running analyses', async () => {
+    activeAnalyses.set('pr-analysis', {
+      id: 'pr-analysis',
+      reviewId: 5,
+      reviewType: 'pr',
+      repository: 'org/project',
+      prNumber: 99,
+      status: 'running'
+    });
+    activeAnalyses.set('local-analysis', {
+      id: 'local-analysis',
+      reviewId: 8,
+      reviewType: 'local',
+      repository: 'my-project',
+      status: 'running'
+    });
+
+    const res = await request(app).get('/api/analyses/active').expect(200);
+    expect(res.body.active).toHaveLength(2);
+
+    const prEntry = res.body.active.find(a => a.reviewType === 'pr');
+    expect(prEntry.prNumber).toBe(99);
+
+    const localEntry = res.body.active.find(a => a.reviewType === 'local');
+    expect(localEntry.prNumber).toBeNull();
+  });
+
+  it('should handle missing optional fields gracefully', async () => {
+    activeAnalyses.set('minimal', {
+      id: 'minimal',
+      reviewId: 1,
+      status: 'running'
+    });
+
+    const res = await request(app).get('/api/analyses/active').expect(200);
+    expect(res.body.active).toHaveLength(1);
+    expect(res.body.active[0]).toEqual({
+      analysisId: 'minimal',
+      reviewId: 1,
+      reviewType: null,
+      repository: null,
+      prNumber: null
+    });
+  });
+});

--- a/tests/unit/shared.test.js
+++ b/tests/unit/shared.test.js
@@ -16,6 +16,7 @@ import {
   activeAnalyses,
   createProgressCallback,
   broadcastProgress,
+  _indexAnnouncedIds,
   parseEnabledLevels
 } from '../../src/routes/shared.js';
 
@@ -1511,5 +1512,114 @@ describe('parseEnabledLevels', () => {
       const result = parseEnabledLevels({ 1: true, 2: true, 3: true }, true);
       expect(result).toEqual({ 1: true, 2: true, 3: true });
     });
+  });
+});
+
+describe('broadcastProgress index:analyses integration', () => {
+  let broadcastSpy;
+
+  beforeEach(() => {
+    activeAnalyses.clear();
+    _indexAnnouncedIds.clear();
+    broadcastSpy = vi.spyOn(ws, 'broadcast').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    broadcastSpy.mockRestore();
+    activeAnalyses.clear();
+    _indexAnnouncedIds.clear();
+  });
+
+  it('should broadcast analysis_started on first running status', () => {
+    const analysisId = 'idx-test-1';
+    const status = {
+      id: analysisId,
+      reviewId: 42,
+      reviewType: 'pr',
+      repository: 'owner/repo',
+      prNumber: 123,
+      status: 'running'
+    };
+
+    broadcastProgress(analysisId, status);
+
+    const indexCalls = broadcastSpy.mock.calls.filter(c => c[0] === 'index:analyses');
+    expect(indexCalls).toHaveLength(1);
+    expect(indexCalls[0][1]).toEqual({
+      type: 'analysis_started',
+      analysisId,
+      reviewId: 42,
+      reviewType: 'pr',
+      repository: 'owner/repo',
+      prNumber: 123
+    });
+    expect(_indexAnnouncedIds.has(analysisId)).toBe(true);
+  });
+
+  it('should not broadcast analysis_started twice for same analysisId', () => {
+    const analysisId = 'idx-test-2';
+    const status = { id: analysisId, reviewId: 10, status: 'running' };
+
+    broadcastProgress(analysisId, status);
+    broadcastProgress(analysisId, status);
+
+    const indexCalls = broadcastSpy.mock.calls.filter(c => c[0] === 'index:analyses');
+    expect(indexCalls).toHaveLength(1);
+  });
+
+  it('should broadcast analysis_ended on completed status', () => {
+    const analysisId = 'idx-test-3';
+
+    // First announce start
+    broadcastProgress(analysisId, { status: 'running', reviewId: 5, reviewType: 'local' });
+    broadcastSpy.mockClear();
+
+    // Then complete
+    broadcastProgress(analysisId, { status: 'completed', reviewId: 5, reviewType: 'local' });
+
+    const indexCalls = broadcastSpy.mock.calls.filter(c => c[0] === 'index:analyses');
+    expect(indexCalls).toHaveLength(1);
+    expect(indexCalls[0][1]).toEqual({
+      type: 'analysis_ended',
+      analysisId,
+      reviewId: 5,
+      reviewType: 'local',
+      repository: null,
+      prNumber: null
+    });
+    expect(_indexAnnouncedIds.has(analysisId)).toBe(false);
+  });
+
+  it('should broadcast analysis_ended on failed status', () => {
+    const analysisId = 'idx-test-4';
+
+    broadcastProgress(analysisId, { status: 'running', reviewId: 7 });
+    broadcastSpy.mockClear();
+
+    broadcastProgress(analysisId, { status: 'failed', reviewId: 7 });
+
+    const indexCalls = broadcastSpy.mock.calls.filter(c => c[0] === 'index:analyses');
+    expect(indexCalls).toHaveLength(1);
+    expect(indexCalls[0][1].type).toBe('analysis_ended');
+  });
+
+  it('should broadcast analysis_ended on cancelled status', () => {
+    const analysisId = 'idx-test-5';
+
+    broadcastProgress(analysisId, { status: 'running', reviewId: 8 });
+    broadcastSpy.mockClear();
+
+    broadcastProgress(analysisId, { status: 'cancelled', reviewId: 8 });
+
+    const indexCalls = broadcastSpy.mock.calls.filter(c => c[0] === 'index:analyses');
+    expect(indexCalls).toHaveLength(1);
+    expect(indexCalls[0][1].type).toBe('analysis_ended');
+  });
+
+  it('should not broadcast analysis_ended if never announced', () => {
+    broadcastProgress('never-started', { status: 'completed', reviewId: 1 });
+
+    const indexCalls = broadcastSpy.mock.calls.filter(c => c[0] === 'index:analyses');
+    expect(indexCalls).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## Summary
- Show a rotating spinner on Pull Requests and Local Reviews tab entries when an AI analysis is running in the background
- New `GET /api/analyses/active` endpoint returns currently-running analyses from the in-memory map
- WebSocket broadcasts on the `index:analyses` topic push real-time start/end events to the index page
- Frontend subscribes to WS events and decorates matching rows, with re-application after data loads and pagination

## Test plan
- [x] Unit tests for `broadcastProgress` index broadcast integration (6 new tests)
- [x] Integration tests for `GET /api/analyses/active` endpoint (4 new tests)
- [x] Full test suite passes (5404 unit/integration tests)
- [x] E2E tests pass (268 passed, 1 pre-existing skip)
- [ ] Manual: open index page, trigger analysis from another tab, confirm spinner appears in real-time
- [ ] Manual: confirm spinner disappears when analysis completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)