### PR TITLE
Allow stack popover height to grow with viewport

### DIFF
--- a/.changeset/stack-popover-height.md
+++ b/.changeset/stack-popover-height.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Allow stack navigation popover to grow up to 80% of the viewport height instead of a fixed 420px max

--- a/public/css/pr.css
+++ b/public/css/pr.css
@@ -13306,7 +13306,7 @@ body.resizing * {
   box-shadow: 0 4px 16px var(--color-shadow, rgba(0, 0, 0, 0.12));
   z-index: 100;
   padding: 6px 0;
-  max-height: 420px;
+  max-height: min(calc(100vh - 120px), 80vh);
   overflow-y: auto;
 }
 


### PR DESCRIPTION
## Summary
- Changed `.stack-nav-menu` max-height from fixed `420px` to `min(calc(100vh - 120px), 80vh)` so the stack navigation dropdown uses available screen space for long stacks instead of scrolling prematurely.

## Test plan
- [ ] Open a PR that is part of a long stack (5+ PRs)
- [ ] Verify the popover grows taller to show more items
- [ ] Verify scrolling still works when the stack exceeds viewport height
- [ ] Test at different window sizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)