### PR TITLE
Add scope-aware chat hints for local reviews

### DIFF
--- a/.changeset/common-results-wear.md
+++ b/.changeset/common-results-wear.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Make chat agent scope-aware for local reviews: system prompt now reflects the current diff scope with accurate git commands, and scope-change notifications include actionable diff command guidance.

--- a/plans/streamed-dreaming-moon.md
+++ b/plans/streamed-dreaming-moon.md
@@ -1,0 +1,71 @@
+# Scope-Aware Chat Hints for Local Reviews
+
+## Context
+
+The chat agent's "Viewing Code Changes" system prompt is hardcoded for the default unstaged+untracked scope, telling the agent to use `git diff --no-ext-diff`. When the user changes the diff scope (e.g., to Branch–Untracked or Staged), the agent doesn't know the correct git commands and gives wrong answers about what's under review.
+
+The review record already stores `local_scope_start`, `local_scope_end`, and `local_base_branch` — these just need to flow into the chat prompt.
+
+## Plan
+
+### Step 1: Add `scopeGitHints()` to `src/local-scope.js`
+
+New function mapping scope range → git command guidance. Returns `{ label, description, diffCommand, excludes, includesUntracked }`.
+
+- Must stay isomorphic (runs in browser + Node)
+- Accepts optional `baseBranch` param; produces `$(git merge-base <branch> HEAD)` when provided, `<merge-base>` placeholder when not
+- Covers all 10 valid scope combinations
+- Export it on the `LocalScope` object
+
+Key mappings:
+| Scope | diffCommand |
+|---|---|
+| branch | `git diff --no-ext-diff $(git merge-base main HEAD)..HEAD` |
+| branch–staged | `git diff --no-ext-diff --cached $(git merge-base main HEAD)` |
+| branch–unstaged/untracked | `git diff --no-ext-diff $(git merge-base main HEAD)` |
+| staged | `git diff --no-ext-diff --cached` |
+| staged–unstaged/untracked | `git diff --no-ext-diff HEAD` |
+| unstaged/unstaged–untracked | `git diff --no-ext-diff` |
+| untracked | `git ls-files --others --exclude-standard` |
+
+### Step 2: Update `buildReviewContext()` in `src/chat/prompt-builder.js`
+
+- Import `local-scope` (`scopeGitHints`, `DEFAULT_SCOPE`)
+- Read `review.local_scope_start`, `local_scope_end`, `local_base_branch`
+- Use `scopeGitHints()` to produce the "Viewing Code Changes" section
+- Fall back to default scope when fields are missing (backward compat)
+
+### Step 3: Enrich scope-change notifications in `public/js/local.js`
+
+Two call sites to update:
+
+**`_handleScopeChange` (line 1618):** After `_applyScopeResult`, `this.localData?.baseBranch` is populated. Call `LS.scopeGitHints(scopeStart, scopeEnd, this.localData?.baseBranch)` and include description + diffCommand in the notification.
+
+**`showBranchReviewDialog` handler (line 1753):** `branchInfo.baseBranch` is in scope. Call `LS.scopeGitHints('branch', newEnd, branchInfo.baseBranch)` and enrich the notification.
+
+### Step 4: Tests
+
+**`tests/unit/local-scope.test.js`:** New `describe('scopeGitHints')` block — all 10 valid combos, baseBranch substitution, invalid scope returns null, includesUntracked correctness.
+
+**`tests/unit/chat/prompt-builder.test.js`:** Scope-aware local review context tests — branch scope with baseBranch, default fallback when scope fields missing, untracked hint presence/absence.
+
+## Hazards
+
+- `buildReviewContext` is called from 3 places in `src/routes/chat.js` (create, auto-resume, explicit resume). All load the full review record, so scope fields are always available.
+- `_applyScopeResult` has two callers: `_handleScopeChange` and `showBranchReviewDialog`. Both notification sites must be updated.
+- System prompt is not updated mid-session. The enriched notification text is the only mechanism for mid-session scope changes — this is an accepted constraint.
+- `scopeGitHints` must be pure (no Node imports) to stay isomorphic.
+
+## Files to modify
+
+- `src/local-scope.js` — add `scopeGitHints()`, export it
+- `src/chat/prompt-builder.js` — import local-scope, update `buildReviewContext` local branch
+- `public/js/local.js` — enrich notifications at two call sites
+- `tests/unit/local-scope.test.js` — tests for `scopeGitHints`
+- `tests/unit/chat/prompt-builder.test.js` — tests for scope-aware prompt
+
+## Verification
+
+1. `npm test` — unit tests pass (especially local-scope and prompt-builder suites)
+2. `npm run test:e2e` — E2E tests pass
+3. Manual: start a local review, open chat, verify system prompt describes current scope correctly. Change scope via dropdown, send a message, verify the notification includes git command guidance.

