### PR TITLE
Constrain diff scope to always include unstaged changes

### DIFF
--- a/.changeset/diff-scope-must-include-unstaged.md
+++ b/.changeset/diff-scope-must-include-unstaged.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Constrain local review diff scope to always include unstaged changes, ensuring the diff matches the working tree files AI reviewers read

--- a/plans/diff-scope-must-include-unstaged.md
+++ b/plans/diff-scope-must-include-unstaged.md
@@ -1,0 +1,167 @@
+# Constrain Diff Scope to Always Include Unstaged
+
+## Context
+
+When AI models analyze local changes, they read files from the working tree. If a user selects a scope that excludes unstaged changes (e.g., "staged only"), the diff and the files the model reads diverge — the diff says one thing, the working tree says another. Since pair-review must not modify local git state (no stash/checkout) and `git show` is too unreliable across diverse AI agents, the fix is to enforce `unstaged` as the minimum right boundary of every valid scope.
+
+**Valid scopes after this change:**
+
+| Scope | Git command |
+|---|---|
+| `unstaged` | `git diff` |
+| `unstaged..untracked` | `git diff` + untracked listing |
+| `staged..unstaged` | `git diff HEAD` |
+| `staged..untracked` | `git diff HEAD` + untracked |
+| `branch..unstaged` | `git diff <merge-base>` |
+| `branch..untracked` | `git diff <merge-base>` + untracked |
+
+**Removed:** `branch..branch`, `branch..staged`, `staged..staged`, `untracked..untracked`
+
+---
+
+## Implementation
+
+### 1. `src/local-scope.js` — Core validation
+
+**Tighten `isValidScope`** — add `si <= 2 && ei >= 2` (index of `unstaged` is 2):
+
+```js
+return si !== -1 && ei !== -1 && si <= ei && si <= 2 && ei >= 2;
+```
+
+This is the keystone change. Every caller of `isValidScope` automatically rejects the 4 removed scopes.
+
+**Add `normalizeScope(start, end)`** — clamps invalid scopes to the nearest valid one. Used by the metadata endpoint and DB migration fallback:
+- Clamps `end` up to at least `unstaged` (index 2)
+- Clamps `start` down to at most `unstaged` (index 2) if start > end after clamping
+- Falls back to `DEFAULT_SCOPE` for unknown stops
+
+Migration mapping: `branch..branch` → `branch..unstaged`, `staged..staged` → `staged..unstaged`, `untracked..untracked` → `unstaged..untracked`.
+
+**Update `fromLegacyMode`** — change `'branch'` mapping from `branch..branch` to `branch..unstaged`.
+
+**Remove dead hint entries from `scopeGitHints`** — delete keys `branch-branch`, `branch-staged`, `staged-staged`, `untracked-untracked`. Also remove the `includesUntracked` special case for `untracked-untracked` since that key no longer exists.
+
+Export `normalizeScope` from the `LocalScope` object.
+
+### 2. `src/database.js` — Migration (version 36)
+
+Bump `CURRENT_SCHEMA_VERSION` to 36. Migration SQL:
+
+```sql
+-- Expand scopes where end < unstaged
+UPDATE reviews SET local_scope_end = 'unstaged'
+  WHERE local_scope_end IN ('branch', 'staged') AND review_type = 'local';
+
+-- Fix untracked-only → unstaged..untracked
+UPDATE reviews SET local_scope_start = 'unstaged'
+  WHERE local_scope_start = 'untracked' AND local_scope_end = 'untracked'
+  AND review_type = 'local';
+```
+
+`analysis_runs` scope columns are historical records — leave them as-is.
+
+### 3. `src/routes/local.js` — Metadata normalization
+
+In `GET /api/local/:reviewId/metadata`, apply `normalizeScope` when reading scope from DB (belt-and-suspenders for un-migrated rows):
+
+```js
+const { start: scopeStart, end: scopeEnd } = normalizeScope(
+  review.local_scope_start || DEFAULT_SCOPE.start,
+  review.local_scope_end || DEFAULT_SCOPE.end
+);
+```
+
+Import `normalizeScope` from `local-scope.js` (already imports other functions from this module).
+
+The `POST set-scope` endpoint already validates via `isValidScope` and returns 400 — no changes needed.
+
+### 4. `src/local-review.js` — Remove dead branches in `generateScopedDiff`
+
+Remove three unreachable branches (lines 488-511):
+- `hasBranch && !hasStaged && !hasUnstaged` (branch-only)
+- `hasBranch && hasStaged && !hasUnstaged` (branch-staged)
+- `hasStaged && !hasUnstaged` (staged-only)
+
+Remove the `// hasUntracked-only` comment at line 525 (also dead).
+
+Add a comment explaining `hasUnstaged` is always true by invariant.
+
+The remaining branches are exhaustive for all valid scopes:
+1. `hasBranch && hasUnstaged` → `git diff <merge-base>`
+2. `hasStaged && hasUnstaged` → `git diff HEAD`
+3. `hasUnstaged` → `git diff`
+
+### 5. `public/js/components/DiffOptionsDropdown.js` — UI constraints
+
+**`_handleStopClick`:**
+
+- **Alt-click:** Replace solo-select with minimum-unstaged enforcement:
+  ```js
+  const ui = stops.indexOf('unstaged');
+  newStart = stops[Math.min(ci, ui)];
+  newEnd = stops[Math.max(ci, ui)];
+  ```
+  Result: alt+branch → `branch..unstaged`, alt+staged → `staged..unstaged`, alt+unstaged → `unstaged..unstaged`, alt+untracked → `unstaged..untracked`.
+
+- **Regular click on `unstaged` when it's a boundary:** Add early return to prevent toggling it off:
+  ```js
+  if (clickedStop === 'unstaged') return; // unstaged is mandatory
+  ```
+  Place this inside the "Toggling OFF" block, before the `ci === si` / `ci === ei` checks.
+
+- The existing `isValidScope` guard at line 434 is the final safety net — any scope that somehow slips through will be rejected there.
+
+**`_updateScopeUI`:**
+
+- Update `isBoundary` calculation to exclude `unstaged` from clickable boundaries:
+  ```js
+  const isMandatory = stop === 'unstaged';
+  const isBoundary = included && (i === si || i === ei) && si !== ei && !isMandatory;
+  ```
+  This ensures the cursor shows `default` (not `pointer`) on `unstaged` when clicking would be a no-op.
+
+### 6. Tests
+
+**`tests/unit/local-scope.test.js`:**
+- `isValidScope`: Move 4 removed scopes to a new "rejects scope that excludes unstaged" test block
+- `scopeLabel`: Update — `scopeLabel('branch','branch')` etc. now return `''`
+- `scopeGitHints`: Reduce valid combo list from 10 to 6, remove tests referencing dead keys
+- `scopeIncludes`: `scopeIncludes('staged','staged','staged')` now returns `false` (invalid scope)
+- `fromLegacyMode`: Update `'branch'` expectation to `{ start: 'branch', end: 'unstaged' }`
+- Add `normalizeScope` test group covering all 4 invalid→valid mappings plus pass-through for valid scopes and unknown stops
+
+**`tests/unit/local-review.test.js`:**
+- Update tests using `staged..staged`, `branch..branch`, `untracked..untracked`, `branch..staged` to use valid scopes instead
+
+**`tests/unit/chat/prompt-builder.test.js`:**
+- Update `local_scope_start: 'staged', local_scope_end: 'staged'` to `staged..unstaged`
+
+**`tests/integration/local-sessions.test.js`:**
+- Update `scopeEnd: 'branch'` to `scopeEnd: 'unstaged'` in set-scope tests
+- Update `updateLocalScope(id, 'branch', 'branch', ...)` calls to use valid scopes
+
+### 7. Changeset
+
+Create `.changeset/<name>.md` — `patch` for `@in-the-loop-labs/pair-review`:
+> Constrain local review diff scope to always include unstaged changes, ensuring the diff matches the working tree files AI reviewers read.
+
+---
+
+## Hazards
+
+- **`isValidScope` has wide call surface**: Called by `scopeIncludes` (→ `generateScopedDiff`, `computeScopedDigest`, `getChangedFiles`, `_updateScopeUI`), `scopeGitHints`, `scopeLabel`, `DiffOptionsDropdown` setter, `POST set-scope`. Tightening it affects all these paths. The `normalizeScope` addition at the metadata endpoint prevents stale DB rows from causing failures.
+- **`_applyScopeResult` has two callers**: `_handleScopeChange` and `showBranchReviewDialog`. Both send scope to the backend first, which validates. After migration, `showBranchReviewDialog` always sends `scopeStart: 'branch'` with `scopeEnd >= 'unstaged'` (valid).
+- **`scopeIncludes` returns `false` for invalid scopes**: So `generateScopedDiff` produces an empty diff if called with a now-invalid scope. The migration + normalization prevents this, but it's a safe failure mode (empty diff > wrong diff).
+- **`updateLocalScope` in DB layer does NOT validate**: It writes whatever is passed. Tests that call it directly with invalid scopes will succeed at DB level but create invalid state. Update tests to use valid scopes.
+- **Integration tests hard-code scope values**: Multiple tests in `local-sessions.test.js` use `branch..branch`. All must be updated.
+
+## Verification
+
+1. `npm test -- tests/unit/local-scope.test.js` — scope validation, normalization, hints
+2. `npm test -- tests/unit/local-review.test.js` — diff generation with valid scopes only
+3. `npm test -- tests/unit/chat/prompt-builder.test.js` — chat hints
+4. `npm test -- tests/integration/local-sessions.test.js` — set-scope endpoint
+5. `npm test` — full suite
+6. `npm run test:e2e` — scope selector in browser
+7. Manual: open local review, verify unstaged dot always filled, alt-click behavior correct

