### PR TITLE
Queue user action hints to chat agent

### DIFF
--- a/.changeset/user-action-hints.md
+++ b/.changeset/user-action-hints.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Send user action hints to the chat agent when the user adopts/dismisses suggestions or creates/dismisses comments directly in the review UI, so the agent stays informed without the user having to explain what they did.

--- a/plans/user-action-hints.md
+++ b/plans/user-action-hints.md
@@ -1,0 +1,119 @@
+# User Action Hints for Chat Agent
+
+## Context
+
+When a user takes actions directly in the review UI (adopting/dismissing suggestions, creating/dismissing comments), the chat agent has no visibility into these actions. The user currently has to tell the agent what they did. This change queues invisible "user action hint" messages that are delivered as context with the next chat message, following the existing `_pendingDiffStateNotifications` pattern.
+
+## Hint Messages
+
+- `[User Action: adopted suggestion <id>]`
+- `[User Action: dismissed suggestion <id>]`
+- `[User Action: dismissed comment <id>]`
+- `[User Action: created comment <id>]`
+
+## Filtering: Not Needed
+
+Chat-mediated actions (`_handleAdoptClick`, etc.) instruct the agent to make API calls via curl. Those API calls never invoke the client-side action methods. WebSocket event handlers (`review:suggestions_changed`, `review:comments_changed`) only reload data — they don't call action methods. Every call site for the action methods originates from user-initiated click handlers. No filtering logic is required.
+
+## Changes
+
+### 1. ChatPanel.js (`public/js/components/ChatPanel.js`)
+
+**a. Constructor** — Add `this._pendingUserActionHints = [];` after `_pendingDiffStateNotifications` init (line ~34).
+
+**b. New method** — Add `queueUserActionHint(message)` after `queueDiffStateNotification()` (line ~1372). Pushes onto the array. Same JSDoc style as `queueDiffStateNotification`.
+
+**c. sendMessage() drain** — After the existing diff-state drain (lines ~1264-1269), drain user action hints into a separate prefix string. Combine both invisible prefixes before merging with `_pendingContext`:
+
+```
+diffStatePrefix + userActionPrefix → invisiblePrefix
+```
+
+Replace all references to `diffStatePrefix` in the context-merge block (lines ~1274-1292) with `invisiblePrefix`.
+
+**d. sendMessage() error recovery** — After the diff-state restore (line ~1355), add:
+```js
+this._pendingUserActionHints = [...savedUserActionHints, ...this._pendingUserActionHints];
+```
+
+**e. `_startNewConversation()`** — Clear `this._pendingUserActionHints = [];` after the `_pendingDiffStateNotifications` clear (line ~669).
+
+**f. `_switchToSession()`** — Clear `this._pendingUserActionHints = [];` after the `_pendingDiffStateNotifications` clear (line ~1032).
+
+**g. `close()`** — Do NOT clear (matches diff-state pattern; hints survive panel close).
+
+### 2. pr.js (`public/js/pr.js`)
+
+**a. `adoptSuggestion()`** (line 3471) — Add hint after the non-file-level success path (after `_notifyAdoption`, line ~3496). Do NOT add in the file-level branch (it delegates to `fileCommentManager.adoptAISuggestion` which gets its own hint).
+```js
+window.chatPanel?.queueUserActionHint(`[User Action: adopted suggestion ${suggestionId}]`);
+```
+
+**b. `editAndAdoptSuggestion()`** (line 3386) — Add hint inside the save callback (after `_notifyAdoption`, line ~3451). Same message format. File-level branch delegates to `fileCommentManager.editAndAdoptAISuggestion` → `adoptWithEdit`, which gets its own hint.
+
+**c. `dismissSuggestion()`** (line 3508) — Add hint after `commentMinimizer.refreshIndicators()` (line ~3559), inside the try block but after the early return for `hiddenForAdoption`.
+```js
+window.chatPanel?.queueUserActionHint(`[User Action: dismissed suggestion ${suggestionId}]`);
+```
+
+**d. `deleteUserComment()`** (line 2881) — Add hint after the success toast (line ~2943).
+```js
+window.chatPanel?.queueUserActionHint(`[User Action: dismissed comment ${commentId}]`);
+```
+
+### 3. comment-manager.js (`public/js/modules/comment-manager.js`)
+
+**a. `saveUserComment()`** (line 424) — Add hint after `commentMinimizer.refreshIndicators()` (line ~506).
+```js
+window.chatPanel?.queueUserActionHint(`[User Action: created comment ${result.commentId}]`);
+```
+
+### 4. file-comment-manager.js (`public/js/modules/file-comment-manager.js`)
+
+**a. `adoptAISuggestion()`** (line 561) — Add hint after `updateFindingStatus` (line ~620).
+```js
+window.chatPanel?.queueUserActionHint(`[User Action: adopted suggestion ${suggestion.id}]`);
+```
+
+**b. `adoptWithEdit()`** (line 802) — Add hint after `updateFindingStatus` (line ~864).
+```js
+window.chatPanel?.queueUserActionHint(`[User Action: adopted suggestion ${suggestion.id}]`);
+```
+
+**c. `dismissAISuggestion()`** (line 635) — Add hint after `updateFindingStatus` (line ~663).
+```js
+window.chatPanel?.queueUserActionHint(`[User Action: dismissed suggestion ${suggestionId}]`);
+```
+
+**d. `saveFileComment()`** (line 266) — Add hint after `prManager.updateCommentCount()` (line ~323).
+```js
+window.chatPanel?.queueUserActionHint(`[User Action: created comment ${result.commentId}]`);
+```
+
+**e. `deleteFileComment()`** (line 993) — Add hint after `updateFindingStatus` (line ~1030).
+```js
+window.chatPanel?.queueUserActionHint(`[User Action: dismissed comment ${commentId}]`);
+```
+
+### 5. Tests (`tests/unit/chat-panel.test.js`)
+
+Add a `describe('queueUserActionHint', ...)` block with:
+
+1. `queueUserActionHint pushes onto the array`
+2. `multiple hints accumulate in order`
+3. `queue survives close()` — queue a hint, call `close()`, assert still present
+4. `queue cleared on _startNewConversation()` — queue, call method, assert empty
+5. `constructor initializes empty array`
+
+## Hazards
+
+- `adoptSuggestion` delegates to `fileCommentManager.adoptAISuggestion` for file-level suggestions. Hint goes in `adoptAISuggestion` (not in the file-level branch of `adoptSuggestion`) to avoid double-hinting while covering both entry points (pr.js delegation + file-comment-zone click handler).
+- `editAndAdoptSuggestion` similarly delegates to `fileCommentManager.editAndAdoptAISuggestion` → `adoptWithEdit`. Hint goes in `adoptWithEdit` for file-level, in the save callback for non-file-level.
+- `sendMessage()` error recovery must merge restored + newly-queued hints (same pattern as diff-state recovery at line 1355).
+
+## Verification
+
+1. Run `npm test -- tests/unit/chat-panel.test.js`
+2. Run E2E tests: `npm run test:e2e`
+3. Manual: adopt a suggestion from the diff view, send a chat message, verify hint appears in context
+4. Manual: close chat panel, dismiss a suggestion, reopen, send message — verify hint is delivered

