### PR TITLE
Respect provider-configured timeouts for reviews

### DIFF
--- a/.changeset/respect-provider-timeouts.md
+++ b/.changeset/respect-provider-timeouts.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Respect provider-configured timeouts for single-model and council reviews instead of always defaulting to 10 minutes

--- a/package.json
+++ b/package.json
@@ -82,5 +82,10 @@
     "jsdom": "^29.0.1",
     "supertest": "^7.1.4",
     "vitest": "^4.0.16"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "better-sqlite3"
+    ]
   }
 }

--- a/src/ai/analyzer.js
+++ b/src/ai/analyzer.js
@@ -96,7 +96,7 @@ function buildVoiceContext(voice, idx, instructions, progressCallback, db) {
   const voiceProvider = isExecutable ? createProvider(voice.provider, voice.model) : null;
 
   const voiceTier = voice.tier || 'balanced';
-  const voiceTimeout = voice.timeout || 600000;
+  const voiceTimeout = voice.timeout || ProviderClass?.defaultTimeout || 600000;
 
   // Wrap progress callback with voice-centric metadata
   const voiceProgressCallback = progressCallback ? (update) => {
@@ -319,7 +319,10 @@ class Analyzer {
     const runId = options.runId || uuidv4();
     const { analysisId, skipRunCreation, skipLevel3, reviewerNum, excludePrevious, serverPort } = options;
     const logPrefix = options.logPrefix || '';
-    const executionTimeout = options.timeout || 600000; // Default 10 minutes
+    // Respect provider-configured timeout (e.g. Pi's 15 min, executable providers)
+    const ProviderClass = getProviderClass(this.provider);
+    const providerTimeout = ProviderClass?.defaultTimeout;
+    const executionTimeout = options.timeout || providerTimeout || 600000; // Default 10 minutes
 
     // Resolve enabledLevels: prefer explicit option, fall back to skipLevel3 compat
     const enabledLevels = options.enabledLevels
@@ -3396,6 +3399,7 @@ File-level suggestions should NOT have a line number. They apply to the entire f
             : voice.customInstructions;
         }
 
+        const VoiceProviderClass = getProviderClass(voice.provider);
         voiceTasks.push({
           voiceId,
           reviewerLabel,
@@ -3404,7 +3408,7 @@ File-level suggestions should NOT have a line number. They apply to the entire f
           provider: voice.provider,
           model: voice.model,
           tier,
-          timeout: voice.timeout || 600000,
+          timeout: voice.timeout || VoiceProviderClass?.defaultTimeout || 600000,
           customInstructions: voiceInstructions,
           voiceCustomInstructions: voice.customInstructions || null
         });

--- a/src/ai/executable-provider.js
+++ b/src/ai/executable-provider.js
@@ -522,6 +522,11 @@ function createExecutableProviderClass(id, config) {
   ExecProvider.getDefaultModel = () => resolveDefaultModel(models) || models[0]?.id;
   ExecProvider.getInstallInstructions = () => config.installInstructions || `Install ${id}`;
 
+  // Surface configured timeout so the UI can pre-populate TimeoutSelect
+  if (config.timeout != null) {
+    ExecProvider.defaultTimeout = config.timeout;
+  }
+
   // Flags for the system
   ExecProvider.isExecutable = true;
   const caps = config.capabilities || {};

--- a/tests/unit/analyzer-validation.test.js
+++ b/tests/unit/analyzer-validation.test.js
@@ -2031,11 +2031,14 @@ describe('Analyzer timeout threading (source verification)', () => {
   });
 
   it('analyzeAllLevels should extract timeout from options and pass it to level analyzers', () => {
-    // Check that analyzeAllLevels reads options.timeout
+    // Check that analyzeAllLevels reads options.timeout with provider fallback
     const allLevelsMatch = analyzerSource.match(
-      /async analyzeAllLevels[^{]*\{[\s\S]*?const executionTimeout = options\.timeout \|\| 600000/
+      /async analyzeAllLevels[^{]*\{[\s\S]*?const executionTimeout = options\.timeout \|\| providerTimeout \|\| 600000/
     );
     expect(allLevelsMatch).not.toBeNull();
+
+    // Check that provider's defaultTimeout is looked up
+    expect(analyzerSource).toContain('const providerTimeout = ProviderClass?.defaultTimeout');
 
     // Check that executionTimeout is passed to level analyzers
     expect(analyzerSource).toContain('timeout: executionTimeout');
@@ -2043,7 +2046,7 @@ describe('Analyzer timeout threading (source verification)', () => {
 
   it('voice-centric council should pass voice.timeout to analyzeAllLevels', () => {
     // Check that runReviewerCentricCouncil reads voice.timeout
-    expect(analyzerSource).toMatch(/voiceTimeout\s*=\s*voice\.timeout\s*\|\|\s*600000/);
+    expect(analyzerSource).toMatch(/voiceTimeout\s*=\s*voice\.timeout\s*\|\|\s*ProviderClass\?\.defaultTimeout\s*\|\|\s*600000/);
     // Check it passes voiceTimeout in options
     expect(analyzerSource).toContain('timeout: voiceTimeout');
   });
@@ -2051,7 +2054,7 @@ describe('Analyzer timeout threading (source verification)', () => {
   it('level-centric council should include timeout in voiceTasks from voice config', () => {
     // Check that voiceTasks.push includes timeout from voice config
     const voiceTaskPush = analyzerSource.match(
-      /voiceTasks\.push\(\{[\s\S]*?timeout:\s*voice\.timeout\s*\|\|\s*600000[\s\S]*?\}\)/
+      /voiceTasks\.push\(\{[\s\S]*?timeout:\s*voice\.timeout\s*\|\|\s*VoiceProviderClass\?\.defaultTimeout\s*\|\|\s*600000[\s\S]*?\}\)/
     );
     expect(voiceTaskPush).not.toBeNull();
   });

--- a/tests/unit/executable-provider.test.js
+++ b/tests/unit/executable-provider.test.js
@@ -186,6 +186,16 @@ describe('createExecutableProviderClass', () => {
       expect(withExcludePrevious.capabilities).toEqual({ review_levels: false, custom_instructions: false, exclude_previous: true, consolidation: false });
     });
 
+    it('sets defaultTimeout from config.timeout when provided', () => {
+      const withTimeout = createExecutableProviderClass('t', { timeout: 1200000 });
+      expect(withTimeout.defaultTimeout).toBe(1200000);
+    });
+
+    it('does not set defaultTimeout when config.timeout is absent', () => {
+      const noTimeout = createExecutableProviderClass('t', {});
+      expect(noTimeout.defaultTimeout).toBeUndefined();
+    });
+
     it('sets getInstallInstructions from config', () => {
       expect(createExecutableProviderClass('t', { installInstructions: 'pip install t' }).getInstallInstructions()).toBe('pip install t');
       expect(createExecutableProviderClass('test-tool', {}).getInstallInstructions()).toBe('Install test-tool');


### PR DESCRIPTION
## Summary
- Single-model reviews now fall back to the provider's `defaultTimeout` before the hardcoded 10-min default
- Council paths (voice-centric and level-centric) use the same fallback chain: `voice.timeout || ProviderClass.defaultTimeout || 600000`
- Executable providers now surface their configured `timeout` as `defaultTimeout` so the council UI pre-populates correctly
- Added `pnpm.onlyBuiltDependencies` for `better-sqlite3` (required by pnpm 10)

## Test plan
- [x] Unit tests pass (194 tests across analyzer-validation and executable-provider)
- [ ] Manual: open council config, add Binks as a voice — timeout should default to 45 min
- [ ] Manual: open council config, add Pi as a voice — timeout should default to 15 min
- [ ] Manual: run single-model review with Pi — should use 15 min timeout (check server logs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)