### PR TITLE
Add provider-specific default timeout for Pi in council config

### DIFF
--- a/.changeset/pi-default-timeout.md
+++ b/.changeset/pi-default-timeout.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Use provider-specific default timeout for Pi and other providers with custom timeouts in council configuration UI

--- a/public/js/components/AdvancedConfigTab.js
+++ b/public/js/components/AdvancedConfigTab.js
@@ -289,7 +289,7 @@ class AdvancedConfigTab {
         '2': { enabled: true, voices: [] },
         '3': { enabled: true, voices: [] }
       },
-      consolidation: { provider: this._defaultProvider || 'claude', model: this._defaultModel || 'sonnet', tier: 'balanced', timeout: AdvancedConfigTab.DEFAULT_TIMEOUT }
+      consolidation: { provider: this._defaultProvider || 'claude', model: this._defaultModel || 'sonnet', tier: 'balanced', timeout: this._getProviderDefaultTimeout(this._defaultProvider || 'claude') }
     };
   }
 
@@ -605,10 +605,11 @@ class AdvancedConfigTab {
       }
     });
 
-    // Provider change -> update model dropdowns
+    // Provider change -> update model dropdowns + timeout default
     panel.addEventListener('change', (e) => {
       if (e.target.classList.contains('voice-provider')) {
         this._updateModelDropdown(e.target);
+        this._applyProviderDefaultTimeout(e.target);
       }
       // Model change -> update tier to match model's recommended tier
       if (e.target.classList.contains('voice-model')) {
@@ -805,6 +806,7 @@ class AdvancedConfigTab {
     const newProviderSelect = voiceList.querySelector(`.voice-provider[data-level="${level}"][data-index="${index}"]`);
     if (newProviderSelect) {
       this._populateProviderDropdown(newProviderSelect);
+      this._applyProviderDefaultTimeout(newProviderSelect);
     }
 
     // Update remove button visibility for this level
@@ -895,6 +897,16 @@ class AdvancedConfigTab {
   }
 
   /**
+   * Get the default timeout for a provider, falling back to the static DEFAULT_TIMEOUT.
+   * @param {string} providerId - Provider ID (e.g., 'pi', 'claude')
+   * @returns {number} Default timeout in ms
+   */
+  _getProviderDefaultTimeout(providerId) {
+    const provider = this.providers[providerId];
+    return provider?.defaultTimeout ?? AdvancedConfigTab.DEFAULT_TIMEOUT;
+  }
+
+  /**
    * Update the clock/timeout icon styling to indicate non-default timeout.
    * @param {Element} panel - The council panel element
    * @param {string} level - Level number
@@ -906,7 +918,9 @@ class AdvancedConfigTab {
     const iconBtn = wrapper?.querySelector(`.toggle-timeout-icon[data-level="${level}"][data-index="${index}"]`);
     if (!iconBtn) return;
 
-    const isNonDefault = parseInt(value, 10) !== AdvancedConfigTab.DEFAULT_TIMEOUT;
+    const providerId = wrapper?.querySelector('.voice-provider')?.value;
+    const defaultTimeout = this._getProviderDefaultTimeout(providerId);
+    const isNonDefault = parseInt(value, 10) !== defaultTimeout;
     iconBtn.classList.toggle('has-custom-timeout', isNonDefault);
   }
 
@@ -914,7 +928,10 @@ class AdvancedConfigTab {
     const iconBtn = panel.querySelector('#adv-orchestration-timeout-toggle');
     if (!iconBtn) return;
 
-    const isNonDefault = parseInt(value, 10) !== AdvancedConfigTab.DEFAULT_TIMEOUT;
+    const orchRow = panel.querySelector('#orchestration-voice');
+    const providerId = orchRow?.querySelector('.voice-provider')?.value;
+    const defaultTimeout = this._getProviderDefaultTimeout(providerId);
+    const isNonDefault = parseInt(value, 10) !== defaultTimeout;
     iconBtn.classList.toggle('has-custom-timeout', isNonDefault);
   }
 
@@ -927,6 +944,48 @@ class AdvancedConfigTab {
       ? AdvancedConfigTab.SPEECH_BUBBLE_SVG_SOLID
       : AdvancedConfigTab.SPEECH_BUBBLE_SVG;
     iconBtn.classList.toggle('has-instructions', hasContent);
+  }
+
+  /**
+   * When a voice's provider changes, update its timeout to the new provider's default,
+   * preserving explicit user overrides via Math.max when the user had customized the value.
+   * @param {HTMLSelectElement} providerSelect - The provider dropdown that changed
+   */
+  _applyProviderDefaultTimeout(providerSelect) {
+    const panel = this.modal.querySelector('#tab-panel-advanced');
+    if (!panel) return;
+
+    const providerId = providerSelect.value;
+    const newDefault = this._getProviderDefaultTimeout(providerId);
+    const oldProviderId = providerSelect.dataset.previousProvider;
+    const oldDefault = oldProviderId ? this._getProviderDefaultTimeout(oldProviderId) : null;
+
+    const isOrchestration = providerSelect.dataset.target === 'orchestration';
+    if (isOrchestration) {
+      const timeoutEl = panel.querySelector('#adv-orchestration-timeout');
+      if (timeoutEl) {
+        const currentValue = parseInt(timeoutEl.value, 10);
+        const resolvedTimeout = (oldDefault !== null && currentValue !== oldDefault)
+          ? Math.max(currentValue, newDefault)
+          : newDefault;
+        timeoutEl.value = String(resolvedTimeout);
+        this._updateOrchestrationTimeoutIcon(panel, String(resolvedTimeout));
+      }
+    } else {
+      const { level, index } = providerSelect.dataset;
+      const wrapper = providerSelect.closest('.participant-wrapper');
+      const timeoutEl = wrapper?.querySelector('.adv-timeout');
+      if (timeoutEl) {
+        const currentValue = parseInt(timeoutEl.value, 10);
+        const resolvedTimeout = (oldDefault !== null && currentValue !== oldDefault)
+          ? Math.max(currentValue, newDefault)
+          : newDefault;
+        timeoutEl.value = String(resolvedTimeout);
+        this._updateTimeoutIcon(panel, level, index, String(resolvedTimeout));
+      }
+    }
+
+    providerSelect.dataset.previousProvider = providerId;
   }
 
   // --- Dirty state tracking ---
@@ -1108,6 +1167,7 @@ class AdvancedConfigTab {
           if (providerSelect) {
             this._populateProviderDropdown(providerSelect);
             providerSelect.value = voice.provider;
+            providerSelect.dataset.previousProvider = voice.provider;
             this._updateModelDropdown(providerSelect);
             const modelSelect = row.querySelector('.voice-model');
             if (modelSelect) modelSelect.value = voice.model;
@@ -1121,13 +1181,17 @@ class AdvancedConfigTab {
             TimeoutSelect.mount(mount, { className: 'adv-timeout', title: 'Per-reviewer timeout' });
           }
           const timeoutEl = row?.querySelector('.adv-timeout');
+          const providerDefaultTimeout = this._getProviderDefaultTimeout(voice.provider);
           if (timeoutEl && voice.timeout) {
             timeoutEl.value = String(voice.timeout);
-            // Show the dropdown if non-default
-            if (voice.timeout !== AdvancedConfigTab.DEFAULT_TIMEOUT) {
+            // Show the dropdown if non-default for this provider
+            if (voice.timeout !== providerDefaultTimeout) {
               timeoutEl.style.display = '';
             }
             this._updateTimeoutIcon(panel, String(level), String(i), String(voice.timeout));
+          } else if (timeoutEl) {
+            // No saved timeout — apply the provider's default
+            timeoutEl.value = String(providerDefaultTimeout);
           }
 
           if (voice.customInstructions) {
@@ -1156,6 +1220,7 @@ class AdvancedConfigTab {
         if (providerSelect) {
           this._populateProviderDropdown(providerSelect);
           providerSelect.value = consolSection.provider;
+          providerSelect.dataset.previousProvider = consolSection.provider;
           this._updateModelDropdown(providerSelect);
           const modelSelect = orchRow.querySelector('.voice-model');
           if (modelSelect) modelSelect.value = consolSection.model;
@@ -1166,13 +1231,18 @@ class AdvancedConfigTab {
 
       // Restore consolidation timeout
       const orchTimeoutSelect = panel.querySelector('#adv-orchestration-timeout');
+      const orchProviderDefaultTimeout = this._getProviderDefaultTimeout(consolSection.provider);
       if (orchTimeoutSelect && consolSection.timeout) {
         orchTimeoutSelect.value = String(consolSection.timeout);
-        // Show the dropdown if non-default
-        if (consolSection.timeout !== AdvancedConfigTab.DEFAULT_TIMEOUT) {
+        // Show the dropdown if non-default for this provider
+        if (consolSection.timeout !== orchProviderDefaultTimeout) {
           orchTimeoutSelect.style.display = '';
         }
         this._updateOrchestrationTimeoutIcon(panel, String(consolSection.timeout));
+      } else if (orchTimeoutSelect) {
+        // No saved timeout — apply the provider's default
+        orchTimeoutSelect.value = String(orchProviderDefaultTimeout);
+        this._updateOrchestrationTimeoutIcon(panel, String(orchProviderDefaultTimeout));
       }
 
       // Restore consolidation custom instructions

--- a/public/js/components/TimeoutSelect.js
+++ b/public/js/components/TimeoutSelect.js
@@ -37,6 +37,8 @@ class TimeoutSelect {
     { value: '600000', label: '10m', selected: true },
     { value: '900000', label: '15m' },
     { value: '1800000', label: '30m' },
+    { value: '2700000', label: '45m' },
+    { value: '3600000', label: '60m' },
   ];
 
   /**

--- a/public/js/components/VoiceCentricConfigTab.js
+++ b/public/js/components/VoiceCentricConfigTab.js
@@ -525,12 +525,13 @@ class VoiceCentricConfigTab {
       }
     });
 
-    // Provider change -> update model dropdowns + executable state
+    // Provider change -> update model dropdowns + executable state + timeout default
     panel.addEventListener('change', (e) => {
       if (e.target.classList.contains('voice-provider')) {
         this._updateModelDropdown(e.target);
         this._updateExecutableState(e.target);
         this._updateLevelToggleState();
+        this._applyProviderDefaultTimeout(e.target);
       }
       // Model change -> update tier to match model's recommended tier
       if (e.target.classList.contains('voice-model')) {
@@ -603,6 +604,7 @@ class VoiceCentricConfigTab {
     const newProviderSelect = list.querySelector(`.voice-provider[data-index="${index}"]`);
     if (newProviderSelect) {
       this._populateProviderDropdown(newProviderSelect);
+      this._applyProviderDefaultTimeout(newProviderSelect);
       this._updateExecutableState(newProviderSelect);
     }
 
@@ -675,6 +677,16 @@ class VoiceCentricConfigTab {
   }
 
   /**
+   * Get the default timeout for a provider, falling back to the static DEFAULT_TIMEOUT.
+   * @param {string} providerId - Provider ID (e.g., 'pi', 'claude')
+   * @returns {number} Default timeout in ms
+   */
+  _getProviderDefaultTimeout(providerId) {
+    const provider = this.providers[providerId];
+    return provider?.defaultTimeout ?? VoiceCentricConfigTab.DEFAULT_TIMEOUT;
+  }
+
+  /**
    * Update the clock/timeout icon styling to indicate non-default timeout.
    * @param {Element} panel - The council panel element
    * @param {string} index - Reviewer index
@@ -685,7 +697,9 @@ class VoiceCentricConfigTab {
     const iconBtn = wrapper?.querySelector(`.toggle-timeout-icon[data-index="${index}"]`);
     if (!iconBtn) return;
 
-    const isNonDefault = parseInt(value, 10) !== VoiceCentricConfigTab.DEFAULT_TIMEOUT;
+    const providerId = wrapper?.querySelector('.voice-provider')?.value;
+    const defaultTimeout = this._getProviderDefaultTimeout(providerId);
+    const isNonDefault = parseInt(value, 10) !== defaultTimeout;
     iconBtn.classList.toggle('has-custom-timeout', isNonDefault);
   }
 
@@ -693,8 +707,54 @@ class VoiceCentricConfigTab {
     const iconBtn = panel.querySelector('#vc-orchestration-timeout-toggle');
     if (!iconBtn) return;
 
-    const isNonDefault = parseInt(value, 10) !== VoiceCentricConfigTab.DEFAULT_TIMEOUT;
+    const orchRow = panel.querySelector('#vc-orchestration-voice');
+    const providerId = orchRow?.querySelector('.voice-provider')?.value;
+    const defaultTimeout = this._getProviderDefaultTimeout(providerId);
+    const isNonDefault = parseInt(value, 10) !== defaultTimeout;
     iconBtn.classList.toggle('has-custom-timeout', isNonDefault);
+  }
+
+  /**
+   * When a voice's provider changes, update its timeout to the new provider's default,
+   * preserving explicit user overrides via Math.max when the user had customized the value.
+   * @param {HTMLSelectElement} providerSelect - The provider dropdown that changed
+   */
+  _applyProviderDefaultTimeout(providerSelect) {
+    const panel = this.modal.querySelector('#tab-panel-council');
+    if (!panel) return;
+
+    const providerId = providerSelect.value;
+    const newDefault = this._getProviderDefaultTimeout(providerId);
+    const oldProviderId = providerSelect.dataset.previousProvider;
+    const oldDefault = oldProviderId ? this._getProviderDefaultTimeout(oldProviderId) : null;
+
+    // Determine which timeout element to update
+    const isOrchestration = providerSelect.dataset.target === 'orchestration';
+    if (isOrchestration) {
+      const timeoutEl = panel.querySelector('#vc-orchestration-timeout');
+      if (timeoutEl) {
+        const currentValue = parseInt(timeoutEl.value, 10);
+        const resolvedTimeout = (oldDefault !== null && currentValue !== oldDefault)
+          ? Math.max(currentValue, newDefault)
+          : newDefault;
+        timeoutEl.value = String(resolvedTimeout);
+        this._updateOrchestrationTimeoutIcon(panel, String(resolvedTimeout));
+      }
+    } else {
+      const idx = providerSelect.dataset.index;
+      const wrapper = providerSelect.closest('.vc-reviewer');
+      const timeoutEl = wrapper?.querySelector('.vc-timeout');
+      if (timeoutEl) {
+        const currentValue = parseInt(timeoutEl.value, 10);
+        const resolvedTimeout = (oldDefault !== null && currentValue !== oldDefault)
+          ? Math.max(currentValue, newDefault)
+          : newDefault;
+        timeoutEl.value = String(resolvedTimeout);
+        this._updateTimeoutIcon(panel, idx, String(resolvedTimeout));
+      }
+    }
+
+    providerSelect.dataset.previousProvider = providerId;
   }
 
   // --- Dropdown / model management ---
@@ -894,10 +954,11 @@ class VoiceCentricConfigTab {
   // --- Config read/write ---
 
   _defaultConfig() {
+    const defaultTimeout = this._getProviderDefaultTimeout(this._defaultProvider);
     return {
-      voices: [{ provider: this._defaultProvider, model: this._defaultModel, tier: 'balanced', timeout: VoiceCentricConfigTab.DEFAULT_TIMEOUT }],
+      voices: [{ provider: this._defaultProvider, model: this._defaultModel, tier: 'balanced', timeout: defaultTimeout }],
       enabledLevels: [1, 2, 3],
-      orchestration: { provider: this._defaultProvider, model: this._defaultModel, tier: 'balanced', timeout: VoiceCentricConfigTab.DEFAULT_TIMEOUT }
+      orchestration: { provider: this._defaultProvider, model: this._defaultModel, tier: 'balanced', timeout: defaultTimeout }
     };
   }
 
@@ -1027,7 +1088,7 @@ class VoiceCentricConfigTab {
       list.innerHTML = '';
       const voices = vcConfig.voices || [];
       if (voices.length === 0) {
-        voices.push({ provider: this._defaultProvider, model: this._defaultModel, tier: 'balanced', timeout: VoiceCentricConfigTab.DEFAULT_TIMEOUT });
+        voices.push({ provider: this._defaultProvider, model: this._defaultModel, tier: 'balanced', timeout: this._getProviderDefaultTimeout(this._defaultProvider) });
       }
       voices.forEach((voice, i) => {
         const wrapper = document.createElement('div');
@@ -1042,6 +1103,7 @@ class VoiceCentricConfigTab {
         if (providerSelect) {
           this._populateProviderDropdown(providerSelect);
           providerSelect.value = voice.provider;
+          providerSelect.dataset.previousProvider = voice.provider;
           this._updateModelDropdown(providerSelect);
           this._updateExecutableState(providerSelect);
           const modelSelect = row.querySelector('.voice-model');
@@ -1054,13 +1116,17 @@ class VoiceCentricConfigTab {
             TimeoutSelect.mount(mount, { className: 'vc-timeout', title: 'Per-reviewer timeout' });
           }
           const timeoutEl = row.querySelector('.vc-timeout');
+          const providerDefaultTimeout = this._getProviderDefaultTimeout(voice.provider);
           if (timeoutEl && voice.timeout) {
             timeoutEl.value = String(voice.timeout);
-            // Show the dropdown if non-default
-            if (voice.timeout !== VoiceCentricConfigTab.DEFAULT_TIMEOUT) {
+            // Show the dropdown if non-default for this provider
+            if (voice.timeout !== providerDefaultTimeout) {
               timeoutEl.style.display = '';
             }
             this._updateTimeoutIcon(panel, String(i), String(voice.timeout));
+          } else if (timeoutEl) {
+            // No saved timeout — apply the provider's default
+            timeoutEl.value = String(providerDefaultTimeout);
           }
         }
 
@@ -1092,6 +1158,7 @@ class VoiceCentricConfigTab {
         if (providerSelect) {
           this._populateProviderDropdown(providerSelect);
           providerSelect.value = vcConfig.orchestration.provider;
+          providerSelect.dataset.previousProvider = vcConfig.orchestration.provider;
           this._updateModelDropdown(providerSelect);
           const modelSelect = orchRow.querySelector('.voice-model');
           if (modelSelect) modelSelect.value = vcConfig.orchestration.model;
@@ -1102,13 +1169,18 @@ class VoiceCentricConfigTab {
 
       // Restore orchestration timeout
       const orchTimeoutSelect = panel.querySelector('#vc-orchestration-timeout');
+      const orchProviderDefaultTimeout = this._getProviderDefaultTimeout(vcConfig.orchestration.provider);
       if (orchTimeoutSelect && vcConfig.orchestration.timeout) {
         orchTimeoutSelect.value = String(vcConfig.orchestration.timeout);
-        // Show the dropdown if non-default
-        if (vcConfig.orchestration.timeout !== VoiceCentricConfigTab.DEFAULT_TIMEOUT) {
+        // Show the dropdown if non-default for this provider
+        if (vcConfig.orchestration.timeout !== orchProviderDefaultTimeout) {
           orchTimeoutSelect.style.display = '';
         }
         this._updateOrchestrationTimeoutIcon(panel, String(vcConfig.orchestration.timeout));
+      } else if (orchTimeoutSelect) {
+        // No saved timeout — apply the provider's default
+        orchTimeoutSelect.value = String(orchProviderDefaultTimeout);
+        this._updateOrchestrationTimeoutIcon(panel, String(orchProviderDefaultTimeout));
       }
 
       // Restore orchestration custom instructions

--- a/src/ai/pi-provider.js
+++ b/src/ai/pi-provider.js
@@ -240,7 +240,7 @@ class PiProvider extends AIProvider {
    */
   async execute(prompt, options = {}) {
     return new Promise((resolve, reject) => {
-      const { cwd = process.cwd(), timeout = 300000, level = 'unknown', analysisId, registerProcess, onStreamEvent, logPrefix } = options;
+      const { cwd = process.cwd(), timeout = 900000, level = 'unknown', analysisId, registerProcess, onStreamEvent, logPrefix } = options;
 
       const levelPrefix = logPrefix || `[Level ${level}]`;
       logger.info(`${levelPrefix} Executing Pi CLI...`);
@@ -849,6 +849,9 @@ class PiProvider extends AIProvider {
     return 'Install Pi: npm install -g @mariozechner/pi-coding-agent\n' +
            'Or visit: https://github.com/badlogic/pi-mono';
   }
+
+  /** Default timeout in ms (15 minutes) — Pi is slower than most providers */
+  static defaultTimeout = 900000;
 }
 
 // Register this provider

--- a/src/ai/provider.js
+++ b/src/ai/provider.js
@@ -449,6 +449,9 @@ function createAliasedProviderClass(aliasId, BaseClass, aliasConfig) {
   if (aliasConfig.installInstructions) {
     AliasedProvider.getInstallInstructions = () => aliasConfig.installInstructions;
   }
+  if (aliasConfig.defaultTimeout != null) {
+    AliasedProvider.defaultTimeout = aliasConfig.defaultTimeout;
+  }
 
   return AliasedProvider;
 }
@@ -628,7 +631,8 @@ function getAllProvidersInfo() {
       defaultModel,
       installInstructions,
       capabilities,
-      isExecutable: ProviderClass.isExecutable || false
+      isExecutable: ProviderClass.isExecutable || false,
+      ...(ProviderClass.defaultTimeout != null ? { defaultTimeout: ProviderClass.defaultTimeout } : {})
     });
   }
   return providers;

--- a/tests/unit/TimeoutSelect.test.js
+++ b/tests/unit/TimeoutSelect.test.js
@@ -232,8 +232,8 @@ describe('TimeoutSelect', () => {
   // -- Static TIMEOUT_OPTIONS -----------------------------------------------
 
   describe('static TIMEOUT_OPTIONS', () => {
-    it('should be an array with 4 default entries', () => {
-      expect(TimeoutSelect.TIMEOUT_OPTIONS).toHaveLength(4);
+    it('should be an array with 6 default entries', () => {
+      expect(TimeoutSelect.TIMEOUT_OPTIONS).toHaveLength(6);
     });
 
     it('should have 600000 (10m) as the default selected value', () => {
@@ -245,7 +245,7 @@ describe('TimeoutSelect', () => {
 
     it('should contain expected timeout values', () => {
       const values = TimeoutSelect.TIMEOUT_OPTIONS.map(o => o.value);
-      expect(values).toEqual(['300000', '600000', '900000', '1800000']);
+      expect(values).toEqual(['300000', '600000', '900000', '1800000', '2700000', '3600000']);
     });
   });
 
@@ -261,7 +261,7 @@ describe('TimeoutSelect', () => {
     it('should create option buttons for each option', () => {
       const ts = new TimeoutSelect();
       const items = ts.el.querySelectorAll('.timeout-select-option');
-      expect(items).toHaveLength(4);
+      expect(items).toHaveLength(6);
     });
 
     it('should accept custom options', () => {
@@ -776,9 +776,9 @@ describe('TimeoutSelect', () => {
 
       const ts = TimeoutSelect.mount(mountSpan);
 
-      // Should have 4 options (from TIMEOUT_OPTIONS)
+      // Should have 6 options (from TIMEOUT_OPTIONS)
       const items = ts.el.querySelectorAll('.timeout-select-option');
-      expect(items).toHaveLength(4);
+      expect(items).toHaveLength(6);
       expect(ts.value).toBe('600000');
     });
 

--- a/tests/unit/config-tab-timeout.test.js
+++ b/tests/unit/config-tab-timeout.test.js
@@ -1,0 +1,696 @@
+// Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+/**
+ * Unit tests for provider-specific timeout logic in AdvancedConfigTab
+ * and VoiceCentricConfigTab.
+ *
+ * Covers:
+ * - _getProviderDefaultTimeout: provider-specific default vs static fallback
+ * - _defaultConfig: uses provider-specific timeout for consolidation/orchestration
+ * - _applyProviderDefaultTimeout: smart logic preserving user overrides
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Minimal DOM helpers — just enough for _applyProviderDefaultTimeout's DOM access
+// ---------------------------------------------------------------------------
+
+function createMockElement(tag) {
+  const children = [];
+  const classList = new Set();
+  const attributes = {};
+  const dataset = {};
+  const listeners = {};
+
+  const el = {
+    tagName: tag?.toUpperCase() || 'DIV',
+    id: '',
+    value: '',
+    style: {},
+    innerHTML: '',
+    textContent: '',
+    parentNode: null,
+    dataset,
+    _children: children,
+    _listeners: listeners,
+
+    classList: {
+      add(...classes) { classes.forEach(c => classList.add(c)); },
+      remove(...classes) { classes.forEach(c => classList.delete(c)); },
+      contains(c) { return classList.has(c); },
+      toggle(c, force) {
+        if (force === undefined) { if (classList.has(c)) classList.delete(c); else classList.add(c); }
+        else if (force) classList.add(c);
+        else classList.delete(c);
+      },
+    },
+
+    setAttribute(name, value) { attributes[name] = String(value); },
+    getAttribute(name) { return attributes[name] ?? null; },
+
+    appendChild(child) {
+      children.push(child);
+      child.parentNode = el;
+      return child;
+    },
+    removeChild(child) {
+      const idx = children.indexOf(child);
+      if (idx >= 0) children.splice(idx, 1);
+      child.parentNode = null;
+      return child;
+    },
+    remove() {
+      if (el.parentNode) el.parentNode.removeChild(el);
+    },
+    contains(other) {
+      if (other === el) return true;
+      return children.some(c => c === other || (c.contains && c.contains(other)));
+    },
+
+    querySelector(selector) {
+      return queryAll(el, selector)[0] || null;
+    },
+    querySelectorAll(selector) {
+      return queryAll(el, selector);
+    },
+
+    addEventListener(event, handler) {
+      if (!listeners[event]) listeners[event] = [];
+      listeners[event].push(handler);
+    },
+    removeEventListener(event, handler) {
+      if (!listeners[event]) return;
+      listeners[event] = listeners[event].filter(h => h !== handler);
+    },
+    dispatchEvent() { return true; },
+
+    closest(selector) {
+      let cur = el;
+      while (cur) {
+        if (matchesSelector(cur, selector)) return cur;
+        cur = cur.parentNode;
+      }
+      return null;
+    },
+    focus: vi.fn(),
+    insertBefore(newChild, refChild) {
+      const idx = children.indexOf(refChild);
+      if (idx >= 0) children.splice(idx, 0, newChild);
+      else children.push(newChild);
+      newChild.parentNode = el;
+      return newChild;
+    },
+    scrollIntoView: vi.fn(),
+    click() {},
+  };
+  return el;
+}
+
+/** Very simple selector matching. */
+function matchesSelector(el, selector) {
+  if (selector.startsWith('.')) return el.classList && el.classList.contains(selector.slice(1));
+  if (selector.startsWith('#')) return el.id === selector.slice(1);
+  const attrMatch = selector.match(/^\[([a-z-]+)(?:="([^"]*)")?\]$/);
+  if (attrMatch) {
+    const val = el.getAttribute(attrMatch[1]);
+    if (attrMatch[2] !== undefined) return val === attrMatch[2];
+    return val != null;
+  }
+  // compound: .class1.class2
+  if (selector.includes('.') && !selector.startsWith('.')) {
+    const parts = selector.split('.').filter(Boolean);
+    return parts.every(p => el.classList && el.classList.contains(p));
+  }
+  return el.tagName === selector.toUpperCase();
+}
+
+function queryAll(root, selector) {
+  const results = [];
+  function walk(node) {
+    if (!node._children) return;
+    for (const child of node._children) {
+      if (matchesSelector(child, selector)) results.push(child);
+      walk(child);
+    }
+  }
+  walk(root);
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// Global stubs for browser environment
+// ---------------------------------------------------------------------------
+
+global.window = global.window || {};
+global.Event = class MockEvent {
+  constructor(type) { this.type = type; this.bubbles = false; this.target = null; }
+  preventDefault() {}
+  stopPropagation() {}
+};
+global.document = {
+  createElement: (tag) => createMockElement(tag),
+  addEventListener: () => {},
+  removeEventListener: () => {},
+};
+
+// TimeoutSelect is referenced in methods but we stub it on window so class-level
+// references don't blow up during module load.
+global.window.TimeoutSelect = {
+  mount: vi.fn(() => ({ el: createMockElement('div'), value: '600000' })),
+  TIMEOUT_OPTIONS: [
+    { value: '300000', label: '5m' },
+    { value: '600000', label: '10m', selected: true },
+    { value: '900000', label: '15m' },
+    { value: '1800000', label: '30m' },
+    { value: '2700000', label: '45m' },
+    { value: '3600000', label: '60m' },
+  ],
+};
+
+// Load browser components
+require('../../public/js/components/AdvancedConfigTab.js');
+require('../../public/js/components/VoiceCentricConfigTab.js');
+
+const { AdvancedConfigTab, VoiceCentricConfigTab } = global.window;
+
+// ---------------------------------------------------------------------------
+// Shared test provider definitions
+// ---------------------------------------------------------------------------
+
+const PROVIDERS = {
+  claude: { id: 'claude', name: 'Claude', models: [], defaultModel: 'sonnet' },
+  pi: { id: 'pi', name: 'Pi', models: [], defaultModel: 'default', defaultTimeout: 900000 },
+  gemini: { id: 'gemini', name: 'Gemini', models: [], defaultModel: 'gemini-2.5-pro' },
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('AdvancedConfigTab timeout logic', () => {
+  let tab;
+  let mockModal;
+
+  beforeEach(() => {
+    mockModal = createMockElement('div');
+    tab = new AdvancedConfigTab(mockModal);
+    tab.providers = PROVIDERS;
+  });
+
+  describe('_getProviderDefaultTimeout', () => {
+    it('should return provider-specific timeout when provider defines one', () => {
+      expect(tab._getProviderDefaultTimeout('pi')).toBe(900000);
+    });
+
+    it('should return DEFAULT_TIMEOUT when provider has no defaultTimeout', () => {
+      expect(tab._getProviderDefaultTimeout('claude')).toBe(AdvancedConfigTab.DEFAULT_TIMEOUT);
+      expect(tab._getProviderDefaultTimeout('claude')).toBe(600000);
+    });
+
+    it('should return DEFAULT_TIMEOUT for unknown provider', () => {
+      expect(tab._getProviderDefaultTimeout('nonexistent')).toBe(AdvancedConfigTab.DEFAULT_TIMEOUT);
+    });
+
+    it('should return DEFAULT_TIMEOUT for null/undefined provider', () => {
+      expect(tab._getProviderDefaultTimeout(null)).toBe(AdvancedConfigTab.DEFAULT_TIMEOUT);
+      expect(tab._getProviderDefaultTimeout(undefined)).toBe(AdvancedConfigTab.DEFAULT_TIMEOUT);
+    });
+  });
+
+  describe('_defaultConfig', () => {
+    it('should use provider-specific timeout when default provider has one', () => {
+      tab._defaultProvider = 'pi';
+      tab._defaultModel = 'default';
+
+      const config = tab._defaultConfig();
+      expect(config.consolidation.timeout).toBe(900000);
+    });
+
+    it('should use DEFAULT_TIMEOUT when default provider has no defaultTimeout', () => {
+      tab._defaultProvider = 'claude';
+      tab._defaultModel = 'sonnet';
+
+      const config = tab._defaultConfig();
+      expect(config.consolidation.timeout).toBe(600000);
+    });
+
+    it('should fall back to claude when _defaultProvider is not set', () => {
+      // _defaultProvider is not set by constructor on AdvancedConfigTab
+      // (it gets set via setDefaultOrchestration), so it defaults to 'claude'
+      const config = tab._defaultConfig();
+      expect(config.consolidation.timeout).toBe(600000);
+      expect(config.consolidation.provider).toBe('claude');
+    });
+  });
+
+  describe('_applyProviderDefaultTimeout', () => {
+    /**
+     * Helper: set up a mock panel with timeout elements for a voice or orchestration.
+     * Returns { panel, timeoutEl, providerSelect }.
+     */
+    function setupForVoice({ providerId, level, index, currentTimeout, previousProvider }) {
+      const panel = createMockElement('div');
+      panel.id = 'tab-panel-advanced';
+
+      const wrapper = createMockElement('div');
+      wrapper.classList.add('participant-wrapper');
+      wrapper.setAttribute('data-level', level);
+      wrapper.setAttribute('data-index', index);
+      wrapper.dataset.level = level;
+      wrapper.dataset.index = index;
+
+      const providerSelect = createMockElement('select');
+      providerSelect.classList.add('voice-provider');
+      providerSelect.value = providerId;
+      providerSelect.dataset.level = level;
+      providerSelect.dataset.index = index;
+      if (previousProvider) {
+        providerSelect.dataset.previousProvider = previousProvider;
+      }
+      wrapper.appendChild(providerSelect);
+
+      const timeoutEl = createMockElement('div');
+      timeoutEl.classList.add('adv-timeout');
+      timeoutEl.value = String(currentTimeout);
+      wrapper.appendChild(timeoutEl);
+
+      // Also add timeout icon button stub
+      const iconBtn = createMockElement('button');
+      iconBtn.classList.add('toggle-timeout-icon');
+      iconBtn.dataset.level = level;
+      iconBtn.dataset.index = index;
+      wrapper.appendChild(iconBtn);
+
+      panel.appendChild(wrapper);
+      mockModal.appendChild(panel);
+
+      return { panel, timeoutEl, providerSelect };
+    }
+
+    function setupForOrchestration({ providerId, currentTimeout, previousProvider }) {
+      const panel = createMockElement('div');
+      panel.id = 'tab-panel-advanced';
+
+      const orchRow = createMockElement('div');
+      orchRow.id = 'orchestration-voice';
+
+      const providerSelect = createMockElement('select');
+      providerSelect.classList.add('voice-provider');
+      providerSelect.value = providerId;
+      providerSelect.dataset.target = 'orchestration';
+      if (previousProvider) {
+        providerSelect.dataset.previousProvider = previousProvider;
+      }
+      orchRow.appendChild(providerSelect);
+      panel.appendChild(orchRow);
+
+      const timeoutEl = createMockElement('div');
+      timeoutEl.id = 'adv-orchestration-timeout';
+      timeoutEl.classList.add('adv-timeout');
+      timeoutEl.value = String(currentTimeout);
+      panel.appendChild(timeoutEl);
+
+      // Orchestration timeout icon stub
+      const iconBtn = createMockElement('button');
+      iconBtn.id = 'adv-orchestration-timeout-toggle';
+      panel.appendChild(iconBtn);
+
+      mockModal.appendChild(panel);
+
+      return { panel, timeoutEl, providerSelect };
+    }
+
+    // ---- Voice (non-orchestration) tests ----
+
+    it('should apply new provider default when timeout matches old default', () => {
+      const { timeoutEl, providerSelect } = setupForVoice({
+        providerId: 'pi',
+        level: '1',
+        index: '0',
+        currentTimeout: 600000,    // matches claude default
+        previousProvider: 'claude',
+      });
+
+      tab._applyProviderDefaultTimeout(providerSelect);
+
+      // Switching from claude (600000) to pi (900000), current matches old default
+      // -> should apply new default directly
+      expect(timeoutEl.value).toBe('900000');
+    });
+
+    it('should use Math.max when user has customized timeout', () => {
+      const { timeoutEl, providerSelect } = setupForVoice({
+        providerId: 'claude',
+        level: '1',
+        index: '0',
+        currentTimeout: 1800000,   // user customized to 30min
+        previousProvider: 'pi',
+      });
+
+      tab._applyProviderDefaultTimeout(providerSelect);
+
+      // Switching from pi (900000) to claude (600000), current (1800000) != old default (900000)
+      // -> should use Math.max(1800000, 600000) = 1800000
+      expect(timeoutEl.value).toBe('1800000');
+    });
+
+    it('should apply new default when current is higher than old default but matches old default', () => {
+      const { timeoutEl, providerSelect } = setupForVoice({
+        providerId: 'claude',
+        level: '1',
+        index: '0',
+        currentTimeout: 900000,    // matches pi default
+        previousProvider: 'pi',
+      });
+
+      tab._applyProviderDefaultTimeout(providerSelect);
+
+      // Switching from pi (900000) to claude (600000), current matches old default
+      // -> should apply new default directly: 600000
+      expect(timeoutEl.value).toBe('600000');
+    });
+
+    it('should apply new default when no previous provider is set', () => {
+      const { timeoutEl, providerSelect } = setupForVoice({
+        providerId: 'pi',
+        level: '1',
+        index: '0',
+        currentTimeout: 600000,
+        previousProvider: null,
+      });
+
+      tab._applyProviderDefaultTimeout(providerSelect);
+
+      // No previous provider -> oldDefault is null -> apply new default directly
+      expect(timeoutEl.value).toBe('900000');
+    });
+
+    it('should use Math.max to preserve user override that exceeds new default', () => {
+      const { timeoutEl, providerSelect } = setupForVoice({
+        providerId: 'pi',
+        level: '1',
+        index: '0',
+        currentTimeout: 1800000,   // user customized to 30min
+        previousProvider: 'claude',
+      });
+
+      tab._applyProviderDefaultTimeout(providerSelect);
+
+      // Switching from claude (600000) to pi (900000), current (1800000) != old default (600000)
+      // -> should use Math.max(1800000, 900000) = 1800000
+      expect(timeoutEl.value).toBe('1800000');
+    });
+
+    it('should raise timeout to new default when user override is below new default', () => {
+      // Simulate a provider with custom high timeout
+      tab.providers = {
+        ...PROVIDERS,
+        'slow-provider': { id: 'slow-provider', defaultTimeout: 2700000 }
+      };
+
+      const { timeoutEl, providerSelect } = setupForVoice({
+        providerId: 'slow-provider',
+        level: '1',
+        index: '0',
+        currentTimeout: 900000,    // user had customized above claude's 600000
+        previousProvider: 'claude',
+      });
+
+      tab._applyProviderDefaultTimeout(providerSelect);
+
+      // current (900000) != old default (600000) -> Math.max(900000, 2700000) = 2700000
+      expect(timeoutEl.value).toBe('2700000');
+    });
+
+    it('should set data-previous-provider after applying', () => {
+      const { providerSelect } = setupForVoice({
+        providerId: 'pi',
+        level: '1',
+        index: '0',
+        currentTimeout: 600000,
+        previousProvider: 'claude',
+      });
+
+      tab._applyProviderDefaultTimeout(providerSelect);
+      expect(providerSelect.dataset.previousProvider).toBe('pi');
+    });
+
+    // ---- Orchestration tests ----
+
+    it('should apply new provider default to orchestration timeout', () => {
+      const { timeoutEl, providerSelect } = setupForOrchestration({
+        providerId: 'pi',
+        currentTimeout: 600000,
+        previousProvider: 'claude',
+      });
+
+      tab._applyProviderDefaultTimeout(providerSelect);
+      expect(timeoutEl.value).toBe('900000');
+    });
+
+    it('should use Math.max for orchestration when user customized timeout', () => {
+      const { timeoutEl, providerSelect } = setupForOrchestration({
+        providerId: 'claude',
+        currentTimeout: 1800000,
+        previousProvider: 'pi',
+      });
+
+      tab._applyProviderDefaultTimeout(providerSelect);
+      // current (1800000) != pi default (900000) -> Math.max(1800000, 600000) = 1800000
+      expect(timeoutEl.value).toBe('1800000');
+    });
+
+    it('should apply orchestration default when no previous provider', () => {
+      const { timeoutEl, providerSelect } = setupForOrchestration({
+        providerId: 'pi',
+        currentTimeout: 600000,
+        previousProvider: null,
+      });
+
+      tab._applyProviderDefaultTimeout(providerSelect);
+      expect(timeoutEl.value).toBe('900000');
+    });
+  });
+});
+
+
+describe('VoiceCentricConfigTab timeout logic', () => {
+  let tab;
+  let mockModal;
+
+  beforeEach(() => {
+    mockModal = createMockElement('div');
+    tab = new VoiceCentricConfigTab(mockModal);
+    tab.providers = PROVIDERS;
+  });
+
+  describe('_getProviderDefaultTimeout', () => {
+    it('should return provider-specific timeout when provider defines one', () => {
+      expect(tab._getProviderDefaultTimeout('pi')).toBe(900000);
+    });
+
+    it('should return DEFAULT_TIMEOUT when provider has no defaultTimeout', () => {
+      expect(tab._getProviderDefaultTimeout('claude')).toBe(VoiceCentricConfigTab.DEFAULT_TIMEOUT);
+      expect(tab._getProviderDefaultTimeout('claude')).toBe(600000);
+    });
+
+    it('should return DEFAULT_TIMEOUT for unknown provider', () => {
+      expect(tab._getProviderDefaultTimeout('nonexistent')).toBe(VoiceCentricConfigTab.DEFAULT_TIMEOUT);
+    });
+  });
+
+  describe('_defaultConfig', () => {
+    it('should use provider-specific timeout when default provider has one', () => {
+      tab._defaultProvider = 'pi';
+      tab._defaultModel = 'default';
+
+      const config = tab._defaultConfig();
+      expect(config.voices[0].timeout).toBe(900000);
+      expect(config.orchestration.timeout).toBe(900000);
+    });
+
+    it('should use DEFAULT_TIMEOUT when default provider has no defaultTimeout', () => {
+      tab._defaultProvider = 'claude';
+      tab._defaultModel = 'sonnet';
+
+      const config = tab._defaultConfig();
+      expect(config.voices[0].timeout).toBe(600000);
+      expect(config.orchestration.timeout).toBe(600000);
+    });
+
+    it('should use the same timeout for both voices and orchestration', () => {
+      tab._defaultProvider = 'pi';
+      tab._defaultModel = 'default';
+
+      const config = tab._defaultConfig();
+      expect(config.voices[0].timeout).toBe(config.orchestration.timeout);
+    });
+  });
+
+  describe('_applyProviderDefaultTimeout', () => {
+    function setupForReviewer({ providerId, index, currentTimeout, previousProvider }) {
+      const panel = createMockElement('div');
+      panel.id = 'tab-panel-council';
+
+      const wrapper = createMockElement('div');
+      wrapper.classList.add('vc-reviewer');
+
+      const providerSelect = createMockElement('select');
+      providerSelect.classList.add('voice-provider');
+      providerSelect.value = providerId;
+      providerSelect.dataset.index = index;
+      if (previousProvider) {
+        providerSelect.dataset.previousProvider = previousProvider;
+      }
+      wrapper.appendChild(providerSelect);
+
+      const timeoutEl = createMockElement('div');
+      timeoutEl.classList.add('vc-timeout');
+      timeoutEl.value = String(currentTimeout);
+      wrapper.appendChild(timeoutEl);
+
+      // Timeout icon stub
+      const iconBtn = createMockElement('button');
+      iconBtn.classList.add('toggle-timeout-icon');
+      iconBtn.dataset.index = index;
+      wrapper.appendChild(iconBtn);
+
+      panel.appendChild(wrapper);
+      mockModal.appendChild(panel);
+
+      return { panel, timeoutEl, providerSelect };
+    }
+
+    function setupForOrchestration({ providerId, currentTimeout, previousProvider }) {
+      const panel = createMockElement('div');
+      panel.id = 'tab-panel-council';
+
+      const orchRow = createMockElement('div');
+      orchRow.id = 'vc-orchestration-voice';
+
+      const providerSelect = createMockElement('select');
+      providerSelect.classList.add('voice-provider');
+      providerSelect.value = providerId;
+      providerSelect.dataset.target = 'orchestration';
+      if (previousProvider) {
+        providerSelect.dataset.previousProvider = previousProvider;
+      }
+      orchRow.appendChild(providerSelect);
+      panel.appendChild(orchRow);
+
+      const timeoutEl = createMockElement('div');
+      timeoutEl.id = 'vc-orchestration-timeout';
+      timeoutEl.classList.add('vc-timeout');
+      timeoutEl.value = String(currentTimeout);
+      panel.appendChild(timeoutEl);
+
+      // Orchestration timeout icon stub
+      const iconBtn = createMockElement('button');
+      iconBtn.id = 'vc-orchestration-timeout-toggle';
+      panel.appendChild(iconBtn);
+
+      mockModal.appendChild(panel);
+
+      return { panel, timeoutEl, providerSelect };
+    }
+
+    // ---- Reviewer tests ----
+
+    it('should apply new provider default when timeout matches old default', () => {
+      const { timeoutEl, providerSelect } = setupForReviewer({
+        providerId: 'pi',
+        index: '0',
+        currentTimeout: 600000,
+        previousProvider: 'claude',
+      });
+
+      tab._applyProviderDefaultTimeout(providerSelect);
+      expect(timeoutEl.value).toBe('900000');
+    });
+
+    it('should use Math.max when user has customized timeout', () => {
+      const { timeoutEl, providerSelect } = setupForReviewer({
+        providerId: 'claude',
+        index: '0',
+        currentTimeout: 1800000,
+        previousProvider: 'pi',
+      });
+
+      tab._applyProviderDefaultTimeout(providerSelect);
+      // current (1800000) != pi default (900000) -> Math.max(1800000, 600000) = 1800000
+      expect(timeoutEl.value).toBe('1800000');
+    });
+
+    it('should apply new default when current matches old default exactly', () => {
+      const { timeoutEl, providerSelect } = setupForReviewer({
+        providerId: 'claude',
+        index: '0',
+        currentTimeout: 900000,
+        previousProvider: 'pi',
+      });
+
+      tab._applyProviderDefaultTimeout(providerSelect);
+      // current (900000) matches pi default -> apply claude default directly: 600000
+      expect(timeoutEl.value).toBe('600000');
+    });
+
+    it('should apply new default when no previous provider is set', () => {
+      const { timeoutEl, providerSelect } = setupForReviewer({
+        providerId: 'pi',
+        index: '0',
+        currentTimeout: 600000,
+        previousProvider: null,
+      });
+
+      tab._applyProviderDefaultTimeout(providerSelect);
+      expect(timeoutEl.value).toBe('900000');
+    });
+
+    it('should set data-previous-provider after applying', () => {
+      const { providerSelect } = setupForReviewer({
+        providerId: 'pi',
+        index: '0',
+        currentTimeout: 600000,
+        previousProvider: 'claude',
+      });
+
+      tab._applyProviderDefaultTimeout(providerSelect);
+      expect(providerSelect.dataset.previousProvider).toBe('pi');
+    });
+
+    // ---- Orchestration tests ----
+
+    it('should apply new provider default to orchestration timeout', () => {
+      const { timeoutEl, providerSelect } = setupForOrchestration({
+        providerId: 'pi',
+        currentTimeout: 600000,
+        previousProvider: 'claude',
+      });
+
+      tab._applyProviderDefaultTimeout(providerSelect);
+      expect(timeoutEl.value).toBe('900000');
+    });
+
+    it('should use Math.max for orchestration when user customized timeout', () => {
+      const { timeoutEl, providerSelect } = setupForOrchestration({
+        providerId: 'claude',
+        currentTimeout: 1800000,
+        previousProvider: 'pi',
+      });
+
+      tab._applyProviderDefaultTimeout(providerSelect);
+      expect(timeoutEl.value).toBe('1800000');
+    });
+
+    it('should apply orchestration default when no previous provider', () => {
+      const { timeoutEl, providerSelect } = setupForOrchestration({
+        providerId: 'pi',
+        currentTimeout: 600000,
+        previousProvider: null,
+      });
+
+      tab._applyProviderDefaultTimeout(providerSelect);
+      expect(timeoutEl.value).toBe('900000');
+    });
+  });
+});

--- a/tests/unit/provider-config.test.js
+++ b/tests/unit/provider-config.test.js
@@ -18,7 +18,8 @@ import {
   getAllProvidersInfo,
   getRegisteredProviderIds,
   getProviderClass,
-  createProvider
+  createProvider,
+  createAliasedProviderClass
 } from '../../src/ai/index.js';
 
 describe('Provider Configuration', () => {
@@ -561,6 +562,18 @@ describe('Provider Configuration', () => {
       // 'multi-model' should be unaffected
       expect(pi.models.find(m => m.id === 'multi-model').tier).toBe('thorough');
     });
+
+    it('should include defaultTimeout for providers that define it', () => {
+      const providers = getAllProvidersInfo();
+      const pi = providers.find(p => p.id === 'pi');
+      expect(pi.defaultTimeout).toBe(900000); // 15 minutes
+    });
+
+    it('should not include defaultTimeout for providers that do not define it', () => {
+      const providers = getAllProvidersInfo();
+      const claude = providers.find(p => p.id === 'claude');
+      expect(claude.defaultTimeout).toBeUndefined();
+    });
   });
 
   describe('yolo mode propagation', () => {
@@ -801,6 +814,150 @@ describe('Provider Configuration', () => {
       const overrides = getProviderConfigOverrides('pi');
       expect(overrides).toBeDefined();
       expect(overrides.command).toBe('/custom/pi');
+    });
+
+    it('should forward defaultTimeout to the aliased class', () => {
+      applyConfigOverrides({
+        providers: {
+          'pi-custom': {
+            type: 'pi',
+            name: 'Pi Custom',
+            defaultTimeout: 1200000,
+            models: [{ id: 'default', tier: 'balanced', default: true }]
+          }
+        }
+      });
+
+      const AliasClass = getProviderClass('pi-custom');
+      expect(AliasClass.defaultTimeout).toBe(1200000);
+    });
+
+    it('should inherit base class defaultTimeout when alias does not define one', () => {
+      applyConfigOverrides({
+        providers: {
+          'pi-inherit': {
+            type: 'pi',
+            name: 'Pi Inherit',
+            models: [{ id: 'default', tier: 'balanced', default: true }]
+          }
+        }
+      });
+
+      const AliasClass = getProviderClass('pi-inherit');
+      const BaseClass = getProviderClass('pi');
+      // Pi's base class has defaultTimeout = 900000
+      // Without an explicit override, the alias inherits from the base prototype chain
+      expect(BaseClass.defaultTimeout).toBe(900000);
+      // The alias should NOT have its own defaultTimeout property set
+      expect(Object.hasOwn(AliasClass, 'defaultTimeout')).toBe(false);
+    });
+
+    it('should surface aliased defaultTimeout in getAllProvidersInfo', () => {
+      applyConfigOverrides({
+        providers: {
+          'pi-slow': {
+            type: 'pi',
+            name: 'Pi Slow',
+            defaultTimeout: 1800000,
+            models: [{ id: 'default', tier: 'balanced', default: true }]
+          }
+        }
+      });
+
+      const providers = getAllProvidersInfo();
+      const alias = providers.find(p => p.id === 'pi-slow');
+      expect(alias).toBeDefined();
+      expect(alias.defaultTimeout).toBe(1800000);
+    });
+
+    it('should surface aliased defaultTimeout: 0 in getAllProvidersInfo', () => {
+      applyConfigOverrides({
+        providers: {
+          'pi-zero-timeout': {
+            type: 'pi',
+            name: 'Pi Zero Timeout',
+            defaultTimeout: 0,
+            models: [{ id: 'default', tier: 'balanced', default: true }]
+          }
+        }
+      });
+
+      const providers = getAllProvidersInfo();
+      const alias = providers.find(p => p.id === 'pi-zero-timeout');
+      expect(alias).toBeDefined();
+      expect(alias.defaultTimeout).toBe(0);
+    });
+
+    it('should not set defaultTimeout on alias when not provided', () => {
+      applyConfigOverrides({
+        providers: {
+          'claude-alias': {
+            type: 'claude',
+            name: 'Claude Alias'
+          }
+        }
+      });
+
+      const AliasClass = getProviderClass('claude-alias');
+      // Claude has no defaultTimeout, alias should not either
+      expect(Object.hasOwn(AliasClass, 'defaultTimeout')).toBe(false);
+    });
+  });
+
+  describe('createAliasedProviderClass defaultTimeout forwarding', () => {
+    it('should set defaultTimeout as static property on alias class', () => {
+      const BaseClass = getProviderClass('claude');
+      const AliasClass = createAliasedProviderClass('test-alias', BaseClass, {
+        name: 'Test Alias',
+        defaultTimeout: 1500000
+      });
+
+      expect(AliasClass.defaultTimeout).toBe(1500000);
+    });
+
+    it('should not set defaultTimeout when not provided in config', () => {
+      const BaseClass = getProviderClass('claude');
+      const AliasClass = createAliasedProviderClass('test-alias-no-timeout', BaseClass, {
+        name: 'Test Alias No Timeout'
+      });
+
+      // Should not have its own defaultTimeout property
+      expect(Object.hasOwn(AliasClass, 'defaultTimeout')).toBe(false);
+    });
+
+    it('should not set defaultTimeout when value is null', () => {
+      const BaseClass = getProviderClass('claude');
+      const AliasClass = createAliasedProviderClass('test-alias-null', BaseClass, {
+        name: 'Test Alias Null',
+        defaultTimeout: null
+      });
+
+      expect(Object.hasOwn(AliasClass, 'defaultTimeout')).toBe(false);
+    });
+
+    it('should set defaultTimeout when value is 0', () => {
+      const BaseClass = getProviderClass('claude');
+      const AliasClass = createAliasedProviderClass('test-alias-zero', BaseClass, {
+        name: 'Test Alias Zero',
+        defaultTimeout: 0
+      });
+
+      // 0 is not null/undefined, so it should be set
+      // The check is `aliasConfig.defaultTimeout != null` — 0 passes this
+      expect(AliasClass.defaultTimeout).toBe(0);
+    });
+
+    it('should inherit base defaultTimeout through prototype chain', () => {
+      const BaseClass = getProviderClass('pi');
+      const AliasClass = createAliasedProviderClass('pi-proto-test', BaseClass, {
+        name: 'Pi Proto Test'
+      });
+
+      // Pi has defaultTimeout = 900000 on the class
+      // Alias does not override it, so accessing it traverses the prototype
+      expect(BaseClass.defaultTimeout).toBe(900000);
+      // The alias should not have its own
+      expect(Object.hasOwn(AliasClass, 'defaultTimeout')).toBe(false);
     });
   });
 });


### PR DESCRIPTION
## Summary
- Providers like Pi that define a custom `defaultTimeout` (15 min vs the standard 10 min) now have their timeout correctly applied throughout the council configuration UI in both Advanced and Voice-Centric tabs
- `_applyProviderDefaultTimeout()` now preserves explicit user overrides via `Math.max` instead of unconditionally overwriting
- `createAliasedProviderClass` forwards `defaultTimeout` from alias config, with consistent `??` / `!= null` null-handling across the pipeline

## Test plan
- [x] 5532 unit tests pass (122 files)
- [x] 268 E2E tests pass
- [ ] Manual: create a council with Pi provider, verify 15m default timeout appears
- [ ] Manual: switch provider from Pi to Claude, verify timeout drops to 10m
- [ ] Manual: set custom timeout (e.g. 30m), switch provider, verify custom value preserved via Math.max

🤖 Generated with [Claude Code](https://claude.com/claude-code)