### PR TITLE
Fix executable provider council analysis and progress tracking

### DIFF
--- a/.changeset/fix-executable-council-progress.md
+++ b/.changeset/fix-executable-council-progress.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Fix executable provider council analysis: emit completion/failure progress for council dialog, reorder diff generation to prioritize scope-aware path over SHA path for local reviews, and stop passing synthetic title/description to executable providers in local mode

--- a/src/ai/analyzer.js
+++ b/src/ai/analyzer.js
@@ -126,8 +126,8 @@ async function runExecutableVoice(voiceProvider, reviewId, worktreePath, prMetad
   const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'pair-review-exec-'));
   try {
     const executableContext = {
-      title: prMetadata.title || '',
-      description: prMetadata.description || '',
+      title: prMetadata.title || null,
+      description: prMetadata.description || null,
       cwd: worktreePath,
       outputDir: tmpDir,
       model: voiceProvider.resolvedModel !== undefined ? voiceProvider.resolvedModel : (voiceProvider.model || null),
@@ -176,11 +176,16 @@ async function runExecutableVoice(voiceProvider, reviewId, worktreePath, prMetad
     });
 
     if (!result?.success || !result?.data) {
+      if (progressCallback) {
+        progressCallback({ level: 'exec', status: 'failed', progress: 'External tool returned no data' });
+      }
       throw new Error(`${logPrefix || ''}Executable provider returned no data`);
     }
 
+    const suggestions = result.data.suggestions || [];
+
     return {
-      suggestions: result.data.suggestions || [],
+      suggestions,
       summary: result.data.summary || ''
     };
   } finally {
@@ -2948,6 +2953,10 @@ File-level suggestions should NOT have a line number. They apply to the entire f
         const finalSuggestions = this.validateAndFinalizeSuggestions(result.suggestions, fileLineCountMap, validFiles);
         await this.storeSuggestions(reviewId, parentRunId, finalSuggestions, null, validFiles);
 
+        if (progressCallback) {
+          progressCallback({ level: 'exec', status: 'completed', progress: `External tool complete: ${finalSuggestions.length} suggestions` });
+        }
+
         try {
           await analysisRunRepo.update(parentRunId, {
             status: 'completed',
@@ -3074,6 +3083,10 @@ File-level suggestions should NOT have a line number. They apply to the entire f
           // Store validated voice suggestions
           await commentRepo.bulkInsertAISuggestions(reviewId, childRunId, validatedSuggestions, null);
 
+          if (voiceProgressCallback) {
+            voiceProgressCallback({ level: 'exec', status: 'completed', progress: `External tool complete: ${validatedSuggestions.length} suggestions` });
+          }
+
           const validatedResult = { ...result, suggestions: validatedSuggestions };
           return { voiceKey, reviewerLabel, childRunId, result: validatedResult, provider: voice.provider, model: voice.model, isExecutable: true, customInstructions: voice.customInstructions || null };
         }
@@ -3120,6 +3133,11 @@ File-level suggestions should NOT have a line number. They apply to the entire f
           });
         } catch (err) {
           logger.warn(`[ReviewerCouncil] Failed to update child run ${childRunId}: ${err.message}`);
+        }
+        // Notify the progress dialog so the voice row stops spinning
+        if (isExecutable && voiceProgressCallback) {
+          const terminalStatus = error.isCancellation ? 'cancelled' : 'failed';
+          voiceProgressCallback({ level: 'exec', status: terminalStatus, progress: error.message || 'Voice failed' });
         }
         throw error;
       }

