### PR TITLE
Add diff_path support for executable providers

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -208,10 +208,12 @@
         "title": "--title",
         "description": "--description",
         "output_dir": "--output-dir",
+        "diff_path": "--diff-path",
         "head_sha": "--sha",
         "model": "--model",
         "head_branch": "--branch"
       },
+      "diff_args": [],
       "output_glob": "**/results.json",
       "mapping_instructions": "The tool outputs JSON with a 'findings' array and a 'summary' string. Each finding has: category (bug/style/perf), priority (high/medium/low), title, body, fix, path, start_line, end_line. Map path to file, body to description, fix to suggestion. Map priority to severity: high=critical, medium=medium, low=minor. Map confidence: high=0.9, medium=0.7, low=0.4.",
       "env": {},

--- a/plans/executable-diff-path.md
+++ b/plans/executable-diff-path.md
@@ -1,0 +1,102 @@
+# Executable Provider: `--diff-path` Integration
+
+## Context
+
+The executable provider currently passes `--base <branch>` so the external tool generates its own diff. This creates a mismatch — pair-review has a well-defined review scope (especially in local mode with branch/staged/unstaged/untracked), but the external tool computes its own diff independently. By generating the diff ourselves and passing it via `--diff-path <temp-file>`, we ensure the external tool reviews exactly what pair-review is showing.
+
+Additionally, we add `--title`/`--description` to the user's local config so PR metadata flows to the external tool when available.
+
+## Changes
+
+### 1. Config: `.pair-review/config.local.json`
+
+Update `context_args` — replace `base_branch`→`--base` with `diff_path`→`--diff-path`, add `title`→`--title` and `description`→`--description`:
+
+```json
+"context_args": {
+  "model": "--model",
+  "output_dir": "--output-dir",
+  "diff_path": "--diff-path",
+  "title": "--title",
+  "description": "--description"
+}
+```
+
+Title/description already exist in the executable context from `buildContext` callbacks (PR mode sets from metadata, local mode sets `null`). `_buildArgs` skips `null` values, so local mode omits these flags automatically.
+
+### 2. Add `diffArgs` property: `src/ai/executable-provider.js`
+
+In `ExecProvider` constructor (~line 131), add:
+```js
+this.diffArgs = config.diff_args || [];
+```
+
+This stores per-provider extra git diff flags (e.g. `["--unified=10", "-w"]`) for the diff generation step.
+
+### 3. Add scope fields to local `buildContext`: `src/routes/local.js`
+
+In `handleExecutableAnalysis`'s `buildContext` callback (line 1003), add:
+```js
+scopeStart: r.local_scope_start || DEFAULT_SCOPE.start,
+scopeEnd: r.local_scope_end || DEFAULT_SCOPE.end,
+```
+
+These are consumed internally by diff generation — they're not in `context_args` so `_buildArgs` ignores them.
+
+### 4. Parameterize `generateScopedDiff`: `src/local-review.js`
+
+Add `options.contextLines` (default `25`, backward-compatible) and `options.extraArgs` (default `[]`). Replace the 6 hardcoded `--unified=25` strings with the configurable value. Do NOT apply `extraArgs` to `generateUntrackedDiffs` calls (`--no-index` invocations are structurally different).
+
+### 5. Diff generation + wiring: `src/routes/executable-analysis.js`
+
+Add `generateDiffForExecutable(cwd, context, diffArgs, outputPath)`:
+- **PR mode** (has `baseSha` + `headSha`): `git diff ${GIT_DIFF_FLAGS} ${diffArgs} baseSha...headSha`
+- **Local mode** (has `scopeStart` + `scopeEnd`): call `generateScopedDiff(cwd, scopeStart, scopeEnd, baseBranch, { contextLines: 3, extraArgs: diffArgs })`
+- Writes diff to `outputPath`
+
+In `runExecutableAnalysis`, after `buildContext` and before `provider.execute()`:
+```js
+const diffPath = path.join(tmpDir, 'review.diff');
+await generateDiffForExecutable(cwd, executableContext, provider.diffArgs || [], diffPath);
+executableContext.diffPath = diffPath;
+```
+
+Graceful degradation: if diff generation fails, log a warning and continue without `--diff-path`. Temp file lives in `tmpDir` — cleaned up by existing `finally` block.
+
+New imports: `generateScopedDiff` from `../local-review` (no circular dependency — verified).
+
+### 6. Update example config: `config.example.json`
+
+Add `diff_path` to `context_args` and add `diff_args` field:
+```json
+"context_args": {
+  "title": "--title",
+  "description": "--description",
+  "output_dir": "--output-dir",
+  "diff_path": "--diff-path",
+  "head_sha": "--sha",
+  "model": "--model",
+  "head_branch": "--branch"
+},
+"diff_args": []
+```
+
+### 7. Tests
+
+- **`executable-provider.test.js`**: `diffArgs` stored from config, defaults to `[]`
+- **`executable-analysis` tests**: `generateDiffForExecutable` — PR mode calls git diff with correct args; local mode calls `generateScopedDiff` with `contextLines: 3`; writes to output path; `diffArgs` appended to commands
+- **`local-review.test.js`**: `contextLines` option changes `--unified` flag; `extraArgs` appended; defaults preserve existing `--unified=25` behavior
+
+## Hazards
+
+- **`generateScopedDiff` callers**: ~7 callers in `local.js` + 2 in `local-review.js`. The defaults (`contextLines: 25`, `extraArgs: []`) preserve existing behavior exactly.
+- **`generateScopedDiff` uses `execSync`**: Acceptable since the async IIFE has already sent the HTTP response.
+- **`baseBranch` remains in context** for local mode (needed by `generateScopedDiff` to compute merge-base) — just no longer in `context_args`.
+- **PR mode has no scope fields**: `baseSha && headSha` check takes precedence in `generateDiffForExecutable`.
+
+## Verification
+
+1. Run unit tests: `npm test`
+2. Manual: start a local review, trigger executable analysis → verify `--diff-path` appears in the spawned command args and the temp file contains the scoped diff
+3. Manual: start a PR review, trigger executable analysis → verify `--diff-path` with base...head diff, `--title`, `--description` in args
+4. Run E2E tests: `npm run test:e2e`

--- a/src/ai/analyzer.js
+++ b/src/ai/analyzer.js
@@ -25,6 +25,7 @@ const { AnalysisRunRepository, CommentRepository } = require('../database');
 const { mergeInstructions } = require('../utils/instructions');
 const { GitWorktreeManager } = require('../git/worktree');
 const { buildSparseCheckoutGuidance } = require('./prompts/sparse-checkout-guidance');
+const { generateDiffForExecutable } = require('../routes/executable-analysis');
 
 
 // GIT_DIFF_FLAGS imported from ../git/diff-flags
@@ -134,8 +135,28 @@ async function runExecutableVoice(voiceProvider, reviewId, worktreePath, prMetad
       headSha: prMetadata.head_sha || null,
       baseBranch: prMetadata.base_branch || null,
       headBranch: prMetadata.head_branch || null,
+      scopeStart: prMetadata.scopeStart || null,
+      scopeEnd: prMetadata.scopeEnd || null,
       customInstructions: requestInstructions || null,
     };
