### PR TITLE
Handle Graphite URLs containing a query string

### DIFF
--- a/src/github/parser.js
+++ b/src/github/parser.js
@@ -113,7 +113,7 @@ class PRArgumentParser {
    */
   parseGraphiteURL(url) {
     // Match Graphite PR URL pattern: https://app.graphite.{dev|com}/github/pr/owner/repo/number[/optional-title]
-    const match = url.match(/^https:\/\/app\.graphite\.(?:dev|com)\/github\/pr\/([^\/]+)\/([^\/]+)\/(\d+)(?:\/.*)?$/);
+    const match = url.match(/^https:\/\/app\.graphite\.(?:dev|com)\/github\/pr\/([^\/]+)\/([^\/]+)\/(\d+)(?:\/[^?]*)?(?:\?.*)?$/);
 
     if (!match) {
       throw new Error('Invalid Graphite URL format. Expected: https://app.graphite.com/github/pr/owner/repo/number');

--- a/tests/unit/parser.test.js
+++ b/tests/unit/parser.test.js
@@ -128,6 +128,11 @@ describe('PRArgumentParser', () => {
       expect(result).toEqual({ owner: 'my-org', repo: 'my-repo', number: 12345 });
     });
 
+    it('should parse Graphite URL with query parameters', () => {
+      const result = parser.parseGraphiteURL('https://app.graphite.com/github/pr/my-org/my-repo/123?ref=gt-pasteable-stack');
+      expect(result).toEqual({ owner: 'my-org', repo: 'my-repo', number: 123 });
+    });
+
     it('should handle org/repo with hyphens', () => {
       const result = parser.parseGraphiteURL('https://app.graphite.dev/github/pr/my-cool-org/my-cool-repo/999');
       expect(result).toEqual({ owner: 'my-cool-org', repo: 'my-cool-repo', number: 999 });


### PR DESCRIPTION
## tl;dr

Graphite URLs with query parameters (e.g. `?ref=gt-pasteable-stack`) are now parsed correctly.

## What changed?

- Updated the Graphite URL regex in `parseGraphiteURL` to allow an optional query string
- Added a test for this case

## Why?

Graphite's "pasteable stack" feature appends a `?ref=gt-pasteable-stack` query parameter to PR URLs. These URLs were rejected by the parser because the regex didn't account for a query string after the PR number.

<img width="868" height="209" alt="Screenshot 2026-03-30 at 4 14 53 PM" src="https://github.com/user-attachments/assets/833ecab5-ea23-4067-99c2-2a9a195af27a" />

