### PR TITLE
Add comment format hint to chat sessions

### DIFF
--- a/.changeset/comment-format-hint.md
+++ b/.changeset/comment-format-hint.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Add comment format template hint to chat sessions so the AI follows the configured format when creating or editing comments

--- a/plans/comment-format-hint.md
+++ b/plans/comment-format-hint.md
@@ -1,0 +1,77 @@
+# Comment Format Hint in Chat
+
+## Context
+
+When the chat agent adopts a comment with edits, it usually does not follow the user's configured comment format (e.g., `{emoji} **{category}**: {description}`). The model needs to be told what format to use. The comment format can also change between server restarts (user edits config), so it must be re-communicated on session resume.
+
+## Approach
+
+Inject the resolved comment format template into the chat at two points:
+
+1. **Session creation** — add a section to the system prompt that explains the comment format and instructs the model to follow it when writing or editing comments.
+2. **Session resume** — inject just the current template value as resume context (alongside the existing port correction), so the model picks up any config changes without repeating the full instructions.
+
+## Files to Modify
+
+### 1. `src/chat/prompt-builder.js` — `buildChatPrompt()`
+
+Add a new optional parameter `commentFormat` (the resolved template string). Add a new section to the system prompt after the domain model section:
+
+```
+## Comment format
+
+When creating or editing review comments, use this template:
+<template>
+{emoji} **{category}**: {description}{?suggestion}\n\n**Suggestion:** {suggestion}{/suggestion}
+</template>
+
+Template placeholders: {emoji}, {category}, {title}, {severity}, {description}, {suggestion}.
+Conditional sections: {?field}...{/field} — include content only when the field has a value.
+Always follow this format for consistency with the reviewer's preferences.
+```
+
+Only add this section when `commentFormat` is provided (non-null).
+
+### 2. `src/routes/chat.js` — `POST /api/chat/session`
+
+Before calling `buildChatPrompt()`, resolve the comment format template from config:
+
+```js
+const { resolveFormat } = require('../utils/comment-formatter');
+// ...
+const formatConfig = resolveFormat(config.comment_format);
+const commentFormatTemplate = formatConfig.template;
+```
+
+Pass `commentFormatTemplate` to `buildChatPrompt()`.
+
+### 3. `src/routes/chat.js` — Resume paths (explicit + auto-resume)
+
+In both the `POST /api/chat/session/:id/resume` handler and the auto-resume block in `POST /api/chat/session/:id/message`:
+
+Append the current comment format template to the resume/port-correction context:
+
+```js
+const formatConfig = resolveFormat(config.comment_format);
+portCorrectionContext += `\n\n[Comment format template: ${formatConfig.template}]`;
+```
+
+This is lightweight — no instructions repeated, just the current template value. The model already knows what it means from the original system prompt.
+
+### 4. Tests
+
+- **Unit test** for `buildChatPrompt`: verify the comment format section appears in the system prompt when `commentFormatTemplate` is provided, and does not appear when omitted.
+- **Unit/integration test** for chat routes: verify the comment format template is included in resume context.
+
+## Hazards
+
+- `buildChatPrompt()` has a single caller in `src/routes/chat.js` (called from both session create and resume/auto-resume paths for system prompt rebuilding). Adding a parameter is safe.
+- The resume context path has two injection points: explicit resume (`POST .../resume`) and auto-resume (in `POST .../message`). Both must include the comment format.
+- `resolveFormat()` is already imported in `src/routes/reviews.js` but not in `src/routes/chat.js` — need to add the import.
+- Config is accessed via `req.app.get('config')` — already available in all relevant route handlers.
+
+## Verification
+
+1. Run `npm test` — existing tests pass
+2. Run new unit tests for prompt builder
+3. Manual test: start a chat session, verify system prompt includes comment format section; resume session, verify resume context includes template

--- a/src/chat/prompt-builder.js
+++ b/src/chat/prompt-builder.js
@@ -18,9 +18,10 @@ const logger = require('../utils/logger');
  * @param {Object} options.review - Review metadata {id, pr_number, repository, review_type, local_path, name}
  * @param {Object} [options.prData] - PR data with base_sha/head_sha (for PR reviews)
  * @param {string} [options.chatInstructions] - Custom instructions from repo settings to append to system prompt
