### PR TITLE
Support Graphite /pull/ URL format

### DIFF
--- a/.changeset/dry-parents-carry.md
+++ b/.changeset/dry-parents-carry.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Support Graphite `/pull/` URL format (e.g. `https://app.graphite.com/github/owner/repo/pull/number`) in addition to the existing `/pr/` format

--- a/src/github/parser.js
+++ b/src/github/parser.js
@@ -30,7 +30,7 @@ class PRArgumentParser {
     // Check if input is a PR number
     const prNumber = parseInt(input);
     if (isNaN(prNumber) || prNumber <= 0) {
-      throw new Error('Invalid input format. Expected: PR number, GitHub URL (https://github.com/owner/repo/pull/number), Graphite URL (https://app.graphite.com/github/pr/owner/repo/number), or pair-review:// URL');
+      throw new Error('Invalid input format. Expected: PR number, GitHub URL (https://github.com/owner/repo/pull/number), Graphite URL (https://app.graphite.com/github/pr/owner/repo/number or https://app.graphite.com/github/owner/repo/pull/number), or pair-review:// URL');
     }
 
     // Parse repository from current directory's git remote
@@ -112,14 +112,18 @@ class PRArgumentParser {
    * @returns {Object} Parsed information { owner, repo, number }
    */
   parseGraphiteURL(url) {
-    // Match Graphite PR URL pattern: https://app.graphite.{dev|com}/github/pr/owner/repo/number[/optional-title]
-    const match = url.match(/^https:\/\/app\.graphite\.(?:dev|com)\/github\/pr\/([^\/]+)\/([^\/]+)\/(\d+)(?:\/[^?]*)?(?:\?.*)?$/);
+    // Match Graphite PR URL patterns:
+    //   https://app.graphite.{dev|com}/github/pr/owner/repo/number[/optional-title]
+    //   https://app.graphite.{dev|com}/github/owner/repo/pull/number[/optional-title]
+    const match = url.match(/^https:\/\/app\.graphite\.(?:dev|com)\/github\/(?:pr\/([^\/]+)\/([^\/]+)\/(\d+)|([^\/]+)\/([^\/]+)\/pull\/(\d+))(?:\/[^?]*)?(?:\?.*)?$/);
 
     if (!match) {
-      throw new Error('Invalid Graphite URL format. Expected: https://app.graphite.com/github/pr/owner/repo/number');
+      throw new Error('Invalid Graphite URL format. Expected: https://app.graphite.com/github/pr/owner/repo/number or https://app.graphite.com/github/owner/repo/pull/number');
     }
 
-    const [, owner, repo, numberStr] = match;
+    const owner = match[1] || match[4];
+    const repo = match[2] || match[5];
+    const numberStr = match[3] || match[6];
     return this._createPRInfo(owner, repo, numberStr, 'Graphite');
   }
 
@@ -156,7 +160,7 @@ class PRArgumentParser {
         ? 'https://github.com/owner/repo/pull/number'
         : source === 'pair-review://'
           ? 'pair-review://pr/owner/repo/number'
-          : 'https://app.graphite.com/github/pr/owner/repo/number';
+          : 'https://app.graphite.com/github/pr/owner/repo/number or https://app.graphite.com/github/owner/repo/pull/number';
       throw new Error(`Invalid ${source} URL format. Expected: ${exampleUrl}`);
     }
 

--- a/tests/unit/parser.test.js
+++ b/tests/unit/parser.test.js
@@ -62,6 +62,16 @@ describe('PRArgumentParser', () => {
       expect(result).toEqual({ owner: 'shop', repo: 'world', number: 337891 });
     });
 
+    it('should parse Graphite /pull/ URL with protocol', () => {
+      const result = parser.parsePRUrl('https://app.graphite.com/github/shop/world/pull/540063');
+      expect(result).toEqual({ owner: 'shop', repo: 'world', number: 540063 });
+    });
+
+    it('should parse Graphite /pull/ URL without protocol', () => {
+      const result = parser.parsePRUrl('app.graphite.com/github/shop/world/pull/540063');
+      expect(result).toEqual({ owner: 'shop', repo: 'world', number: 540063 });
+    });
+
     it('should parse Graphite .dev URL without protocol', () => {
       const result = parser.parsePRUrl('app.graphite.dev/github/pr/shop/world/337891');
       expect(result).toEqual({ owner: 'shop', repo: 'world', number: 337891 });
@@ -153,6 +163,26 @@ describe('PRArgumentParser', () => {
     it('should throw error for Graphite URL with wrong path structure', () => {
       expect(() => parser.parseGraphiteURL('https://app.graphite.dev/gitlab/pr/owner/repo/123')).toThrow('Invalid Graphite URL format');
     });
+
+    it('should parse Graphite /pull/ URL with .com domain', () => {
+      const result = parser.parseGraphiteURL('https://app.graphite.com/github/shop/world/pull/540063');
+      expect(result).toEqual({ owner: 'shop', repo: 'world', number: 540063 });
+    });
+
+    it('should parse Graphite /pull/ URL with .dev domain', () => {
+      const result = parser.parseGraphiteURL('https://app.graphite.dev/github/shop/world/pull/540063');
+      expect(result).toEqual({ owner: 'shop', repo: 'world', number: 540063 });
+    });
+
+    it('should parse Graphite /pull/ URL with title segment', () => {
+      const result = parser.parseGraphiteURL('https://app.graphite.com/github/shop/world/pull/540063/fix-something');
+      expect(result).toEqual({ owner: 'shop', repo: 'world', number: 540063 });
+    });
+
+    it('should parse Graphite /pull/ URL with query parameters', () => {
+      const result = parser.parseGraphiteURL('https://app.graphite.com/github/shop/world/pull/540063?ref=gt-pasteable-stack');
+      expect(result).toEqual({ owner: 'shop', repo: 'world', number: 540063 });
+    });
   });
 
   describe('parseProtocolURL', () => {
@@ -203,6 +233,11 @@ describe('PRArgumentParser', () => {
     it('should parse Graphite URL with title', async () => {
       const result = await parser.parsePRArguments(['https://app.graphite.com/github/pr/shop/world/338808/%5BConveyor%5D-Minor-update-to-audit-release-cycle-help']);
       expect(result).toEqual({ owner: 'shop', repo: 'world', number: 338808 });
+    });
+
+    it('should parse Graphite /pull/ URL', async () => {
+      const result = await parser.parsePRArguments(['https://app.graphite.com/github/shop/world/pull/540063']);
+      expect(result).toEqual({ owner: 'shop', repo: 'world', number: 540063 });
     });
 
     it('should parse PR number and fetch repo from git remote', async () => {


### PR DESCRIPTION
## Summary
- Graphite uses two URL formats for PRs: `/github/pr/owner/repo/number` (already supported) and `/github/owner/repo/pull/number` (new, copied from Graphite UI)
- Updated `parseGraphiteURL` regex to accept both formats
- Added tests for the new format across all parser test sections

## Test plan
- [x] All 71 parser unit tests pass
- [ ] Manual test: `npx pair-review https://app.graphite.com/github/shop/world/pull/540063`

🤖 Generated with [Claude Code](https://claude.com/claude-code)