+
+    // Generate scoped diff file when provider expects diff_path
+    if (voiceProvider.contextArgs?.diff_path) {
+      const diffPath = path.join(tmpDir, 'review.diff');
+      try {
+        await generateDiffForExecutable(
+          worktreePath,
+          executableContext,
+          voiceProvider.diffArgs || [],
+          diffPath
+        );
+        executableContext.diffPath = diffPath;
+      } catch (diffError) {
+        logger.warn(
+          `${logPrefix || ''}Failed to generate diff for executable voice: ${diffError.message} — continuing without diff`
+        );
+      }
+    }
 
     // Emit initial running status (non-stream) so the progress modal
     // populates exec.voices[voiceId] and transitions from Pending to Running

--- a/src/ai/executable-provider.js
+++ b/src/ai/executable-provider.js
@@ -129,6 +129,7 @@ function createExecutableProviderClass(id, config) {
         ...(configOverrides.extra_args || [])
       ];
       this.contextArgs = config.context_args || {};
+      this.diffArgs = config.diff_args || [];
       this.outputGlob = config.output_glob || '**/results.json';
       this.mappingInstructions = config.mapping_instructions || '';
       this.timeout = config.timeout || 600000; // Default 10 minutes

--- a/src/local-review.js
+++ b/src/local-review.js
@@ -394,9 +394,11 @@ async function findMergeBase(repoPath, baseBranch) {
  * @param {string} repoPath - Path to the git repository
  * @param {Array} untrackedFiles - Array from getUntrackedFiles()
  * @param {string} wFlag - Whitespace flag (e.g. ' -w' or '')
+ * @param {string} [contextFlag=''] - Unified context flag (e.g. ' --unified=3')
+ * @param {string} [extraArgsStr=''] - Additional git diff flags (e.g. ' --patience')
  * @returns {string} Combined diff text for untracked files
  */
-function generateUntrackedDiffs(repoPath, untrackedFiles, wFlag) {
+function generateUntrackedDiffs(repoPath, untrackedFiles, wFlag, contextFlag = '', extraArgsStr = '') {
   let diff = '';
   for (const untracked of untrackedFiles) {
     if (!untracked.skipped) {
@@ -404,7 +406,7 @@ function generateUntrackedDiffs(repoPath, untrackedFiles, wFlag) {
         const filePath = path.join(repoPath, untracked.file);
         let fileDiff;
         try {
-          fileDiff = execSync(`git diff --no-index ${GIT_DIFF_FLAGS}${wFlag} -- /dev/null "${filePath}"`, {
+          fileDiff = execSync(`git diff --no-index ${GIT_DIFF_FLAGS}${contextFlag}${extraArgsStr}${wFlag} -- /dev/null "${filePath}"`, {
             cwd: repoPath,
             encoding: 'utf8',
             stdio: ['pipe', 'pipe', 'pipe'],
@@ -450,10 +452,14 @@ function generateUntrackedDiffs(repoPath, untrackedFiles, wFlag) {
  * @param {string} [baseBranch] - Base branch name (required when branch is in scope)
  * @param {Object} [options]
  * @param {boolean} [options.hideWhitespace] - Whether to hide whitespace changes
+ * @param {number} [options.contextLines=25] - Number of unified context lines (--unified=N). Defaults to 25.
+ * @param {string[]} [options.extraArgs=[]] - Additional git diff flags appended to each diff command
  * @returns {Promise<{diff: string, stats: Object, mergeBaseSha: string|null}>}
  */
 async function generateScopedDiff(repoPath, scopeStart, scopeEnd, baseBranch, options = {}) {
   const wFlag = options.hideWhitespace ? ' -w' : '';
+  const contextFlag = ` --unified=${options.contextLines ?? 25}`;
+  const extraArgsStr = (options.extraArgs || []).length > 0 ? ' ' + options.extraArgs.join(' ') : '';
   const stats = {
     trackedChanges: 0,
     untrackedFiles: 0,
@@ -481,37 +487,37 @@ async function generateScopedDiff(repoPath, scopeStart, scopeEnd, baseBranch, op
   try {
     if (hasBranch && !hasStaged && !hasUnstaged) {
       // Branch only → committed changes since merge-base
-      diff = execSync(`git diff ${mergeBaseSha}..HEAD ${GIT_DIFF_FLAGS} --unified=25${wFlag}`, {
+      diff = execSync(`git diff ${mergeBaseSha}..HEAD ${GIT_DIFF_FLAGS}${contextFlag}${extraArgsStr}${wFlag}`, {
         cwd: repoPath, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'],
         maxBuffer: 50 * 1024 * 1024
       });
     } else if (hasBranch && hasStaged && !hasUnstaged) {
       // Branch–Staged → staged changes relative to merge-base
-      diff = execSync(`git diff --cached ${mergeBaseSha} ${GIT_DIFF_FLAGS} --unified=25${wFlag}`, {
+      diff = execSync(`git diff --cached ${mergeBaseSha} ${GIT_DIFF_FLAGS}${contextFlag}${extraArgsStr}${wFlag}`, {
         cwd: repoPath, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'],
         maxBuffer: 50 * 1024 * 1024
       });
     } else if (hasBranch && hasUnstaged) {
       // Branch–Unstaged (or Branch–Untracked) → working tree vs merge-base
-      diff = execSync(`git diff ${mergeBaseSha} ${GIT_DIFF_FLAGS} --unified=25${wFlag}`, {
+      diff = execSync(`git diff ${mergeBaseSha} ${GIT_DIFF_FLAGS}${contextFlag}${extraArgsStr}${wFlag}`, {
         cwd: repoPath, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'],
         maxBuffer: 50 * 1024 * 1024
       });
     } else if (hasStaged && !hasUnstaged) {
       // Staged only → cached changes
-      diff = execSync(`git diff --cached ${GIT_DIFF_FLAGS} --unified=25${wFlag}`, {
+      diff = execSync(`git diff --cached ${GIT_DIFF_FLAGS}${contextFlag}${extraArgsStr}${wFlag}`, {
         cwd: repoPath, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'],
         maxBuffer: 50 * 1024 * 1024
       });
     } else if (hasStaged && hasUnstaged) {
       // Staged–Unstaged (or Staged–Untracked) → all changes vs HEAD
-      diff = execSync(`git diff HEAD ${GIT_DIFF_FLAGS} --unified=25${wFlag}`, {
+      diff = execSync(`git diff HEAD ${GIT_DIFF_FLAGS}${contextFlag}${extraArgsStr}${wFlag}`, {
         cwd: repoPath, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'],
         maxBuffer: 50 * 1024 * 1024
       });
     } else if (hasUnstaged) {
       // Unstaged only or Unstaged–Untracked → working tree changes
-      diff = execSync(`git diff ${GIT_DIFF_FLAGS} --unified=25${wFlag}`, {
+      diff = execSync(`git diff ${GIT_DIFF_FLAGS}${contextFlag}${extraArgsStr}${wFlag}`, {
         cwd: repoPath, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'],
         maxBuffer: 50 * 1024 * 1024
       });
@@ -555,7 +561,7 @@ async function generateScopedDiff(repoPath, scopeStart, scopeEnd, baseBranch, op
     const untrackedFiles = await getUntrackedFiles(repoPath);
     stats.untrackedFiles = untrackedFiles.length;
 
-    const untrackedDiff = generateUntrackedDiffs(repoPath, untrackedFiles, wFlag);
+    const untrackedDiff = generateUntrackedDiffs(repoPath, untrackedFiles, wFlag, contextFlag, extraArgsStr);
     if (untrackedDiff) {
       if (diff) diff += '\n';
       diff += untrackedDiff;

--- a/src/routes/executable-analysis.js
+++ b/src/routes/executable-analysis.js
@@ -28,34 +28,128 @@ const { buildAnalysisStartedPayload, buildAnalysisCompletedPayload, getCachedUse
 const { normalizePath, resolveRenamedFile } = require('../utils/paths');
 const { buildFileLineCountMap, validateSuggestionLineNumbers } = require('../utils/line-validation');
 const { GIT_DIFF_FLAGS } = require('../git/diff-flags');
+const { generateScopedDiff, findMergeBase } = require('../local-review');
+const { scopeIncludes } = require('../local-scope');
+
+/**
+ * Generate a diff for the executable provider and write it to a file.
+ *
+ * Local mode: scope-aware diff via generateScopedDiff (checked first).
+ * PR mode: uses baseSha...headSha (three-dot merge-base diff).
+ *
+ * Uses GIT_DIFF_FLAGS for normalized output and git-default context (3 lines).
+ * Additional flags can be passed via diffArgs (from provider config.diff_args).
+ *
+ * @param {string} cwd - Working directory (repo path)
+ * @param {Object} context - Executable context
+ * @param {string|null} context.baseSha - Base SHA (PR mode)
+ * @param {string|null} context.headSha - Head SHA (PR mode)
+ * @param {string|null} context.scopeStart - Scope start stop (local mode)
+ * @param {string|null} context.scopeEnd - Scope end stop (local mode)
+ * @param {string|null} context.baseBranch - Base branch (local mode, for merge-base)
+ * @param {string[]} diffArgs - Extra git diff flags from provider config
+ * @param {string} outputPath - Path to write the diff file
+ * @returns {Promise<string>} The diff content
+ */
+async function generateDiffForExecutable(cwd, context, diffArgs, outputPath) {
+  let diff;
+  const extraFlags = diffArgs.length > 0 ? ' ' + diffArgs.join(' ') : '';
+
+  if (context.scopeStart && context.scopeEnd) {
+    // Local mode: scope-aware diff generation
+    // Note: diffArgs are passed as extraArgs to generateScopedDiff, which handles
+    // appending them to the git diff command internally (extraFlags is not used here).
+    const result = await generateScopedDiff(
+      cwd,
+      context.scopeStart,
+      context.scopeEnd,
+      context.baseBranch || null,
+      { contextLines: 3, extraArgs: diffArgs }
+    );
+    diff = result.diff;
+  } else if (context.baseSha && context.headSha) {
+    // PR mode: straightforward base...head diff
+    const { stdout } = await execPromise(
+      `git diff ${GIT_DIFF_FLAGS}${extraFlags} ${context.baseSha}...${context.headSha}`,
+      { cwd, maxBuffer: 50 * 1024 * 1024 }
+    );
+    diff = stdout;
+  } else {
+    // Fallback: simple working-tree diff
+    const { stdout } = await execPromise(
+      `git diff ${GIT_DIFF_FLAGS}${extraFlags}`,
+      { cwd, maxBuffer: 50 * 1024 * 1024 }
+    );
+    diff = stdout;
+  }
+
+  await fsPromises.writeFile(outputPath, diff || '', 'utf-8');
+  return diff;
+}
 
 /**
  * Get the list of changed files from git for suggestion validation.
- * PR mode uses base...head diff; local mode uses unstaged + untracked + staged.
+ * PR mode uses base...head diff.
+ * Local mode is scope-aware: only includes files from the scope stops
+ * (branch, staged, unstaged, untracked) that were included in the diff.
  * @param {string} cwd - Working directory
- * @param {Object} context - Executable context with baseSha/headSha
+ * @param {Object} context - Executable context with baseSha/headSha or scope fields
  * @returns {Promise<string[]>} Changed file paths
  */
 async function getChangedFiles(cwd, context) {
   try {
-    if (context.baseSha && context.headSha) {
+    // Scope-aware file list checked first — when both scope and SHA fields
+    // are present, scope is the more specific intent.
+    const { scopeStart, scopeEnd, baseBranch } = context;
+    const commands = [];
+
+    if (scopeStart && scopeEnd) {
+      const hasBranch = scopeIncludes(scopeStart, scopeEnd, 'branch');
+      const hasStaged = scopeIncludes(scopeStart, scopeEnd, 'staged');
+      const hasUnstaged = scopeIncludes(scopeStart, scopeEnd, 'unstaged');
+      const hasUntracked = scopeIncludes(scopeStart, scopeEnd, 'untracked');
+
+      if (hasBranch && baseBranch) {
+        const mergeBase = await findMergeBase(cwd, baseBranch);
+        commands.push(
+          execPromise(`git diff ${GIT_DIFF_FLAGS} ${mergeBase}..HEAD --name-only`, { cwd }).then(r => r.stdout)
+        );
+      }
+      if (hasStaged) {
+        commands.push(
+          execPromise(`git diff ${GIT_DIFF_FLAGS} --cached --name-only`, { cwd }).then(r => r.stdout)
+        );
+      }
+      if (hasUnstaged) {
+        commands.push(
+          execPromise(`git diff ${GIT_DIFF_FLAGS} --name-only`, { cwd }).then(r => r.stdout)
+        );
+      }
+      if (hasUntracked) {
+        commands.push(
+          execPromise('git ls-files --others --exclude-standard', { cwd }).then(r => r.stdout)
+        );
+      }
+    } else if (context.baseSha && context.headSha) {
+      // PR mode: straightforward base...head diff
       const { stdout } = await execPromise(
         `git diff ${GIT_DIFF_FLAGS} ${context.baseSha}...${context.headSha} --name-only`,
         { cwd }
       );
       return stdout.trim().split('\n').filter(f => f.length > 0);
+    } else {
+      // Fallback: no scope info — include unstaged + untracked + staged
+      commands.push(
+        execPromise(`git diff ${GIT_DIFF_FLAGS} --name-only`, { cwd }).then(r => r.stdout),
+        execPromise('git ls-files --others --exclude-standard', { cwd }).then(r => r.stdout),
+        execPromise(`git diff ${GIT_DIFF_FLAGS} --cached --name-only`, { cwd }).then(r => r.stdout)
+      );
     }
-    // Local mode: unstaged + untracked + staged
-    const [unstaged, untracked, staged] = await Promise.all([
-      execPromise(`git diff ${GIT_DIFF_FLAGS} --name-only`, { cwd }).then(r => r.stdout),
-      execPromise('git ls-files --others --exclude-standard', { cwd }).then(r => r.stdout),
-      execPromise(`git diff ${GIT_DIFF_FLAGS} --cached --name-only`, { cwd }).then(r => r.stdout)
-    ]);
-    const all = [
-      ...unstaged.trim().split('\n'),
-      ...untracked.trim().split('\n'),
-      ...staged.trim().split('\n')
-    ].filter(f => f.length > 0);
+
+    const results = await Promise.all(commands);
+    const all = results
+      .flatMap(output => output.trim().split('\n'))
+      .filter(f => f.length > 0);
     return [...new Set(all)];
   } catch (error) {
     logger.warn(`Could not get changed files list: ${error.message}`);
@@ -230,11 +324,25 @@ async function runExecutableAnalysis(req, res, params, shared, callbacks) {
       };
       const cwd = executableContext.cwd || process.cwd();
 
+      // Only generate a diff file when the provider's context_args maps diff_path to a CLI flag
+      if (provider.contextArgs?.diff_path) {
+        const diffPath = path.join(tmpDir, 'review.diff');
+        try {
+          await generateDiffForExecutable(cwd, executableContext, provider.diffArgs || [], diffPath);
+          executableContext.diffPath = diffPath;
+        } catch (diffError) {
+          logger.warn(`Failed to generate diff for executable: ${diffError.message} — continuing without diff`);
+        }
+      }
+
       logger.section(`Executable Provider Analysis - ${logLabel}`);
       logger.log('API', `Provider: ${selectedProvider}`, 'cyan');
       logger.log('API', `Model: ${selectedModel}`, 'cyan');
       logger.log('API', `Working dir: ${cwd}`, 'magenta');
       logger.log('API', `Output dir: ${tmpDir}`, 'magenta');
+      if (executableContext.diffPath) {
+        logger.log('API', `Diff file: ${executableContext.diffPath}`, 'magenta');
+      }
 
       // Throttled stream event handler — avoids flooding WebSocket
       let lastBroadcastTime = 0;
@@ -383,4 +491,4 @@ async function runExecutableAnalysis(req, res, params, shared, callbacks) {
   })();
 }
 
-module.exports = { runExecutableAnalysis };
+module.exports = { runExecutableAnalysis, generateDiffForExecutable, getChangedFiles };

--- a/src/routes/local.js
+++ b/src/routes/local.js
@@ -34,7 +34,7 @@ const { TIERS, TIER_ALIASES, VALID_TIERS, resolveTier } = require('../ai/prompts
 const { getProviderClass, createProvider } = require('../ai/provider');
 const { getDefaultBranch } = require('../git/base-branch');
 const { CommentRepository } = require('../database');
-const { runExecutableAnalysis } = require('./executable-analysis');
+const { runExecutableAnalysis, getChangedFiles } = require('./executable-analysis');
 const {
   activeAnalyses,
   localReviewDiffs,
@@ -69,6 +69,26 @@ function setLocalReviewDiff(reviewId, value) {
 }
 function deleteLocalReviewDiff(reviewId) {
   localReviewDiffs.delete(toIntKey(reviewId));
+}
+
+/**
+ * Guard: reject the request if the review's scope resolves to zero changed files.
+ * Returns true if the guard fired (response already sent), false otherwise.
+ */
+async function rejectIfEmptyScope(res, review, localPath) {
+  const scopeContext = {
+    scopeStart: review.local_scope_start || DEFAULT_SCOPE.start,
+    scopeEnd: review.local_scope_end || DEFAULT_SCOPE.end,
+    baseBranch: review.local_base_branch || null,
+  };
+  const changedFiles = await getChangedFiles(localPath, scopeContext);
+  if (changedFiles.length === 0) {
+    res.status(409).json({
+      error: 'No changes found in the selected scope. Check that your scope includes files with modifications, or adjust the scope range.'
+    });
+    return true;
+  }
+  return false;
 }
 
 /**
@@ -1009,6 +1029,8 @@ async function handleExecutableAnalysis(req, res, {
       headSha: r.local_head_sha || null,
       baseBranch: r.local_base_branch || null,
       headBranch: r.local_head_branch || null,
+      scopeStart: r.local_scope_start || DEFAULT_SCOPE.start,
+      scopeEnd: r.local_scope_end || DEFAULT_SCOPE.end,
       customInstructions: customInstructions || null
     }),
     buildHookPayload: () => ({
@@ -1071,6 +1093,9 @@ router.post('/api/local/:reviewId/analyses', async (req, res) => {
 
     const localPath = review.local_path;
     const repository = review.repository;
+
+    // Guard: reject if scope resolves to zero changed files
+    if (await rejectIfEmptyScope(res, review, localPath)) return;
 
     // Fetch repo settings for default instructions
     const repoSettingsRepo = new RepoSettingsRepository(db);
@@ -1971,6 +1996,9 @@ router.post('/api/local/:reviewId/analyses/council', async (req, res) => {
 
     const localPath = review.local_path;
 
+    // Guard: reject if scope resolves to zero changed files
+    if (await rejectIfEmptyScope(res, review, localPath)) return;
+
     const councilScopeStart = review.local_scope_start || DEFAULT_SCOPE.start;
     const councilScopeEnd = review.local_scope_end || DEFAULT_SCOPE.end;
     const councilHasBranch = includesBranch(councilScopeStart);
@@ -1993,7 +2021,9 @@ router.post('/api/local/:reviewId/analyses/council', async (req, res) => {
       base_sha: analysisBaseSha,
       head_sha: review.local_head_sha,
       base_branch: review.local_base_branch || null,
-      head_branch: review.local_head_branch || null
+      head_branch: review.local_head_branch || null,
+      scopeStart: councilScopeStart,
+      scopeEnd: councilScopeEnd,
     };
 
     const analyzer = new Analyzer(db, 'council', 'council');

--- a/tests/integration/council-analysis-validation.test.js
+++ b/tests/integration/council-analysis-validation.test.js
@@ -30,8 +30,12 @@ vi.mock('../../src/git/gitattributes', () => ({
 
 vi.mock('../../src/local-review', () => ({
   generateScopedDiff: vi.fn().mockResolvedValue({ diff: '', stats: {}, mergeBaseSha: null }),
-  computeScopedDigest: vi.fn().mockResolvedValue('abc123')
+  computeScopedDigest: vi.fn().mockResolvedValue('abc123'),
+  findMergeBase: vi.fn().mockResolvedValue('abc123')
 }));
+
+const executableAnalysis = require('../../src/routes/executable-analysis');
+vi.spyOn(executableAnalysis, 'getChangedFiles').mockResolvedValue(['mock-file.js']);
 
 const { GitWorktreeManager } = require('../../src/git/worktree');
 vi.spyOn(GitWorktreeManager.prototype, 'worktreeExists').mockResolvedValue(true);

--- a/tests/unit/executable-analysis.test.js
+++ b/tests/unit/executable-analysis.test.js
@@ -1,0 +1,521 @@
+// Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+/**
+ * Unit tests for generateDiffForExecutable in executable-analysis.js
+ *
+ * Note: child_process.exec and fs.promises are captured at module load time
+ * via promisify(exec) and require('fs').promises. vi.mock does not intercept
+ * CJS requires for Node built-in modules in vitest's forks pool mode, so we
+ * use vi.spyOn on the actual module objects and then require the source module.
+ * Since execPromise = promisify(exec) is bound at load time, we spy on exec
+ * before requiring the module under test.
+ */
+
+vi.mock('../../src/utils/logger', () => ({
+  info: vi.fn(), warn: vi.fn(), error: vi.fn(), success: vi.fn(),
+  debug: vi.fn(), streamDebug: vi.fn(), section: vi.fn(),
+  log: vi.fn(),
+  isStreamDebugEnabled: () => false
+}));
+
+vi.mock('../../src/ai/provider', () => ({
+  createProvider: vi.fn()
+}));
+vi.mock('../../src/database', () => ({
+  AnalysisRunRepository: vi.fn(),
+  CommentRepository: vi.fn()
+}));
+vi.mock('../../src/hooks/hook-runner', () => ({
+  fireHooks: vi.fn(),
+  hasHooks: vi.fn(() => false)
+}));
+vi.mock('../../src/hooks/payloads', () => ({
+  buildAnalysisStartedPayload: vi.fn(),
+  buildAnalysisCompletedPayload: vi.fn(),
+  getCachedUser: vi.fn()
+}));
+vi.mock('../../src/utils/paths', () => ({
+  normalizePath: vi.fn(p => p),
+  resolveRenamedFile: vi.fn(p => p)
+}));
+vi.mock('../../src/utils/line-validation', () => ({
+  buildFileLineCountMap: vi.fn(),
+  validateSuggestionLineNumbers: vi.fn(() => ({ valid: [], converted: [] }))
+}));
+
+// For Node built-in modules and CJS requires, vi.mock does not intercept in
+// vitest's forks pool mode. Use vi.spyOn on the actual module objects instead.
+// These spies must be in place BEFORE requiring the source module, because
+// execPromise = promisify(exec) is bound at load time.
+const childProcess = require('child_process');
+const mockExec = vi.spyOn(childProcess, 'exec');
+
+const fsModule = require('fs');
+const mockWriteFile = vi.spyOn(fsModule.promises, 'writeFile');
+
+// Spy on local-review's generateScopedDiff and findMergeBase (also CJS requires in the source)
+const localReviewModule = require('../../src/local-review');
+const mockGenerateScopedDiff = vi.spyOn(localReviewModule, 'generateScopedDiff');
+const mockFindMergeBase = vi.spyOn(localReviewModule, 'findMergeBase');
+
+// Import source module after all spies are set up
+const { generateDiffForExecutable, getChangedFiles } = require('../../src/routes/executable-analysis');
+
+describe('generateDiffForExecutable', () => {
+  beforeEach(() => {
+    mockExec.mockReset();
+    mockWriteFile.mockReset();
+    mockGenerateScopedDiff.mockReset();
+    mockFindMergeBase.mockReset();
+    mockWriteFile.mockResolvedValue(undefined);
+  });
+
+  // Helper: make mockExec behave like exec with callback(null, { stdout, stderr })
+  function mockExecSuccess(stdout) {
+    mockExec.mockImplementation((cmd, opts, cb) => {
+      // exec(cmd, opts, cb) or exec(cmd, cb)
+      const callback = typeof opts === 'function' ? opts : cb;
+      process.nextTick(() => callback(null, { stdout, stderr: '' }));
+    });
+  }
+
+  // ── PR mode ────────────────────────────────────────────────────
+
+  describe('PR mode (baseSha + headSha)', () => {
+    it('runs git diff with baseSha...headSha and GIT_DIFF_FLAGS', async () => {
+      mockExecSuccess('diff --git a/file.js b/file.js\n');
+
+      await generateDiffForExecutable(
+        '/repo',
+        { baseSha: 'abc123', headSha: 'def456' },
+        [],
+        '/tmp/review.diff'
+      );
+
+      const cmd = mockExec.mock.calls[0][0];
+      expect(cmd).toContain('git diff');
+      expect(cmd).toContain('--no-color --no-ext-diff --src-prefix=a/ --dst-prefix=b/ --no-relative');
+      expect(cmd).toContain('abc123...def456');
+    });
+
+    it('appends diffArgs to the git diff command', async () => {
+      mockExecSuccess('diff output');
+
+      await generateDiffForExecutable(
+        '/repo',
+        { baseSha: 'abc', headSha: 'def' },
+        ['--ignore-all-space', '-M'],
+        '/tmp/review.diff'
+      );
+
+      const cmd = mockExec.mock.calls[0][0];
+      expect(cmd).toContain('--ignore-all-space -M');
+      expect(cmd).toContain('abc...def');
+    });
+
+    it('writes diff content to outputPath', async () => {
+      const diffContent = 'diff --git a/file.js b/file.js\n+new line\n';
+      mockExecSuccess(diffContent);
+
+      await generateDiffForExecutable(
+        '/repo',
+        { baseSha: 'abc', headSha: 'def' },
+        [],
+        '/tmp/review.diff'
+      );
+
+      expect(mockWriteFile).toHaveBeenCalledWith('/tmp/review.diff', diffContent, 'utf-8');
+    });
+
+    it('returns the diff content', async () => {
+      const diffContent = 'some diff';
+      mockExecSuccess(diffContent);
+
+      const result = await generateDiffForExecutable(
+        '/repo',
+        { baseSha: 'abc', headSha: 'def' },
+        [],
+        '/tmp/review.diff'
+      );
+
+      expect(result).toBe(diffContent);
+    });
+  });
+
+  // ── Local mode ─────────────────────────────────────────────────
+
+  describe('local mode (scopeStart + scopeEnd)', () => {
+    it('calls generateScopedDiff with contextLines: 3 and extraArgs from diffArgs', async () => {
+      mockGenerateScopedDiff.mockResolvedValue({ diff: 'scoped diff output' });
+
+      await generateDiffForExecutable(
+        '/repo',
+        { scopeStart: 'unstaged', scopeEnd: 'untracked', baseBranch: 'main' },
+        ['--patience'],
+        '/tmp/review.diff'
+      );
+
+      expect(mockGenerateScopedDiff).toHaveBeenCalledWith(
+        '/repo',
+        'unstaged',
+        'untracked',
+        'main',
+        { contextLines: 3, extraArgs: ['--patience'] }
+      );
+    });
+
+    it('uses null baseBranch when not provided in context', async () => {
+      mockGenerateScopedDiff.mockResolvedValue({ diff: 'diff' });
+
+      await generateDiffForExecutable(
+        '/repo',
+        { scopeStart: 'staged', scopeEnd: 'unstaged' },
+        [],
+        '/tmp/review.diff'
+      );
+
+      expect(mockGenerateScopedDiff).toHaveBeenCalledWith(
+        '/repo',
+        'staged',
+        'unstaged',
+        null,
+        { contextLines: 3, extraArgs: [] }
+      );
+    });
+
+    it('writes the scoped diff result to outputPath', async () => {
+      mockGenerateScopedDiff.mockResolvedValue({ diff: 'scoped diff content' });
+
+      await generateDiffForExecutable(
+        '/repo',
+        { scopeStart: 'unstaged', scopeEnd: 'untracked' },
+        [],
+        '/tmp/review.diff'
+      );
+
+      expect(mockWriteFile).toHaveBeenCalledWith('/tmp/review.diff', 'scoped diff content', 'utf-8');
+    });
+  });
+
+  // ── Fallback mode ──────────────────────────────────────────────
+
+  describe('fallback mode (no baseSha/headSha, no scopeStart/scopeEnd)', () => {
+    it('runs plain git diff with GIT_DIFF_FLAGS', async () => {
+      mockExecSuccess('fallback diff');
+
+      await generateDiffForExecutable(
+        '/repo',
+        {},
+        [],
+        '/tmp/review.diff'
+      );
+
+      const cmd = mockExec.mock.calls[0][0];
+      expect(cmd).toBe('git diff --no-color --no-ext-diff --src-prefix=a/ --dst-prefix=b/ --no-relative');
+    });
+
+    it('appends diffArgs to fallback git diff', async () => {
+      mockExecSuccess('diff');
+
+      await generateDiffForExecutable(
+        '/repo',
+        {},
+        ['-w', '--stat'],
+        '/tmp/review.diff'
+      );
+
+      const cmd = mockExec.mock.calls[0][0];
+      expect(cmd).toContain('-w --stat');
+      // Should NOT contain baseSha...headSha
+      expect(cmd).not.toContain('...');
+    });
+  });
+
+  // ── Edge cases ─────────────────────────────────────────────────
+
+  describe('edge cases', () => {
+    it('writes empty string when diff is empty (PR mode)', async () => {
+      mockExecSuccess('');
+
+      await generateDiffForExecutable(
+        '/repo',
+        { baseSha: 'abc', headSha: 'def' },
+        [],
+        '/tmp/review.diff'
+      );
+
+      expect(mockWriteFile).toHaveBeenCalledWith('/tmp/review.diff', '', 'utf-8');
+    });
+
+    it('writes empty string when diff is undefined (fallback mode)', async () => {
+      mockExec.mockImplementation((cmd, opts, cb) => {
+        const callback = typeof opts === 'function' ? opts : cb;
+        process.nextTick(() => callback(null, { stdout: undefined, stderr: '' }));
+      });
+
+      await generateDiffForExecutable(
+        '/repo',
+        {},
+        [],
+        '/tmp/review.diff'
+      );
+
+      expect(mockWriteFile).toHaveBeenCalledWith('/tmp/review.diff', '', 'utf-8');
+    });
+
+    it('writes empty string when scoped diff is empty (local mode)', async () => {
+      mockGenerateScopedDiff.mockResolvedValue({ diff: '' });
+
+      await generateDiffForExecutable(
+        '/repo',
+        { scopeStart: 'unstaged', scopeEnd: 'untracked' },
+        [],
+        '/tmp/review.diff'
+      );
+
+      expect(mockWriteFile).toHaveBeenCalledWith('/tmp/review.diff', '', 'utf-8');
+    });
+  });
+});
+
+describe('getChangedFiles', () => {
+  beforeEach(() => {
+    mockExec.mockReset();
+    mockFindMergeBase.mockReset();
+  });
+
+  // Helper: make mockExec behave like exec with callback(null, { stdout, stderr })
+  function mockExecForCalls(callMap) {
+    mockExec.mockImplementation((cmd, opts, cb) => {
+      const callback = typeof opts === 'function' ? opts : cb;
+      for (const [pattern, stdout] of Object.entries(callMap)) {
+        if (cmd.includes(pattern)) {
+          process.nextTick(() => callback(null, { stdout, stderr: '' }));
+          return;
+        }
+      }
+      process.nextTick(() => callback(null, { stdout: '', stderr: '' }));
+    });
+  }
+
+  // ── PR mode ────────────────────────────────────────────────────
+
+  describe('PR mode (baseSha + headSha)', () => {
+    it('runs git diff --name-only with baseSha...headSha', async () => {
+      mockExecForCalls({ '...': 'file1.js\nfile2.js\n' });
+
+      const files = await getChangedFiles('/repo', { baseSha: 'abc', headSha: 'def' });
+
+      expect(files).toEqual(['file1.js', 'file2.js']);
+      const cmd = mockExec.mock.calls[0][0];
+      expect(cmd).toContain('abc...def');
+      expect(cmd).toContain('--name-only');
+    });
+  });
+
+  // ── Local mode: scope-aware ────────────────────────────────────
+
+  describe('local mode with scope', () => {
+    it('includes branch files when scope includes branch', async () => {
+      mockFindMergeBase.mockResolvedValue('merge-base-sha');
+      mockExecForCalls({
+        'merge-base-sha..HEAD': 'branch-file.js\n',
+        '--cached': '',
+        'ls-files': ''
+      });
+
+      const files = await getChangedFiles('/repo', {
+        scopeStart: 'branch', scopeEnd: 'branch', baseBranch: 'main'
+      });
+
+      expect(files).toContain('branch-file.js');
+      expect(mockFindMergeBase).toHaveBeenCalledWith('/repo', 'main');
+    });
+
+    it('includes staged files when scope includes staged', async () => {
+      mockExecForCalls({
+        '--cached': 'staged.js\n'
+      });
+
+      const files = await getChangedFiles('/repo', {
+        scopeStart: 'staged', scopeEnd: 'staged'
+      });
+
+      expect(files).toEqual(['staged.js']);
+    });
+
+    it('includes unstaged files when scope includes unstaged', async () => {
+      // mockExec must match unstaged diff (no --cached, no merge-base)
+      mockExec.mockImplementation((cmd, opts, cb) => {
+        const callback = typeof opts === 'function' ? opts : cb;
+        if (cmd.includes('--name-only') && !cmd.includes('--cached') && !cmd.includes('..')) {
+          process.nextTick(() => callback(null, { stdout: 'unstaged.js\n', stderr: '' }));
+        } else {
+          process.nextTick(() => callback(null, { stdout: '', stderr: '' }));
+        }
+      });
+
+      const files = await getChangedFiles('/repo', {
+        scopeStart: 'unstaged', scopeEnd: 'unstaged'
+      });
+
+      expect(files).toEqual(['unstaged.js']);
+    });
+
+    it('includes untracked files when scope includes untracked', async () => {
+      mockExecForCalls({
+        'ls-files': 'untracked.js\n'
+      });
+
+      const files = await getChangedFiles('/repo', {
+        scopeStart: 'untracked', scopeEnd: 'untracked'
+      });
+
+      expect(files).toEqual(['untracked.js']);
+    });
+
+    it('includes branch + staged + unstaged + untracked for full scope', async () => {
+      mockFindMergeBase.mockResolvedValue('mb-sha');
+      let callIndex = 0;
+      mockExec.mockImplementation((cmd, opts, cb) => {
+        const callback = typeof opts === 'function' ? opts : cb;
+        if (cmd.includes('mb-sha..HEAD')) {
+          process.nextTick(() => callback(null, { stdout: 'branch.js\n', stderr: '' }));
+        } else if (cmd.includes('--cached')) {
+          process.nextTick(() => callback(null, { stdout: 'staged.js\n', stderr: '' }));
+        } else if (cmd.includes('ls-files')) {
+          process.nextTick(() => callback(null, { stdout: 'untracked.js\n', stderr: '' }));
+        } else if (cmd.includes('--name-only')) {
+          process.nextTick(() => callback(null, { stdout: 'unstaged.js\n', stderr: '' }));
+        } else {
+          process.nextTick(() => callback(null, { stdout: '', stderr: '' }));
+        }
+      });
+
+      const files = await getChangedFiles('/repo', {
+        scopeStart: 'branch', scopeEnd: 'untracked', baseBranch: 'main'
+      });
+
+      expect(files).toContain('branch.js');
+      expect(files).toContain('staged.js');
+      expect(files).toContain('unstaged.js');
+      expect(files).toContain('untracked.js');
+    });
+
+    it('deduplicates files across scope stops', async () => {
+      mockExecForCalls({
+        '--cached': 'shared.js\n',
+        'ls-files': 'shared.js\n'
+      });
+
+      // staged–untracked scope: same file in both
+      mockExec.mockImplementation((cmd, opts, cb) => {
+        const callback = typeof opts === 'function' ? opts : cb;
+        if (cmd.includes('--cached')) {
+          process.nextTick(() => callback(null, { stdout: 'shared.js\n', stderr: '' }));
+        } else if (cmd.includes('ls-files')) {
+          process.nextTick(() => callback(null, { stdout: 'shared.js\n', stderr: '' }));
+        } else if (cmd.includes('--name-only')) {
+          process.nextTick(() => callback(null, { stdout: 'shared.js\n', stderr: '' }));
+        } else {
+          process.nextTick(() => callback(null, { stdout: '', stderr: '' }));
+        }
+      });
+
+      const files = await getChangedFiles('/repo', {
+        scopeStart: 'staged', scopeEnd: 'untracked'
+      });
+
+      // Should be deduplicated
+      expect(files).toEqual(['shared.js']);
+    });
+
+    it('does NOT include untracked files when scope is branch-only', async () => {
+      mockFindMergeBase.mockResolvedValue('mb-sha');
+      mockExec.mockImplementation((cmd, opts, cb) => {
+        const callback = typeof opts === 'function' ? opts : cb;
+        if (cmd.includes('mb-sha..HEAD')) {
+          process.nextTick(() => callback(null, { stdout: 'branch.js\n', stderr: '' }));
+        } else {
+          process.nextTick(() => callback(null, { stdout: 'should-not-appear.js\n', stderr: '' }));
+        }
+      });
+
+      const files = await getChangedFiles('/repo', {
+        scopeStart: 'branch', scopeEnd: 'branch', baseBranch: 'main'
+      });
+
+      expect(files).toEqual(['branch.js']);
+      // Should only have made one exec call (for branch diff)
+      expect(mockExec).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ── Fallback (no scope info) ──────────────────────────────────
+
+  describe('fallback mode (no scope fields)', () => {
+    it('includes unstaged + untracked + staged when no scope info', async () => {
+      mockExec.mockImplementation((cmd, opts, cb) => {
+        const callback = typeof opts === 'function' ? opts : cb;
+        if (cmd.includes('--cached')) {
+          process.nextTick(() => callback(null, { stdout: 'staged.js\n', stderr: '' }));
+        } else if (cmd.includes('ls-files')) {
+          process.nextTick(() => callback(null, { stdout: 'untracked.js\n', stderr: '' }));
+        } else if (cmd.includes('--name-only')) {
+          process.nextTick(() => callback(null, { stdout: 'unstaged.js\n', stderr: '' }));
+        } else {
+          process.nextTick(() => callback(null, { stdout: '', stderr: '' }));
+        }
+      });
+
+      const files = await getChangedFiles('/repo', {});
+
+      expect(files).toContain('unstaged.js');
+      expect(files).toContain('untracked.js');
+      expect(files).toContain('staged.js');
+    });
+  });
+
+  // ── Error handling ────────────────────────────────────────────
+
+  describe('error handling', () => {
+    it('returns empty array on error', async () => {
+      mockExec.mockImplementation((cmd, opts, cb) => {
+        const callback = typeof opts === 'function' ? opts : cb;
+        process.nextTick(() => callback(new Error('git failed'), null));
+      });
+
+      const files = await getChangedFiles('/repo', {});
+
+      expect(files).toEqual([]);
+    });
+
+    it('returns empty array when findMergeBase fails for branch scope', async () => {
+      mockFindMergeBase.mockRejectedValue(new Error('no merge-base'));
+
+      const files = await getChangedFiles('/repo', {
+        scopeStart: 'branch', scopeEnd: 'branch', baseBranch: 'main'
+      });
+
+      expect(files).toEqual([]);
+    });
+
+    it('returns empty array when branch scope has no baseBranch', async () => {
+      // When hasBranch is true but baseBranch is null/undefined, the branch
+      // command is skipped entirely, resulting in no commands and an empty list.
+      mockExec.mockImplementation((cmd, opts, cb) => {
+        const callback = typeof opts === 'function' ? opts : cb;
+        process.nextTick(() => callback(null, { stdout: '', stderr: '' }));
+      });
+
+      const files = await getChangedFiles('/repo', {
+        scopeStart: 'branch', scopeEnd: 'branch', baseBranch: null
+      });
+
+      expect(files).toEqual([]);
+      // findMergeBase should NOT be called since baseBranch is null
+      expect(mockFindMergeBase).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/unit/executable-provider.test.js
+++ b/tests/unit/executable-provider.test.js
@@ -224,6 +224,18 @@ describe('createExecutableProviderClass', () => {
       expect(new (createExecutableProviderClass('t', { command: 'x' }))().baseArgs).toEqual([]);
     });
 
+    it('stores diffArgs from config.diff_args', () => {
+      const P = createExecutableProviderClass('t', {
+        command: 'x', diff_args: ['--ignore-all-space', '-M']
+      });
+      expect(new P().diffArgs).toEqual(['--ignore-all-space', '-M']);
+    });
+
+    it('defaults diffArgs to empty array when not in config', () => {
+      const P = createExecutableProviderClass('t', { command: 'x' });
+      expect(new P().diffArgs).toEqual([]);
+    });
+
     it('stores contextArgs, outputGlob, mappingInstructions', () => {
       const i = new (createExecutableProviderClass('t', {
         command: 'x', context_args: { title: '--t' },

--- a/tests/unit/local-review.test.js
+++ b/tests/unit/local-review.test.js
@@ -547,6 +547,140 @@ describe('generateScopedDiff', () => {
       expect(result.stats.untrackedFiles).toBe(0);
     });
   });
+
+  describe('contextLines option', () => {
+    it('should default to --unified=25 when no contextLines option is provided', async () => {
+      await fs.writeFile(path.join(testDir, 'file.txt'), 'modified\n');
+
+      const result = await generateScopedDiff(testDir, 'unstaged', 'untracked');
+
+      // The diff should use --unified=25 (default), which shows 25 context lines
+      // We can verify this indirectly: the diff was generated without error
+      expect(result.diff).toContain('diff --git a/file.txt b/file.txt');
+    });
+
+    it('should use custom contextLines when provided', async () => {
+      // Create a file with many lines so context line count matters
+      const lines = [];
+      for (let i = 1; i <= 50; i++) lines.push(`line ${i}`);
+      await fs.writeFile(path.join(testDir, 'file.txt'), lines.join('\n') + '\n');
+      execSync('git add file.txt', { cwd: testDir, stdio: 'pipe' });
+      execSync('git commit -m "Add many lines"', { cwd: testDir, stdio: 'pipe' });
+
+      // Modify a line in the middle
+      lines[25] = 'MODIFIED line 26';
+      await fs.writeFile(path.join(testDir, 'file.txt'), lines.join('\n') + '\n');
+
+      // With contextLines: 3, we get fewer context lines
+      const result3 = await generateScopedDiff(testDir, 'unstaged', 'unstaged', null, { contextLines: 3 });
+      // With default (25), we get more context lines
+      const resultDefault = await generateScopedDiff(testDir, 'unstaged', 'unstaged');
+
+      // The diff with 3 context lines should be shorter than with 25
+      expect(result3.diff.length).toBeLessThan(resultDefault.diff.length);
+      // Both should contain the modification
+      expect(result3.diff).toContain('MODIFIED line 26');
+      expect(resultDefault.diff).toContain('MODIFIED line 26');
+    });
+  });
+
+  describe('extraArgs option', () => {
+    it('should append extraArgs to git diff commands', async () => {
+      // Create files with whitespace-only changes
+      await fs.writeFile(path.join(testDir, 'file.txt'), 'hello world\n');
+      execSync('git add file.txt', { cwd: testDir, stdio: 'pipe' });
+      execSync('git commit -m "Add file"', { cwd: testDir, stdio: 'pipe' });
+
+      // Make a whitespace-only change
+      await fs.writeFile(path.join(testDir, 'file.txt'), 'hello  world\n');
+
+      // Without -w, the diff should show the whitespace change
+      const resultWithout = await generateScopedDiff(testDir, 'unstaged', 'unstaged');
+      expect(resultWithout.diff).toContain('file.txt');
+
+      // With -w (ignore whitespace), git should produce no diff
+      const resultWith = await generateScopedDiff(testDir, 'unstaged', 'unstaged', null, { extraArgs: ['-w'] });
+      // The -w flag causes git to ignore whitespace changes entirely
+      expect(resultWith.diff).toBeFalsy();
+    });
+
+    it('should work together with contextLines', async () => {
+      // Create a file with many lines
+      const lines = [];
+      for (let i = 1; i <= 50; i++) lines.push(`line ${i}`);
+      await fs.writeFile(path.join(testDir, 'file.txt'), lines.join('\n') + '\n');
+      execSync('git add file.txt', { cwd: testDir, stdio: 'pipe' });
+      execSync('git commit -m "Add lines"', { cwd: testDir, stdio: 'pipe' });
+
+      // Make a real change
+      lines[25] = 'CHANGED line 26';
+      await fs.writeFile(path.join(testDir, 'file.txt'), lines.join('\n') + '\n');
+
+      // Use both options together
+      const result = await generateScopedDiff(testDir, 'unstaged', 'unstaged', null, {
+        contextLines: 3,
+        extraArgs: ['--stat']
+      });
+
+      // Should contain the change
+      expect(result.diff).toContain('CHANGED line 26');
+      // --stat appends a summary at the end of the diff
+      expect(result.diff).toContain('1 file changed');
+    });
+  });
+
+  describe('untracked file options threading', () => {
+    it('should apply contextLines to untracked file diffs', async () => {
+      // Create a large untracked file so context line count is visible
+      const lines = [];
+      for (let i = 1; i <= 50; i++) lines.push(`new line ${i}`);
+      await fs.writeFile(path.join(testDir, 'big-new.txt'), lines.join('\n') + '\n');
+
+      // With contextLines: 3, the diff header should use --unified=3
+      const result3 = await generateScopedDiff(testDir, 'untracked', 'untracked', null, { contextLines: 3 });
+      // With default (25), the diff header should use --unified=25
+      const resultDefault = await generateScopedDiff(testDir, 'untracked', 'untracked');
+
+      // Both should contain the untracked file
+      expect(result3.diff).toContain('big-new.txt');
+      expect(resultDefault.diff).toContain('big-new.txt');
+      // The diff with 3 context lines should have @@ -0,0 +1,50 @@ style header
+      // Both produce the same output for new files (all lines are additions),
+      // but the flag should be threaded through without error
+      expect(result3.diff).toContain('new line 1');
+      expect(resultDefault.diff).toContain('new line 1');
+    });
+
+    it('should apply extraArgs to untracked file diffs', async () => {
+      // Create an untracked file
+      await fs.writeFile(path.join(testDir, 'new-file.txt'), 'new content\n');
+
+      // extraArgs like --stat should be applied to untracked file diffs too
+      const result = await generateScopedDiff(testDir, 'untracked', 'untracked', null, {
+        extraArgs: ['--stat']
+      });
+
+      // Should contain the untracked file diff
+      expect(result.diff).toContain('new-file.txt');
+      // --stat appends a summary to each file diff
+      expect(result.diff).toContain('1 file changed');
+    });
+
+    it('should apply both contextLines and extraArgs to untracked file diffs in mixed scope', async () => {
+      // Make an unstaged change AND an untracked file
+      await fs.writeFile(path.join(testDir, 'file.txt'), 'modified content\n');
+      await fs.writeFile(path.join(testDir, 'brand-new.txt'), 'brand new content\n');
+
+      const result = await generateScopedDiff(testDir, 'unstaged', 'untracked', null, {
+        contextLines: 3,
+        extraArgs: ['--stat']
+      });
+
+      // Should contain both tracked and untracked changes
+      expect(result.diff).toContain('file.txt');
+      expect(result.diff).toContain('brand-new.txt');
+    });
+  });
 });
 
 describe('computeScopedDigest', () => {


### PR DESCRIPTION
## Summary
- **Executable provider diff_path**: Executable providers configured with `context_args.diff_path` now receive a scoped diff file via `generateDiffForExecutable()`. This works for both standalone executable analysis and as a council voice — previously only the standalone path generated the diff.
- **Scope-first priority**: `generateDiffForExecutable()` and `getChangedFiles()` now check scope fields before SHA fields, fixing a bug where local council voices would get an empty `HEAD...HEAD` diff instead of the scope-aware diff.
- **Empty-scope guard**: Both analysis launch endpoints (`/analyses` and `/analyses/council`) now return 409 before creating a run when the resolved scope contains no changed files.
- **generateScopedDiff options**: Supports `contextLines` and `extraArgs` options for controlling diff context and passing additional git diff flags (e.g. from provider `diff_args` config).
- **config.example.json**: Documents `diff_path` and `diff_args` as first-class executable provider config fields.

## Test plan
- [x] Unit tests for `generateDiffForExecutable` — PR mode, local mode (scope-aware), fallback mode, edge cases
- [x] Unit tests for `getChangedFiles` — PR mode, scope-aware local mode (all stop combinations), fallback, deduplication, error handling
- [x] Unit tests for `generateScopedDiff` with `contextLines` and `extraArgs` options
- [x] Unit test for degenerate case: branch scope with null baseBranch returns empty array
- [ ] Manual test: executable provider with `diff_path` in standalone analysis
- [ ] Manual test: executable provider with `diff_path` as council voice
- [ ] Manual test: launch analysis against empty scope triggers 409

🤖 Generated with [Claude Code](https://claude.com/claude-code)