### PR TITLE
Use provider display name in council progress dialog

### DIFF
--- a/.changeset/ten-nights-accept.md
+++ b/.changeset/ten-nights-accept.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Use provider display name instead of ID in council progress dialog

--- a/public/js/components/CouncilProgressModal.js
+++ b/public/js/components/CouncilProgressModal.js
@@ -1621,7 +1621,8 @@ class CouncilProgressModal {
    *       -> "Claude sonnet-4-5 (Balanced)"
    */
   _formatVoiceLabel(voice, { isExecutable = false } = {}) {
-    const provider = this._capitalize(voice.provider || 'unknown');
+    const providersMap = window.analysisConfigModal?.providers || {};
+    const provider = providersMap[voice.provider]?.name || this._capitalize(voice.provider || 'unknown');
     const model = voice.model || 'default';
     if (isExecutable) return `${provider} ${model}`;
     const tier = this._capitalize(voice.tier || 'balanced');

--- a/tests/unit/council-progress-modal.test.js
+++ b/tests/unit/council-progress-modal.test.js
@@ -1469,5 +1469,41 @@ describe('CouncilProgressModal', () => {
       const voice = { provider: 'custom-tool', model: 'v1' };
       expect(modal._formatVoiceLabel(voice, { isExecutable: true })).toBe('Custom-tool v1');
     });
+
+    it('uses display name from providers map when available', () => {
+      const { modal } = createTestCouncilProgressModal();
+      window.analysisConfigModal = {
+        providers: {
+          'my-review-tool': { name: 'My Review Tool', isExecutable: true }
+        }
+      };
+      const voice = { provider: 'my-review-tool', model: 'default' };
+      expect(modal._formatVoiceLabel(voice, { isExecutable: true })).toBe('My Review Tool default');
+      delete window.analysisConfigModal;
+    });
+
+    it('falls back to capitalized id when providers map has no name', () => {
+      const { modal } = createTestCouncilProgressModal();
+      window.analysisConfigModal = {
+        providers: {
+          'my-tool': { isExecutable: true }
+        }
+      };
+      const voice = { provider: 'my-tool', model: 'v2' };
+      expect(modal._formatVoiceLabel(voice, { isExecutable: true })).toBe('My-tool v2');
+      delete window.analysisConfigModal;
+    });
+
+    it('uses display name for native providers too', () => {
+      const { modal } = createTestCouncilProgressModal();
+      window.analysisConfigModal = {
+        providers: {
+          claude: { name: 'Claude', isExecutable: false }
+        }
+      };
+      const voice = { provider: 'claude', model: 'opus-4', tier: 'thorough' };
+      expect(modal._formatVoiceLabel(voice)).toBe('Claude opus-4 (Thorough)');
+      delete window.analysisConfigModal;
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Executable providers with a configured `name` field were showing the raw provider ID (capitalized) instead of the display name in the council progress modal
- `_formatVoiceLabel` now looks up the provider name from the `/api/providers` data cached in `window.analysisConfigModal.providers`, falling back to the existing capitalize-ID behavior

## Test plan
- [x] Unit tests added for name lookup, fallback, and native provider paths
- [x] All 65 council progress modal tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)