### PR TITLE
Fix diff scope selector not rendering in local mode

### DIFF
--- a/.changeset/fix-scope-selector-rendering.md
+++ b/.changeset/fix-scope-selector-rendering.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Fix diff scope selector not rendering in the diff options dropdown in local mode

--- a/plans/always-show-diff-scope-in-dropdown.md
+++ b/plans/always-show-diff-scope-in-dropdown.md
@@ -1,0 +1,47 @@
+# Always-Visible Diff Scope in Diff Options Dropdown
+
+## Context
+
+The diff scope selector (branch/staged/unstaged/untracked) inside the gear-icon dropdown (`DiffOptionsDropdown`) sometimes fails to render in local mode. When a local checkout has only staged changes, the default scope (unstaged–untracked) shows nothing — and the user cannot change the scope because the scope control is missing from the dropdown. The scope selector must always render inside the diff options dropdown in local mode, and the branch stop should show a tooltip explaining why it's disabled when unavailable.
+
+## Approach
+
+Harden the scope selector rendering in `DiffOptionsDropdown` so it always appears in local mode. Add a tooltip to the disabled branch stop. The scope selector stays inside the gear dropdown (not extracted to the toolbar).
+
+## File Changes
+
+### 1. Modify: `public/js/components/DiffOptionsDropdown.js`
+
+**Rendering guard (L192)**: Currently checks `window.PAIR_REVIEW_LOCAL_MODE && window.LocalScope`. Change to also render when scope params are explicitly provided (i.e., `onScopeChange` was passed), as a belt-and-suspenders approach:
+```js
+const isLocalScope = (window.PAIR_REVIEW_LOCAL_MODE && window.LocalScope) || this._onScopeChange;
+if (isLocalScope) {
+  this._renderScopeSelector(popover);
+  // divider...
+}
+```
+
+**Disabled branch tooltip (in `_updateScopeUI`, L477-484)**: Add `title` attribute to the branch stop container when disabled:
+```js
+containerEl.title = disabled ? 'No branch commits ahead of base — nothing to review' : '';
+```
+
+### 2. Tests
+
+- Add unit tests for `DiffOptionsDropdown` covering:
+  - Scope selector renders when `onScopeChange` is provided even if `window.LocalScope` is not set
+  - Scope selector renders when both globals are set (existing behavior)
+  - Disabled branch stop has a tooltip explaining why
+  - Branch stop click is ignored when disabled
+
+## Hazards
+
+- `_renderScopeSelector` references `window.LocalScope` internally (e.g., `LS.STOPS`, `LS.DEFAULT_SCOPE`). If `window.LocalScope` is truly undefined but `onScopeChange` was passed, this would crash. Need a fallback: use a minimal inline `STOPS` constant if `window.LocalScope` is unavailable.
+- The pr.js construction (L195) does NOT pass `onScopeChange`, so the guard change won't cause the scope selector to appear in PR mode.
+
+## Verification
+
+1. Unit tests for the rendering guard and tooltip
+2. Manual: open local mode with staged-only changes → open gear dropdown → scope selector is present, can expand to staged
+3. Manual: PR mode → gear dropdown has no scope selector
+4. E2E test suite passes