--- a/public/js/components/ChatPanel.js
+++ b/public/js/components/ChatPanel.js
@@ -32,6 +32,7 @@ class ChatPanel {
     this._pendingContext = [];
     this._pendingContextData = [];
     this._pendingDiffStateNotifications = [];
+    this._pendingUserActionHints = [];
     this._contextSource = null;   // 'suggestion' or 'user' — set when opened with context
     this._contextItemId = null;   // suggestion ID or comment ID from context
     this._contextLineMeta = null;  // { file, line_start, line_end } — set when opened with line context
@@ -667,6 +668,7 @@ class ChatPanel {
     this._pendingContext = [];
     this._pendingContextData = [];
     this._pendingDiffStateNotifications = [];
+    this._pendingUserActionHints = [];
     this._contextSource = null;
     this._contextItemId = null;
     this._contextLineMeta = null;
@@ -1030,6 +1032,7 @@ class ChatPanel {
     this._pendingContext = [];
     this._pendingContextData = [];
     this._pendingDiffStateNotifications = [];
+    this._pendingUserActionHints = [];
     this._contextSource = null;
     this._contextItemId = null;
     this._contextLineMeta = null;
@@ -1269,12 +1272,28 @@ class ChatPanel {
       this._pendingDiffStateNotifications = [];
     }
 
+    // Snapshot user-action-hints queue for error recovery (invisible to user, no UI cards)
+    const savedUserActionHints = this._pendingUserActionHints.slice();
+    let userActionPrefix = '';
+    if (this._pendingUserActionHints.length > 0) {
+      userActionPrefix = '[User Action Hints]\n' + this._pendingUserActionHints.join('\n');
+      this._pendingUserActionHints = [];
+    }
+
+    // Combine invisible prefixes (diff state + user action hints)
+    let invisiblePrefix = '';
+    if (diffStatePrefix && userActionPrefix) {
+      invisiblePrefix = diffStatePrefix + '\n\n' + userActionPrefix;
+    } else {
+      invisiblePrefix = diffStatePrefix || userActionPrefix;
+    }
+
     const savedContext = this._pendingContext;
     const savedContextData = this._pendingContextData;
     if (this._pendingContext.length > 0) {
       const userContext = this._pendingContext.join('\n\n');
-      payload.context = diffStatePrefix
-        ? diffStatePrefix + '\n\n' + userContext
+      payload.context = invisiblePrefix
+        ? invisiblePrefix + '\n\n' + userContext
         : userContext;
       payload.contextData = this._pendingContextData;
       this._pendingContext = [];
@@ -1287,8 +1306,8 @@ class ChatPanel {
         if (btn) btn.remove();
         delete card.dataset.contextIndex;
       });
-    } else if (diffStatePrefix) {
-      payload.context = diffStatePrefix;
+    } else if (invisiblePrefix) {
+      payload.context = invisiblePrefix;
     }
 
     // Lock analysis context card (not indexed, handled separately from pending context)
@@ -1353,6 +1372,7 @@ class ChatPanel {
       this._pendingContext = savedContext;
       this._pendingContextData = savedContextData;
       this._pendingDiffStateNotifications = [...savedDiffState, ...this._pendingDiffStateNotifications];
+      this._pendingUserActionHints = [...savedUserActionHints, ...this._pendingUserActionHints];
       // Restore removability on context cards that were locked before the failed send
       this._restoreRemovableCards();
       console.error('[ChatPanel] Error sending message:', error);
@@ -1369,6 +1389,16 @@ class ChatPanel {
    */
   queueDiffStateNotification(message) {
     this._pendingDiffStateNotifications.push(message);
+  }
+
+  /**
+   * Queue an invisible user-action hint for the chat agent.
+   * Like diff-state notifications, these do NOT render UI cards and survive panel close.
+   * Drained into the context parameter on the next sendMessage() call.
+   * @param {string} message - Description of the user action (e.g., "[User Action: adopted suggestion 42]")
+   */
+  queueUserActionHint(message) {
+    this._pendingUserActionHints.push(message);
   }
 
   /**

--- a/public/js/modules/comment-manager.js
+++ b/public/js/modules/comment-manager.js
@@ -505,6 +505,8 @@ class CommentManager {
         window.prManager.commentMinimizer.refreshIndicators();
       }
 
+      window.chatPanel?.queueUserActionHint(`[User Action: created comment ${result.commentId}]`);
+
     } catch (error) {
       console.error('Error saving comment:', error);
       alert('Failed to save comment');

--- a/public/js/modules/file-comment-manager.js
+++ b/public/js/modules/file-comment-manager.js
@@ -322,6 +322,8 @@ class FileCommentManager {
         this.prManager.updateCommentCount();
       }
 
+      window.chatPanel?.queueUserActionHint(`[User Action: created comment ${result.commentId}]`);
+
     } catch (error) {
       console.error('Error saving file-level comment:', error);
       if (window.toast) {
@@ -619,6 +621,8 @@ class FileCommentManager {
         window.aiPanel.updateFindingStatus(suggestion.id, 'adopted');
       }
 
+      window.chatPanel?.queueUserActionHint(`[User Action: adopted suggestion ${suggestion.id}]`);
+
     } catch (error) {
       console.error('Error adopting suggestion:', error);
       if (window.toast) {
@@ -662,6 +666,8 @@ class FileCommentManager {
         window.aiPanel.updateFindingStatus(suggestionId, 'dismissed');
       }
 
+      window.chatPanel?.queueUserActionHint(`[User Action: dismissed suggestion ${suggestionId}]`);
+
     } catch (error) {
       console.error('Error dismissing suggestion:', error);
       if (window.toast) {
@@ -702,6 +708,8 @@ class FileCommentManager {
 
       // Update comment count (for consistency with dismissAISuggestion)
       this.updateCommentCount(zone);
+
+      window.chatPanel?.queueUserActionHint(`[User Action: restored suggestion ${suggestionId}]`);
 
     } catch (error) {
       console.error('Error restoring suggestion:', error);
@@ -862,6 +870,8 @@ class FileCommentManager {
       if (window.aiPanel?.updateFindingStatus) {
         window.aiPanel.updateFindingStatus(suggestion.id, 'adopted');
       }
+
+      window.chatPanel?.queueUserActionHint(`[User Action: adopted suggestion ${suggestion.id}]`);
 
     } catch (error) {
       console.error('Error adopting suggestion with edit:', error);
@@ -1028,6 +1038,11 @@ class FileCommentManager {
       if (apiResult.dismissedSuggestionId && window.aiPanel?.updateFindingStatus) {
         window.aiPanel.updateFindingStatus(apiResult.dismissedSuggestionId, 'dismissed');
       }
+
+      if (apiResult.dismissedSuggestionId) {
+        window.chatPanel?.queueUserActionHint(`[User Action: dismissed suggestion ${apiResult.dismissedSuggestionId}]`);
+      }
+      window.chatPanel?.queueUserActionHint(`[User Action: dismissed comment ${commentId}]`);
 
     } catch (error) {
       console.error('Error deleting comment:', error);

--- a/public/js/pr.js
+++ b/public/js/pr.js
@@ -2941,6 +2941,11 @@ class PRManager {
       if (window.toast) {
         window.toast.showSuccess('Comment dismissed');
       }
+
+      if (apiResult.dismissedSuggestionId) {
+        window.chatPanel?.queueUserActionHint(`[User Action: dismissed suggestion ${apiResult.dismissedSuggestionId}]`);
+      }
+      window.chatPanel?.queueUserActionHint(`[User Action: dismissed comment ${commentId}]`);
     } catch (error) {
       console.error('Error deleting comment:', error);
       if (window.toast) {
@@ -2969,6 +2974,8 @@ class PRManager {
       if (window.toast) {
         window.toast.showSuccess('Comment restored');
       }
+
+      window.chatPanel?.queueUserActionHint(`[User Action: restored comment ${commentId}]`);
     } catch (error) {
       console.error('Error restoring comment:', error);
       if (window.toast) {
@@ -3449,6 +3456,7 @@ class PRManager {
             });
             this.displayUserComment(newComment, suggestionRow);
             this._notifyAdoption(suggestionId, newComment);
+            window.chatPanel?.queueUserActionHint(`[User Action: adopted suggestion ${suggestionId}]`);
           } catch (error) {
             console.error('Error saving edited suggestion:', error);
             alert(`Failed to save suggestion: ${error.message}`);
@@ -3494,6 +3502,7 @@ class PRManager {
 
       this.displayUserComment(result.newComment, result.suggestionRow);
       this._notifyAdoption(suggestionId, result.newComment);
+      window.chatPanel?.queueUserActionHint(`[User Action: adopted suggestion ${suggestionId}]`);
     } catch (error) {
       console.error('Error adopting suggestion:', error);
       alert(`Failed to adopt suggestion: ${error.message}`);
@@ -3557,6 +3566,8 @@ class PRManager {
       if (this.commentMinimizer) {
         this.commentMinimizer.refreshIndicators();
       }
+
+      window.chatPanel?.queueUserActionHint(`[User Action: dismissed suggestion ${suggestionId}]`);
     } catch (error) {
       console.error('Error dismissing suggestion:', error);
       alert('Failed to dismiss suggestion');
@@ -3612,6 +3623,8 @@ class PRManager {
       if (this.commentMinimizer) {
         this.commentMinimizer.refreshIndicators();
       }
+
+      window.chatPanel?.queueUserActionHint(`[User Action: restored suggestion ${suggestionId}]`);
     } catch (error) {
       console.error('Error restoring suggestion:', error);
       alert('Failed to restore suggestion');

--- a/tests/unit/chat-panel.test.js
+++ b/tests/unit/chat-panel.test.js
@@ -1007,6 +1007,112 @@ describe('ChatPanel', () => {
   });
 
   // -----------------------------------------------------------------------
+  // queueUserActionHint
+  // -----------------------------------------------------------------------
+  describe('queueUserActionHint', () => {
+    it('should initialize _pendingUserActionHints as empty array', () => {
+      expect(chatPanel._pendingUserActionHints).toEqual([]);
+    });
+
+    it('should push a hint onto the array', () => {
+      chatPanel.queueUserActionHint('[User Action: adopted suggestion 42]');
+      expect(chatPanel._pendingUserActionHints).toEqual(['[User Action: adopted suggestion 42]']);
+    });
+
+    it('should accumulate multiple hints in order', () => {
+      chatPanel.queueUserActionHint('[User Action: adopted suggestion 1]');
+      chatPanel.queueUserActionHint('[User Action: dismissed suggestion 2]');
+      chatPanel.queueUserActionHint('[User Action: created comment 3]');
+      expect(chatPanel._pendingUserActionHints).toEqual([
+        '[User Action: adopted suggestion 1]',
+        '[User Action: dismissed suggestion 2]',
+        '[User Action: created comment 3]',
+      ]);
+    });
+
+    it('should survive close() — not cleared when panel is closed', () => {
+      chatPanel._pendingUserActionHints = ['[User Action: adopted suggestion 5]'];
+      chatPanel.close();
+      expect(chatPanel._pendingUserActionHints).toEqual(['[User Action: adopted suggestion 5]']);
+    });
+
+    it('should be cleared on _startNewConversation()', async () => {
+      chatPanel._pendingUserActionHints = ['[User Action: adopted suggestion 5]'];
+      await chatPanel._startNewConversation();
+      expect(chatPanel._pendingUserActionHints).toEqual([]);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // sendMessage — user action hints drain / error recovery
+  // -----------------------------------------------------------------------
+  describe('sendMessage user action hints integration', () => {
+    it('should include user action hints in payload context', async () => {
+      chatPanel.currentSessionId = 'sess-1';
+      chatPanel.isStreaming = false;
+      chatPanel.inputEl.value = 'hello';
+
+      chatPanel.queueUserActionHint('[User Action: adopted suggestion 42]');
+
+      global.fetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({}),
+      });
+
+      await chatPanel.sendMessage();
+
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+      const [url, opts] = global.fetch.mock.calls[0];
+      expect(url).toBe('/api/chat/session/sess-1/message');
+      const body = JSON.parse(opts.body);
+      expect(body.context).toContain('[User Action Hints]');
+      expect(body.context).toContain('[User Action: adopted suggestion 42]');
+
+      // Queue should be drained
+      expect(chatPanel._pendingUserActionHints).toEqual([]);
+    });
+
+    it('should combine user action hints with diff state notifications', async () => {
+      chatPanel.currentSessionId = 'sess-1';
+      chatPanel.isStreaming = false;
+      chatPanel.inputEl.value = 'hello';
+
+      chatPanel.queueDiffStateNotification('User expanded file foo.js');
+      chatPanel.queueUserActionHint('[User Action: dismissed suggestion 7]');
+
+      global.fetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({}),
+      });
+
+      await chatPanel.sendMessage();
+
+      const body = JSON.parse(global.fetch.mock.calls[0][1].body);
+      expect(body.context).toContain('[Diff State Update]');
+      expect(body.context).toContain('User expanded file foo.js');
+      expect(body.context).toContain('[User Action Hints]');
+      expect(body.context).toContain('[User Action: dismissed suggestion 7]');
+    });
+
+    it('should restore user action hints on send error', async () => {
+      chatPanel.currentSessionId = 'sess-1';
+      chatPanel.isStreaming = false;
+      chatPanel.inputEl.value = 'hello';
+
+      chatPanel.queueUserActionHint('[User Action: adopted suggestion 10]');
+
+      global.fetch.mockRejectedValueOnce(new Error('network failure'));
+
+      await chatPanel.sendMessage();
+
+      // Hints should be restored after the error
+      expect(chatPanel._pendingUserActionHints).toEqual([
+        '[User Action: adopted suggestion 10]',
+      ]);
+    });
+  });
+
+  // -----------------------------------------------------------------------
   // _startNewConversation()
   // -----------------------------------------------------------------------
   describe('_startNewConversation()', () => {


### PR DESCRIPTION
## Summary
- When users take actions directly in the review UI (adopt/dismiss suggestions, create/dismiss/restore comments), queue invisible context hints delivered with the next chat message
- Follows the existing `_pendingDiffStateNotifications` pattern: survives panel close, drained on send, restored on error
- Covers both line-level (pr.js, comment-manager.js) and file-level (file-comment-manager.js) action paths
- Includes cascading hint when deleting an adopted comment also dismisses the parent suggestion

## Test plan
- [x] 392 unit tests pass (5 new queue mechanics tests + 3 new sendMessage integration tests)
- [x] 268 E2E tests pass
- [ ] Manual: adopt suggestion from diff, send chat message, verify hint in context
- [ ] Manual: close panel, dismiss suggestion, reopen, send message — hint delivered
- [ ] Manual: delete adopted comment — both suggestion dismissal and comment dismissal hints queued

🤖 Generated with [Claude Code](https://claude.com/claude-code)