--- a/public/js/components/DiffOptionsDropdown.js
+++ b/public/js/components/DiffOptionsDropdown.js
@@ -383,13 +383,43 @@ class DiffOptionsDropdown {
       stopEl.appendChild(dot);
       stopEl.appendChild(labelEl);
 
+      // Custom tooltip element (positioned above the dot, hidden by default)
+      const tooltipEl = document.createElement('div');
+      tooltipEl.style.position = 'absolute';
+      tooltipEl.style.bottom = '100%';
+      tooltipEl.style.left = '50%';
+      tooltipEl.style.transform = 'translateX(-50%)';
+      tooltipEl.style.marginBottom = '6px';
+      tooltipEl.style.padding = '4px 8px';
+      tooltipEl.style.fontSize = '11px';
+      tooltipEl.style.lineHeight = '1.3';
+      tooltipEl.style.color = 'var(--color-text-on-emphasis, #ffffff)';
+      tooltipEl.style.background = 'var(--color-neutral-emphasis, #24292f)';
+      tooltipEl.style.borderRadius = '4px';
+      tooltipEl.style.whiteSpace = 'nowrap';
+      tooltipEl.style.pointerEvents = 'none';
+      tooltipEl.style.opacity = '0';
+      tooltipEl.style.transition = 'opacity 0.12s ease';
+      tooltipEl.style.zIndex = '2';
+      stopEl.style.position = 'relative';
+      stopEl.appendChild(tooltipEl);
+
+      stopEl.addEventListener('mouseenter', () => {
+        if (tooltipEl.textContent) {
+          tooltipEl.style.opacity = '1';
+        }
+      });
+      stopEl.addEventListener('mouseleave', () => {
+        tooltipEl.style.opacity = '0';
+      });
+
       stopEl.addEventListener('click', (e) => {
         e.stopPropagation();
         this._handleStopClick(stop, e);
       });
 
       stopsRow.appendChild(stopEl);
-      this._scopeStops.push({ stop, dotEl: dot, labelEl, containerEl: stopEl });
+      this._scopeStops.push({ stop, dotEl: dot, labelEl, containerEl: stopEl, tooltipEl });
     });
 
     trackContainer.appendChild(stopsRow);