+ * @param {string} [options.commentFormatTemplate] - Resolved comment format template for consistent comment formatting
  * @returns {string} System prompt for the chat agent
  */
-function buildChatPrompt({ review, prData, chatInstructions }) {
+function buildChatPrompt({ review, prData, chatInstructions, commentFormatTemplate }) {
   const sections = [];
 
   // Role
@@ -52,6 +53,21 @@ function buildChatPrompt({ review, prData, chatInstructions }) {
     domainLines.push(`- The internal review ID for this session to use with API requests is: ${review.id} (e.g. \`/api/reviews/${review.id}/comments\`).`);
   }
   sections.push(domainLines.join('\n'));
+
+  // Comment format template — injected when the user has a configured format
+  if (commentFormatTemplate) {
+    sections.push(
+      '## Comment format\n\n' +
+      'When creating or editing review comments, use this template:\n' +
+      '<template>\n' +
+      commentFormatTemplate + '\n' +
+      '</template>\n\n' +
+      'Template placeholders: {emoji}, {category}, {title}, {severity}, {SEVERITY}, {description}, {suggestion}.\n' +
+      '{severity} renders as Title Case (e.g. "Critical"), {SEVERITY} renders as UPPERCASE (e.g. "CRITICAL").\n' +
+      'Conditional sections: {?field}...{/field} — include content only when the field has a value.\n' +
+      'Always follow this format for consistency with the reviewer\'s preferences.'
+    );
+  }
 
   // API Access — cheat-sheet is injected into initial context; full docs available via GET /api.md
   sections.push(

--- a/src/routes/chat.js
+++ b/src/routes/chat.js
@@ -20,6 +20,7 @@ const logger = require('../utils/logger');
 const ws = require('../ws');
 const { fireHooks, hasHooks } = require('../hooks/hook-runner');
 const { buildChatStartedPayload, buildChatResumedPayload, buildChatHookContext, getCachedUser } = require('../hooks/payloads');
+const { resolveFormat } = require('../utils/comment-formatter');
 
 /**
  * Fire a chat hook event (non-blocking). Skips async work when no hooks are configured.
@@ -259,8 +260,10 @@ router.post('/api/chat/session', async (req, res) => {
 
       const chatInstructions = await getChatInstructions(db, review);
       const prData = await fetchPrData(db, review);
+      const config = req.app.get('config') || {};
+      const formatConfig = resolveFormat(config.comment_format);
 
-      finalSystemPrompt = buildChatPrompt({ review, prData, chatInstructions });
+      finalSystemPrompt = buildChatPrompt({ review, prData, chatInstructions, commentFormatTemplate: formatConfig.template });
 
       if (!skipAnalysisContext) {
         // Fetch all AI suggestions from the latest analysis run
@@ -390,8 +393,10 @@ router.post('/api/chat/session/:id/message', async (req, res) => {
       }
       const chatInstructions = await getChatInstructions(db, review);
       const prData = await fetchPrData(db, review);
+      const config = req.app.get('config') || {};
+      const fmtConfig = resolveFormat(config.comment_format);
 
-      const systemPrompt = buildChatPrompt({ review, prData, chatInstructions });
+      const systemPrompt = buildChatPrompt({ review, prData, chatInstructions, commentFormatTemplate: fmtConfig.template });
       const cwd = await resolveReviewCwd(db, review);
 
       try {
@@ -405,7 +410,7 @@ router.post('/api/chat/session/:id/message', async (req, res) => {
         // Inject port correction so the agent knows the current server address,
         // even if the conversational history has a stale port from session creation.
         const serverPort = req.socket.localPort;
-        portCorrectionContext = `[Server port: ${serverPort}] The pair-review API is at http://localhost:${serverPort}`;
+        portCorrectionContext = `[Server port: ${serverPort}] The pair-review API is at http://localhost:${serverPort}\n\n[Comment format template: ${fmtConfig.template}]`;
         // Note: we intentionally do NOT re-inject the API cheat sheet on resume.
         // The agent already has the endpoint shapes from the original session context —
         // it only needs the updated port to adjust its curl calls.
@@ -530,8 +535,10 @@ router.post('/api/chat/session/:id/resume', async (req, res) => {
     // initial session's context.
     const chatInstructions = await getChatInstructions(db, review);
     const prData = await fetchPrData(db, review);
+    const config = req.app.get('config') || {};
+    const fmtConfig = resolveFormat(config.comment_format);
 
-    const systemPrompt = buildChatPrompt({ review, prData, chatInstructions });
+    const systemPrompt = buildChatPrompt({ review, prData, chatInstructions, commentFormatTemplate: fmtConfig.template });
     const cwd = await resolveReviewCwd(db, review);
 
     await chatSessionManager.resumeSession(sessionId, { systemPrompt, cwd });
@@ -544,7 +551,7 @@ router.post('/api/chat/session/:id/resume', async (req, res) => {
     // Uses resumeContext (consumed on next sendMessage) instead of saveContextMessage
     // (which only writes to DB and never reaches the agent process).
     chatSessionManager.setResumeContext(sessionId,
-      `[Server port: ${serverPort}] The pair-review API is at http://localhost:${serverPort}`
+      `[Server port: ${serverPort}] The pair-review API is at http://localhost:${serverPort}\n\n[Comment format template: ${fmtConfig.template}]`
     );
 
     logger.info(`[ChatRoute] Explicitly resumed session ${sessionId}`);

--- a/tests/integration/chat-routes.test.js
+++ b/tests/integration/chat-routes.test.js
@@ -261,6 +261,33 @@ describe('Chat Routes', () => {
       expect(res.status).toBe(404);
       expect(res.body.error).toContain('Review not found');
     });
+
+    it('should include comment format in system prompt when config has comment_format', async () => {
+      app.set('config', { comment_format: 'minimal' });
+
+      const res = await request(app)
+        .post('/api/chat/session')
+        .send({ provider: 'pi', reviewId: 1 });
+
+      expect(res.status).toBe(200);
+      const callArgs = mockManager.createSession.mock.calls[0][0];
+      expect(callArgs.systemPrompt).toContain('## Comment format');
+      expect(callArgs.systemPrompt).toContain('[{category}] {description}');
+    });
+
+    it('should use default comment format when config has no comment_format', async () => {
+      app.set('config', {});
+
+      const res = await request(app)
+        .post('/api/chat/session')
+        .send({ provider: 'pi', reviewId: 1 });
+
+      expect(res.status).toBe(200);
+      const callArgs = mockManager.createSession.mock.calls[0][0];
+      // Default (legacy) format is always injected
+      expect(callArgs.systemPrompt).toContain('## Comment format');
+      expect(callArgs.systemPrompt).toContain('{emoji} **{category}**');
+    });
   });
 
   describe('POST /api/chat/session/:id/message', () => {
@@ -475,6 +502,9 @@ describe('Chat Routes', () => {
         "INSERT INTO chat_sessions (id, review_id, provider, status, agent_session_id) VALUES (5, 1, 'pi', 'closed', '/tmp/session.json')"
       ).run();
 
+      // Set config with comment_format so the auto-resume path includes it
+      app.set('config', { comment_format: 'minimal' });
+
       // Session is NOT active in memory
       mockManager.isSessionActive.mockReturnValue(false);
       mockManager.getSession.mockReturnValue({
@@ -500,6 +530,14 @@ describe('Chat Routes', () => {
         'hello after restart',
         expect.objectContaining({
           context: expect.stringContaining('Server port:')
+        })
+      );
+      // Comment format template should be included in auto-resume context
+      expect(mockManager.sendMessage).toHaveBeenCalledWith(
+        5,
+        'hello after restart',
+        expect.objectContaining({
+          context: expect.stringContaining('[Comment format template:')
         })
       );
     });
@@ -600,6 +638,31 @@ describe('Chat Routes', () => {
         expect.stringContaining('Server port:')
       );
       expect(mockManager.saveContextMessage).not.toHaveBeenCalled();
+    });
+
+    it('should include comment format template in resume context', async () => {
+      app.set('config', { comment_format: 'minimal' });
+      mockManager.isSessionActive.mockReturnValue(false);
+      mockManager.getSession.mockReturnValue({
+        id: 1,
+        review_id: 1,
+        agent_session_id: '/tmp/session.json',
+        status: 'closed'
+      });
+
+      const res = await request(app)
+        .post('/api/chat/session/1/resume');
+
+      expect(res.status).toBe(200);
+      expect(mockManager.setResumeContext).toHaveBeenCalledWith(
+        1,
+        expect.stringContaining('[Comment format template:')
+      );
+      // The minimal preset template should be in the resume context
+      expect(mockManager.setResumeContext).toHaveBeenCalledWith(
+        1,
+        expect.stringContaining('[{category}] {description}')
+      );
     });
 
     it('should return 404 for unknown session', async () => {

--- a/tests/unit/chat/prompt-builder.test.js
+++ b/tests/unit/chat/prompt-builder.test.js
@@ -163,6 +163,67 @@ describe('buildChatPrompt', () => {
     });
   });
 
+  describe('commentFormatTemplate', () => {
+    it('should include comment format section when commentFormatTemplate is provided', () => {
+      const template = '{emoji} **{category}**: {description}';
+      const prompt = buildChatPrompt({
+        review: { repository: 'owner/repo', pr_number: 1 },
+        commentFormatTemplate: template
+      });
+
+      expect(prompt).toContain('## Comment format');
+      expect(prompt).toContain('<template>');
+      expect(prompt).toContain(template);
+      expect(prompt).toContain('</template>');
+      expect(prompt).toContain('Template placeholders: {emoji}, {category}, {title}, {severity}, {SEVERITY}, {description}, {suggestion}.');
+      expect(prompt).toContain('{severity} renders as Title Case (e.g. "Critical"), {SEVERITY} renders as UPPERCASE (e.g. "CRITICAL").');
+      expect(prompt).toContain('Conditional sections: {?field}...{/field}');
+    });
+
+    it('should place comment format section after domain model and before API Access', () => {
+      const prompt = buildChatPrompt({
+        review: { id: 1, repository: 'owner/repo', pr_number: 1 },
+        commentFormatTemplate: '{emoji} {description}'
+      });
+
+      const domainIdx = prompt.indexOf('## pair-review app domain model');
+      const formatIdx = prompt.indexOf('## Comment format');
+      const apiIdx = prompt.indexOf('## API Access');
+
+      expect(domainIdx).toBeGreaterThan(-1);
+      expect(formatIdx).toBeGreaterThan(-1);
+      expect(apiIdx).toBeGreaterThan(-1);
+      expect(domainIdx).toBeLessThan(formatIdx);
+      expect(formatIdx).toBeLessThan(apiIdx);
+    });
+
+    it('should not include comment format section when commentFormatTemplate is null', () => {
+      const prompt = buildChatPrompt({
+        review: { repository: 'owner/repo', pr_number: 1 },
+        commentFormatTemplate: null
+      });
+
+      expect(prompt).not.toContain('## Comment format');
+    });
+
+    it('should not include comment format section when commentFormatTemplate is undefined', () => {
+      const prompt = buildChatPrompt({
+        review: { repository: 'owner/repo', pr_number: 1 }
+      });
+
+      expect(prompt).not.toContain('## Comment format');
+    });
+
+    it('should not include comment format section when commentFormatTemplate is empty string', () => {
+      const prompt = buildChatPrompt({
+        review: { repository: 'owner/repo', pr_number: 1 },
+        commentFormatTemplate: ''
+      });
+
+      expect(prompt).not.toContain('## Comment format');
+    });
+  });
+
   describe('general prompt structure', () => {
     it('should always include role and instructions', () => {
       const prompt = buildChatPrompt({


### PR DESCRIPTION
## Summary
- Inject the user's configured comment format template into chat sessions so the AI follows the correct format when creating or editing comments
- Template is included in the system prompt at session creation with placeholder documentation
- On resume (explicit or auto), the current template value is re-injected as context since config can change between server restarts
- Documents both `{severity}` (Title Case) and `{SEVERITY}` (UPPERCASE) placeholder variants

## Test plan
- [ ] Unit tests for `buildChatPrompt` verify format section inclusion/exclusion
- [ ] Integration tests cover session creation, explicit resume, and auto-resume paths
- [ ] All 5588 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)