### PR TITLE
Fix test suite hang by isolating git config in vitest

### DIFF
--- a/vitest.config.js
+++ b/vitest.config.js
@@ -6,8 +6,12 @@ export default defineConfig({
     environment: 'node',
 
     // Suppress browser opening during tests
+    // Isolate test git repos from developer's global/system git config
+    // (prevents hangs from e.g. commit.gpgsign requiring TTY-based pinentry)
     env: {
       PAIR_REVIEW_NO_OPEN: '1',
+      GIT_CONFIG_NOSYSTEM: '1',
+      GIT_CONFIG_GLOBAL: '/dev/null',
     },
 
     // Test file patterns


### PR DESCRIPTION
## Summary
- Tests creating temporary git repos (`branch-diff`, `local-review`, `git-diff-lines-cwd`, `worktree-sparse-checkout`) were hanging because global `commit.gpgsign=true` triggers a GPG pinentry that blocks without a TTY in vitest's forked workers
- Set `GIT_CONFIG_NOSYSTEM=1` and `GIT_CONFIG_GLOBAL=/dev/null` in vitest's `env` config to fully isolate test git repos from global/system git configuration

## Test plan
- [x] Full test suite passes: 121 files, 5489 tests, ~22s
- [x] Previously-hanging files (`branch-diff`, `git-diff-lines-cwd`, `local-review`, `worktree-sparse-checkout`) now complete
- [ ] Verify CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)