### PR TITLE
Fix missing stream text for per-voice orchestration progress

### DIFF
--- a/.changeset/orchestration-progress-snippet.md
+++ b/.changeset/orchestration-progress-snippet.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Fix missing stream text in council progress dialog for per-voice orchestration step

--- a/public/js/components/CouncilProgressModal.js
+++ b/public/js/components/CouncilProgressModal.js
@@ -1312,6 +1312,9 @@ class CouncilProgressModal {
               <span class="council-voice-icon pending">\u25CB</span>
               <span class="council-voice-label">Consolidation</span>
               <span class="council-voice-status pending">Pending</span>
+              <div class="council-voice-detail">
+                <div class="council-voice-snippet" style="display: none;"></div>
+              </div>
             </div>
         `;
       }


### PR DESCRIPTION
## Summary
- The per-voice orchestration (consolidation) child in the council progress dialog was missing the `.council-voice-snippet` DOM element, so stream text from the backend was silently dropped during rendering
- Added the `.council-voice-detail` / `.council-voice-snippet` wrapper to match the structure used by level 1-3 children

## Test plan
- [x] Unit tests pass (67/67 in `council-progress-modal.test.js`)
- [ ] Run a council analysis and verify stream text appears in the per-voice "Consolidation" row

🤖 Generated with [Claude Code](https://claude.com/claude-code)