@@ -417,10 +447,14 @@ class DiffOptionsDropdown {
     let newStart = this._scopeStart;
     let newEnd = this._scopeEnd;
 
-    // Alt/Option-click: solo-select this single stop
+    // 'unstaged' is always included — the AI reads files from the working
+    // tree, so the diff must always cover at least the unstaged state.
+    const ui = stops.indexOf('unstaged');
+
+    // Alt/Option-click: select this stop with minimum scope including unstaged
     if (event && event.altKey) {
-      newStart = clickedStop;
-      newEnd = clickedStop;
+      newStart = stops[Math.min(ci, ui)];
+      newEnd = stops[Math.max(ci, ui)];
     } else {
       // Checkbox-like toggle with contiguity constraint
       const included = ci >= si && ci <= ei;
@@ -428,6 +462,7 @@ class DiffOptionsDropdown {
       if (included) {
         // Toggling OFF — only allowed at boundaries, and range must have >1 stop
         if (si === ei) return;
+        if (clickedStop === 'unstaged') return; // unstaged is mandatory
         if (ci === si) {
           newStart = stops[si + 1];
         } else if (ci === ei) {
@@ -485,18 +520,33 @@ class DiffOptionsDropdown {
     const si = stops.indexOf(this._scopeStart);
     const ei = stops.indexOf(this._scopeEnd);
 
-    this._scopeStops.forEach(({ stop, dotEl, labelEl, containerEl }, i) => {
+    this._scopeStops.forEach(({ stop, dotEl, labelEl, containerEl, tooltipEl }, i) => {
       const included = LS.scopeIncludes(this._scopeStart, this._scopeEnd, stop);
       const isBranch = stop === 'branch';
       const disabled = isBranch && !this._branchAvailable;
 
-      // Determine if clicking this stop would do anything (for cursor hint)
-      const isBoundary = included && (i === si || i === ei) && si !== ei;
+      // Determine if clicking this stop would do anything (for cursor hint).
+      // 'unstaged' is mandatory and cannot be toggled off, so it is never a
+      // clickable boundary even when it sits at a range edge.
+      const isMandatory = stop === 'unstaged';
+      const atRangeEdge = included && (i === si || i === ei) && si !== ei;
+      const isBoundary = atRangeEdge && !isMandatory;
       const isAdjacent = !included && (i === si - 1 || i === ei + 1);
       const clickable = !disabled && (isBoundary || isAdjacent);
 
       // Tooltip for disabled branch stop
       containerEl.title = disabled ? 'No feature branch detected' : '';
+
+      // Mandatory stop sitting at a range edge — user might expect to toggle
+      // it off but can't.  Show not-allowed cursor and explanatory tooltip.
+      const mandatoryEdge = isMandatory && atRangeEdge;
+
+      // Update tooltip text (empty string hides the tooltip on hover)
+      if (tooltipEl) {
+        tooltipEl.textContent = mandatoryEdge
+          ? 'Unstaged changes are always included \u2014 the agent reads from your working tree'
+          : '';
+      }
 
       if (disabled) {
         // Disabled state
@@ -513,7 +563,7 @@ class DiffOptionsDropdown {
         dotEl.style.boxShadow = '0 0 0 2px rgba(139, 92, 246, 0.2)';
         labelEl.style.color = 'var(--color-text-primary, #24292f)';
         labelEl.style.fontWeight = '600';
-        containerEl.style.cursor = clickable ? 'pointer' : 'default';
+        containerEl.style.cursor = clickable ? 'pointer' : (mandatoryEdge ? 'not-allowed' : 'default');
         containerEl.style.opacity = '1';
       } else {
         // Excluded (empty) state

--- a/src/chat/prompt-builder.js
+++ b/src/chat/prompt-builder.js
@@ -8,7 +8,7 @@
  */
 
 const logger = require('../utils/logger');
-const { scopeGitHints, DEFAULT_SCOPE } = require('../local-scope');
+const { scopeGitHints, reviewScope } = require('../local-scope');
 
 /**
  * Build a lean system prompt for chat sessions.
@@ -142,8 +142,7 @@ function buildReviewContext(review, prData) {
     lines.push('');
     lines.push('## Viewing Code Changes');
 
-    const scopeStart = review.local_scope_start || DEFAULT_SCOPE.start;
-    const scopeEnd = review.local_scope_end || DEFAULT_SCOPE.end;
+    const { start: scopeStart, end: scopeEnd } = reviewScope(review);
     const baseBranch = review.local_base_branch || null;
     const hints = scopeGitHints(scopeStart, scopeEnd, baseBranch);
 

--- a/src/database.js
+++ b/src/database.js
@@ -20,7 +20,7 @@ function getDbPath() {
 /**
  * Current schema version - increment this when adding new migrations
  */
-const CURRENT_SCHEMA_VERSION = 35;
+const CURRENT_SCHEMA_VERSION = 36;
 
 /**
  * Database schema SQL statements
@@ -1605,6 +1605,36 @@ const MIGRATIONS = {
     addColumnIfNotExists('comments', 'severity', 'TEXT');
 
     console.log('Migration to schema version 35 complete');
+  },
+
+  // Migration to version 36: Normalize diff scopes to always include 'unstaged'.
+  // AI models read files from the working tree, so the diff scope must always
+  // cover at least the unstaged state for review context to be coherent.
+  36: (db) => {
+    console.log('Running migration to schema version 36...');
+
+    // Expand scopes where end < unstaged (branch-only, branch-staged, staged-only)
+    const expandEnd = db.prepare(
+      `UPDATE reviews SET local_scope_end = 'unstaged'
+       WHERE local_scope_end IN ('branch', 'staged') AND review_type = 'local'`
+    );
+    const expandResult = expandEnd.run();
+    if (expandResult.changes > 0) {
+      console.log(`  Expanded scope end to 'unstaged' for ${expandResult.changes} review(s)`);
+    }
+
+    // Fix untracked-only → unstaged..untracked
+    const fixUntracked = db.prepare(
+      `UPDATE reviews SET local_scope_start = 'unstaged'
+       WHERE local_scope_start = 'untracked' AND local_scope_end = 'untracked'
+       AND review_type = 'local'`
+    );
+    const fixResult = fixUntracked.run();
+    if (fixResult.changes > 0) {
+      console.log(`  Normalized untracked-only scope for ${fixResult.changes} review(s)`);
+    }
+
+    console.log('Migration to schema version 36 complete');
   }
 };
 

--- a/src/local-review.js
+++ b/src/local-review.js
@@ -10,7 +10,7 @@ const { fireHooks, hasHooks } = require('./hooks/hook-runner');
 const { buildReviewStartedPayload, buildReviewLoadedPayload, getCachedUser } = require('./hooks/payloads');
 
 const execAsync = promisify(exec);
-const { STOPS, scopeIncludes, includesBranch, DEFAULT_SCOPE, scopeLabel } = require('./local-scope');
+const { STOPS, scopeIncludes, includesBranch, DEFAULT_SCOPE, scopeLabel, reviewScope } = require('./local-scope');
 const { initializeDatabase, ReviewRepository, RepoSettingsRepository } = require('./database');
 const { startServer } = require('./server');
 const { localReviewDiffs } = require('./routes/shared');
@@ -472,6 +472,13 @@ async function generateScopedDiff(repoPath, scopeStart, scopeEnd, baseBranch, op
   const hasUnstaged = scopeIncludes(scopeStart, scopeEnd, 'unstaged');
   const hasUntracked = scopeIncludes(scopeStart, scopeEnd, 'untracked');
 
+  // Fail fast if the scope is invalid. scopeIncludes returns false for all
+  // stops when the scope is invalid, so all four flags would be false and the
+  // branching logic below would silently produce a wrong diff.
+  if (!hasUnstaged) {
+    throw new Error(`Invalid scope ${scopeStart}..${scopeEnd}: scope must include 'unstaged'`);
+  }
+
   let mergeBaseSha = null;
   let diff = '';
 
@@ -483,46 +490,30 @@ async function generateScopedDiff(repoPath, scopeStart, scopeEnd, baseBranch, op
     mergeBaseSha = await findMergeBase(repoPath, baseBranch);
   }
 
-  // Build the git diff command based on scope range
+  // Build the git diff command based on scope range.
+  // hasUnstaged is always true by invariant — isValidScope requires the scope
+  // to include 'unstaged', since AI models read files from the working tree
+  // and the diff must cover at least the unstaged state.
   try {
-    if (hasBranch && !hasStaged && !hasUnstaged) {
-      // Branch only → committed changes since merge-base
-      diff = execSync(`git diff ${mergeBaseSha}..HEAD ${GIT_DIFF_FLAGS}${contextFlag}${extraArgsStr}${wFlag}`, {
-        cwd: repoPath, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'],
-        maxBuffer: 50 * 1024 * 1024
-      });
-    } else if (hasBranch && hasStaged && !hasUnstaged) {
-      // Branch–Staged → staged changes relative to merge-base
-      diff = execSync(`git diff --cached ${mergeBaseSha} ${GIT_DIFF_FLAGS}${contextFlag}${extraArgsStr}${wFlag}`, {
-        cwd: repoPath, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'],
-        maxBuffer: 50 * 1024 * 1024
-      });
-    } else if (hasBranch && hasUnstaged) {
-      // Branch–Unstaged (or Branch–Untracked) → working tree vs merge-base
+    if (hasBranch) {
+      // Branch scope → working tree vs merge-base (includes committed + staged + unstaged)
       diff = execSync(`git diff ${mergeBaseSha} ${GIT_DIFF_FLAGS}${contextFlag}${extraArgsStr}${wFlag}`, {
         cwd: repoPath, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'],
         maxBuffer: 50 * 1024 * 1024
       });
-    } else if (hasStaged && !hasUnstaged) {
-      // Staged only → cached changes
-      diff = execSync(`git diff --cached ${GIT_DIFF_FLAGS}${contextFlag}${extraArgsStr}${wFlag}`, {
-        cwd: repoPath, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'],
-        maxBuffer: 50 * 1024 * 1024
-      });
-    } else if (hasStaged && hasUnstaged) {
-      // Staged–Unstaged (or Staged–Untracked) → all changes vs HEAD
+    } else if (hasStaged) {
+      // Staged + Unstaged scope → all changes vs HEAD
       diff = execSync(`git diff HEAD ${GIT_DIFF_FLAGS}${contextFlag}${extraArgsStr}${wFlag}`, {
         cwd: repoPath, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'],
         maxBuffer: 50 * 1024 * 1024
       });
-    } else if (hasUnstaged) {
-      // Unstaged only or Unstaged–Untracked → working tree changes
+    } else {
+      // Unstaged only (or Unstaged–Untracked) → working tree changes
       diff = execSync(`git diff ${GIT_DIFF_FLAGS}${contextFlag}${extraArgsStr}${wFlag}`, {
         cwd: repoPath, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'],
         maxBuffer: 50 * 1024 * 1024
       });
     }
-    // hasUntracked-only: no git diff needed, just untracked files below
   } catch (error) {
     if (error.message && error.message.includes('maxBuffer')) {
       throw new Error('Diff output exceeded maximum buffer size (50MB).');
@@ -798,8 +789,8 @@ async function handleLocalReview(targetPath, flags = {}) {
     }
 
     // Read scope from session (or use defaults for new sessions)
-    const scopeStart = existingReview?.local_scope_start || DEFAULT_SCOPE.start;
-    const scopeEnd = existingReview?.local_scope_end || DEFAULT_SCOPE.end;
+    // Use reviewScope() to normalize legacy scopes that may not include 'unstaged'
+    const { start: scopeStart, end: scopeEnd } = existingReview ? reviewScope(existingReview) : DEFAULT_SCOPE;
 
     // Fire review hook (non-blocking)
     const hookEvent = existingReview ? 'review.loaded' : 'review.started';
@@ -937,7 +928,7 @@ async function computeLocalDiffDigest(localPath) {
  * @returns {Promise<{diff: string, stats: Object, mergeBaseSha: string}>}
  */
 async function generateBranchDiff(repoPath, baseBranch, options = {}) {
-  return generateScopedDiff(repoPath, 'branch', 'branch', baseBranch, options);
+  return generateScopedDiff(repoPath, 'branch', 'unstaged', baseBranch, options);
 }
 
 /**

--- a/src/local-scope.js
+++ b/src/local-scope.js
@@ -4,10 +4,29 @@ const STOPS = ['branch', 'staged', 'unstaged', 'untracked'];
 
 const DEFAULT_SCOPE = { start: 'unstaged', end: 'untracked' };
 
+const UNSTAGED_INDEX = STOPS.indexOf('unstaged');
+
 function isValidScope(start, end) {
   const si = STOPS.indexOf(start);
   const ei = STOPS.indexOf(end);
-  return si !== -1 && ei !== -1 && si <= ei;
+  // Scope must be contiguous AND must include the 'unstaged' stop.
+  // This ensures the diff always covers the working tree state that AI models
+  // see when reading files, since we cannot modify local git state.
+  return si !== -1 && ei !== -1 && si <= ei && si <= UNSTAGED_INDEX && ei >= UNSTAGED_INDEX;
+}
+
+function normalizeScope(start, end) {
+  if (isValidScope(start, end)) return { start, end };
+  const si = STOPS.indexOf(start);
+  const ei = STOPS.indexOf(end);
+  if (si === -1 || ei === -1) return { start: DEFAULT_SCOPE.start, end: DEFAULT_SCOPE.end };
+  const newEi = Math.max(ei, UNSTAGED_INDEX);
+  const newSi = Math.min(si, UNSTAGED_INDEX);
+  const finalSi = Math.min(newSi, newEi);
+  const newStart = STOPS[finalSi];
+  const newEnd = STOPS[newEi];
+  if (isValidScope(newStart, newEnd)) return { start: newStart, end: newEnd };
+  return { start: DEFAULT_SCOPE.start, end: DEFAULT_SCOPE.end };
 }
 
 function scopeIncludes(start, end, stop) {
@@ -27,9 +46,16 @@ function fromLegacyMode(localMode) {
     return { start: 'unstaged', end: 'untracked' };
   }
   if (localMode === 'branch') {
-    return { start: 'branch', end: 'branch' };
+    return { start: 'branch', end: 'unstaged' };
   }
   return { start: DEFAULT_SCOPE.start, end: DEFAULT_SCOPE.end };
+}
+
+function reviewScope(review) {
+  return normalizeScope(
+    review.local_scope_start || DEFAULT_SCOPE.start,
+    review.local_scope_end || DEFAULT_SCOPE.end
+  );
 }
 
 function scopeLabel(start, end) {
@@ -57,16 +83,6 @@ function scopeGitHints(start, end, baseBranch) {
 
   const key = start + '-' + end;
   const hints = {
-    'branch-branch': {
-      description: 'Committed changes on this branch since the merge-base.',
-      diffCommand: 'git diff --no-ext-diff ' + mb + '..HEAD',
-      excludes: 'Staged, unstaged, and untracked changes are NOT included in the review.'
-    },
-    'branch-staged': {
-      description: 'Committed changes plus staged changes, relative to the merge-base.',
-      diffCommand: 'git diff --no-ext-diff --cached ' + mb,
-      excludes: 'Unstaged and untracked changes are NOT included in the review.'
-    },
     'branch-unstaged': {
       description: 'All tracked changes (committed, staged, and unstaged) relative to the merge-base.',
       diffCommand: 'git diff --no-ext-diff ' + mb,
@@ -76,11 +92,6 @@ function scopeGitHints(start, end, baseBranch) {
       description: 'All changes (committed, staged, unstaged, and untracked) relative to the merge-base.',
       diffCommand: 'git diff --no-ext-diff ' + mb,
       excludes: ''
-    },
-    'staged-staged': {
-      description: 'Only staged changes (added to the index but not yet committed).',
-      diffCommand: 'git diff --no-ext-diff --cached',
-      excludes: 'Unstaged, untracked, and committed branch changes are NOT included in the review.'
     },
     'staged-unstaged': {
       description: 'Staged and unstaged changes relative to HEAD.',
@@ -101,11 +112,6 @@ function scopeGitHints(start, end, baseBranch) {
       description: 'Unstaged and untracked local changes.',
       diffCommand: 'git diff --no-ext-diff',
       excludes: 'Staged changes (`git diff --no-ext-diff --cached`) are treated as already reviewed.'
-    },
-    'untracked-untracked': {
-      description: 'Only untracked files (new files not yet added to git).',
-      diffCommand: 'git ls-files --others --exclude-standard',
-      excludes: 'Tracked file changes (staged, unstaged, committed) are NOT included in the review.'
     }
   };
 
@@ -117,7 +123,7 @@ function scopeGitHints(start, end, baseBranch) {
     description: entry.description,
     diffCommand: entry.diffCommand,
     excludes: entry.excludes,
-    includesUntracked: incUntracked && key !== 'untracked-untracked'
+    includesUntracked: incUntracked
   };
 }
 
@@ -125,6 +131,8 @@ const LocalScope = {
   STOPS,
   DEFAULT_SCOPE,
   isValidScope,
+  normalizeScope,
+  reviewScope,
   scopeIncludes,
   includesBranch,
   fromLegacyMode,

--- a/src/routes/local.js
+++ b/src/routes/local.js
@@ -26,7 +26,7 @@ const { buildReviewStartedPayload, buildReviewLoadedPayload, buildAnalysisStarte
 const { mergeInstructions } = require('../utils/instructions');
 const { getGitHubToken } = require('../config');
 const { generateScopedDiff, computeScopedDigest, getBranchCommitCount, getFirstCommitSubject, detectAndBuildBranchInfo, findMergeBase, getCurrentBranch, getRepositoryName } = require('../local-review');
-const { STOPS, isValidScope, scopeIncludes, includesBranch, DEFAULT_SCOPE } = require('../local-scope');
+const { STOPS, isValidScope, normalizeScope, reviewScope, includesBranch, DEFAULT_SCOPE } = require('../local-scope');
 const { getGeneratedFilePatterns } = require('../git/gitattributes');
 const { getShaAbbrevLength } = require('../git/sha-abbrev');
 const { validateCouncilConfig, normalizeCouncilConfig } = require('./councils');
@@ -76,9 +76,10 @@ function deleteLocalReviewDiff(reviewId) {
  * Returns true if the guard fired (response already sent), false otherwise.
  */
 async function rejectIfEmptyScope(res, review, localPath) {
+  const { start: scopeStart, end: scopeEnd } = reviewScope(review);
   const scopeContext = {
-    scopeStart: review.local_scope_start || DEFAULT_SCOPE.start,
-    scopeEnd: review.local_scope_end || DEFAULT_SCOPE.end,
+    scopeStart,
+    scopeEnd,
     baseBranch: review.local_base_branch || null,
   };
   const changedFiles = await getChangedFiles(localPath, scopeContext);
@@ -460,8 +461,7 @@ router.post('/api/local/start', async (req, res) => {
     const config = req.app.get('config') || {};
     // Generate diff using default scope
     logger.log('API', `Starting local review for ${repoPath}`, 'cyan');
-    const scopeStart = existing?.local_scope_start || DEFAULT_SCOPE.start;
-    const scopeEnd = existing?.local_scope_end || DEFAULT_SCOPE.end;
+    const { start: scopeStart, end: scopeEnd } = existing ? reviewScope(existing) : DEFAULT_SCOPE;
 
     // Fire review hook (non-blocking, after scope is resolved)
     const hookEvent = existing ? 'review.loaded' : 'review.started';
@@ -579,9 +579,11 @@ router.get('/api/local/:reviewId', async (req, res) => {
       }
     }
 
-    // Build scope info for the response
-    const scopeStart = review.local_scope_start || DEFAULT_SCOPE.start;
-    const scopeEnd = review.local_scope_end || DEFAULT_SCOPE.end;
+    // Build scope info for the response.
+    // normalizeScope clamps any legacy invalid scopes (e.g. branch-only,
+    // staged-only) to always include 'unstaged', since AI models read files
+    // from the working tree and the diff must match what they see.
+    const { start: scopeStart, end: scopeEnd } = reviewScope(review);
     const baseBranch = review.local_base_branch || null;
 
     // When scope does NOT include branch, check for branch detection info
@@ -697,8 +699,7 @@ router.get('/api/local/:reviewId', async (req, res) => {
     const hookConfig = req.app.get('config') || {};
     if (hasHooks('review.loaded', hookConfig)) {
       getCachedUser(hookConfig).then(user => {
-        const hookScopeStart = review.local_scope_start || DEFAULT_SCOPE.start;
-        const hookScopeEnd = review.local_scope_end || DEFAULT_SCOPE.end;
+        const { start: hookScopeStart, end: hookScopeEnd } = reviewScope(review);
         const si = STOPS.indexOf(hookScopeStart);
         const ei = STOPS.indexOf(hookScopeEnd);
         const scope = STOPS.slice(si, ei + 1);
@@ -791,8 +792,7 @@ router.get('/api/local/:reviewId/diff', async (req, res) => {
     // When ?w=1 or ?base=<branch>, regenerate the diff (transient view, not cached)
     const hideWhitespace = req.query.w === '1';
     const baseBranchOverride = req.query.base;
-    const scopeStart = review.local_scope_start || DEFAULT_SCOPE.start;
-    const scopeEnd = review.local_scope_end || DEFAULT_SCOPE.end;
+    const { start: scopeStart, end: scopeEnd } = reviewScope(review);
     const baseBranch = baseBranchOverride || review.local_base_branch;
     let diffData;
 
@@ -904,8 +904,7 @@ router.get('/api/local/:reviewId/check-stale', async (req, res) => {
       });
     }
 
-    const scopeStart = review.local_scope_start || DEFAULT_SCOPE.start;
-    const scopeEnd = review.local_scope_end || DEFAULT_SCOPE.end;
+    const { start: scopeStart, end: scopeEnd } = reviewScope(review);
 
     // Always check HEAD SHA for supplementary fields
     let headShaChanged = false;
@@ -1046,19 +1045,22 @@ async function handleExecutableAnalysis(req, res, {
     registerProcessForCancellation
   }, {
     logLabel: `Review #${reviewId}`,
-    buildContext: (r, { selectedModel: model, requestInstructions: customInstructions }) => ({
-      title: null,
-      description: null,
-      cwd: localPath,
-      model,
-      baseSha: null,
-      headSha: r.local_head_sha || null,
-      baseBranch: r.local_base_branch || null,
-      headBranch: r.local_head_branch || null,
-      scopeStart: r.local_scope_start || DEFAULT_SCOPE.start,
-      scopeEnd: r.local_scope_end || DEFAULT_SCOPE.end,
-      customInstructions: customInstructions || null
-    }),
+    buildContext: (r, { selectedModel: model, requestInstructions: customInstructions }) => {
+      const { start: scopeStart, end: scopeEnd } = reviewScope(r);
+      return {
+        title: null,
+        description: null,
+        cwd: localPath,
+        model,
+        baseSha: null,
+        headSha: r.local_head_sha || null,
+        baseBranch: r.local_base_branch || null,
+        headBranch: r.local_head_branch || null,
+        scopeStart,
+        scopeEnd,
+        customInstructions: customInstructions || null
+      };
+    },
     buildHookPayload: () => ({
       mode: review.review_type || 'local',
       localContext: { path: localPath, branch: review.local_head_branch, headSha: review.local_head_sha }
@@ -1189,8 +1191,7 @@ router.post('/api/local/:reviewId/analyses', async (req, res) => {
     }
 
     // Extract scope early — needed for both analysis run creation and diff generation
-    const scopeStart = review.local_scope_start || DEFAULT_SCOPE.start;
-    const scopeEnd = review.local_scope_end || DEFAULT_SCOPE.end;
+    const { start: scopeStart, end: scopeEnd } = reviewScope(review);
 
     // Create DB analysis_runs record immediately so it's queryable for polling
     const analysisRunRepo = new AnalysisRunRepository(db);
@@ -1285,13 +1286,14 @@ router.post('/api/local/:reviewId/analyses', async (req, res) => {
       reviewType: 'local'
     };
 
-    // Get changed files for local mode path validation
-    // When branch is in scope, pass null so analyzer falls through to getChangedFilesList
-    // which correctly uses git diff base_sha...head_sha --name-only
-    const hasStaged = scopeIncludes(scopeStart, scopeEnd, 'staged');
-    const changedFiles = hasBranch
-      ? null
-      : await analyzer.getLocalChangedFiles(localPath, { includeStaged: hasStaged });
+    // Get changed files for local mode path validation.
+    // Use the scope-aware helper so the file list matches the generated diff
+    // (covers branch, staged, unstaged, and untracked stops as appropriate).
+    const changedFiles = await getChangedFiles(localPath, {
+      scopeStart,
+      scopeEnd,
+      baseBranch: review.local_base_branch || null,
+    });
 
     // Log analysis start
     logger.section(`Local AI Analysis Request - Review #${reviewId}`);
@@ -1301,7 +1303,7 @@ router.post('/api/local/:reviewId/analyses', async (req, res) => {
     logger.log('API', `Provider: ${selectedProvider}`, 'cyan');
     logger.log('API', `Model: ${selectedModel}`, 'cyan');
     logger.log('API', `Tier: ${tier}`, 'cyan');
-    logger.log('API', `Changed files: ${changedFiles ? changedFiles.length : '(branch mode)'}`, 'cyan');
+    logger.log('API', `Changed files: ${changedFiles.length}`, 'cyan');
     if (combinedInstructions) {
       logger.log('API', `Custom instructions: ${combinedInstructions.length} chars`, 'cyan');
     }
@@ -1512,8 +1514,7 @@ router.post('/api/local/:reviewId/refresh', async (req, res) => {
 
     // Check if HEAD has changed
     const { getHeadSha } = require('../local-review');
-    const scopeStart = review.local_scope_start || DEFAULT_SCOPE.start;
-    const scopeEnd = review.local_scope_end || DEFAULT_SCOPE.end;
+    const { start: scopeStart, end: scopeEnd } = reviewScope(review);
     const hasBranch = includesBranch(scopeStart);
     let currentHeadSha;
     let headShaChanged = false;
@@ -1631,8 +1632,7 @@ router.post('/api/local/:reviewId/resolve-head-change', async (req, res) => {
       return res.status(400).json({ error: 'Local review is missing path information' });
     }
 
-    const scopeStart = review.local_scope_start || DEFAULT_SCOPE.start;
-    const scopeEnd = review.local_scope_end || DEFAULT_SCOPE.end;
+    const { start: scopeStart, end: scopeEnd } = reviewScope(review);
 
     if (action === 'update') {
       // Read live branch — may differ from stored value after a checkout.
@@ -1792,7 +1792,7 @@ router.post('/api/local/:reviewId/set-scope', async (req, res) => {
     await reviewRepo.updateLocalHeadSha(reviewId, headSha);
 
     // Auto-name review from first commit subject when branch is newly in scope
-    const oldScopeStart = review.local_scope_start || DEFAULT_SCOPE.start;
+    const { start: oldScopeStart } = reviewScope(review);
     if (!review.name && includesBranch(scopeStart) && !includesBranch(oldScopeStart) && baseBranch) {
       const firstSubject = await getFirstCommitSubject(localPath, baseBranch);
       if (firstSubject) {
@@ -2025,8 +2025,7 @@ router.post('/api/local/:reviewId/analyses/council', async (req, res) => {
     // Guard: reject if scope resolves to zero changed files
     if (await rejectIfEmptyScope(res, review, localPath)) return;
 
-    const councilScopeStart = review.local_scope_start || DEFAULT_SCOPE.start;
-    const councilScopeEnd = review.local_scope_end || DEFAULT_SCOPE.end;
+    const { start: councilScopeStart, end: councilScopeEnd } = reviewScope(review);
     const councilHasBranch = includesBranch(councilScopeStart);
 
     // Compute merge-base when branch is in scope
@@ -2053,10 +2052,13 @@ router.post('/api/local/:reviewId/analyses/council', async (req, res) => {
     };
 
     const analyzer = new Analyzer(db, 'council', 'council');
-    const councilHasStaged = scopeIncludes(councilScopeStart, councilScopeEnd, 'staged');
-    const changedFiles = councilHasBranch
-      ? null
-      : await analyzer.getLocalChangedFiles(localPath, { includeStaged: councilHasStaged });
+    // Use the scope-aware helper so the file list matches the generated diff
+    // (covers branch, staged, unstaged, and untracked stops as appropriate).
+    const changedFiles = await getChangedFiles(localPath, {
+      scopeStart: councilScopeStart,
+      scopeEnd: councilScopeEnd,
+      baseBranch: review.local_base_branch || null,
+    });
 
     // Generate and cache diff
     try {

--- a/src/setup/local-setup.js
+++ b/src/setup/local-setup.js
@@ -1,10 +1,10 @@
 // Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
-const { findGitRoot, getHeadSha, getCurrentBranch, getRepositoryName, generateLocalDiff, generateLocalReviewId, computeLocalDiffDigest, findMainGitRoot } = require('../local-review');
+const { findGitRoot, getHeadSha, getCurrentBranch, getRepositoryName, generateScopedDiff, generateLocalReviewId, computeScopedDigest, findMainGitRoot } = require('../local-review');
 const { ReviewRepository, RepoSettingsRepository } = require('../database');
 const { localReviewDiffs } = require('../routes/shared');
 const { fireHooks, hasHooks } = require('../hooks/hook-runner');
 const { buildReviewStartedPayload, buildReviewLoadedPayload, getCachedUser } = require('../hooks/payloads');
-const { STOPS, DEFAULT_SCOPE } = require('../local-scope');
+const { STOPS, DEFAULT_SCOPE, reviewScope } = require('../local-scope');
 const logger = require('../utils/logger');
 const path = require('path');
 const fs = require('fs').promises;
@@ -102,13 +102,16 @@ async function setupLocalReview({ db, targetPath, onProgress, config }) {
   // ── Step: diff ──────────────────────────────────────────────────────
   let diff, stats, digest;
   try {
+    const { start: scopeStart, end: scopeEnd } = existingReview ? reviewScope(existingReview) : DEFAULT_SCOPE;
+    const baseBranch = existingReview?.local_base_branch || null;
+
     progress({ step: 'diff', status: 'running', message: 'Generating diff for local changes...' });
 
-    const diffResult = await generateLocalDiff(repoPath);
+    const diffResult = await generateScopedDiff(repoPath, scopeStart, scopeEnd, baseBranch);
     diff = diffResult.diff;
     stats = diffResult.stats;
 
-    digest = await computeLocalDiffDigest(repoPath);
+    digest = await computeScopedDigest(repoPath, scopeStart, scopeEnd);
 
     progress({ step: 'diff', status: 'completed', message: `Diff ready: ${stats.unstagedChanges} unstaged, ${stats.untrackedFiles} untracked` });
   } catch (err) {
@@ -152,8 +155,7 @@ async function setupLocalReview({ db, targetPath, onProgress, config }) {
   if (config && hasHooks(hookEvent, config)) {
     getCachedUser(config).then(user => {
       const builder = existingReview ? buildReviewLoadedPayload : buildReviewStartedPayload;
-      const scopeStart = existingReview?.local_scope_start || DEFAULT_SCOPE.start;
-      const scopeEnd = existingReview?.local_scope_end || DEFAULT_SCOPE.end;
+      const { start: scopeStart, end: scopeEnd } = existingReview ? reviewScope(existingReview) : DEFAULT_SCOPE;
       const si = STOPS.indexOf(scopeStart);
       const ei = STOPS.indexOf(scopeEnd);
       const scope = STOPS.slice(si, ei + 1);

--- a/tests/integration/local-sessions.test.js
+++ b/tests/integration/local-sessions.test.js
@@ -534,6 +534,43 @@ describe('Local Sessions API', () => {
       expect(res.body.error).toMatch(/invalid scope/i);
     });
 
+    it('should return 400 for scopes that do not include the unstaged stop', async () => {
+      const reviewRepo = new ReviewRepository(db);
+      const id = await reviewRepo.upsertLocalReview({
+        localPath: '/path/no-unstaged',
+        localHeadSha: 'shaNoUnstaged',
+        repository: 'owner/no-unstaged-repo'
+      });
+
+      // branch..branch (end < unstaged index)
+      let res = await request(app)
+        .post(`/api/local/${id}/set-scope`)
+        .send({ scopeStart: 'branch', scopeEnd: 'branch' });
+      expect(res.status).toBe(400);
+      expect(res.body.error).toMatch(/invalid scope/i);
+
+      // branch..staged (end < unstaged index)
+      res = await request(app)
+        .post(`/api/local/${id}/set-scope`)
+        .send({ scopeStart: 'branch', scopeEnd: 'staged' });
+      expect(res.status).toBe(400);
+      expect(res.body.error).toMatch(/invalid scope/i);
+
+      // staged..staged (end < unstaged index)
+      res = await request(app)
+        .post(`/api/local/${id}/set-scope`)
+        .send({ scopeStart: 'staged', scopeEnd: 'staged' });
+      expect(res.status).toBe(400);
+      expect(res.body.error).toMatch(/invalid scope/i);
+
+      // untracked..untracked (start > unstaged index)
+      res = await request(app)
+        .post(`/api/local/${id}/set-scope`)
+        .send({ scopeStart: 'untracked', scopeEnd: 'untracked' });
+      expect(res.status).toBe(400);
+      expect(res.body.error).toMatch(/invalid scope/i);
+    });
+
     it('should return 400 when scopeStart is missing', async () => {
       const reviewRepo = new ReviewRepository(db);
       const id = await reviewRepo.upsertLocalReview({
@@ -646,7 +683,7 @@ describe('Local Sessions API', () => {
 
       const res = await request(app)
         .post(`/api/local/${id}/set-scope`)
-        .send({ scopeStart: 'branch', scopeEnd: 'branch', baseBranch: 'main' });
+        .send({ scopeStart: 'branch', scopeEnd: 'unstaged', baseBranch: 'main' });
 
       expect(res.status).toBe(200);
       expect(res.body.success).toBe(true);
@@ -656,7 +693,7 @@ describe('Local Sessions API', () => {
       // Verify DB columns are persisted
       const review = await reviewRepo.getLocalReviewById(id);
       expect(review.local_scope_start).toBe('branch');
-      expect(review.local_scope_end).toBe('branch');
+      expect(review.local_scope_end).toBe('unstaged');
       expect(review.local_base_branch).toBe('main');
     });
 
@@ -679,7 +716,7 @@ describe('Local Sessions API', () => {
 
       const res = await request(app)
         .post(`/api/local/${id}/set-scope`)
-        .send({ scopeStart: 'branch', scopeEnd: 'branch' });
+        .send({ scopeStart: 'branch', scopeEnd: 'unstaged' });
 
       expect(res.status).toBe(200);
       expect(res.body.success).toBe(true);
@@ -706,7 +743,7 @@ describe('Local Sessions API', () => {
 
       const res = await request(app)
         .post(`/api/local/${id}/set-scope`)
-        .send({ scopeStart: 'branch', scopeEnd: 'branch' });
+        .send({ scopeStart: 'branch', scopeEnd: 'unstaged' });
 
       expect(res.status).toBe(200);
       expect(res.body.success).toBe(true);
@@ -997,14 +1034,14 @@ describe('Local Sessions API', () => {
         localHeadSha: 'sha-feature-a',
         repository: 'owner/repo'
       });
-      await reviewRepo.updateLocalScope(id1, 'branch', 'branch', 'main', 'feature-a');
+      await reviewRepo.updateLocalScope(id1, 'branch', 'unstaged', 'main', 'feature-a');
 
       const id2 = await reviewRepo.upsertLocalReview({
         localPath: '/repo',
         localHeadSha: 'sha-feature-b',
         repository: 'owner/repo'
       });
-      await reviewRepo.updateLocalScope(id2, 'branch', 'branch', 'main', 'feature-b');
+      await reviewRepo.updateLocalScope(id2, 'branch', 'unstaged', 'main', 'feature-b');
 
       expect(id1).not.toBe(id2);
 
@@ -1023,7 +1060,7 @@ describe('Local Sessions API', () => {
         localHeadSha: 'sha-old',
         repository: 'owner/repo'
       });
-      await reviewRepo.updateLocalScope(id1, 'branch', 'branch', 'main', 'feature-a');
+      await reviewRepo.updateLocalScope(id1, 'branch', 'unstaged', 'main', 'feature-a');
 
       // Simulate finding the session on the same branch with a new HEAD
       const found = await reviewRepo.getLocalBranchScopeReview('/repo', 'feature-a');
@@ -1039,7 +1076,7 @@ describe('Local Sessions API', () => {
         localHeadSha: 'sha-1',
         repository: 'owner/repo'
       });
-      await reviewRepo.updateLocalScope(id, 'branch', 'branch', 'main', 'feature-a');
+      await reviewRepo.updateLocalScope(id, 'branch', 'unstaged', 'main', 'feature-a');
 
       const found = await reviewRepo.getLocalBranchScopeReview('/repo', 'feature-b');
       expect(found).toBeNull();
@@ -1059,7 +1096,7 @@ describe('Local Sessions API', () => {
       expect(review.local_head_branch).toBeNull();
 
       // Set when entering branch scope
-      await reviewRepo.updateLocalScope(id, 'branch', 'branch', 'main', 'my-branch');
+      await reviewRepo.updateLocalScope(id, 'branch', 'unstaged', 'main', 'my-branch');
       review = await reviewRepo.getLocalReviewById(id);
       expect(review.local_head_branch).toBe('my-branch');
 
@@ -1082,7 +1119,7 @@ describe('Local Sessions API', () => {
 
       // Switch scope to branch mode (stores headBranch via updateLocalScope)
       const reviewRepo = new ReviewRepository(db);
-      await reviewRepo.updateLocalScope(sessionA, 'branch', 'branch', 'main', 'feature-a');
+      await reviewRepo.updateLocalScope(sessionA, 'branch', 'unstaged', 'main', 'feature-a');
 
       // Start session on feature-b (different branch)
       localReviewModule.getCurrentBranch.mockResolvedValue('feature-b');
@@ -1486,7 +1523,7 @@ describe('Local Sessions API', () => {
       });
 
       // Set scope to branch
-      await reviewRepo.updateLocalScope(id, 'branch', 'branch', 'main', 'feature-x');
+      await reviewRepo.updateLocalScope(id, 'branch', 'unstaged', 'main', 'feature-x');
 
       // Mock getHeadSha to return a different SHA
       localReviewModule.getHeadSha.mockResolvedValue('sha-branch-new');

--- a/tests/unit/chat/prompt-builder.test.js
+++ b/tests/unit/chat/prompt-builder.test.js
@@ -77,20 +77,20 @@ describe('buildChatPrompt', () => {
           review_type: 'local',
           local_path: '/p',
           local_scope_start: 'staged',
-          local_scope_end: 'staged'
+          local_scope_end: 'unstaged'
         }
       });
 
       expect(prompt).not.toContain('git ls-files --others --exclude-standard');
     });
 
-    it('should include excludes text for staged-only scope', () => {
+    it('should include excludes text for staged-unstaged scope', () => {
       const prompt = buildChatPrompt({
         review: {
           review_type: 'local',
           local_path: '/p',
           local_scope_start: 'staged',
-          local_scope_end: 'staged'
+          local_scope_end: 'unstaged'
         }
       });
 

--- a/tests/unit/executable-analysis.test.js
+++ b/tests/unit/executable-analysis.test.js
@@ -319,30 +319,44 @@ describe('getChangedFiles', () => {
   describe('local mode with scope', () => {
     it('includes branch files when scope includes branch', async () => {
       mockFindMergeBase.mockResolvedValue('merge-base-sha');
-      mockExecForCalls({
-        'merge-base-sha..HEAD': 'branch-file.js\n',
-        '--cached': '',
-        'ls-files': ''
+      mockExec.mockImplementation((cmd, opts, cb) => {
+        const callback = typeof opts === 'function' ? opts : cb;
+        if (cmd.includes('merge-base-sha..HEAD')) {
+          process.nextTick(() => callback(null, { stdout: 'branch-file.js\n', stderr: '' }));
+        } else if (cmd.includes('--name-only') && !cmd.includes('--cached') && !cmd.includes('..')) {
+          process.nextTick(() => callback(null, { stdout: 'unstaged-file.js\n', stderr: '' }));
+        } else {
+          process.nextTick(() => callback(null, { stdout: '', stderr: '' }));
+        }
       });
 
       const files = await getChangedFiles('/repo', {
-        scopeStart: 'branch', scopeEnd: 'branch', baseBranch: 'main'
+        scopeStart: 'branch', scopeEnd: 'unstaged', baseBranch: 'main'
       });
 
       expect(files).toContain('branch-file.js');
+      expect(files).toContain('unstaged-file.js');
       expect(mockFindMergeBase).toHaveBeenCalledWith('/repo', 'main');
     });
 
     it('includes staged files when scope includes staged', async () => {
-      mockExecForCalls({
-        '--cached': 'staged.js\n'
+      mockExec.mockImplementation((cmd, opts, cb) => {
+        const callback = typeof opts === 'function' ? opts : cb;
+        if (cmd.includes('--cached')) {
+          process.nextTick(() => callback(null, { stdout: 'staged.js\n', stderr: '' }));
+        } else if (cmd.includes('--name-only') && !cmd.includes('--cached') && !cmd.includes('..')) {
+          process.nextTick(() => callback(null, { stdout: 'unstaged.js\n', stderr: '' }));
+        } else {
+          process.nextTick(() => callback(null, { stdout: '', stderr: '' }));
+        }
       });
 
       const files = await getChangedFiles('/repo', {
-        scopeStart: 'staged', scopeEnd: 'staged'
+        scopeStart: 'staged', scopeEnd: 'unstaged'
       });
 
-      expect(files).toEqual(['staged.js']);
+      expect(files).toContain('staged.js');
+      expect(files).toContain('unstaged.js');
     });
 
     it('includes unstaged files when scope includes unstaged', async () => {
@@ -364,15 +378,23 @@ describe('getChangedFiles', () => {
     });
 
     it('includes untracked files when scope includes untracked', async () => {
-      mockExecForCalls({
-        'ls-files': 'untracked.js\n'
+      mockExec.mockImplementation((cmd, opts, cb) => {
+        const callback = typeof opts === 'function' ? opts : cb;
+        if (cmd.includes('ls-files')) {
+          process.nextTick(() => callback(null, { stdout: 'untracked.js\n', stderr: '' }));
+        } else if (cmd.includes('--name-only') && !cmd.includes('--cached') && !cmd.includes('..')) {
+          process.nextTick(() => callback(null, { stdout: 'unstaged.js\n', stderr: '' }));
+        } else {
+          process.nextTick(() => callback(null, { stdout: '', stderr: '' }));
+        }
       });
 
       const files = await getChangedFiles('/repo', {
-        scopeStart: 'untracked', scopeEnd: 'untracked'
+        scopeStart: 'unstaged', scopeEnd: 'untracked'
       });
 
-      expect(files).toEqual(['untracked.js']);
+      expect(files).toContain('untracked.js');
+      expect(files).toContain('unstaged.js');
     });
 
     it('includes branch + staged + unstaged + untracked for full scope', async () => {
@@ -431,24 +453,31 @@ describe('getChangedFiles', () => {
       expect(files).toEqual(['shared.js']);
     });
 
-    it('does NOT include untracked files when scope is branch-only', async () => {
+    it('does NOT include untracked files when scope excludes untracked', async () => {
       mockFindMergeBase.mockResolvedValue('mb-sha');
       mockExec.mockImplementation((cmd, opts, cb) => {
         const callback = typeof opts === 'function' ? opts : cb;
         if (cmd.includes('mb-sha..HEAD')) {
           process.nextTick(() => callback(null, { stdout: 'branch.js\n', stderr: '' }));
+        } else if (cmd.includes('--cached')) {
+          process.nextTick(() => callback(null, { stdout: 'staged.js\n', stderr: '' }));
+        } else if (cmd.includes('--name-only') && !cmd.includes('--cached') && !cmd.includes('..')) {
+          process.nextTick(() => callback(null, { stdout: 'unstaged.js\n', stderr: '' }));
         } else {
           process.nextTick(() => callback(null, { stdout: 'should-not-appear.js\n', stderr: '' }));
         }
       });
 
       const files = await getChangedFiles('/repo', {
-        scopeStart: 'branch', scopeEnd: 'branch', baseBranch: 'main'
+        scopeStart: 'branch', scopeEnd: 'unstaged', baseBranch: 'main'
       });
 
-      expect(files).toEqual(['branch.js']);
-      // Should only have made one exec call (for branch diff)
-      expect(mockExec).toHaveBeenCalledTimes(1);
+      expect(files).toContain('branch.js');
+      expect(files).toContain('staged.js');
+      expect(files).toContain('unstaged.js');
+      expect(files).not.toContain('should-not-appear.js');
+      // Should have made 3 exec calls (branch, staged, unstaged) but NOT untracked
+      expect(mockExec).toHaveBeenCalledTimes(3);
     });
   });
 
@@ -495,7 +524,7 @@ describe('getChangedFiles', () => {
       mockFindMergeBase.mockRejectedValue(new Error('no merge-base'));
 
       const files = await getChangedFiles('/repo', {
-        scopeStart: 'branch', scopeEnd: 'branch', baseBranch: 'main'
+        scopeStart: 'branch', scopeEnd: 'unstaged', baseBranch: 'main'
       });
 
       expect(files).toEqual([]);
@@ -503,14 +532,15 @@ describe('getChangedFiles', () => {
 
     it('returns empty array when branch scope has no baseBranch', async () => {
       // When hasBranch is true but baseBranch is null/undefined, the branch
-      // command is skipped entirely, resulting in no commands and an empty list.
+      // command is skipped. Staged and unstaged commands still run but return
+      // empty output, resulting in an empty list.
       mockExec.mockImplementation((cmd, opts, cb) => {
         const callback = typeof opts === 'function' ? opts : cb;
         process.nextTick(() => callback(null, { stdout: '', stderr: '' }));
       });
 
       const files = await getChangedFiles('/repo', {
-        scopeStart: 'branch', scopeEnd: 'branch', baseBranch: null
+        scopeStart: 'branch', scopeEnd: 'unstaged', baseBranch: null
       });
 
       expect(files).toEqual([]);

--- a/tests/unit/local-review.test.js
+++ b/tests/unit/local-review.test.js
@@ -425,21 +425,6 @@ describe('generateScopedDiff', () => {
     });
   });
 
-  describe('staged scope', () => {
-    it('should return only staged changes', async () => {
-      await fs.writeFile(path.join(testDir, 'file.txt'), 'staged content\n');
-      execSync('git add file.txt', { cwd: testDir, stdio: 'pipe' });
-      // Make another unstaged change
-      await fs.writeFile(path.join(testDir, 'file.txt'), 'unstaged on top\n');
-
-      const result = await generateScopedDiff(testDir, 'staged', 'staged');
-
-      expect(result.diff).toContain('staged content');
-      expect(result.diff).not.toContain('unstaged on top');
-      expect(result.mergeBaseSha).toBeNull();
-    });
-  });
-
   describe('staged–unstaged scope', () => {
     it('should return staged + unstaged via diff HEAD', async () => {
       await fs.writeFile(path.join(testDir, 'file.txt'), 'staged content\n');
@@ -467,20 +452,20 @@ describe('generateScopedDiff', () => {
     });
   });
 
-  describe('untracked-only scope', () => {
-    it('should return only untracked file diffs', async () => {
+  describe('unstaged–untracked scope', () => {
+    it('should return unstaged and untracked file diffs', async () => {
       await fs.writeFile(path.join(testDir, 'file.txt'), 'modified\n');
       await fs.writeFile(path.join(testDir, 'new.txt'), 'untracked\n');
 
-      const result = await generateScopedDiff(testDir, 'untracked', 'untracked');
+      const result = await generateScopedDiff(testDir, 'unstaged', 'untracked');
 
-      expect(result.diff).not.toContain('file.txt');
+      expect(result.diff).toContain('diff --git a/file.txt b/file.txt');
       expect(result.diff).toContain('diff --git a/new.txt b/new.txt');
       expect(result.stats.untrackedFiles).toBe(1);
     });
   });
 
-  describe('branch scope', () => {
+  describe('branch–unstaged scope', () => {
     it('should return committed changes since merge-base', async () => {
       // Create a branch and add a commit
       execSync('git checkout -b feature', { cwd: testDir, stdio: 'pipe' });
@@ -488,7 +473,7 @@ describe('generateScopedDiff', () => {
       execSync('git add feature.txt', { cwd: testDir, stdio: 'pipe' });
       execSync('git commit -m "Feature commit"', { cwd: testDir, stdio: 'pipe' });
 
-      const result = await generateScopedDiff(testDir, 'branch', 'branch', defaultBranch);
+      const result = await generateScopedDiff(testDir, 'branch', 'unstaged', defaultBranch);
 
       expect(result.diff).toContain('feature.txt');
       expect(result.diff).toContain('feature work');
@@ -497,12 +482,10 @@ describe('generateScopedDiff', () => {
 
     it('should throw when baseBranch is missing', async () => {
       await expect(
-        generateScopedDiff(testDir, 'branch', 'branch')
+        generateScopedDiff(testDir, 'branch', 'unstaged')
       ).rejects.toThrow('baseBranch is required');
     });
-  });
 
-  describe('branch–unstaged scope', () => {
     it('should include both committed and working tree changes', async () => {
       execSync('git checkout -b feature2', { cwd: testDir, stdio: 'pipe' });
       await fs.writeFile(path.join(testDir, 'committed.txt'), 'committed\n');
@@ -519,21 +502,26 @@ describe('generateScopedDiff', () => {
     });
   });
 
-  describe('branch–staged scope', () => {
-    it('should include both committed and staged-only changes against merge-base', async () => {
+  describe('branch–untracked scope', () => {
+    it('should include committed, staged, unstaged, and untracked changes against merge-base', async () => {
       execSync('git checkout -b feature3', { cwd: testDir, stdio: 'pipe' });
       await fs.writeFile(path.join(testDir, 'committed2.txt'), 'committed\n');
       execSync('git add committed2.txt', { cwd: testDir, stdio: 'pipe' });
       execSync('git commit -m "Feature3"', { cwd: testDir, stdio: 'pipe' });
-      // Add a staged-only change (not committed)
+      // Add a staged change
       await fs.writeFile(path.join(testDir, 'staged-only.txt'), 'staged content\n');
       execSync('git add staged-only.txt', { cwd: testDir, stdio: 'pipe' });
+      // Add an untracked file (do NOT git add)
+      await fs.writeFile(path.join(testDir, 'untracked.txt'), 'untracked content\n');
 
-      const result = await generateScopedDiff(testDir, 'branch', 'staged', defaultBranch);
+      const result = await generateScopedDiff(testDir, 'branch', 'untracked', defaultBranch);
 
       expect(result.diff).toContain('committed2.txt');
       expect(result.diff).toContain('staged-only.txt');
       expect(result.diff).toContain('staged content');
+      expect(result.diff).toContain('untracked.txt');
+      expect(result.diff).toContain('untracked content');
+      expect(result.stats.untrackedFiles).toBe(1);
       expect(result.mergeBaseSha).toBeTruthy();
     });
   });
@@ -637,9 +625,9 @@ describe('generateScopedDiff', () => {
       await fs.writeFile(path.join(testDir, 'big-new.txt'), lines.join('\n') + '\n');
 
       // With contextLines: 3, the diff header should use --unified=3
-      const result3 = await generateScopedDiff(testDir, 'untracked', 'untracked', null, { contextLines: 3 });
+      const result3 = await generateScopedDiff(testDir, 'unstaged', 'untracked', null, { contextLines: 3 });
       // With default (25), the diff header should use --unified=25
-      const resultDefault = await generateScopedDiff(testDir, 'untracked', 'untracked');
+      const resultDefault = await generateScopedDiff(testDir, 'unstaged', 'untracked');
 
       // Both should contain the untracked file
       expect(result3.diff).toContain('big-new.txt');
@@ -656,7 +644,7 @@ describe('generateScopedDiff', () => {
       await fs.writeFile(path.join(testDir, 'new-file.txt'), 'new content\n');
 
       // extraArgs like --stat should be applied to untracked file diffs too
-      const result = await generateScopedDiff(testDir, 'untracked', 'untracked', null, {
+      const result = await generateScopedDiff(testDir, 'unstaged', 'untracked', null, {
         extraArgs: ['--stat']
       });
 
@@ -679,6 +667,26 @@ describe('generateScopedDiff', () => {
       // Should contain both tracked and untracked changes
       expect(result.diff).toContain('file.txt');
       expect(result.diff).toContain('brand-new.txt');
+    });
+  });
+
+  describe('invalid scope rejection', () => {
+    it('should reject scope branch..branch because it does not include unstaged', async () => {
+      await expect(
+        generateScopedDiff(testDir, 'branch', 'branch', defaultBranch)
+      ).rejects.toThrow("Invalid scope branch..branch: scope must include 'unstaged'");
+    });
+
+    it('should reject scope staged..staged because it does not include unstaged', async () => {
+      await expect(
+        generateScopedDiff(testDir, 'staged', 'staged')
+      ).rejects.toThrow("Invalid scope staged..staged: scope must include 'unstaged'");
+    });
+
+    it('should reject scope untracked..untracked because it does not include unstaged', async () => {
+      await expect(
+        generateScopedDiff(testDir, 'untracked', 'untracked')
+      ).rejects.toThrow("Invalid scope untracked..untracked: scope must include 'unstaged'");
     });
   });
 });
@@ -729,20 +737,20 @@ describe('computeScopedDigest', () => {
   it('should change when staged content changes', async () => {
     await fs.writeFile(path.join(testDir, 'file.txt'), 'staged-v1\n');
     execSync('git add file.txt', { cwd: testDir, stdio: 'pipe' });
-    const d1 = await computeScopedDigest(testDir, 'staged', 'staged');
+    const d1 = await computeScopedDigest(testDir, 'staged', 'unstaged');
 
     await fs.writeFile(path.join(testDir, 'file.txt'), 'staged-v2\n');
     execSync('git add file.txt', { cwd: testDir, stdio: 'pipe' });
-    const d2 = await computeScopedDigest(testDir, 'staged', 'staged');
+    const d2 = await computeScopedDigest(testDir, 'staged', 'unstaged');
 
     expect(d1).not.toBe(d2);
   });
 
   it('should change when untracked file is added', async () => {
-    const d1 = await computeScopedDigest(testDir, 'untracked', 'untracked');
+    const d1 = await computeScopedDigest(testDir, 'unstaged', 'untracked');
 
     await fs.writeFile(path.join(testDir, 'new.txt'), 'new\n');
-    const d2 = await computeScopedDigest(testDir, 'untracked', 'untracked');
+    const d2 = await computeScopedDigest(testDir, 'unstaged', 'untracked');
 
     expect(d1).not.toBe(d2);
   });
@@ -752,12 +760,12 @@ describe('computeScopedDigest', () => {
     await fs.writeFile(path.join(testDir, 'a.txt'), 'a\n');
     execSync('git add a.txt', { cwd: testDir, stdio: 'pipe' });
     execSync('git commit -m "commit a"', { cwd: testDir, stdio: 'pipe' });
-    const d1 = await computeScopedDigest(testDir, 'branch', 'branch');
+    const d1 = await computeScopedDigest(testDir, 'branch', 'unstaged');
 
     await fs.writeFile(path.join(testDir, 'b.txt'), 'b\n');
     execSync('git add b.txt', { cwd: testDir, stdio: 'pipe' });
     execSync('git commit -m "commit b"', { cwd: testDir, stdio: 'pipe' });
-    const d2 = await computeScopedDigest(testDir, 'branch', 'branch');
+    const d2 = await computeScopedDigest(testDir, 'branch', 'unstaged');
 
     expect(d1).not.toBe(d2);
   });

--- a/tests/unit/local-scope.test.js
+++ b/tests/unit/local-scope.test.js
@@ -2,7 +2,7 @@
 import { describe, it, expect } from 'vitest';
 import LocalScope from '../../src/local-scope.js';
 
-const { STOPS, DEFAULT_SCOPE, isValidScope, scopeIncludes, includesBranch, fromLegacyMode, scopeLabel, scopeGitHints } = LocalScope;
+const { STOPS, DEFAULT_SCOPE, isValidScope, normalizeScope, reviewScope, scopeIncludes, includesBranch, fromLegacyMode, scopeLabel, scopeGitHints } = LocalScope;
 
 describe('LocalScope', () => {
   describe('STOPS', () => {
@@ -19,20 +19,23 @@ describe('LocalScope', () => {
 
   describe('isValidScope', () => {
     const validCombinations = [
-      ['branch', 'branch'],
-      ['branch', 'staged'],
       ['branch', 'unstaged'],
       ['branch', 'untracked'],
-      ['staged', 'staged'],
       ['staged', 'unstaged'],
       ['staged', 'untracked'],
       ['unstaged', 'unstaged'],
       ['unstaged', 'untracked'],
-      ['untracked', 'untracked'],
     ];
 
     it.each(validCombinations)('accepts valid scope %s–%s', (start, end) => {
       expect(isValidScope(start, end)).toBe(true);
+    });
+
+    it('rejects scope that excludes unstaged', () => {
+      expect(isValidScope('branch', 'branch')).toBe(false);
+      expect(isValidScope('branch', 'staged')).toBe(false);
+      expect(isValidScope('staged', 'staged')).toBe(false);
+      expect(isValidScope('untracked', 'untracked')).toBe(false);
     });
 
     it('rejects reversed order (staged before branch)', () => {
@@ -70,11 +73,98 @@ describe('LocalScope', () => {
     });
   });
 
+  describe('normalizeScope', () => {
+    it('passes through already-valid scopes unchanged', () => {
+      expect(normalizeScope('branch', 'unstaged')).toEqual({ start: 'branch', end: 'unstaged' });
+      expect(normalizeScope('branch', 'untracked')).toEqual({ start: 'branch', end: 'untracked' });
+      expect(normalizeScope('staged', 'unstaged')).toEqual({ start: 'staged', end: 'unstaged' });
+      expect(normalizeScope('staged', 'untracked')).toEqual({ start: 'staged', end: 'untracked' });
+      expect(normalizeScope('unstaged', 'unstaged')).toEqual({ start: 'unstaged', end: 'unstaged' });
+      expect(normalizeScope('unstaged', 'untracked')).toEqual({ start: 'unstaged', end: 'untracked' });
+    });
+
+    it('clamps branch..branch to branch..unstaged', () => {
+      expect(normalizeScope('branch', 'branch')).toEqual({ start: 'branch', end: 'unstaged' });
+    });
+
+    it('clamps branch..staged to branch..unstaged', () => {
+      expect(normalizeScope('branch', 'staged')).toEqual({ start: 'branch', end: 'unstaged' });
+    });
+
+    it('clamps staged..staged to staged..unstaged', () => {
+      expect(normalizeScope('staged', 'staged')).toEqual({ start: 'staged', end: 'unstaged' });
+    });
+
+    it('clamps untracked..untracked to unstaged..untracked', () => {
+      expect(normalizeScope('untracked', 'untracked')).toEqual({ start: 'unstaged', end: 'untracked' });
+    });
+
+    it('falls back to DEFAULT_SCOPE for unknown start', () => {
+      expect(normalizeScope('bogus', 'unstaged')).toEqual(DEFAULT_SCOPE);
+    });
+
+    it('falls back to DEFAULT_SCOPE for unknown end', () => {
+      expect(normalizeScope('branch', 'bogus')).toEqual(DEFAULT_SCOPE);
+    });
+
+    it('falls back to DEFAULT_SCOPE for both unknown', () => {
+      expect(normalizeScope('foo', 'bar')).toEqual(DEFAULT_SCOPE);
+    });
+  });
+
+  describe('reviewScope', () => {
+    it('returns valid scope from review with valid fields', () => {
+      const review = { local_scope_start: 'branch', local_scope_end: 'untracked' };
+      expect(reviewScope(review)).toEqual({ start: 'branch', end: 'untracked' });
+    });
+
+    it('normalizes legacy scope that excludes unstaged (staged-only)', () => {
+      // Regression: legacy reviews stored scope_start=staged, scope_end=staged
+      // which excludes the mandatory 'unstaged' stop
+      const review = { local_scope_start: 'staged', local_scope_end: 'staged' };
+      expect(reviewScope(review)).toEqual({ start: 'staged', end: 'unstaged' });
+    });
+
+    it('normalizes legacy scope that excludes unstaged (branch-only)', () => {
+      const review = { local_scope_start: 'branch', local_scope_end: 'branch' };
+      expect(reviewScope(review)).toEqual({ start: 'branch', end: 'unstaged' });
+    });
+
+    it('normalizes legacy scope that excludes unstaged (branch-staged)', () => {
+      const review = { local_scope_start: 'branch', local_scope_end: 'staged' };
+      expect(reviewScope(review)).toEqual({ start: 'branch', end: 'unstaged' });
+    });
+
+    it('normalizes legacy scope that excludes unstaged (untracked-only)', () => {
+      const review = { local_scope_start: 'untracked', local_scope_end: 'untracked' };
+      expect(reviewScope(review)).toEqual({ start: 'unstaged', end: 'untracked' });
+    });
+
+    it('falls back to DEFAULT_SCOPE when fields are null', () => {
+      const review = { local_scope_start: null, local_scope_end: null };
+      expect(reviewScope(review)).toEqual(DEFAULT_SCOPE);
+    });
+
+    it('falls back to DEFAULT_SCOPE when fields are undefined', () => {
+      const review = {};
+      expect(reviewScope(review)).toEqual(DEFAULT_SCOPE);
+    });
+
+    it('falls back to DEFAULT_SCOPE when fields are empty strings', () => {
+      const review = { local_scope_start: '', local_scope_end: '' };
+      expect(reviewScope(review)).toEqual(DEFAULT_SCOPE);
+    });
+  });
+
   describe('scopeIncludes', () => {
     it('single-stop scope includes only that stop', () => {
-      expect(scopeIncludes('staged', 'staged', 'staged')).toBe(true);
-      expect(scopeIncludes('staged', 'staged', 'branch')).toBe(false);
-      expect(scopeIncludes('staged', 'staged', 'unstaged')).toBe(false);
+      expect(scopeIncludes('unstaged', 'unstaged', 'unstaged')).toBe(true);
+      expect(scopeIncludes('unstaged', 'unstaged', 'branch')).toBe(false);
+      expect(scopeIncludes('unstaged', 'unstaged', 'untracked')).toBe(false);
+    });
+
+    it('returns false for scope that excludes unstaged', () => {
+      expect(scopeIncludes('staged', 'staged', 'staged')).toBe(false);
     });
 
     it('branch–untracked includes all stops', () => {
@@ -123,8 +213,8 @@ describe('LocalScope', () => {
       expect(fromLegacyMode('uncommitted')).toEqual({ start: 'unstaged', end: 'untracked' });
     });
 
-    it('maps branch to branch–branch', () => {
-      expect(fromLegacyMode('branch')).toEqual({ start: 'branch', end: 'branch' });
+    it('maps branch to branch–unstaged', () => {
+      expect(fromLegacyMode('branch')).toEqual({ start: 'branch', end: 'unstaged' });
     });
 
     it('returns default scope for unknown mode', () => {
@@ -141,37 +231,37 @@ describe('LocalScope', () => {
   });
 
   describe('scopeLabel', () => {
-    it('returns single capitalized name for same start/end', () => {
-      expect(scopeLabel('branch', 'branch')).toBe('Branch');
-      expect(scopeLabel('staged', 'staged')).toBe('Staged');
+    it('returns single capitalized name for unstaged (only valid single-stop scope)', () => {
       expect(scopeLabel('unstaged', 'unstaged')).toBe('Unstaged');
-      expect(scopeLabel('untracked', 'untracked')).toBe('Untracked');
+    });
+
+    it('returns empty string for invalid single-stop scopes', () => {
+      expect(scopeLabel('branch', 'branch')).toBe('');
+      expect(scopeLabel('staged', 'staged')).toBe('');
+      expect(scopeLabel('untracked', 'untracked')).toBe('');
     });
 
     it('returns en-dash separated label for range', () => {
-      expect(scopeLabel('branch', 'staged')).toBe('Branch\u2013Staged');
       expect(scopeLabel('unstaged', 'untracked')).toBe('Unstaged\u2013Untracked');
       expect(scopeLabel('branch', 'untracked')).toBe('Branch\u2013Untracked');
       expect(scopeLabel('staged', 'untracked')).toBe('Staged\u2013Untracked');
+      expect(scopeLabel('branch', 'unstaged')).toBe('Branch\u2013Unstaged');
     });
 
     it('returns empty string for invalid scope', () => {
       expect(scopeLabel('untracked', 'branch')).toBe('');
       expect(scopeLabel('bogus', 'branch')).toBe('');
+      expect(scopeLabel('branch', 'staged')).toBe('');
     });
 
-    it('covers all 10 valid combinations', () => {
+    it('covers all 6 valid combinations', () => {
       const validCombinations = [
-        ['branch', 'branch', 'Branch'],
-        ['branch', 'staged', 'Branch\u2013Staged'],
         ['branch', 'unstaged', 'Branch\u2013Unstaged'],
         ['branch', 'untracked', 'Branch\u2013Untracked'],
-        ['staged', 'staged', 'Staged'],
         ['staged', 'unstaged', 'Staged\u2013Unstaged'],
         ['staged', 'untracked', 'Staged\u2013Untracked'],
         ['unstaged', 'unstaged', 'Unstaged'],
         ['unstaged', 'untracked', 'Unstaged\u2013Untracked'],
-        ['untracked', 'untracked', 'Untracked'],
       ];
       for (const [start, end, expected] of validCombinations) {
         expect(scopeLabel(start, end)).toBe(expected);
@@ -187,16 +277,12 @@ describe('LocalScope', () => {
 
     it('returns correct diff command for each scope', () => {
       const expected = [
-        ['branch', 'branch', 'git diff --no-ext-diff <merge-base>..HEAD'],
-        ['branch', 'staged', 'git diff --no-ext-diff --cached <merge-base>'],
         ['branch', 'unstaged', 'git diff --no-ext-diff <merge-base>'],
         ['branch', 'untracked', 'git diff --no-ext-diff <merge-base>'],
-        ['staged', 'staged', 'git diff --no-ext-diff --cached'],
         ['staged', 'unstaged', 'git diff --no-ext-diff HEAD'],
         ['staged', 'untracked', 'git diff --no-ext-diff HEAD'],
         ['unstaged', 'unstaged', 'git diff --no-ext-diff'],
         ['unstaged', 'untracked', 'git diff --no-ext-diff'],
-        ['untracked', 'untracked', 'git ls-files --others --exclude-standard'],
       ];
       for (const [start, end, cmd] of expected) {
         const hints = scopeGitHints(start, end);
@@ -205,9 +291,16 @@ describe('LocalScope', () => {
       }
     });
 
+    it('returns null for scopes that exclude unstaged', () => {
+      expect(scopeGitHints('branch', 'branch')).toBeNull();
+      expect(scopeGitHints('branch', 'staged')).toBeNull();
+      expect(scopeGitHints('staged', 'staged')).toBeNull();
+      expect(scopeGitHints('untracked', 'untracked')).toBeNull();
+    });
+
     it('substitutes baseBranch into merge-base command', () => {
-      const hints = scopeGitHints('branch', 'branch', 'main');
-      expect(hints.diffCommand).toBe('git diff --no-ext-diff $(git merge-base main HEAD)..HEAD');
+      const hints = scopeGitHints('branch', 'unstaged', 'main');
+      expect(hints.diffCommand).toBe('git diff --no-ext-diff $(git merge-base main HEAD)');
     });
 
     it('uses placeholder when baseBranch is not provided', () => {
@@ -218,16 +311,15 @@ describe('LocalScope', () => {
     it('sets includesUntracked correctly', () => {
       expect(scopeGitHints('branch', 'untracked').includesUntracked).toBe(true);
       expect(scopeGitHints('unstaged', 'untracked').includesUntracked).toBe(true);
-      expect(scopeGitHints('untracked', 'untracked').includesUntracked).toBe(false);
-      expect(scopeGitHints('branch', 'branch').includesUntracked).toBe(false);
-      expect(scopeGitHints('staged', 'staged').includesUntracked).toBe(false);
+      expect(scopeGitHints('staged', 'untracked').includesUntracked).toBe(true);
       expect(scopeGitHints('branch', 'unstaged').includesUntracked).toBe(false);
       expect(scopeGitHints('staged', 'unstaged').includesUntracked).toBe(false);
+      expect(scopeGitHints('unstaged', 'unstaged').includesUntracked).toBe(false);
     });
 
     it('label matches scopeLabel output', () => {
       const combos = [
-        ['branch', 'branch'],
+        ['branch', 'unstaged'],
         ['branch', 'untracked'],
         ['staged', 'unstaged'],
         ['unstaged', 'untracked'],
@@ -246,18 +338,17 @@ describe('LocalScope', () => {
     });
 
     it('excludes is non-empty for scopes that omit stops', () => {
-      expect(scopeGitHints('branch', 'branch').excludes).toBeTruthy();
-      expect(scopeGitHints('staged', 'staged').excludes).toBeTruthy();
+      expect(scopeGitHints('branch', 'unstaged').excludes).toBeTruthy();
+      expect(scopeGitHints('staged', 'unstaged').excludes).toBeTruthy();
       expect(scopeGitHints('unstaged', 'unstaged').excludes).toBeTruthy();
-      expect(scopeGitHints('untracked', 'untracked').excludes).toBeTruthy();
+      expect(scopeGitHints('unstaged', 'untracked').excludes).toBeTruthy();
     });
 
     it('has non-empty description for all valid scopes', () => {
       const validCombinations = [
-        ['branch', 'branch'], ['branch', 'staged'], ['branch', 'unstaged'], ['branch', 'untracked'],
-        ['staged', 'staged'], ['staged', 'unstaged'], ['staged', 'untracked'],
+        ['branch', 'unstaged'], ['branch', 'untracked'],
+        ['staged', 'unstaged'], ['staged', 'untracked'],
         ['unstaged', 'unstaged'], ['unstaged', 'untracked'],
-        ['untracked', 'untracked'],
       ];
       for (const [start, end] of validCombinations) {
         const hints = scopeGitHints(start, end);


### PR DESCRIPTION
## Summary
- Enforces `unstaged` as the minimum right boundary of every valid local review scope, ensuring the diff always matches the working tree files that AI reviewers read
- Adds `normalizeScope` for graceful legacy scope migration plus DB migration 36 to normalize existing rows
- Removes dead diff generation branches and updates UI to make the unstaged stop mandatory with `not-allowed` cursor and explanatory tooltip
- Applies `reviewScope()` normalization at all scope extraction points (CLI resume, setup flow, prompt builder, analysis paths)
- Uses scope-aware `getChangedFiles` in analysis and council paths so file validation matches the actual diff

## Test plan
- [x] Unit tests for `isValidScope`, `normalizeScope`, `reviewScope`, `scopeGitHints`, `scopeLabel`
- [x] Unit tests for `generateScopedDiff` invalid scope rejection
- [x] Integration tests for set-scope endpoint with valid scopes
- [x] Prompt builder tests with normalized scopes
- [ ] E2E: verify unstaged dot always filled, alt-click behavior, not-allowed cursor
- [ ] Manual: reopen an existing local review session and verify diff matches scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)