--- a/src/routes/executable-analysis.js
+++ b/src/routes/executable-analysis.js
@@ -55,15 +55,10 @@ async function generateDiffForExecutable(cwd, context, diffArgs, outputPath) {
   let diff;
   const extraFlags = diffArgs.length > 0 ? ' ' + diffArgs.join(' ') : '';
 
-  if (context.baseSha && context.headSha) {
-    // PR mode: straightforward base...head diff
-    const { stdout } = await execPromise(
-      `git diff ${GIT_DIFF_FLAGS}${extraFlags} ${context.baseSha}...${context.headSha}`,
-      { cwd, maxBuffer: 50 * 1024 * 1024 }
-    );
-    diff = stdout;
-  } else if (context.scopeStart && context.scopeEnd) {
-    // Local mode: scope-aware diff generation
+  if (context.scopeStart && context.scopeEnd) {
+    // Local mode: scope-aware diff generation (checked first because local reviews
+    // may also carry baseSha/headSha pointing at the same commit, which would
+    // produce an empty diff if the SHA path ran instead).
     // Note: diffArgs are passed as extraArgs to generateScopedDiff, which handles
     // appending them to the git diff command internally (extraFlags is not used here).
     const result = await generateScopedDiff(
@@ -74,6 +69,13 @@ async function generateDiffForExecutable(cwd, context, diffArgs, outputPath) {
       { contextLines: 3, extraArgs: diffArgs }
     );
     diff = result.diff;
+  } else if (context.baseSha && context.headSha) {
+    // PR mode: straightforward base...head diff
+    const { stdout } = await execPromise(
+      `git diff ${GIT_DIFF_FLAGS}${extraFlags} ${context.baseSha}...${context.headSha}`,
+      { cwd, maxBuffer: 50 * 1024 * 1024 }
+    );
+    diff = stdout;
   } else {
     // Fallback: simple working-tree diff
     const { stdout } = await execPromise(

--- a/src/routes/local.js
+++ b/src/routes/local.js
@@ -2042,8 +2042,8 @@ router.post('/api/local/:reviewId/analyses/council', async (req, res) => {
     const prMetadata = {
       reviewType: 'local',
       repository: review.repository,
-      title: review.name || (councilHasBranch ? `Branch changes: ${review.local_base_branch}..HEAD` : 'Local changes'),
-      description: '',
+      title: null,
+      description: null,
       base_sha: analysisBaseSha,
       head_sha: review.local_head_sha,
       base_branch: review.local_base_branch || null,

--- a/tests/unit/council-progress-modal.test.js
+++ b/tests/unit/council-progress-modal.test.js
@@ -1201,6 +1201,62 @@ describe('CouncilProgressModal', () => {
       expect(setStreamTextSpy).toHaveBeenCalledWith('my-tool-default', 'exec', 'Processing files...');
     });
 
+    it('updates executable voice row to completed when status is completed', () => {
+      const { modal } = createTestCouncilProgressModal();
+
+      modal._renderMode = 'council';
+
+      const setLevelStateSpy = vi.spyOn(modal, '_setVoiceCentricLevelState').mockImplementation(() => {});
+      vi.spyOn(modal, '_refreshAllVoiceHeaders').mockImplementation(() => {});
+      vi.spyOn(modal, '_updateConsolidation').mockImplementation(() => {});
+
+      const status = {
+        levels: {
+          exec: {
+            status: 'completed',
+            voices: {
+              'my-tool-default': { status: 'completed', progress: 'External tool complete: 3 suggestions' }
+            }
+          }
+        }
+      };
+
+      modal._updateVoiceCentric(status);
+
+      expect(setLevelStateSpy).toHaveBeenCalledWith('my-tool-default', 'exec', 'completed', {
+        status: 'completed',
+        progress: 'External tool complete: 3 suggestions'
+      });
+    });
+
+    it('updates executable voice row to failed when status is failed', () => {
+      const { modal } = createTestCouncilProgressModal();
+
+      modal._renderMode = 'council';
+
+      const setLevelStateSpy = vi.spyOn(modal, '_setVoiceCentricLevelState').mockImplementation(() => {});
+      vi.spyOn(modal, '_refreshAllVoiceHeaders').mockImplementation(() => {});
+      vi.spyOn(modal, '_updateConsolidation').mockImplementation(() => {});
+
+      const status = {
+        levels: {
+          exec: {
+            status: 'failed',
+            voices: {
+              'my-tool-default': { status: 'failed', progress: 'External tool returned no data' }
+            }
+          }
+        }
+      };
+
+      modal._updateVoiceCentric(status);
+
+      expect(setLevelStateSpy).toHaveBeenCalledWith('my-tool-default', 'exec', 'failed', {
+        status: 'failed',
+        progress: 'External tool returned no data'
+      });
+    });
+
     it('does not crash when status.levels has no exec key', () => {
       const { modal } = createTestCouncilProgressModal();
 


### PR DESCRIPTION
## Summary
- Emit completed/failed/cancelled progress callbacks for executable voices so the council progress dialog correctly reflects their terminal state instead of spinning indefinitely
- Reorder `generateDiffForExecutable` to check scope-aware path before SHA path, fixing empty diffs for local reviews where base and head SHA are identical
- Use `null` instead of synthetic values for title/description in local mode so executable providers skip those CLI args via the `!= null` guard in `_buildArgs`

## Test plan
- [x] Unit tests pass (council-progress-modal, analyzer-consolidation, analyzer-validation, executable-provider, executable-analysis, integration routes)
- [ ] Manual: run executable provider as part of a council on a local review — verify progress dialog shows completion
- [ ] Manual: run executable provider council on a PR review — verify title/description still passed correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)