### PR TITLE
Add exclude_previous capability for executable providers

### DIFF
--- a/.changeset/exclude-previous-capability.md
+++ b/.changeset/exclude-previous-capability.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Add exclude_previous capability for executable providers to disable the Exclude Previous Findings control when the provider does not support it

--- a/config.example.json
+++ b/config.example.json
@@ -202,7 +202,8 @@
       "name": "My Review Tool",
       "capabilities": {
         "review_levels": false,
-        "custom_instructions": false
+        "custom_instructions": false,
+        "exclude_previous": false
       },
       "context_args": {
         "title": "--title",

--- a/plans/exclude-previous-executable-providers.md
+++ b/plans/exclude-previous-executable-providers.md
@@ -1,0 +1,93 @@
+# Add `exclude_previous` Capability for Executable Providers
+
+## Context
+
+The "Exclude Previous Findings" section in the AnalysisConfigModal lets users skip issues already noted in GitHub PR comments or previous pair-review feedback. Executable providers may not support this feature (they run their own analysis pipeline). We need a capability flag to gate the UI, and visually disable the entire section when the selected provider cannot honour it — without altering persisted checkbox state.
+
+The exclude-previous section is **hoisted outside all tab panels** so it's visible on every tab. It must be disabled only when on the Single Model tab with a non-capable provider, and re-enabled when switching to Council/Advanced tabs (where orchestration handles dedup regardless of reviewer capabilities).
+
+## Hazards
+
+- `selectProvider()` has 4 callers (lines 486, 510, 935, 938). The new `_updateExcludePreviousState()` call at the end must not break any.
+- `_restoreExcludePrevious()` (line 969) runs AFTER `selectProvider()` (line 935) in the show flow. The section-level disable must not interfere with checkbox restore or the no-token GitHub disable logic — since we never touch individual checkboxes, this is safe.
+
+## Design Principle
+
+Disable the **entire `<details>` section** as a visual indicator. Never modify individual checkbox `checked` or `disabled` state for this capability. The persisted localStorage state is untouched. On submit, simply omit `excludePrevious` when the capability is `false`.
+
+## Changes
+
+### 1. Backend — Add capability flag
+
+**`src/ai/executable-provider.js`** (line 526-529): Add `exclude_previous`:
+```javascript
+exclude_previous: caps.exclude_previous !== undefined ? caps.exclude_previous : false
+```
+
+**`src/ai/provider.js`** (line 622-625): Add `exclude_previous: true` to built-in defaults.
+
+**`config.example.json`** (line 203-206): Add `"exclude_previous": false` to example.
+
+### 2. Frontend — New `_updateExcludePreviousState()` method
+
+**`public/js/components/AnalysisConfigModal.js`**: Add after `_getAndSaveExcludePrevious()`:
+
+- If `activeTab === 'single'` AND selected provider's `exclude_previous === false`:
+  - Add class `exclude-previous-disabled` to the `<details>` element
+  - Close the `<details>` (remove `open` attribute) so it collapses
+  - Inject `.executable-provider-note.executable-provider-exclude-note` after the `<summary>` (before the options div)
+- Otherwise:
+  - Remove the class and note
+  - Do NOT re-open the `<details>` (leave that to the user)
+
+No checkbox state is modified. The section is simply made inert and visually muted.
+
+### 3. Frontend — Wire up the helper
+
+**`selectProvider()`** — call `_updateExcludePreviousState()` after line 618.
+
+**`_switchTab()`** — call `_updateExcludePreviousState()` after the dirty hint logic (after line 1153).
+
+**`handleSubmit()`** — single model path (line 830): when `exclude_previous === false`, set `excludePrevious: undefined` instead of calling `_getAndSaveExcludePrevious()`.
+
+### 4. CSS
+
+**`public/css/analysis-config.css`**: Add disabled state for the section:
+
+```css
+/* Section disabled by provider capability */
+.exclude-previous-section.exclude-previous-disabled {
+  opacity: 0.5;
+  pointer-events: none;
+}
+
+.exclude-previous-section .executable-provider-note {
+  margin: 8px 14px;
+  pointer-events: auto;
+}
+```
+
+`pointer-events: none` prevents opening the `<details>` or interacting with checkboxes. The note gets `pointer-events: auto` so the text is selectable.
+
+### 5. Tests
+
+**`tests/unit/executable-provider.test.js`** (lines 169-182): Update all capability assertions to include `exclude_previous`:
+- Full caps: `{ review_levels: true, custom_instructions: true, exclude_previous: true }`
+- Partial: `{ review_levels: true }` → defaults others to `false`
+- None: all three default to `false`
+- Add case: `{ exclude_previous: true }` alone
+
+## Files Modified
+
+- `src/ai/executable-provider.js` — add capability
+- `src/ai/provider.js` — add default capability
+- `config.example.json` — add to example
+- `public/js/components/AnalysisConfigModal.js` — new helper, wire into selectProvider/switchTab/handleSubmit
+- `public/css/analysis-config.css` — disabled section styling
+- `tests/unit/executable-provider.test.js` — update assertions
+
+## Verification
+
+1. `npm test` — unit tests pass
+2. `npm run test:e2e` — E2E tests pass
+3. Manual: select executable provider on Single Model tab → section collapses, grayed out with note. Switch to Council → section re-enabled. Switch back → disabled again. Submit → no `excludePrevious` in request.

--- a/public/css/analysis-config.css
+++ b/public/css/analysis-config.css
@@ -81,3 +81,23 @@
 .option-hint:last-child {
   margin-bottom: 0;
 }
+
+/* Section disabled by provider capability —
+   pointer-events on the section blocks interaction; opacity is applied
+   only to the options area so the note remains clearly readable and
+   the already-disabled GitHub toggle doesn't double-dim. */
+.exclude-previous-section.exclude-previous-disabled {
+  pointer-events: none;
+}
+
+.exclude-previous-section.exclude-previous-disabled > summary {
+  opacity: 0.5;
+}
+
+.exclude-previous-section.exclude-previous-disabled .exclude-previous-options {
+  opacity: 0.5;
+}
+
+.exclude-previous-section .executable-provider-note {
+  margin: 8px 14px;
+}

--- a/public/js/components/AnalysisConfigModal.js
+++ b/public/js/components/AnalysisConfigModal.js
@@ -616,6 +616,9 @@ class AnalysisConfigModal {
     if (this.selectedModel) {
       this.selectModel(this.selectedModel);
     }
+
+    // Update exclude-previous section based on provider's exclude_previous capability
+    this._updateExcludePreviousState();
   }
 
   /**
@@ -827,7 +830,9 @@ class AnalysisConfigModal {
       enabledLevels: [...this.enabledLevels],
       skipLevel3: !this.enabledLevels.includes(3),
       noLevels,
-      excludePrevious: this._getAndSaveExcludePrevious()
+      excludePrevious: selectedProvider?.capabilities?.exclude_previous === false
+        ? undefined
+        : this._getAndSaveExcludePrevious()
     };
 
     if (this.onSubmit) this.onSubmit(config);
@@ -1151,6 +1156,9 @@ class AnalysisConfigModal {
         dirtyHintContainer.style.display = 'none';
       }
     }
+
+    // Re-evaluate exclude-previous section based on new tab context
+    this._updateExcludePreviousState();
   }
 
   /**
@@ -1360,6 +1368,49 @@ class AnalysisConfigModal {
       localStorage.setItem('pair-review-exclude-previous', JSON.stringify(state));
     } catch (_) { /* ignore storage errors */ }
     return state;
