### PR TITLE
Fix exclude-previous-findings spacing and background fill

### DIFF
--- a/public/css/analysis-config.css
+++ b/public/css/analysis-config.css
@@ -3,6 +3,7 @@
 /* Exclude Previous Findings — collapsible <details> section */
 
 .exclude-previous-section {
+  margin-top: 24px;
   margin-bottom: 20px;
   border: 1px solid var(--color-border-primary);
   border-radius: 8px;
@@ -15,6 +16,11 @@
   padding: 10px 14px;
   background: var(--color-bg-secondary);
   transition: background 0.15s ease;
+  margin-bottom: 0;
+}
+
+.exclude-previous-section[open] > summary {
+  margin-bottom: 0;
 }
 
 .exclude-previous-section > summary::-webkit-details-marker {

--- a/public/css/pr.css
+++ b/public/css/pr.css
@@ -9776,7 +9776,7 @@ body.resizing * {
 .instructions-container {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 4px;
 }
 
 .repo-instructions-banner {


### PR DESCRIPTION
## Summary
- Fix the summary background not filling the bordered container when collapsed (inherited `margin-bottom: 10px` from `.section-title` created a gap)
- Add `margin-top: 24px` to the exclude section so the "0 / 5,000 characters" counter is clearly associated with Custom Instructions above
- Tighten the instructions container gap from 8px to 4px to keep the char counter close to the textarea

## Test plan
- [ ] Open the analysis config modal and verify the exclude-previous-findings collapsed state has no background gap inside the border
- [ ] Verify the "0 / 5,000 characters" text reads as part of the Custom Instructions group, not the Exclude Previous Findings section
- [ ] Expand the exclude section and verify spacing still looks correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)