--- a/public/js/local.js
+++ b/public/js/local.js
@@ -1527,6 +1527,23 @@ class LocalManager {
   }
 
   /**
+   * Build a notification string describing a scope change for the chat agent.
+   * @param {string} prefix - Leading message (e.g. "Diff scope changed to X.")
+   * @param {{ description: string, diffCommand: string, excludes: string, includesUntracked: boolean }|null} hints - Scope git hints
+   * @returns {string} Formatted notification text
+   */
+  _buildScopeNotification(prefix, hints) {
+    const parts = [prefix];
+    if (hints) {
+      parts.push(`Scope: ${hints.description}`);
+      parts.push(`Diff command: \`${hints.diffCommand}\``);
+      if (hints.excludes) parts.push(hints.excludes);
+      if (hints.includesUntracked) parts.push('Untracked files are included. List them with: `git ls-files --others --exclude-standard`');
+    }
+    return parts.join('\n');
+  }
+
+  /**
    * Apply the result of a scope-change POST to local state, UI, and diff.
    * Shared by _handleScopeChange and showBranchReviewDialog.handleConfirm.
    * @param {string} scopeStart - New start stop
@@ -1617,9 +1634,11 @@ class LocalManager {
       // Notify chat agent about scope change
       if (window.chatPanel) {
         const label = LS ? LS.scopeLabel(scopeStart, scopeEnd) : `${scopeStart}\u2013${scopeEnd}`;
-        window.chatPanel.queueDiffStateNotification(
-          `Diff scope changed to ${label}. The set of reviewed files has changed.`
+        const hints = LS ? LS.scopeGitHints(scopeStart, scopeEnd, this.localData?.baseBranch) : null;
+        const notification = this._buildScopeNotification(
+          `Diff scope changed to ${label}. The set of reviewed files has changed.`, hints
         );
+        window.chatPanel.queueDiffStateNotification(notification);
       }
 
       if (window.toast) {
@@ -1752,9 +1771,11 @@ class LocalManager {
 
         if (window.chatPanel) {
           const label = LS ? LS.scopeLabel('branch', newEnd) : 'branch';
-          window.chatPanel.queueDiffStateNotification(
-            `Diff scope changed to ${label} via branch review. The set of reviewed files has changed.`
+          const hints = LS ? LS.scopeGitHints('branch', newEnd, branchInfo.baseBranch) : null;
+          const notification = self._buildScopeNotification(
+            `Diff scope changed to ${label} via branch review. The set of reviewed files has changed.`, hints
           );
+          window.chatPanel.queueDiffStateNotification(notification);
         }
 
         if (window.toast) {

--- a/src/chat/prompt-builder.js
+++ b/src/chat/prompt-builder.js
@@ -8,6 +8,7 @@
  */
 
 const logger = require('../utils/logger');
