### PR TITLE
Add separate Open and Analyze buttons to index page

### DIFF
--- a/.changeset/open-analyze-buttons.md
+++ b/.changeset/open-analyze-buttons.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": minor
+---
+
+Replace "Start Review" and "Review Local" buttons on the index page with separate "Open" and "Analyze" buttons. "Open" opens the review page as before. "Analyze" opens the review page and automatically starts AI analysis using the repository's default settings.

--- a/public/index.html
+++ b/public/index.html
@@ -473,22 +473,53 @@
             font-size: 14px;
             font-weight: 500;
             line-height: 20px;
-            color: #ffffff;
-            background-color: var(--ai-primary);
-            border: none;
+            color: var(--ai-primary);
+            background-color: var(--ai-subtle);
+            border: 1px solid var(--ai-border);
             border-radius: var(--radius-md);
             cursor: pointer;
-            transition: background-color var(--transition-fast);
+            transition: background-color var(--transition-fast), border-color var(--transition-fast);
             white-space: nowrap;
         }
 
         .start-review-btn:hover:not(:disabled) {
-            background-color: #b45309;
+            background-color: var(--ai-glow);
+            border-color: var(--ai-primary);
         }
 
         .start-review-btn:disabled {
             opacity: 0.6;
             cursor: not-allowed;
+        }
+
+        .start-review-btn-primary {
+            color: #ffffff;
+            background-color: var(--ai-primary);
+            border-color: var(--ai-primary);
+        }
+
+        .start-review-btn-primary:hover:not(:disabled) {
+            background-color: #b45309;
+            border-color: #b45309;
+        }
+
+        [data-theme="dark"] .start-review-btn-primary:hover:not(:disabled) {
+            background-color: #d97706;
+            border-color: #d97706;
+        }
+
+        .start-review-btn-analyze {
+            transition: background-color var(--transition-fast), border-color var(--transition-fast), box-shadow 0.3s ease;
+        }
+
+        .start-review-btn-analyze:hover:not(:disabled) {
+            box-shadow: 0 0 8px rgba(217, 119, 6, 0.35), 0 0 20px rgba(251, 191, 36, 0.15);
+            animation: glow-pulse 2s ease-in-out infinite;
+        }
+
+        @keyframes glow-pulse {
+            0%, 100% { box-shadow: 0 0 8px rgba(217, 119, 6, 0.35), 0 0 20px rgba(251, 191, 36, 0.15); }
+            50% { box-shadow: 0 0 12px rgba(217, 119, 6, 0.5), 0 0 28px rgba(251, 191, 36, 0.25); }
         }
 
         .btn-browse {
@@ -1330,8 +1361,11 @@
                                     autocomplete="off"
                                     spellcheck="false"
                                 >
-                                <button type="submit" class="start-review-btn" id="start-review-btn">
-                                    Start Review
+                                <button type="submit" class="start-review-btn start-review-btn-primary" id="start-review-btn" title="Open review without running analysis">
+                                    Open
+                                </button>
+                                <button type="button" class="start-review-btn start-review-btn-analyze" id="analyze-review-btn" title="Open and analyze with default settings">
+                                    Analyze
                                 </button>
                             </form>
                             <div class="start-review-error" id="start-review-error-pr"></div>
@@ -1386,8 +1420,11 @@
                                 <button type="button" class="start-review-btn btn-browse" id="browse-local-btn" title="Browse for directory">
                                     Browse
                                 </button>
-                                <button type="submit" class="start-review-btn" id="start-local-btn">
-                                    Review Local
+                                <button type="submit" class="start-review-btn start-review-btn-primary" id="start-local-btn" title="Open review without running analysis">
+                                    Open
+                                </button>
+                                <button type="button" class="start-review-btn start-review-btn-analyze" id="analyze-local-btn" title="Open and analyze with default settings">
+                                    Analyze
                                 </button>
                             </form>
                             <div class="start-review-error" id="start-review-error-local"></div>

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -141,11 +141,12 @@
    */
   function setFormLoading(tab, loading, text) {
     const ids = tab === 'pr'
-      ? { input: 'pr-url-input', btn: 'start-review-btn', loadingEl: 'start-review-loading-pr', loadingText: 'start-review-loading-text-pr', errorEl: 'start-review-error-pr', btnLabel: 'Start Review' }
-      : { input: 'local-path-input', btn: 'start-local-btn', loadingEl: 'start-review-loading-local', loadingText: 'start-review-loading-text-local', errorEl: 'start-review-error-local', btnLabel: 'Review Local' };
+      ? { input: 'pr-url-input', btn: 'start-review-btn', analyzeBtn: 'analyze-review-btn', loadingEl: 'start-review-loading-pr', loadingText: 'start-review-loading-text-pr', errorEl: 'start-review-error-pr', btnLabel: 'Open' }
+      : { input: 'local-path-input', btn: 'start-local-btn', analyzeBtn: 'analyze-local-btn', loadingEl: 'start-review-loading-local', loadingText: 'start-review-loading-text-local', errorEl: 'start-review-error-local', btnLabel: 'Open' };
 
     const inputEl = document.getElementById(ids.input);
     const btnEl = document.getElementById(ids.btn);
+    const analyzeBtnEl = document.getElementById(ids.analyzeBtn);
     const loadingEl = document.getElementById(ids.loadingEl);
     const loadingTextEl = document.getElementById(ids.loadingText);
     const errorEl = document.getElementById(ids.errorEl);
@@ -153,12 +154,14 @@
     if (loading) {
       if (inputEl) inputEl.disabled = true;
       if (btnEl) { btnEl.disabled = true; btnEl.textContent = 'Starting...'; }
+      if (analyzeBtnEl) analyzeBtnEl.disabled = true;
       if (loadingEl) loadingEl.classList.add('visible');
       if (loadingTextEl && text) loadingTextEl.textContent = text;
       if (errorEl) errorEl.classList.remove('visible', 'info');
     } else {
       if (inputEl) inputEl.disabled = false;
       if (btnEl) { btnEl.disabled = false; btnEl.textContent = ids.btnLabel; }
+      if (analyzeBtnEl) analyzeBtnEl.disabled = false;
       if (loadingEl) loadingEl.classList.remove('visible');
     }
   }
@@ -688,8 +691,10 @@
    * Navigates to the setup page which shows step-by-step progress,
    * matching the flow used when reviews are started from the MCP/CLI.
    * @param {Event} event - Form submit event
+   * @param {Object} [options] - Optional settings
+   * @param {boolean} [options.analyze=false] - When true, append analyze=true to the navigation URL
    */
-  async function handleStartLocal(event) {
+  async function handleStartLocal(event, { analyze = false } = {}) {
     event.preventDefault();
 
     const input = document.getElementById('local-path-input');
@@ -707,7 +712,9 @@
 
     // Navigate to the setup page which shows step-by-step progress
     // The /local?path= route serves setup.html which handles the full setup flow
-    window.location.href = '/local?path=' + encodeURIComponent(pathValue);
+    let href = '/local?path=' + encodeURIComponent(pathValue);
+    if (analyze) href += '&analyze=true';
+    window.location.href = href;
   }
 
   // ─── Browse Directory ──────────────────────────────────────────────────────
@@ -1080,7 +1087,7 @@
    * directly for PRs that already exist in the database.
    * @param {Event} event - Form submit event
    */
-  async function handleStartReview(event) {
+  async function handleStartReview(event, { analyze = false } = {}) {
     event.preventDefault();
 
     const input = document.getElementById('pr-url-input');
@@ -1111,7 +1118,9 @@
 
     // Navigate to the PR route which serves setup.html (with step-by-step progress)
     // for new PRs, or pr.html directly for PRs already in the database
-    window.location.href = '/pr/' + encodeURIComponent(parsed.owner) + '/' + encodeURIComponent(parsed.repo) + '/' + encodeURIComponent(parsed.prNumber);
+    let href = '/pr/' + encodeURIComponent(parsed.owner) + '/' + encodeURIComponent(parsed.repo) + '/' + encodeURIComponent(parsed.prNumber);
+    if (analyze) href += '?analyze=true';
+    window.location.href = href;
   }
 
   // ─── Config & Command Examples ──────────────────────────────────────────────
@@ -1868,6 +1877,22 @@
     const browseBtn = document.getElementById('browse-local-btn');
     if (browseBtn) {
       browseBtn.addEventListener('click', handleBrowseLocal);
+    }
+
+    // Set up PR Analyze button handler
+    const analyzeReviewBtn = document.getElementById('analyze-review-btn');
+    if (analyzeReviewBtn) {
+      analyzeReviewBtn.addEventListener('click', function (event) {
+        handleStartReview(event, { analyze: true });
+      });
+    }
+
+    // Set up Local Analyze button handler
+    const analyzeLocalBtn = document.getElementById('analyze-local-btn');
+    if (analyzeLocalBtn) {
+      analyzeLocalBtn.addEventListener('click', function (event) {
+        handleStartLocal(event, { analyze: true });
+      });
     }
 
     // Note: No explicit Enter keypress handlers are needed here.

--- a/tests/unit/index-open-analyze-buttons.test.js
+++ b/tests/unit/index-open-analyze-buttons.test.js
@@ -1,0 +1,416 @@
+// Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+/**
+ * Tests the Open/Analyze button behavior on the index page.
+ *
+ * Covers:
+ * - PR Open button navigates without analyze param
+ * - PR Analyze button navigates with analyze=true param
+ * - Local Open button navigates without analyze param
+ * - Local Analyze button navigates with analyze=true param
+ * - setFormLoading disables both PR buttons
+ * - setFormLoading re-enables both PR buttons after failed parse
+ * - Open button label is restored to 'Open' after loading resolves
+ *
+ * Uses the same DOM mock pattern as index-tab-persistence.test.js:
+ * global DOM mocks are set up BEFORE requiring the IIFE so that all
+ * getElementById calls during module initialisation succeed.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// DOM + browser globals setup
+// ---------------------------------------------------------------------------
+
+let documentListeners = {};
+let windowListeners = {};
+
+function createMockElement(overrides = {}) {
+  const classes = new Set(overrides.classes || []);
+  const children = [];
+  const listeners = {};
+  const attrs = { ...(overrides.attrs || {}) };
+
+  const el = {
+    tagName: (overrides.tagName || 'DIV').toUpperCase(),
+    id: overrides.id || '',
+    dataset: { ...(overrides.dataset || {}) },
+    value: overrides.value || '',
+    disabled: false,
+    style: { overflow: '', display: '' },
+    innerHTML: '',
+    _textContent: '',
+    get textContent() { return this._textContent; },
+    set textContent(val) {
+      this._textContent = val;
+      this.innerHTML = String(val)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;');
+    },
+    classList: {
+      add: vi.fn((...cls) => cls.forEach(c => classes.add(c))),
+      remove: vi.fn((...cls) => cls.forEach(c => classes.delete(c))),
+      contains: vi.fn((c) => classes.has(c)),
+      toggle: vi.fn((c) => { if (classes.has(c)) classes.delete(c); else classes.add(c); }),
+    },
+    setAttribute: vi.fn((k, v) => { attrs[k] = v; }),
+    getAttribute: vi.fn((k) => attrs[k] ?? null),
+    addEventListener: vi.fn((evt, fn) => {
+      if (!listeners[evt]) listeners[evt] = [];
+      listeners[evt].push(fn);
+    }),
+    removeEventListener: vi.fn(),
+    appendChild: vi.fn((child) => children.push(child)),
+    insertBefore: vi.fn((newNode, refNode) => children.push(newNode)),
+    querySelector: vi.fn(() => null),
+    querySelectorAll: vi.fn(() => []),
+    closest: vi.fn(() => null),
+    dispatchEvent: vi.fn(),
+    focus: vi.fn(),
+    _listeners: listeners,
+    _children: children,
+  };
+  return el;
+}
+
+// Track all elements by id so getElementById works
+let elementsById = {};
+
+function registerElement(el) {
+  if (el.id) elementsById[el.id] = el;
+  return el;
+}
+
+function setupGlobals() {
+  documentListeners = {};
+  windowListeners = {};
+  elementsById = {};
+
+  // Create all elements that the IIFE accesses via getElementById at load time
+  const themeToggle = registerElement(createMockElement({ id: 'theme-toggle' }));
+  const helpBtn = registerElement(createMockElement({ id: 'help-btn' }));
+  const helpModalClose = registerElement(createMockElement({ id: 'help-modal-close' }));
+  const helpModalOverlay = registerElement(createMockElement({ id: 'help-modal-overlay' }));
+
+  // Tab bar with tab buttons
+  const prTabBtn = createMockElement({ id: 'pr-tab-btn', dataset: { tab: 'pr-tab' }, classes: ['tab-btn', 'active'] });
+  const localTabBtn = createMockElement({ id: 'local-tab-btn', dataset: { tab: 'local-tab' }, classes: ['tab-btn'] });
+  const reviewRequestsTabBtn = createMockElement({ id: 'rr-tab-btn', dataset: { tab: 'review-requests-tab' }, classes: ['tab-btn'] });
+  const myPrsTabBtn = createMockElement({ id: 'mp-tab-btn', dataset: { tab: 'my-prs-tab' }, classes: ['tab-btn'] });
+
+  const allTabBtns = [prTabBtn, localTabBtn, reviewRequestsTabBtn, myPrsTabBtn];
+
+  const tabBar = registerElement(createMockElement({ id: 'unified-tab-bar' }));
+  tabBar.querySelectorAll = vi.fn((selector) => {
+    if (selector === '.tab-btn') return allTabBtns;
+    return [];
+  });
+  tabBar.querySelector = vi.fn((selector) => {
+    const match = selector.match(/\[data-tab="([^"]+)"\]/);
+    if (match) {
+      return allTabBtns.find(b => b.dataset.tab === match[1]) || null;
+    }
+    return null;
+  });
+  // switchTab calls tabBar.closest('.recent-reviews-section')
+  const recentReviewsSection = createMockElement({ id: 'recent-reviews-section', classes: ['recent-reviews-section'] });
+  recentReviewsSection.querySelectorAll = vi.fn(() => []);
+  recentReviewsSection.querySelector = vi.fn(() => null);
+  tabBar.closest = vi.fn((sel) => {
+    if (sel === '.recent-reviews-section') return recentReviewsSection;
+    return null;
+  });
+
+  // PR form elements
+  const prUrlInput = registerElement(createMockElement({ id: 'pr-url-input' }));
+  const startReviewForm = registerElement(createMockElement({ id: 'start-review-form' }));
+  const startReviewBtn = registerElement(createMockElement({ id: 'start-review-btn' }));
+
+  // Loading/error elements accessed by setFormLoading
+  registerElement(createMockElement({ id: 'start-review-loading-pr' }));
+  registerElement(createMockElement({ id: 'start-review-loading-text-pr' }));
+  registerElement(createMockElement({ id: 'start-review-error-pr' }));
+  registerElement(createMockElement({ id: 'start-local-btn' }));
+  registerElement(createMockElement({ id: 'local-path-input' }));
+  registerElement(createMockElement({ id: 'start-review-loading-local' }));
+  registerElement(createMockElement({ id: 'start-review-loading-text-local' }));
+  registerElement(createMockElement({ id: 'start-review-error-local' }));
+  registerElement(createMockElement({ id: 'start-local-form' }));
+  registerElement(createMockElement({ id: 'browse-local-btn' }));
+
+  // Collection containers accessed by loadCollectionPrs on lazy-load
+  registerElement(createMockElement({ id: 'review-requests-container' }));
+  registerElement(createMockElement({ id: 'my-prs-container' }));
+
+  // Analyze buttons (new for this test file)
+  registerElement(createMockElement({ id: 'analyze-review-btn' }));
+  registerElement(createMockElement({ id: 'analyze-local-btn' }));
+
+  // Tab pane elements needed by DOMContentLoaded select-button creation
+  registerElement(createMockElement({ id: 'pr-tab' }));
+  registerElement(createMockElement({ id: 'local-tab' }));
+
+  // Container elements accessed by loadRecentReviews / loadLocalReviews
+  registerElement(createMockElement({ id: 'recent-reviews-container' }));
+  registerElement(createMockElement({ id: 'local-reviews-container' }));
+
+  // localStorage mock
+  const store = {};
+  global.localStorage = {
+    getItem: vi.fn((key) => store[key] ?? null),
+    setItem: vi.fn((key, value) => { store[key] = String(value); }),
+    removeItem: vi.fn((key) => { delete store[key]; }),
+    clear: vi.fn(() => { Object.keys(store).forEach(k => delete store[k]); }),
+    _store: store,
+  };
+
+  global.document = {
+    documentElement: {
+      setAttribute: vi.fn(),
+      getAttribute: vi.fn(() => 'light'),
+    },
+    body: { style: { overflow: '' } },
+    getElementById: vi.fn((id) => elementsById[id] || null),
+    querySelector: vi.fn(() => null),
+    querySelectorAll: vi.fn(() => []),
+    createElement: vi.fn((tag) => createMockElement({ tagName: tag })),
+    addEventListener: vi.fn((evt, fn) => {
+      if (!documentListeners[evt]) documentListeners[evt] = [];
+      documentListeners[evt].push(fn);
+    }),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+    contains: vi.fn(() => true),
+  };
+
+  global.window = {
+    matchMedia: vi.fn(() => ({
+      matches: false,
+      addEventListener: vi.fn(),
+    })),
+    addEventListener: vi.fn((evt, fn) => {
+      if (!windowListeners[evt]) windowListeners[evt] = [];
+      windowListeners[evt].push(fn);
+    }),
+    dispatchEvent: vi.fn(),
+    location: { href: '', pathname: '/' },
+  };
+
+  global.fetch = vi.fn(() => Promise.resolve({ ok: false }));
+  global.Event = class Event {
+    constructor(type, opts = {}) {
+      this.type = type;
+      this.cancelable = opts.cancelable || false;
+    }
+  };
+  global.CustomEvent = class CustomEvent extends global.Event {
+    constructor(type, opts = {}) {
+      super(type, opts);
+      this.detail = opts.detail || null;
+    }
+  };
+  global.confirm = vi.fn(() => false);
+  global.CSS = { escape: vi.fn((s) => s) };
+  global.URLSearchParams = URLSearchParams;
+  global.console = { ...console, error: vi.fn(), log: vi.fn(), warn: vi.fn() };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('Index page Open/Analyze buttons', () => {
+  beforeEach(async () => {
+    setupGlobals();
+
+    // Clear module cache so the IIFE runs fresh each time
+    const modulePath = require.resolve('../../public/js/index.js');
+    delete require.cache[modulePath];
+
+    // Load the actual production IIFE — this registers the document click
+    // handler and the DOMContentLoaded listener (but does NOT trigger it)
+    require('../../public/js/index.js');
+
+    // Trigger DOMContentLoaded so that form submit and analyze-button click
+    // handlers are registered on the elements.
+    // The DOMContentLoaded handler is async (it awaits loadConfigAndUpdateUI)
+    // so we must await it and flush microtasks.
+    const domContentLoadedFns = documentListeners['DOMContentLoaded'] || [];
+    for (const fn of domContentLoadedFns) {
+      await fn();
+    }
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // Helper: mock fetch to return a valid parsed PR response
+  function mockFetchValidPR() {
+    global.fetch = vi.fn((url) => {
+      if (typeof url === 'string' && url.includes('/api/parse-pr-url')) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({
+            valid: true,
+            owner: 'testowner',
+            repo: 'testrepo',
+            prNumber: 42,
+          }),
+        });
+      }
+      // Default: return ok: false for any other fetch
+      return Promise.resolve({ ok: false });
+    });
+  }
+
+  // Helper: mock fetch to return a failed (invalid) parse response
+  function mockFetchInvalidPR() {
+    global.fetch = vi.fn((url) => {
+      if (typeof url === 'string' && url.includes('/api/parse-pr-url')) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ valid: false }),
+        });
+      }
+      return Promise.resolve({ ok: false });
+    });
+  }
+
+  // ─── Test 1: PR Open button navigates without analyze param ──────────────
+
+  it('PR Open button navigates without analyze param', async () => {
+    const form = elementsById['start-review-form'];
+    const input = elementsById['pr-url-input'];
+    input.value = 'https://github.com/testowner/testrepo/pull/42';
+
+    mockFetchValidPR();
+
+    const submitHandler = form._listeners.submit[0];
+    await submitHandler({ preventDefault: vi.fn() });
+
+    expect(global.window.location.href).toBe('/pr/testowner/testrepo/42');
+  });
+
+  // ─── Test 2: PR Analyze button navigates with analyze param ──────────────
+
+  it('PR Analyze button navigates with analyze param', async () => {
+    const analyzeBtn = elementsById['analyze-review-btn'];
+    const input = elementsById['pr-url-input'];
+    input.value = 'https://github.com/testowner/testrepo/pull/42';
+
+    mockFetchValidPR();
+
+    // The IIFE wraps handleStartReview in an anonymous function that does NOT
+    // return the promise, so `await clickHandler(...)` resolves immediately.
+    // Flush microtasks so the inner async handleStartReview completes.
+    const clickHandler = analyzeBtn._listeners.click[0];
+    clickHandler({ preventDefault: vi.fn() });
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(global.window.location.href).toBe('/pr/testowner/testrepo/42?analyze=true');
+  });
+
+  // ─── Test 3: Local Open button navigates without analyze param ───────────
+
+  it('Local Open button navigates without analyze param', async () => {
+    const form = elementsById['start-local-form'];
+    const input = elementsById['local-path-input'];
+    input.value = '/tmp/myproject';
+
+    const submitHandler = form._listeners.submit[0];
+    await submitHandler({ preventDefault: vi.fn() });
+
+    expect(global.window.location.href).toBe('/local?path=%2Ftmp%2Fmyproject');
+  });
+
+  // ─── Test 4: Local Analyze button navigates with analyze param ───────────
+
+  it('Local Analyze button navigates with analyze param', async () => {
+    const analyzeBtn = elementsById['analyze-local-btn'];
+    const input = elementsById['local-path-input'];
+    input.value = '/tmp/myproject';
+
+    const clickHandler = analyzeBtn._listeners.click[0];
+    await clickHandler({ preventDefault: vi.fn() });
+
+    expect(global.window.location.href).toBe('/local?path=%2Ftmp%2Fmyproject&analyze=true');
+  });
+
+  // ─── Test 5: setFormLoading disables both PR buttons ─────────────────────
+
+  it('setFormLoading disables both PR buttons during fetch', async () => {
+    const input = elementsById['pr-url-input'];
+    const startBtn = elementsById['start-review-btn'];
+    const analyzeBtn = elementsById['analyze-review-btn'];
+
+    input.value = 'https://github.com/testowner/testrepo/pull/42';
+
+    // Use a fetch mock that we can control timing on — resolve later
+    let resolveFetch;
+    global.fetch = vi.fn((url) => {
+      if (typeof url === 'string' && url.includes('/api/parse-pr-url')) {
+        return new Promise((resolve) => { resolveFetch = resolve; });
+      }
+      return Promise.resolve({ ok: false });
+    });
+
+    const form = elementsById['start-review-form'];
+    const submitHandler = form._listeners.submit[0];
+    // Start the handler (don't await yet — fetch is pending)
+    const promise = submitHandler({ preventDefault: vi.fn() });
+
+    // At this point setFormLoading('pr', true) has been called,
+    // but parsePRUrl is still waiting for the fetch.
+    // Use a microtask tick so the code up to `await fetch(...)` runs.
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(startBtn.disabled).toBe(true);
+    expect(analyzeBtn.disabled).toBe(true);
+
+    // Resolve fetch so the handler completes (avoid dangling promise)
+    resolveFetch({
+      ok: true,
+      json: () => Promise.resolve({ valid: true, owner: 'testowner', repo: 'testrepo', prNumber: 42 }),
+    });
+    await promise;
+  });
+
+  // ─── Test 6: setFormLoading re-enables both PR buttons after failed parse ─
+
+  it('setFormLoading re-enables both PR buttons after failed parse', async () => {
+    const input = elementsById['pr-url-input'];
+    const startBtn = elementsById['start-review-btn'];
+    const analyzeBtn = elementsById['analyze-review-btn'];
+
+    input.value = 'https://github.com/testowner/testrepo/pull/42';
+
+    mockFetchInvalidPR();
+
+    const form = elementsById['start-review-form'];
+    const submitHandler = form._listeners.submit[0];
+    await submitHandler({ preventDefault: vi.fn() });
+
+    // After failed parse, setFormLoading('pr', false) should have been called
+    expect(startBtn.disabled).toBe(false);
+    expect(analyzeBtn.disabled).toBe(false);
+  });
+
+  // ─── Test 7: Open button label is restored to 'Open' ────────────────────
+
+  it('Open button label is restored to Open after loading resolves', async () => {
+    const input = elementsById['pr-url-input'];
+    const startBtn = elementsById['start-review-btn'];
+
+    input.value = 'https://github.com/testowner/testrepo/pull/42';
+
+    mockFetchInvalidPR();
+
+    const form = elementsById['start-review-form'];
+    const submitHandler = form._listeners.submit[0];
+    await submitHandler({ preventDefault: vi.fn() });
+
+    expect(startBtn.textContent).toBe('Open');
+  });
+});