--- a/public/js/components/DiffOptionsDropdown.js
+++ b/public/js/components/DiffOptionsDropdown.js
@@ -57,11 +57,29 @@ class DiffOptionsDropdown {
     this._outsideClickHandler = null;
     this._escapeHandler = null;
 
-    // Scope state
-    const LS = window.LocalScope;
+    // Scope state — resolve LocalScope with inline fallback so the scope selector
+    // renders even if window.LocalScope failed to load (race condition guard).
+    const FALLBACK_STOPS = ['branch', 'staged', 'unstaged', 'untracked']; // Keep in sync with local-scope.js:STOPS
+    const FALLBACK_DEFAULT = { start: 'unstaged', end: 'untracked' };
+    this._localScope = window.LocalScope || {
+      STOPS: FALLBACK_STOPS,
+      DEFAULT_SCOPE: FALLBACK_DEFAULT,
+      isValidScope: (s, e) => {
+        const si = FALLBACK_STOPS.indexOf(s);
+        const ei = FALLBACK_STOPS.indexOf(e);
+        return si !== -1 && ei !== -1 && si <= ei;
+      },
+      scopeIncludes: (s, e, stop) => {
+        const si = FALLBACK_STOPS.indexOf(s);
+        const ei = FALLBACK_STOPS.indexOf(e);
+        const ti = FALLBACK_STOPS.indexOf(stop);
+        return ti !== -1 && ti >= si && ti <= ei;
+      }
+    };
+    const LS = this._localScope;
     this._branchAvailable = Boolean(branchAvailable);
-    this._scopeStart = (initialScope && initialScope.start) || (LS ? LS.DEFAULT_SCOPE.start : 'unstaged');
-    this._scopeEnd = (initialScope && initialScope.end) || (LS ? LS.DEFAULT_SCOPE.end : 'untracked');
+    this._scopeStart = (initialScope && initialScope.start) || LS.DEFAULT_SCOPE.start;
+    this._scopeEnd = (initialScope && initialScope.end) || LS.DEFAULT_SCOPE.end;
     this._scopeStops = [];
     this._scopeTrackEl = null;
     this._scopeDebounceTimer = null;
@@ -144,7 +162,7 @@ class DiffOptionsDropdown {
   /** Programmatically set scope. */
   set scope(val) {
     if (!val) return;
-    const LS = window.LocalScope;
+    const LS = this._localScope;
     if (LS && !LS.isValidScope(val.start, val.end)) return;
     this._scopeStart = val.start;
     this._scopeEnd = val.end;
@@ -188,8 +206,11 @@ class DiffOptionsDropdown {
     popover.style.zIndex = '1100';
     popover.style.transition = 'opacity 0.15s ease, transform 0.15s ease';
 
-    // Scope selector first — only in local mode
-    if (window.PAIR_REVIEW_LOCAL_MODE && window.LocalScope) {
+    // Scope selector first — only in local mode.
+    // Belt-and-suspenders: also render when scope callbacks were explicitly provided,
+    // in case a race condition prevents the globals from being set in time.
+    const hasLocalScope = (window.PAIR_REVIEW_LOCAL_MODE && window.LocalScope) || this._onScopeChange;
+    if (hasLocalScope) {
       this._renderScopeSelector(popover);
 
       // Divider between scope selector and whitespace checkbox
@@ -261,7 +282,7 @@ class DiffOptionsDropdown {
   }
 
   _renderScopeSelector(popover) {
-    const LS = window.LocalScope;
+    const LS = this._localScope;
 
     // Section container — generous horizontal padding so dots/labels breathe
     const section = document.createElement('div');
@@ -382,7 +403,7 @@ class DiffOptionsDropdown {
   }
 
   _handleStopClick(clickedStop, event) {
-    const LS = window.LocalScope;
+    const LS = this._localScope;
     if (!LS) return;
 
     // Branch disabled? Ignore.
@@ -457,7 +478,7 @@ class DiffOptionsDropdown {
   }
 
   _updateScopeUI() {
-    const LS = window.LocalScope;
+    const LS = this._localScope;
     if (!LS || !this._scopeStops.length) return;
 
     const stops = LS.STOPS;
@@ -474,13 +495,16 @@ class DiffOptionsDropdown {
       const isAdjacent = !included && (i === si - 1 || i === ei + 1);
       const clickable = !disabled && (isBoundary || isAdjacent);
 
+      // Tooltip for disabled branch stop
+      containerEl.title = disabled ? 'No feature branch detected' : '';
+
       if (disabled) {
         // Disabled state
         dotEl.style.background = 'var(--color-bg-tertiary, #f6f8fa)';
         dotEl.style.borderColor = 'var(--color-border-secondary, #e1e4e8)';
         dotEl.style.boxShadow = 'none';
         labelEl.style.color = 'var(--color-text-tertiary, #8b949e)';
-        containerEl.style.cursor = 'not-allowed';
+        containerEl.style.cursor = 'default';
         containerEl.style.opacity = '0.5';
       } else if (included) {
         // Included (filled) state

--- a/tests/unit/diff-options-dropdown.test.js
+++ b/tests/unit/diff-options-dropdown.test.js
@@ -1,0 +1,258 @@
+// Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+/**
+ * Unit tests for DiffOptionsDropdown component
+ *
+ * Tests scope selector rendering conditions, disabled branch tooltip,
+ * branch click-when-disabled behavior, and tooltip clearing.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+/**
+ * Create a mock DOM element with the methods used by DiffOptionsDropdown.
+ */
+function createMockElement(tag) {
+  const children = [];
+  let textContentValue = '';
+
+  const element = {
+    tagName: tag?.toUpperCase(),
+    className: '',
+    style: {},
+    title: '',
+    dataset: {},
+    _children: children,
+    get textContent() {
+      return textContentValue;
+    },
+    set textContent(val) {
+      textContentValue = val;
+    },
+    appendChild: vi.fn((child) => {
+      children.push(child);
+      return child;
+    }),
+    remove: vi.fn(),
+    querySelector: vi.fn((selector) => {
+      // Support 'input' selector for checkbox lookup inside labels
+      if (selector === 'input') {
+        return children.find((c) => c.tagName === 'INPUT') || null;
+      }
+      return null;
+    }),
+    querySelectorAll: vi.fn().mockReturnValue([]),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    contains: vi.fn(() => false),
+    classList: {
+      _classes: [],
+      add: vi.fn(function (cls) { if (!this._classes.includes(cls)) this._classes.push(cls); }),
+      remove: vi.fn(function (cls) { this._classes = this._classes.filter((c) => c !== cls); }),
+      contains: vi.fn(function (cls) { return this._classes.includes(cls); }),
+      toggle: vi.fn(function (cls, force) {
+        if (force) {
+          if (!this._classes.includes(cls)) this._classes.push(cls);
+        } else {
+          this._classes = this._classes.filter((c) => c !== cls);
+        }
+      })
+    },
+    getBoundingClientRect: vi.fn(() => ({ top: 0, left: 0, right: 100, bottom: 30, width: 100, height: 30 })),
+    focus: vi.fn(),
+    click: vi.fn()
+  };
+  return element;
+}
+
+// Setup minimal DOM globals before importing the component
+beforeEach(() => {
+  vi.resetAllMocks();
+
+  global.document = {
+    readyState: 'complete',
+    getElementById: vi.fn().mockReturnValue(null),
+    createElement: vi.fn().mockImplementation((tag) => createMockElement(tag)),
+    createTextNode: vi.fn((text) => ({ nodeType: 3, textContent: text })),
+    body: { appendChild: vi.fn() },
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn()
+  };
+
+  global.window = {
+    PAIR_REVIEW_LOCAL_MODE: false,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn()
+  };
+
+  global.localStorage = {
+    _store: {},
+    getItem: vi.fn((key) => global.localStorage._store[key] ?? null),
+    setItem: vi.fn((key, value) => { global.localStorage._store[key] = value; }),
+    removeItem: vi.fn((key) => { delete global.localStorage._store[key]; }),
+    clear: vi.fn(() => { global.localStorage._store = {}; })
+  };
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  delete global.document;
+  delete global.window;
+  delete global.localStorage;
+});
+
+/**
+ * Import the component after globals are set. Clears the native CJS require
+ * cache so the file re-evaluates with the current window/document globals.
+ * (vi.resetModules() only clears Vitest's ESM transform cache, not require.cache.)
+ */
+const MODULE_PATH = '../../public/js/components/DiffOptionsDropdown.js';
+
+function getDiffOptionsDropdown() {
+  const resolved = require.resolve(MODULE_PATH);
+  delete require.cache[resolved];
+  require(MODULE_PATH);
+  return global.window.DiffOptionsDropdown;
+}
+
+/**
+ * Helper: create a dropdown instance with sensible defaults.
+ * Merges caller overrides into the callbacks object.
+ */
+function createDropdown(overrides = {}) {
+  const DiffOptionsDropdown = getDiffOptionsDropdown();
+  const btn = createMockElement('button');
+  const opts = {
+    onToggleWhitespace: vi.fn(),
+    onToggleMinimize: vi.fn(),
+    ...overrides
+  };
+  return new DiffOptionsDropdown(btn, opts);
+}
+
+/**
+ * Helper: find the scope-selector-section child inside the popover.
+ */
+function findScopeSection(dropdown) {
+  const popover = dropdown._popoverEl;
+  if (!popover) return null;
+  return popover._children.find((c) => c.className === 'scope-selector-section') || null;
+}
+
+/**
+ * Helper: find the stop container with dataset.stop === stopName.
+ * Walks through the scope stops tracked by the component.
+ */
+function findStopContainer(dropdown, stopName) {
+  const entry = dropdown._scopeStops.find((s) => s.stop === stopName);
+  return entry ? entry.containerEl : null;
+}
+
+describe('DiffOptionsDropdown', () => {
+  describe('scope selector rendering', () => {
+    it('renders scope selector when onScopeChange is provided (fallback path, no globals)', () => {
+      // No PAIR_REVIEW_LOCAL_MODE, no window.LocalScope — only the callback
+      global.window.PAIR_REVIEW_LOCAL_MODE = false;
+      delete global.window.LocalScope;
+
+      const dropdown = createDropdown({
+        onScopeChange: vi.fn(),
+        initialScope: { start: 'unstaged', end: 'untracked' },
+        branchAvailable: false
+      });
+
+      const section = findScopeSection(dropdown);
+      expect(section).not.toBeNull();
+    });
+
+    it('renders scope selector when both globals are set (normal local mode path)', () => {
+      global.window.PAIR_REVIEW_LOCAL_MODE = true;
+      global.window.LocalScope = {
+        STOPS: ['branch', 'staged', 'unstaged', 'untracked'],
+        DEFAULT_SCOPE: { start: 'unstaged', end: 'untracked' },
+        isValidScope: () => true,
+        scopeIncludes: (s, e, stop) => {
+          const stops = ['branch', 'staged', 'unstaged', 'untracked'];
+          return stops.indexOf(stop) >= stops.indexOf(s) && stops.indexOf(stop) <= stops.indexOf(e);
+        }
+      };
+
+      const dropdown = createDropdown({
+        initialScope: { start: 'unstaged', end: 'untracked' },
+        branchAvailable: true
+      });
+
+      const section = findScopeSection(dropdown);
+      expect(section).not.toBeNull();
+    });
+
+    it('does NOT render scope selector in PR mode (no globals, no onScopeChange)', () => {
+      global.window.PAIR_REVIEW_LOCAL_MODE = false;
+      delete global.window.LocalScope;
+
+      const dropdown = createDropdown();
+
+      const section = findScopeSection(dropdown);
+      expect(section).toBeNull();
+    });
+  });
+
+  describe('disabled branch stop tooltip', () => {
+    it('shows tooltip when branchAvailable is false', () => {
+      const dropdown = createDropdown({
+        onScopeChange: vi.fn(),
+        initialScope: { start: 'unstaged', end: 'untracked' },
+        branchAvailable: false
+      });
+
+      const branchContainer = findStopContainer(dropdown, 'branch');
+      expect(branchContainer).not.toBeNull();
+      expect(branchContainer.title).toBe('No feature branch detected');
+    });
+
+    it('clears tooltip when branchAvailable becomes true', () => {
+      const dropdown = createDropdown({
+        onScopeChange: vi.fn(),
+        initialScope: { start: 'unstaged', end: 'untracked' },
+        branchAvailable: false
+      });
+
+      const branchContainer = findStopContainer(dropdown, 'branch');
+      expect(branchContainer.title).toBe('No feature branch detected');
+
+      // Simulate branch becoming available
+      dropdown.branchAvailable = true;
+
+      expect(branchContainer.title).toBe('');
+    });
+  });
+
+  describe('branch stop click when disabled', () => {
+    it('ignores click on disabled branch stop (scope does not change)', () => {
+      vi.useFakeTimers();
+      try {
+        const onScopeChange = vi.fn();
+        const dropdown = createDropdown({
+          onScopeChange,
+          initialScope: { start: 'staged', end: 'untracked' },
+          branchAvailable: false
+        });
+
+        const scopeBefore = { ...dropdown.scope };
+
+        // Simulate clicking the branch stop via the internal handler
+        dropdown._handleStopClick('branch', { stopPropagation: vi.fn(), altKey: false });
+
+        // Advance past the 600ms debounce window
+        vi.advanceTimersByTime(700);
+
+        // Scope should remain unchanged
+        expect(dropdown.scope.start).toBe(scopeBefore.start);
+        expect(dropdown.scope.end).toBe(scopeBefore.end);
+        // onScopeChange should never have been called, not even after debounce
+        expect(onScopeChange).not.toHaveBeenCalled();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Hardened the scope selector rendering guard in `DiffOptionsDropdown` to also trigger when `onScopeChange` is explicitly provided (belt-and-suspenders for race conditions where `window.LocalScope` isn't set in time)
- Added inline fallback `LocalScope` implementation so the scope selector works even if the global fails to load
- Added tooltip on the disabled branch stop ("No feature branch detected") so users understand why it can't be selected

## Test plan
- [x] 6 new unit tests covering scope rendering conditions, tooltip behavior, and disabled branch click handling
- [x] Full unit suite passes (5621 tests)
- [x] E2E suite passes (268 passed, 1 pre-existing skip)
- [ ] Manual: open local mode with staged-only changes → open gear dropdown → scope selector present, can expand to staged
- [ ] Manual: PR mode → gear dropdown has no scope selector

🤖 Generated with [Claude Code](https://claude.com/claude-code)