### PR TITLE
Use formattedBody for chat suggestion context

### DIFF
--- a/.changeset/formatted-body-chat-context.md
+++ b/.changeset/formatted-body-chat-context.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Use formattedBody (including suggestion text and code examples) instead of raw body when building suggestion context for chat, and include suggestionId consistently across all chat context call sites

--- a/public/js/components/AIPanel.js
+++ b/public/js/components/AIPanel.js
@@ -807,8 +807,9 @@ class AIPanel {
                     const finding = this.findings.find(f => f.id === findingId);
                     if (finding) {
                         suggestionContext = {
+                            suggestionId: findingId ? String(findingId) : null,
                             title: finding.title || title,
-                            body: finding.body || '',
+                            body: finding.formattedBody || finding.body || '',
                             type: finding.type || '',
                             file: finding.file || file,
                             line_start: finding.line_start || null,

--- a/public/js/modules/file-comment-manager.js
+++ b/public/js/modules/file-comment-manager.js
@@ -17,12 +17,15 @@ class FileCommentManager {
       if (chatBtn && window.chatPanel) {
         e.stopPropagation();
         const suggestionCard = chatBtn.closest('.ai-suggestion');
-        const bodyText = suggestionCard?.dataset?.originalBody
-          ? JSON.parse(suggestionCard.dataset.originalBody) : '';
+        const bodyText = suggestionCard?.dataset?.formattedBody
+          ? JSON.parse(suggestionCard.dataset.formattedBody)
+          : suggestionCard?.dataset?.originalBody
+            ? JSON.parse(suggestionCard.dataset.originalBody) : '';
         window.chatPanel.open({
           reviewId: this.prManager?.currentPR?.id,
           suggestionId: chatBtn.dataset.suggestionId,
           suggestionContext: {
+            suggestionId: chatBtn.dataset.suggestionId || null,
             title: chatBtn.dataset.title || '',
             body: bodyText,
             type: suggestionCard?.querySelector('.ai-suggestion-badge')?.dataset?.type || '',
@@ -444,6 +447,7 @@ class FileCommentManager {
     // Store original markdown body for adopt functionality via extractSuggestionData
     // Use JSON.stringify to preserve newlines and special characters (matches line-level suggestions)
     card.dataset.originalBody = JSON.stringify(suggestion.body || '');
+    card.dataset.formattedBody = JSON.stringify(suggestion.formattedBody || '');
 
     // Store target info on the card for reliable retrieval in getFileAndLineInfo
     // File-level suggestions don't have line numbers, just the file name

--- a/public/js/modules/suggestion-manager.js
+++ b/public/js/modules/suggestion-manager.js
@@ -24,8 +24,9 @@ class SuggestionManager {
           reviewId: this.prManager?.currentPR?.id,
           suggestionId: chatBtn.dataset.suggestionId,
           suggestionContext: {
+            suggestionId: chatBtn.dataset.suggestionId || null,
             title: chatBtn.dataset.title || suggestionData.suggestionTitle || '',
-            body: suggestionData.suggestionText || '',
+            body: suggestionData.formattedBody || suggestionData.suggestionText || '',
             type: suggestionData.suggestionType || '',
             file: chatBtn.dataset.file || '',
             line_start: suggestionDiv?.dataset?.lineNumber ? parseInt(suggestionDiv.dataset.lineNumber) : null,


### PR DESCRIPTION
## Summary
- Use `formattedBody` (which includes the "**Suggestion:**" section with code examples) instead of raw `body` when building suggestion context for chat across all three call sites: AIPanel, SuggestionManager, and FileCommentManager
- Add `suggestionId` consistently to the `suggestionContext` object in all three call sites
- Store `formattedBody` in DOM dataset for file-level suggestion cards (was missing)

Closes #439

## Test plan
- [x] All 5736 unit tests pass
- [ ] Manually click "Ask about this" on an AI suggestion in the review panel sidebar — verify chat agent receives the full formatted body
- [ ] Manually click "Ask about this" on an inline suggestion in the diff panel — verify chat agent receives the full formatted body
- [ ] Manually click "Ask about this" on a file-level suggestion — verify chat agent receives the full formatted body

🤖 Generated with [Claude Code](https://claude.com/claude-code)