--- a/tests/unit/index-tab-persistence.test.js
+++ b/tests/unit/index-tab-persistence.test.js
@@ -133,6 +133,8 @@ function setupGlobals() {
   registerElement(createMockElement({ id: 'start-review-error-local' }));
   registerElement(createMockElement({ id: 'start-local-form' }));
   registerElement(createMockElement({ id: 'browse-local-btn' }));
+  registerElement(createMockElement({ id: 'analyze-review-btn' }));
+  registerElement(createMockElement({ id: 'analyze-local-btn' }));
 
   // Collection containers accessed by loadCollectionPrs on lazy-load
   registerElement(createMockElement({ id: 'review-requests-container' }));


### PR DESCRIPTION
## Summary
- Replace single "Start Review"/"Review Local" buttons with separate **Open** and **Analyze** buttons on both PR and Local tabs
- Open navigates to the review page as before; Analyze appends `analyze=true` to auto-start AI analysis
- Open button gets primary amber styling; Analyze gets a subtle glow-pulse hover effect
- Both buttons include descriptive tooltips
- Includes new unit tests for button behavior and updated existing tab persistence tests

## Test plan
- [ ] Verify Open button navigates to review page without `analyze` param (PR and Local tabs)
- [ ] Verify Analyze button navigates with `analyze=true` param (PR and Local tabs)
- [ ] Verify button styling: Open is solid amber, Analyze is subtle with glow on hover
- [ ] Verify tooltips appear on hover for both buttons
- [ ] Verify both buttons are disabled during loading state
- [ ] Run `npm test` — all unit tests pass
- [ ] Check light and dark themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)