+const { scopeGitHints, DEFAULT_SCOPE } = require('../local-scope');
 
 /**
  * Build a lean system prompt for chat sessions.
@@ -140,9 +141,27 @@ function buildReviewContext(review, prData) {
     lines.push(`This is a local code review for: ${name}`);
     lines.push('');
     lines.push('## Viewing Code Changes');
-    lines.push('The changes under review are **unstaged and untracked local changes**. Staged changes (`git diff --no-ext-diff --cached`) are treated as already reviewed.');
-    lines.push('To see the diff under review: `git diff --no-ext-diff`');
-    lines.push('Do NOT use `git diff HEAD~1` or `git log` — those show committed history, not the changes under review.');
+
+    const scopeStart = review.local_scope_start || DEFAULT_SCOPE.start;
+    const scopeEnd = review.local_scope_end || DEFAULT_SCOPE.end;
+    const baseBranch = review.local_base_branch || null;
+    const hints = scopeGitHints(scopeStart, scopeEnd, baseBranch);
+
+    if (hints) {
+      lines.push(`The current diff scope is **${hints.label}**: ${hints.description}`);
+      lines.push(`To see the diff under review: \`${hints.diffCommand}\``);
+      if (hints.includesUntracked) {
+        lines.push('Untracked files are included. List them with: `git ls-files --others --exclude-standard`');
+      }
+      if (hints.excludes) {
+        lines.push(hints.excludes);
+      }
+    } else {
+      lines.push('The changes under review are **unstaged and untracked local changes**. Staged changes (`git diff --no-ext-diff --cached`) are treated as already reviewed.');
+      lines.push('To see the diff under review: `git diff --no-ext-diff`');
+      lines.push('Do NOT use `git diff HEAD~1` or `git log` — those show committed history, not the changes under review.');
+    }
+    lines.push('The diff scope can change during this session. If you receive a "[Diff State Update]" notification, follow the updated diff command it provides.');
   } else {
     const parts = [];
     if (review.repository) {

--- a/src/local-scope.js
+++ b/src/local-scope.js
@@ -39,6 +39,88 @@ function scopeLabel(start, end) {
   return `${label(start)}\u2013${label(end)}`;
 }
 
+/**
+ * Return git command hints for a scope range.
+ * @param {string} start - Scope start
+ * @param {string} end - Scope end
+ * @param {string} [baseBranch] - Base branch name (e.g. 'main'); used in merge-base commands
+ * @returns {{ label: string, description: string, diffCommand: string, excludes: string, includesUntracked: boolean }|null}
+ */
+function scopeGitHints(start, end, baseBranch) {
+  if (!isValidScope(start, end)) return null;
+
+  const mb = baseBranch
+    ? '$(git merge-base ' + baseBranch + ' HEAD)'
+    : '<merge-base>';
+  const incUntracked = scopeIncludes(start, end, 'untracked');
+  const label = scopeLabel(start, end);
+
+  const key = start + '-' + end;
+  const hints = {
+    'branch-branch': {
+      description: 'Committed changes on this branch since the merge-base.',
+      diffCommand: 'git diff --no-ext-diff ' + mb + '..HEAD',
+      excludes: 'Staged, unstaged, and untracked changes are NOT included in the review.'
+    },
+    'branch-staged': {
+      description: 'Committed changes plus staged changes, relative to the merge-base.',
+      diffCommand: 'git diff --no-ext-diff --cached ' + mb,
+      excludes: 'Unstaged and untracked changes are NOT included in the review.'
+    },
+    'branch-unstaged': {
+      description: 'All tracked changes (committed, staged, and unstaged) relative to the merge-base.',
+      diffCommand: 'git diff --no-ext-diff ' + mb,
+      excludes: 'Untracked files are NOT included in the review.'
+    },
+    'branch-untracked': {
+      description: 'All changes (committed, staged, unstaged, and untracked) relative to the merge-base.',
+      diffCommand: 'git diff --no-ext-diff ' + mb,
+      excludes: ''
+    },
+    'staged-staged': {
+      description: 'Only staged changes (added to the index but not yet committed).',
+      diffCommand: 'git diff --no-ext-diff --cached',
+      excludes: 'Unstaged, untracked, and committed branch changes are NOT included in the review.'
+    },
+    'staged-unstaged': {
+      description: 'Staged and unstaged changes relative to HEAD.',
+      diffCommand: 'git diff --no-ext-diff HEAD',
+      excludes: 'Untracked files are NOT included in the review.'
+    },
+    'staged-untracked': {
+      description: 'Staged, unstaged, and untracked changes relative to HEAD.',
+      diffCommand: 'git diff --no-ext-diff HEAD',
+      excludes: ''
+    },
+    'unstaged-unstaged': {
+      description: 'Only unstaged working tree changes (not staged, not committed).',
+      diffCommand: 'git diff --no-ext-diff',
+      excludes: 'Staged changes (`git diff --no-ext-diff --cached`) are treated as already reviewed. Untracked files are NOT included in the review.'
+    },
+    'unstaged-untracked': {
+      description: 'Unstaged and untracked local changes.',
+      diffCommand: 'git diff --no-ext-diff',
+      excludes: 'Staged changes (`git diff --no-ext-diff --cached`) are treated as already reviewed.'
+    },
+    'untracked-untracked': {
+      description: 'Only untracked files (new files not yet added to git).',
+      diffCommand: 'git ls-files --others --exclude-standard',
+      excludes: 'Tracked file changes (staged, unstaged, committed) are NOT included in the review.'
+    }
+  };
+
+  const entry = hints[key];
+  if (!entry) return null;
+
+  return {
+    label: label,
+    description: entry.description,
+    diffCommand: entry.diffCommand,
+    excludes: entry.excludes,
+    includesUntracked: incUntracked && key !== 'untracked-untracked'
+  };
+}
+
 const LocalScope = {
   STOPS,
   DEFAULT_SCOPE,
@@ -47,6 +129,7 @@ const LocalScope = {
   includesBranch,
   fromLegacyMode,
   scopeLabel,
+  scopeGitHints,
 };
 
 if (typeof window !== 'undefined') {

--- a/tests/unit/chat/prompt-builder.test.js
+++ b/tests/unit/chat/prompt-builder.test.js
@@ -33,6 +33,78 @@ describe('buildChatPrompt', () => {
       expect(prompt).toContain('/home/user/project');
     });
 
+    it('should use scope fields for local review diff instructions', () => {
+      const prompt = buildChatPrompt({
+        review: {
+          review_type: 'local',
+          local_path: '/home/user/project',
+          local_scope_start: 'branch',
+          local_scope_end: 'untracked',
+          local_base_branch: 'main'
+        }
+      });
+
+      expect(prompt).toContain('Branch\u2013Untracked');
+      expect(prompt).toContain('$(git merge-base main HEAD)');
+      expect(prompt).not.toContain('unstaged and untracked local changes');
+    });
+
+    it('should fall back to default scope when scope fields are missing', () => {
+      const prompt = buildChatPrompt({
+        review: { review_type: 'local', local_path: '/home/user/project' }
+      });
+
+      expect(prompt).toContain('Unstaged\u2013Untracked');
+      expect(prompt).toContain('git diff --no-ext-diff');
+    });
+
+    it('should include untracked hint when untracked is in scope', () => {
+      const prompt = buildChatPrompt({
+        review: {
+          review_type: 'local',
+          local_path: '/p',
+          local_scope_start: 'staged',
+          local_scope_end: 'untracked'
+        }
+      });
+
+      expect(prompt).toContain('git ls-files --others --exclude-standard');
+    });
+
+    it('should not include untracked hint when untracked is not in scope', () => {
+      const prompt = buildChatPrompt({
+        review: {
+          review_type: 'local',
+          local_path: '/p',
+          local_scope_start: 'staged',
+          local_scope_end: 'staged'
+        }
+      });
+
+      expect(prompt).not.toContain('git ls-files --others --exclude-standard');
+    });
+
+    it('should include excludes text for staged-only scope', () => {
+      const prompt = buildChatPrompt({
+        review: {
+          review_type: 'local',
+          local_path: '/p',
+          local_scope_start: 'staged',
+          local_scope_end: 'staged'
+        }
+      });
+
+      expect(prompt).toContain('NOT included in the review');
+    });
+
+    it('should mention that scope can change during session', () => {
+      const prompt = buildChatPrompt({
+        review: { review_type: 'local', local_path: '/p' }
+      });
+
+      expect(prompt).toContain('Diff State Update');
+    });
+
     it('should handle null review gracefully', () => {
       const prompt = buildChatPrompt({ review: null });
 

--- a/tests/unit/local-scope.test.js
+++ b/tests/unit/local-scope.test.js
@@ -2,7 +2,7 @@
 import { describe, it, expect } from 'vitest';
 import LocalScope from '../../src/local-scope.js';
 
-const { STOPS, DEFAULT_SCOPE, isValidScope, scopeIncludes, includesBranch, fromLegacyMode, scopeLabel } = LocalScope;
+const { STOPS, DEFAULT_SCOPE, isValidScope, scopeIncludes, includesBranch, fromLegacyMode, scopeLabel, scopeGitHints } = LocalScope;
 
 describe('LocalScope', () => {
   describe('STOPS', () => {
@@ -175,6 +175,93 @@ describe('LocalScope', () => {
       ];
       for (const [start, end, expected] of validCombinations) {
         expect(scopeLabel(start, end)).toBe(expected);
+      }
+    });
+  });
+
+  describe('scopeGitHints', () => {
+    it('returns null for invalid scope', () => {
+      expect(scopeGitHints('untracked', 'branch')).toBeNull();
+      expect(scopeGitHints('bogus', 'branch')).toBeNull();
+    });
+
+    it('returns correct diff command for each scope', () => {
+      const expected = [
+        ['branch', 'branch', 'git diff --no-ext-diff <merge-base>..HEAD'],
+        ['branch', 'staged', 'git diff --no-ext-diff --cached <merge-base>'],
+        ['branch', 'unstaged', 'git diff --no-ext-diff <merge-base>'],
+        ['branch', 'untracked', 'git diff --no-ext-diff <merge-base>'],
+        ['staged', 'staged', 'git diff --no-ext-diff --cached'],
+        ['staged', 'unstaged', 'git diff --no-ext-diff HEAD'],
+        ['staged', 'untracked', 'git diff --no-ext-diff HEAD'],
+        ['unstaged', 'unstaged', 'git diff --no-ext-diff'],
+        ['unstaged', 'untracked', 'git diff --no-ext-diff'],
+        ['untracked', 'untracked', 'git ls-files --others --exclude-standard'],
+      ];
+      for (const [start, end, cmd] of expected) {
+        const hints = scopeGitHints(start, end);
+        expect(hints).not.toBeNull();
+        expect(hints.diffCommand).toBe(cmd);
+      }
+    });
+
+    it('substitutes baseBranch into merge-base command', () => {
+      const hints = scopeGitHints('branch', 'branch', 'main');
+      expect(hints.diffCommand).toBe('git diff --no-ext-diff $(git merge-base main HEAD)..HEAD');
+    });
+
+    it('uses placeholder when baseBranch is not provided', () => {
+      const hints = scopeGitHints('branch', 'untracked');
+      expect(hints.diffCommand).toContain('<merge-base>');
+    });
+
+    it('sets includesUntracked correctly', () => {
+      expect(scopeGitHints('branch', 'untracked').includesUntracked).toBe(true);
+      expect(scopeGitHints('unstaged', 'untracked').includesUntracked).toBe(true);
+      expect(scopeGitHints('untracked', 'untracked').includesUntracked).toBe(false);
+      expect(scopeGitHints('branch', 'branch').includesUntracked).toBe(false);
+      expect(scopeGitHints('staged', 'staged').includesUntracked).toBe(false);
+      expect(scopeGitHints('branch', 'unstaged').includesUntracked).toBe(false);
+      expect(scopeGitHints('staged', 'unstaged').includesUntracked).toBe(false);
+    });
+
+    it('label matches scopeLabel output', () => {
+      const combos = [
+        ['branch', 'branch'],
+        ['branch', 'untracked'],
+        ['staged', 'unstaged'],
+        ['unstaged', 'untracked'],
+      ];
+      for (const [start, end] of combos) {
+        expect(scopeGitHints(start, end).label).toBe(scopeLabel(start, end));
+      }
+    });
+
+    it('excludes is empty for branch–untracked (nothing excluded)', () => {
+      expect(scopeGitHints('branch', 'untracked').excludes).toBe('');
+    });
+
+    it('excludes is empty for staged–untracked (nothing excluded)', () => {
+      expect(scopeGitHints('staged', 'untracked').excludes).toBe('');
+    });
+
+    it('excludes is non-empty for scopes that omit stops', () => {
+      expect(scopeGitHints('branch', 'branch').excludes).toBeTruthy();
+      expect(scopeGitHints('staged', 'staged').excludes).toBeTruthy();
+      expect(scopeGitHints('unstaged', 'unstaged').excludes).toBeTruthy();
+      expect(scopeGitHints('untracked', 'untracked').excludes).toBeTruthy();
+    });
+
+    it('has non-empty description for all valid scopes', () => {
+      const validCombinations = [
+        ['branch', 'branch'], ['branch', 'staged'], ['branch', 'unstaged'], ['branch', 'untracked'],
+        ['staged', 'staged'], ['staged', 'unstaged'], ['staged', 'untracked'],
+        ['unstaged', 'unstaged'], ['unstaged', 'untracked'],
+        ['untracked', 'untracked'],
+      ];
+      for (const [start, end] of validCombinations) {
+        const hints = scopeGitHints(start, end);
+        expect(hints.description).toBeTruthy();
       }
     });
   });


### PR DESCRIPTION
## Summary
- The chat agent's system prompt was hardcoded for the default unstaged+untracked scope, causing it to give wrong git commands when the user changed the diff scope (e.g., to Branch–Untracked or Staged)
- Added `scopeGitHints()` to `local-scope.js` mapping all 10 valid scope combinations to descriptions, git diff commands, and exclusion notes
- Updated `buildReviewContext()` in `prompt-builder.js` to read the review's scope fields and produce accurate "Viewing Code Changes" instructions
- Enriched mid-session scope-change chat notifications with actionable git command guidance via extracted `_buildScopeNotification()` helper

## Test plan
- [x] Unit tests for `scopeGitHints` (all 10 combos, baseBranch substitution, edge cases)
- [x] Unit tests for scope-aware prompt building (branch scope, default fallback, untracked hint, excludes)
- [x] Full test suite passes (5605 tests)
- [ ] Manual: start local review, open chat, verify prompt describes current scope. Change scope, send message, verify notification includes correct git commands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)