### PR TITLE
Add consolidation capability to provider system

### DIFF
--- a/.changeset/metal-peaches-stare.md
+++ b/.changeset/metal-peaches-stare.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Add `consolidation` capability flag to providers, filtering non-consolidation-capable providers from the consolidation dropdown in council config dialogs

--- a/config.example.json
+++ b/config.example.json
@@ -203,7 +203,8 @@
       "capabilities": {
         "review_levels": false,
         "custom_instructions": false,
-        "exclude_previous": false
+        "exclude_previous": false,
+        "consolidation": false
       },
       "context_args": {
         "title": "--title",

--- a/plans/consolidation-capability.md
+++ b/plans/consolidation-capability.md
@@ -1,0 +1,88 @@
+# Add `consolidation` capability to providers
+
+## Context
+
+Executable providers can be used for review analysis but may not support consolidation (merging multiple reviewers' findings into a coherent result). Currently, the consolidation provider dropdown in the Council/Advanced config dialogs shows *all* available providers, including those that can't perform consolidation. The backend already skips executable providers when choosing a *default* consolidation provider (`_defaultConsolidation` in analyzer.js:3868), but users can still manually select an incapable provider from the dropdown.
+
+We need a `consolidation` capability flag so that:
+1. Built-in providers default to `consolidation: true`
+2. Executable providers default to `consolidation: false` (configurable to `true`)
+3. The consolidation provider dropdowns in both VoiceCentricConfigTab and AdvancedConfigTab filter out providers where `consolidation` is `false`
+
+## Changes
+
+### 1. Backend: Add `consolidation` capability
+
+**`src/ai/executable-provider.js`** (~line 526)
+- Add `consolidation` to the capabilities object, defaulting to `false`:
+```js
+ExecProvider.capabilities = {
+  review_levels: caps.review_levels !== undefined ? caps.review_levels : false,
+  custom_instructions: caps.custom_instructions !== undefined ? caps.custom_instructions : false,
+  consolidation: caps.consolidation !== undefined ? caps.consolidation : false
+};
+```
+- Update the JSDoc `@param` for `config.capabilities` to document the new field.
+
+**`src/ai/provider.js`** (~line 622)
+- Add `consolidation: true` to the default capabilities for built-in providers:
+```js
+const capabilities = ProviderClass.capabilities || {
+  review_levels: true,
+  custom_instructions: true,
+  consolidation: true
+};
+```
+
+### 2. Frontend: Filter consolidation dropdown
+
+Both `VoiceCentricConfigTab.js` and `AdvancedConfigTab.js` use `_populateProviderDropdown(select)` for *all* provider dropdowns (voices and consolidation). The consolidation dropdown is identified by `data-target="orchestration"` on the `<select>`.
+
+**`public/js/components/VoiceCentricConfigTab.js`** (~line 771)
+**`public/js/components/AdvancedConfigTab.js`** (~line 706)
+
+In `_populateProviderDropdown`, add filtering when the select is for consolidation:
+
+```js
+_populateProviderDropdown(select) {
+  const currentValue = select.value;
+  const isConsolidation = select.dataset.target === 'orchestration';
+  select.innerHTML = '';
+  const providerIds = Object.keys(this.providers).filter(id => {
+    const p = this.providers[id];
+    if (p.availability && !p.availability.available) return false;
+    if (isConsolidation && p.capabilities?.consolidation === false) return false;
+    return true;
+  }).sort((a, b) => (this.providers[a].name || a).localeCompare(this.providers[b].name || b));
+  // ... rest unchanged
+}
+```
+
+### 3. Config example
+
+**`config.example.json`** (~line 203)
+- Add `consolidation: false` to the example capabilities block so users know it's configurable.
+
+### 4. Tests
+
+**`tests/unit/provider-config.test.js`**
+- Update existing capability assertions to include `consolidation: true` for built-in providers and `consolidation: false` for unconfigured executable providers.
+- Add test for executable provider with `consolidation: true` explicitly set.
+
+**`tests/unit/executable-provider.test.js`**
+- Update capability assertions to include the new `consolidation` field.
+
+**`tests/unit/voice-centric-config-tab.test.js`** and/or **`tests/unit/advanced-config-tab.test.js`** (if they exist)
+- Add test that the consolidation dropdown excludes providers with `consolidation: false`.
+
+## Hazards
+
+- `_populateProviderDropdown` is called for ALL `<select class="voice-provider">` elements — both voice rows and the consolidation row. The `data-target="orchestration"` check must be precise to avoid accidentally filtering voice dropdowns.
+- The `_defaultConsolidation()` and `_defaultOrchestration()` methods in `analyzer.js` already skip executable providers using `isExecutable`. They don't need changes since they select from *voices* not from the full provider list, but they should remain consistent with the new capability.
+- Both `VoiceCentricConfigTab` and `AdvancedConfigTab` have independent copies of `_populateProviderDropdown` — both must be updated.
+
+## Verification
+
+1. `npm test` — all unit/integration tests pass
+2. `npm run test:e2e` — E2E tests pass
+3. Manual: configure an executable provider without `consolidation: true`, open council dialog, verify it doesn't appear in the consolidation dropdown but does appear in voice dropdowns

--- a/public/js/components/AdvancedConfigTab.js
+++ b/public/js/components/AdvancedConfigTab.js
@@ -705,10 +705,13 @@ class AdvancedConfigTab {
 
   _populateProviderDropdown(select) {
     const currentValue = select.value;
+    const isConsolidation = select.dataset.target === 'orchestration';
     select.innerHTML = '';
     const providerIds = Object.keys(this.providers).filter(id => {
       const p = this.providers[id];
-      return !p.availability || p.availability.available;
+      if (p.availability && !p.availability.available) return false;
+      if (isConsolidation && p.capabilities?.consolidation === false) return false;
+      return true;
     }).sort((a, b) => (this.providers[a].name || a).localeCompare(this.providers[b].name || b));
 
     for (const id of providerIds) {

--- a/public/js/components/VoiceCentricConfigTab.js
+++ b/public/js/components/VoiceCentricConfigTab.js
@@ -770,10 +770,13 @@ class VoiceCentricConfigTab {
 
   _populateProviderDropdown(select) {
     const currentValue = select.value;
+    const isConsolidation = select.dataset.target === 'orchestration';
     select.innerHTML = '';
     const providerIds = Object.keys(this.providers).filter(id => {
       const p = this.providers[id];
-      return !p.availability || p.availability.available;
+      if (p.availability && !p.availability.available) return false;
+      if (isConsolidation && p.capabilities?.consolidation === false) return false;
+      return true;
     }).sort((a, b) => (this.providers[a].name || a).localeCompare(this.providers[b].name || b));
 
     for (const id of providerIds) {

--- a/src/ai/executable-provider.js
+++ b/src/ai/executable-provider.js
@@ -87,6 +87,7 @@ ${rawOutput}`;
  * @param {boolean} config.capabilities.review_levels - Whether the tool supports L1/L2/L3 analysis
  * @param {boolean} config.capabilities.custom_instructions - Whether the tool supports custom instructions
  * @param {boolean} config.capabilities.exclude_previous - Whether the tool supports excluding previous findings
+ * @param {boolean} config.capabilities.consolidation - Whether the tool can be used for consolidation
  * @param {Object} config.context_args - Maps context keys to CLI flags
  * @param {string} config.output_glob - Glob pattern to find result file
  * @param {string} config.mapping_instructions - Tool-specific mapping instructions for LLM
@@ -527,7 +528,8 @@ function createExecutableProviderClass(id, config) {
   ExecProvider.capabilities = {
     review_levels: caps.review_levels !== undefined ? caps.review_levels : false,
     custom_instructions: caps.custom_instructions !== undefined ? caps.custom_instructions : false,
-    exclude_previous: caps.exclude_previous !== undefined ? caps.exclude_previous : false
+    exclude_previous: caps.exclude_previous !== undefined ? caps.exclude_previous : false,
+    consolidation: caps.consolidation !== undefined ? caps.consolidation : false
   };
 
   return ExecProvider;

--- a/src/ai/provider.js
+++ b/src/ai/provider.js
@@ -622,7 +622,8 @@ function getAllProvidersInfo() {
     const capabilities = ProviderClass.capabilities || {
       review_levels: true,
       custom_instructions: true,
-      exclude_previous: true
+      exclude_previous: true,
+      consolidation: true
     };
 
     providers.push({

--- a/tests/unit/executable-provider.test.js
+++ b/tests/unit/executable-provider.test.js
@@ -168,22 +168,22 @@ describe('createExecutableProviderClass', () => {
 
     it('sets capabilities from config', () => {
       const withCaps = createExecutableProviderClass('t1', {
-        capabilities: { review_levels: true, custom_instructions: true, exclude_previous: true }
+        capabilities: { review_levels: true, custom_instructions: true, exclude_previous: true, consolidation: true }
       });
-      expect(withCaps.capabilities).toEqual({ review_levels: true, custom_instructions: true, exclude_previous: true });
+      expect(withCaps.capabilities).toEqual({ review_levels: true, custom_instructions: true, exclude_previous: true, consolidation: true });
 
       const withPartialCaps = createExecutableProviderClass('t2', {
         capabilities: { review_levels: true }
       });
-      expect(withPartialCaps.capabilities).toEqual({ review_levels: true, custom_instructions: false, exclude_previous: false });
+      expect(withPartialCaps.capabilities).toEqual({ review_levels: true, custom_instructions: false, exclude_previous: false, consolidation: false });
 
       const withNoCaps = createExecutableProviderClass('t3', {});
-      expect(withNoCaps.capabilities).toEqual({ review_levels: false, custom_instructions: false, exclude_previous: false });
+      expect(withNoCaps.capabilities).toEqual({ review_levels: false, custom_instructions: false, exclude_previous: false, consolidation: false });
 
       const withExcludePrevious = createExecutableProviderClass('t4', {
         capabilities: { exclude_previous: true }
       });
-      expect(withExcludePrevious.capabilities).toEqual({ review_levels: false, custom_instructions: false, exclude_previous: true });
+      expect(withExcludePrevious.capabilities).toEqual({ review_levels: false, custom_instructions: false, exclude_previous: true, consolidation: false });
     });
 
     it('sets getInstallInstructions from config', () => {

--- a/tests/unit/provider-config.test.js
+++ b/tests/unit/provider-config.test.js
@@ -322,7 +322,8 @@ describe('Provider Configuration', () => {
       expect(claude.capabilities).toEqual({
         review_levels: true,
         custom_instructions: true,
-        exclude_previous: true
+        exclude_previous: true,
+        consolidation: true
       });
     });
 
@@ -350,7 +351,8 @@ describe('Provider Configuration', () => {
       expect(myTool.capabilities).toEqual({
         review_levels: true,
         custom_instructions: false,
-        exclude_previous: false
+        exclude_previous: false,
+        consolidation: false
       });
     });
 
@@ -374,7 +376,8 @@ describe('Provider Configuration', () => {
       expect(bareTool.capabilities).toEqual({
         review_levels: false,
         custom_instructions: false,
-        exclude_previous: false
+        exclude_previous: false,
+        consolidation: false
       });
     });
   });


### PR DESCRIPTION
## Summary
- Adds a `consolidation` capability flag to the provider system. Built-in providers default to `true`; executable providers default to `false` (configurable via `config.capabilities.consolidation`).
- Filters the consolidation provider dropdown in both VoiceCentricConfigTab and AdvancedConfigTab to exclude providers with `consolidation: false`.
- Updates config example and all relevant tests.

## Test plan
- [x] Unit tests pass (provider-config, executable-provider)
- [x] Full test suite passes (5592 tests)
- [ ] Manual: configure an executable provider without `consolidation: true`, open council dialog, verify it doesn't appear in the consolidation dropdown but does appear in voice dropdowns

🤖 Generated with [Claude Code](https://claude.com/claude-code)