+  }
+
+  /**
+   * Update the exclude-previous section's enabled/disabled state based on
+   * the active tab and the selected provider's capabilities.
+   *
+   * Council/Advanced tabs: always enabled (orchestration handles dedup).
+   * Single Model tab: disabled when provider has exclude_previous === false.
+   *
+   * This only toggles the visual state of the entire section — individual
+   * checkbox checked/disabled state is never modified, so persisted
+   * localStorage values remain untouched.
+   * @private
+   */
+  _updateExcludePreviousState() {
+    const section = this.modal.querySelector('.exclude-previous-section');
+    if (!section) return;
+
+    const provider = this.providers[this.selectedProvider];
+    const disabledByCapability = this.activeTab === 'single'
+      && provider?.capabilities?.exclude_previous === false;
+
+    const existingNote = section.querySelector('.executable-provider-exclude-note');
+
+    if (disabledByCapability) {
+      section.classList.add('exclude-previous-disabled');
+      section.setAttribute('open', '');  // Ensure note is visible even if section was collapsed
+
+      if (!existingNote) {
+        const note = document.createElement('div');
+        note.className = 'executable-provider-note executable-provider-exclude-note';
+        note.textContent = 'This provider does not support excluding previous findings.';
+        const options = section.querySelector('.exclude-previous-options');
+        if (options) {
+          section.insertBefore(note, options);
+        } else {
+          section.appendChild(note);
+        }
+      }
+    } else {
+      section.classList.remove('exclude-previous-disabled');
+      if (existingNote) existingNote.remove();
+    }
   }
 
   /**

--- a/src/ai/executable-provider.js
+++ b/src/ai/executable-provider.js
@@ -86,6 +86,7 @@ ${rawOutput}`;
  * @param {Object} config.capabilities - Provider capabilities overrides
  * @param {boolean} config.capabilities.review_levels - Whether the tool supports L1/L2/L3 analysis
  * @param {boolean} config.capabilities.custom_instructions - Whether the tool supports custom instructions
+ * @param {boolean} config.capabilities.exclude_previous - Whether the tool supports excluding previous findings
  * @param {Object} config.context_args - Maps context keys to CLI flags
  * @param {string} config.output_glob - Glob pattern to find result file
  * @param {string} config.mapping_instructions - Tool-specific mapping instructions for LLM
@@ -525,7 +526,8 @@ function createExecutableProviderClass(id, config) {
   const caps = config.capabilities || {};
   ExecProvider.capabilities = {
     review_levels: caps.review_levels !== undefined ? caps.review_levels : false,
-    custom_instructions: caps.custom_instructions !== undefined ? caps.custom_instructions : false
+    custom_instructions: caps.custom_instructions !== undefined ? caps.custom_instructions : false,
+    exclude_previous: caps.exclude_previous !== undefined ? caps.exclude_previous : false
   };
 
   return ExecProvider;

--- a/src/ai/provider.js
+++ b/src/ai/provider.js
@@ -621,7 +621,8 @@ function getAllProvidersInfo() {
     // Build capabilities: executable providers define their own, others get defaults
     const capabilities = ProviderClass.capabilities || {
       review_levels: true,
-      custom_instructions: true
+      custom_instructions: true,
+      exclude_previous: true
     };
 
     providers.push({

--- a/tests/unit/executable-provider.test.js
+++ b/tests/unit/executable-provider.test.js
@@ -168,17 +168,22 @@ describe('createExecutableProviderClass', () => {
 
     it('sets capabilities from config', () => {
       const withCaps = createExecutableProviderClass('t1', {
-        capabilities: { review_levels: true, custom_instructions: true }
+        capabilities: { review_levels: true, custom_instructions: true, exclude_previous: true }
       });
-      expect(withCaps.capabilities).toEqual({ review_levels: true, custom_instructions: true });
+      expect(withCaps.capabilities).toEqual({ review_levels: true, custom_instructions: true, exclude_previous: true });
 
       const withPartialCaps = createExecutableProviderClass('t2', {
         capabilities: { review_levels: true }
       });
-      expect(withPartialCaps.capabilities).toEqual({ review_levels: true, custom_instructions: false });
+      expect(withPartialCaps.capabilities).toEqual({ review_levels: true, custom_instructions: false, exclude_previous: false });
 
       const withNoCaps = createExecutableProviderClass('t3', {});
-      expect(withNoCaps.capabilities).toEqual({ review_levels: false, custom_instructions: false });
+      expect(withNoCaps.capabilities).toEqual({ review_levels: false, custom_instructions: false, exclude_previous: false });
+
+      const withExcludePrevious = createExecutableProviderClass('t4', {
+        capabilities: { exclude_previous: true }
+      });
+      expect(withExcludePrevious.capabilities).toEqual({ review_levels: false, custom_instructions: false, exclude_previous: true });
     });
 
     it('sets getInstallInstructions from config', () => {

--- a/tests/unit/provider-config.test.js
+++ b/tests/unit/provider-config.test.js
@@ -321,7 +321,8 @@ describe('Provider Configuration', () => {
       expect(claude).toBeDefined();
       expect(claude.capabilities).toEqual({
         review_levels: true,
-        custom_instructions: true
+        custom_instructions: true,
+        exclude_previous: true
       });
     });
 
@@ -348,7 +349,8 @@ describe('Provider Configuration', () => {
       expect(myTool).toBeDefined();
       expect(myTool.capabilities).toEqual({
         review_levels: true,
-        custom_instructions: false
+        custom_instructions: false,
+        exclude_previous: false
       });
     });
 
@@ -371,7 +373,8 @@ describe('Provider Configuration', () => {
       expect(bareTool).toBeDefined();
       expect(bareTool.capabilities).toEqual({
         review_levels: false,
-        custom_instructions: false
+        custom_instructions: false,
+        exclude_previous: false
       });
     });
   });


### PR DESCRIPTION
## Summary
- Adds `exclude_previous` to the executable provider capabilities system (defaults to `false` for executables, `true` for built-in providers)
- When on the Single Model tab with a provider that lacks this capability, the Exclude Previous Findings section is visually disabled (dimmed, inert) with an explanatory note
- Switching to Council/Advanced tabs re-enables the section since orchestration handles dedup regardless of reviewer capabilities
- On submit, `excludePrevious` is omitted from the config when the capability is `false`
- Persisted localStorage checkbox state is never modified by the disable — toggling providers preserves the user's preferences

## Test plan
- [x] Unit tests updated for `executable-provider.test.js` and `provider-config.test.js`
- [x] `npm test` passes (5579/5580, 1 pre-existing flaky test)
- [x] `npm run test:e2e` passes (268/268)
- [ ] Manual: select executable provider on Single Model tab — section dims with note
- [ ] Manual: switch to Council tab — section re-enables
- [ ] Manual: switch back to Single Model — section re-disables
- [ ] Manual: submit with non-capable provider — verify no `excludePrevious` in request body

🤖 Generated with [Claude Code](https://claude.com/claude-code)