### PR TITLE
Add load_skills config with per-provider resolution

### DIFF
--- a/.changeset/skip-skills.md
+++ b/.changeset/skip-skills.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": minor
+---
+
+Add per-repository and per-provider `load_skills` configuration to control whether AI providers load skill extensions during analysis. Resolution follows a 4-tier cascade: DB repo settings > repo JSON config > provider-level config > default (enabled). Council mode resolves overrides per-voice so mixed-provider councils respect provider-specific settings. Includes a toggle in the repo settings UI.

--- a/config.example.json
+++ b/config.example.json
@@ -247,7 +247,7 @@
   },
 
   "repos": {
-    "_comment": "Repository configurations (renamed from 'monorepos'; the old key still works). 'path' points to an existing local clone. 'checkout_script' runs after worktree creation. 'reset_script' runs when switching a pool worktree to a new PR.",
+    "_comment": "Repository configurations (renamed from 'monorepos'; the old key still works). 'path' points to an existing local clone. 'checkout_script' runs after worktree creation. 'reset_script' runs when switching a pool worktree to a new PR. 'load_skills' controls whether AI providers load environment-level skills (default: true).",
     "owner/repo": {
       "path": "~/path/to/monorepo",
       "checkout_script": "my-repo-checkout $BASE_SHA $HEAD_BRANCH",
@@ -256,7 +256,8 @@
       "worktree_directory": "~/custom/worktrees",
       "worktree_name_template": "{id}/src",
       "pool_size": 0,
-      "pool_fetch_interval_minutes": null
+      "pool_fetch_interval_minutes": null,
+      "load_skills": true
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,8 @@
         "simple-git": "^3.19.1",
         "update-notifier": "^5.1.0",
         "uuid": "^11.1.0",
-        "ws": "^8.19.0"
+        "ws": "^8.19.0",
+        "zod": "^4.3.6"
       },
       "bin": {
         "git-diff-lines": "bin/git-diff-lines",

--- a/public/js/repo-settings.js
+++ b/public/js/repo-settings.js
@@ -214,6 +214,16 @@ class RepoSettingsPage {
       });
     }
 
+    // Load skills select
+    const loadSkillsSelect = document.getElementById('load-skills-select');
+    if (loadSkillsSelect) {
+      loadSkillsSelect.addEventListener('change', () => {
+        const val = loadSkillsSelect.value;
+        this.currentSettings.load_skills = val === '' ? null : parseInt(val, 10);
+        this.checkForChanges();
+      });
+    }
+
     // Analysis mode segmented control
     const modeToggle = document.getElementById('analysis-mode-toggle');
     if (modeToggle) {
@@ -847,7 +857,8 @@ class RepoSettingsPage {
         local_path: settings.local_path || null,
         default_chat_instructions: settings.default_chat_instructions || '',
         pool_size: settings.pool_size ?? null,
-        pool_fetch_interval_minutes: settings.pool_fetch_interval_minutes ?? null
+        pool_fetch_interval_minutes: settings.pool_fetch_interval_minutes ?? null,
+        load_skills: settings.load_skills ?? null
       };
 
       // Set current settings
@@ -868,7 +879,8 @@ class RepoSettingsPage {
         local_path: null,
         default_chat_instructions: '',
         pool_size: null,
-        pool_fetch_interval_minutes: null
+        pool_fetch_interval_minutes: null,
+        load_skills: null
       };
       this.currentSettings = { ...this.originalSettings };
       this.updateUI();
@@ -1205,6 +1217,13 @@ class RepoSettingsPage {
     if (poolFetchInput) {
       poolFetchInput.value = this.currentSettings.pool_fetch_interval_minutes ?? '';
     }
+
+    // Update load skills select
+    const loadSkillsSelect = document.getElementById('load-skills-select');
+    if (loadSkillsSelect) {
+      const val = this.currentSettings.load_skills;
+      loadSkillsSelect.value = val === null || val === undefined ? '' : String(val);
+    }
   }
 
   /**
@@ -1256,8 +1275,9 @@ class RepoSettingsPage {
     const chatInstructionsChanged = (this.currentSettings.default_chat_instructions ?? '') !== (this.originalSettings.default_chat_instructions ?? '');
     const poolSizeChanged = (this.currentSettings.pool_size ?? null) !== (this.originalSettings.pool_size ?? null);
     const poolFetchChanged = (this.currentSettings.pool_fetch_interval_minutes ?? null) !== (this.originalSettings.pool_fetch_interval_minutes ?? null);
+    const loadSkillsChanged = (this.currentSettings.load_skills ?? null) !== (this.originalSettings.load_skills ?? null);
 
-    this.hasUnsavedChanges = providerChanged || modelChanged || tabChanged || councilChanged || instructionsChanged || chatInstructionsChanged || poolSizeChanged || poolFetchChanged;
+    this.hasUnsavedChanges = providerChanged || modelChanged || tabChanged || councilChanged || instructionsChanged || chatInstructionsChanged || poolSizeChanged || poolFetchChanged || loadSkillsChanged;
 
     // Show/hide action bar
     const actionBar = document.getElementById('action-bar');
@@ -1294,7 +1314,8 @@ class RepoSettingsPage {
           default_instructions: this.currentSettings.default_instructions,
           default_chat_instructions: this.currentSettings.default_chat_instructions,
           pool_size: this.currentSettings.pool_size,
-          pool_fetch_interval_minutes: this.currentSettings.pool_fetch_interval_minutes
+          pool_fetch_interval_minutes: this.currentSettings.pool_fetch_interval_minutes,
+          load_skills: this.currentSettings.load_skills
         })
       });
 
@@ -1371,7 +1392,8 @@ class RepoSettingsPage {
           local_path: null,
           default_chat_instructions: '',
           pool_size: null,
-          pool_fetch_interval_minutes: null
+          pool_fetch_interval_minutes: null,
+          load_skills: null
         })
       });
 
@@ -1389,7 +1411,8 @@ class RepoSettingsPage {
         local_path: null,
         default_chat_instructions: '',
         pool_size: null,
-        pool_fetch_interval_minutes: null
+        pool_fetch_interval_minutes: null,
+        load_skills: null
       };
       this.currentSettings = { ...this.originalSettings };
       this.hasUnsavedChanges = false;

--- a/public/repo-settings.html
+++ b/public/repo-settings.html
@@ -198,6 +198,22 @@ Examples:
                         </div>
                     </section>
 
+                    <!-- Provider Skill Discovery Section -->
+                    <section class="settings-section">
+                        <div class="section-header">
+                            <h2>Provider Skill Discovery</h2>
+                            <p class="section-description">Controls whether AI providers load environment-level skills automatically. Currently applies to Pi's skill auto-discovery. When disabled, Pi runs with <code>--no-skills</code>.</p>
+                        </div>
+                        <div class="form-group" style="max-width: 300px;">
+                            <label for="load-skills-select" class="settings-label">Load Skills</label>
+                            <select class="settings-select" id="load-skills-select">
+                                <option value="">Default (inherit from config)</option>
+                                <option value="1">Enabled</option>
+                                <option value="0">Disabled</option>
+                            </select>
+                        </div>
+                    </section>
+
                     <!-- Repository Location Section -->
                     <section class="settings-section" id="local-path-section">
                         <div class="section-header">

--- a/src/ai/analyzer.js
+++ b/src/ai/analyzer.js
@@ -73,9 +73,10 @@ async function captureDiffSnapshot(analyzer, worktreePath, prMetadata, logPrefix
  * @param {Object|null} instructions - Instructions object { repoInstructions, requestInstructions }
  * @param {Function|null} progressCallback - Parent progress callback to wrap
  * @param {Object} db - Database instance
+ * @param {Object} providerOverrides - Per-call config overrides passed to createProvider (optional)
  * @returns {Object} { voiceAnalyzer, voiceKey, reviewerLabel, voiceRequestInstructions, voiceProgressCallback, voiceTier, voiceTimeout }
  */
-function buildVoiceContext(voice, idx, instructions, progressCallback, db) {
+function buildVoiceContext(voice, idx, instructions, progressCallback, db, providerOverrides = {}, providerOverridesMap = null) {
   const voiceKey = `${voice.provider}-${voice.model}${idx > 0 ? `-${idx}` : ''}`;
   const reviewerLabel = buildReviewerLabel(idx, voice);
 
@@ -87,13 +88,16 @@ function buildVoiceContext(voice, idx, instructions, progressCallback, db) {
       : voice.customInstructions;
   }
 
+  // Resolve per-voice overrides: prefer provider-specific from map, fall back to shared overrides
+  const effectiveOverrides = providerOverridesMap?.[voice.provider] || providerOverrides;
+
   const ProviderClass = getProviderClass(voice.provider);
   const isExecutable = ProviderClass?.isExecutable || false;
 
   // Only create Analyzer for native voices
-  const voiceAnalyzer = isExecutable ? null : new Analyzer(db, voice.model, voice.provider);
+  const voiceAnalyzer = isExecutable ? null : new Analyzer(db, voice.model, voice.provider, effectiveOverrides);
   // Create provider instance for executable voices (used directly)
-  const voiceProvider = isExecutable ? createProvider(voice.provider, voice.model) : null;
+  const voiceProvider = isExecutable ? createProvider(voice.provider, voice.model, effectiveOverrides) : null;
 
   const voiceTier = voice.tier || 'balanced';
   const voiceTimeout = voice.timeout || ProviderClass?.defaultTimeout || 600000;
@@ -272,12 +276,16 @@ class Analyzer {
    * @param {Object} database - Database instance
    * @param {string} model - Model to use (e.g., 'opus', 'gemini-2.5-pro')
    * @param {string} provider - Provider ID (e.g., 'claude', 'gemini'). Defaults to 'claude'.
+   * @param {Object} providerOverrides - Per-call config overrides passed to createProvider (optional)
+   * @param {Object|null} providerOverridesMap - Per-provider overrides map for council mode (provider ID → overrides)
    */
-  constructor(database, model = 'opus', provider = 'claude') {
+  constructor(database, model = 'opus', provider = 'claude', providerOverrides = {}, providerOverridesMap = null) {
     // Store model and provider for creating provider instances per level
     this.model = model;
     this.provider = provider;
     this.db = database;
+    this.providerOverrides = providerOverrides;
+    this.providerOverridesMap = providerOverridesMap;
     this.testContextCache = new Map(); // Cache test detection results per worktree
     this._worktreeManager = null; // Lazy-initialized for sparse-checkout queries
   }
@@ -1015,7 +1023,7 @@ Or simply ignore any changes to files matching these patterns in your analysis.
       }
 
       // Create provider instance for this level
-      const aiProvider = createProvider(this.provider, this.model);
+      const aiProvider = createProvider(this.provider, this.model, this.providerOverrides);
 
       const updateProgress = (step) => {
         const progress = `${lp}[Level 1] ${step}...`;
@@ -1975,7 +1983,7 @@ If you are unsure, use "NEW" - it is correct for the vast majority of suggestion
       }
 
       // Create provider instance for this level
-      const aiProvider = createProvider(this.provider, this.model);
+      const aiProvider = createProvider(this.provider, this.model, this.providerOverrides);
 
       const updateProgress = (step) => {
         const progress = `${lp}[Level 2] ${step}...`;
@@ -2085,7 +2093,7 @@ If you are unsure, use "NEW" - it is correct for the vast majority of suggestion
       }
 
       // Create provider instance for this level
-      const aiProvider = createProvider(this.provider, this.model);
+      const aiProvider = createProvider(this.provider, this.model, this.providerOverrides);
 
       const updateProgress = (step) => {
         const progress = `${lp}[Level 3] ${step}...`;
@@ -2655,7 +2663,7 @@ File-level suggestions should NOT have a line number. They apply to the entire f
       }
 
       // Create provider instance for consolidation (use overrides if provided)
-      const aiProvider = createProvider(providerOverride || this.provider, modelOverride || this.model);
+      const aiProvider = createProvider(providerOverride || this.provider, modelOverride || this.model, this.providerOverrides);
 
       // Build the consolidation prompt
       const prompt = this.buildOrchestrationPrompt(allSuggestions, prMetadata, customInstructions, worktreePath, tier, lp, { excludePrevious, dedupContext });
@@ -2932,7 +2940,7 @@ File-level suggestions should NOT have a line number. They apply to the entire f
     if (voices.length === 1) {
       const voice = voices[0];
       const { voiceAnalyzer, voiceProvider, isExecutable, voiceKey, reviewerLabel, voiceRequestInstructions, voiceProgressCallback, voiceTier, voiceTimeout } =
-        buildVoiceContext(voice, 0, instructions, progressCallback, this.db);
+        buildVoiceContext(voice, 0, instructions, progressCallback, this.db, this.providerOverrides, this.providerOverridesMap);
       logger.info(`[ReviewerCouncil] Single reviewer (${reviewerLabel}) — running directly on parent run, no child run`);
 
       // Report voice-centric progress structure
@@ -3034,7 +3042,7 @@ File-level suggestions should NOT have a line number. They apply to the entire f
     const commentRepo = new CommentRepository(this.db);
     const voicePromises = voices.map(async (voice, idx) => {
       const { voiceAnalyzer, voiceProvider, isExecutable, voiceKey, reviewerLabel, voiceRequestInstructions, voiceProgressCallback, voiceTier, voiceTimeout } =
-        buildVoiceContext(voice, idx, instructions, progressCallback, this.db);
+        buildVoiceContext(voice, idx, instructions, progressCallback, this.db, this.providerOverrides, this.providerOverridesMap);
       const childRunId = uuidv4();
 
       // Create child analysis run record
@@ -3271,7 +3279,7 @@ File-level suggestions should NOT have a line number. They apply to the entire f
 
       const consolidated = await this._crossVoiceConsolidate(
         voiceReviews, prMetadata, consolInstructions, worktreePath,
-        { provider: consolProvider, model: consolModel, tier: consolTier, timeout: consolConfig.timeout, analysisId, progressCallback, excludePrevious, dedupContext }
+        { provider: consolProvider, model: consolModel, tier: consolTier, timeout: consolConfig.timeout, analysisId, progressCallback, excludePrevious, dedupContext, providerOverrides: this.providerOverrides }
       );
 
       const finalSuggestions = this.validateAndFinalizeSuggestions(
@@ -3410,7 +3418,8 @@ File-level suggestions should NOT have a line number. They apply to the entire f
           tier,
           timeout: voice.timeout || VoiceProviderClass?.defaultTimeout || 600000,
           customInstructions: voiceInstructions,
-          voiceCustomInstructions: voice.customInstructions || null
+          voiceCustomInstructions: voice.customInstructions || null,
+          providerOverrides: this.providerOverridesMap?.[voice.provider] || this.providerOverrides
         });
       }
     }
@@ -3575,7 +3584,7 @@ File-level suggestions should NOT have a line number. They apply to the entire f
           }));
           const consolidated = await this._intraLevelConsolidate(
             level, voiceGroups, prMetadata, orchInstructions, worktreePath,
-            { provider: orchProvider, model: orchModel, tier: orchTier, timeout: orchConfig.timeout, analysisId, progressCallback, reviewerCount: successfulVoicesForLevel.length }
+            { provider: orchProvider, model: orchModel, tier: orchTier, timeout: orchConfig.timeout, analysisId, progressCallback, reviewerCount: successfulVoicesForLevel.length, providerOverrides: this.providerOverrides }
           );
           consolidatedPerLevel[level] = consolidated;
           // Report intra-level consolidation step as completed
@@ -3661,7 +3670,7 @@ File-level suggestions should NOT have a line number. They apply to the entire f
    * @private
    */
   async _executeCouncilVoice(task, context) {
-    const { voiceId, reviewerLabel, reviewerLogPrefix, level, provider, model, tier, timeout = 600000, customInstructions } = task;
+    const { voiceId, reviewerLabel, reviewerLogPrefix, level, provider, model, tier, timeout = 600000, customInstructions, providerOverrides } = task;
     const { reviewId, runId, worktreePath, prMetadata, generatedPatterns, validFiles, analysisId, progressCallback } = context;
     const displayLabel = reviewerLabel || voiceId;
 
@@ -3672,7 +3681,7 @@ File-level suggestions should NOT have a line number. They apply to the entire f
     }
 
     // Create provider instance for this voice
-    const aiProvider = createProvider(provider, model);
+    const aiProvider = createProvider(provider, model, providerOverrides || {});
 
     // Build prompt based on level
     let prompt;
@@ -3748,9 +3757,9 @@ File-level suggestions should NOT have a line number. They apply to the entire f
    * @private
    */
   async _intraLevelConsolidate(level, voiceGroups, prMetadata, customInstructions, worktreePath, orchConfig) {
-    const { provider, model, tier, timeout, analysisId, progressCallback, reviewerCount } = orchConfig;
+    const { provider, model, tier, timeout, analysisId, progressCallback, reviewerCount, providerOverrides } = orchConfig;
 
-    const aiProvider = createProvider(provider, model);
+    const aiProvider = createProvider(provider, model, providerOverrides || {});
 
     const isLocal = prMetadata.reviewType === 'local';
     const reviewDescription = isLocal
@@ -3916,9 +3925,9 @@ File-level suggestions should NOT have a line number. They apply to the entire f
    * @private
    */
   async _crossVoiceConsolidate(voiceReviews, prMetadata, customInstructions, worktreePath, config) {
-    const { provider, model, tier, timeout, analysisId, progressCallback, excludePrevious, dedupContext } = config;
+    const { provider, model, tier, timeout, analysisId, progressCallback, excludePrevious, dedupContext, providerOverrides } = config;
 
-    const aiProvider = createProvider(provider, model);
+    const aiProvider = createProvider(provider, model, providerOverrides || {});
 
     const voiceDescriptions = voiceReviews.map(v => {
       let desc = `### Reviewer: ${v.voiceKey}`;

--- a/src/ai/provider.js
+++ b/src/ai/provider.js
@@ -671,10 +671,11 @@ function getAllProvidersInfo() {
  * Create a provider instance
  * @param {string} providerId - Provider ID (e.g., 'claude', 'gemini')
  * @param {string} model - Model to use (optional, uses default if not specified)
+ * @param {Object} overrides - Per-call config overrides that supersede global providerConfigOverrides (optional)
  * @returns {AIProvider}
  * @throws {Error} If provider is not registered
  */
-function createProvider(providerId, model = null) {
+function createProvider(providerId, model = null, overrides = {}) {
   const ProviderClass = providerRegistry.get(providerId);
 
   if (!ProviderClass) {
@@ -683,7 +684,7 @@ function createProvider(providerId, model = null) {
   }
 
   // Get config overrides for this provider
-  const overrides = providerConfigOverrides.get(providerId);
+  const configOverrides = providerConfigOverrides.get(providerId);
 
   // Determine the actual model to use
   let actualModel = model;
@@ -691,8 +692,8 @@ function createProvider(providerId, model = null) {
     // Resolve default from merged models (config + built-in).
     // Checks both sources because some providers (e.g., Pi) define built-in
     // modes with default:true that aren't in config overrides.
-    if (overrides?.models || ProviderClass.getModels().length > 0) {
-      actualModel = resolveDefaultModel(mergeModels(ProviderClass.getModels(), overrides?.models));
+    if (configOverrides?.models || ProviderClass.getModels().length > 0) {
+      actualModel = resolveDefaultModel(mergeModels(ProviderClass.getModels(), configOverrides?.models));
     }
     // Fall back to provider's built-in default
     if (!actualModel) {
@@ -700,8 +701,8 @@ function createProvider(providerId, model = null) {
     }
   }
 
-  // Create provider instance with config overrides
-  return new ProviderClass(actualModel, { ...(overrides || {}), yolo: yoloMode });
+  // Create provider instance with config overrides, per-call overrides, and yolo mode
+  return new ProviderClass(actualModel, { ...(configOverrides || {}), ...overrides, yolo: yoloMode });
 }
 
 /**

--- a/src/chat/session-manager.js
+++ b/src/chat/session-manager.js
@@ -43,7 +43,7 @@ class ChatSessionManager {
    * @param {string} [options.initialContext] - Initial context to prepend to the first user message
    * @returns {Promise<{id: number, status: string}>}
    */
-  async createSession({ provider, model, reviewId, contextCommentId, systemPrompt, cwd, initialContext }) {
+  async createSession({ provider, model, reviewId, contextCommentId, systemPrompt, cwd, initialContext, loadSkills }) {
     // Resolve provider definition once — used for model fallback and bridge construction
     const providerDef = getChatProvider(provider);
 
@@ -72,6 +72,7 @@ class ChatSessionManager {
       model: resolvedModel,
       cwd,
       systemPrompt,
+      loadSkills,
     }, providerDef);
 
     const listeners = {
@@ -413,9 +414,10 @@ class ChatSessionManager {
    * @param {Object} options
    * @param {string} [options.systemPrompt] - System prompt text
    * @param {string} [options.cwd] - Working directory for agent
+   * @param {boolean} [options.loadSkills] - Resolved load_skills override for the session
    * @returns {Promise<{id: number, status: string}>}
    */
-  async resumeSession(sessionId, { systemPrompt, cwd } = {}) {
+  async resumeSession(sessionId, { systemPrompt, cwd, loadSkills } = {}) {
     // Already active — return immediately
     if (this._sessions.has(sessionId)) {
       return { id: sessionId, status: 'active' };
@@ -459,6 +461,7 @@ class ChatSessionManager {
       model: row.model,
       cwd,
       systemPrompt,
+      loadSkills,
       ...resumeOptions,
     });
 
@@ -588,7 +591,7 @@ class ChatSessionManager {
       useShell: def?.useShell,
       tools: CHAT_TOOLS,
       extensions: appExtensions ? [taskExtensionDir] : [],
-      loadSkills: def?.load_skills,
+      loadSkills: options.loadSkills ?? def?.load_skills,
     });
   }
 

--- a/src/config.js
+++ b/src/config.js
@@ -544,6 +544,74 @@ function getRepoPoolFetchInterval(config, repository) {
 }
 
 /**
+ * Gets the configured load_skills setting for a repository from file config.
+ * @param {Object} config - Configuration object from loadConfig()
+ * @param {string} repository - Repository in "owner/repo" format
+ * @returns {boolean|null} - true/false if set, null if not configured
+ */
+function getRepoLoadSkills(config, repository) {
+  const repoConfig = getRepoConfig(config, repository);
+  const val = repoConfig?.load_skills;
+  return typeof val === 'boolean' ? val : null;
+}
+
+/**
+ * Resolves the load_skills setting for a repository, checking DB repo_settings first,
+ * then repo JSON config, then provider config. Returns a boolean suitable for passing
+ * directly to provider constructors (which check `!== false`).
+ *
+ * @param {Object} config - Configuration object from loadConfig()
+ * @param {string} repository - Repository in "owner/repo" format
+ * @param {Object|null} repoSettings - DB repo_settings row (from RepoSettingsRepository.getRepoSettings)
+ * @param {boolean} [providerLoadSkills] - Provider-level load_skills from config.providers
+ * @returns {boolean} - Resolved load_skills value
+ */
+function resolveLoadSkills(config, repository, repoSettings, providerLoadSkills) {
+  // Tier 1: DB repo settings (1 = true, 0 = false, null = not set)
+  const dbVal = repoSettings?.load_skills;
+  if (typeof dbVal === 'number' && (dbVal === 0 || dbVal === 1)) {
+    return dbVal === 1;
+  }
+
+  // Tier 2: Repo JSON config (config.repos["owner/repo"].load_skills)
+  const repoVal = getRepoLoadSkills(config, repository);
+  if (repoVal !== null) {
+    return repoVal;
+  }
+
+  // Tier 3: Provider-level config
+  if (typeof providerLoadSkills === 'boolean') {
+    return providerLoadSkills;
+  }
+
+  // Tier 4: Default
+  return true;
+}
+
+/**
+ * Builds council-mode provider overrides: a shared (tier 1+2) base and a per-provider
+ * map that includes tier 3 resolution for each configured provider.
+ *
+ * @param {Object} config - Configuration object from loadConfig()
+ * @param {string} repository - Repository in "owner/repo" format
+ * @param {Object|null} repoSettings - DB repo_settings row
+ * @returns {{ providerOverrides: Object, providerOverridesMap: Object }}
+ */
+function buildCouncilProviderOverrides(config, repository, repoSettings) {
+  const baseLoadSkills = resolveLoadSkills(config, repository, repoSettings);
+  const providerOverrides = { load_skills: baseLoadSkills };
+  const providerOverridesMap = {};
+  if (config.providers) {
+    for (const [pid, pconf] of Object.entries(config.providers)) {
+      providerOverridesMap[pid] = {
+        load_skills: resolveLoadSkills(config, repository, repoSettings, pconf?.load_skills)
+      };
+    }
+  }
+  return { providerOverrides, providerOverridesMap };
+}
+
+/**
  * Resolves pool configuration for a repository, checking DB repo_settings first,
  * then falling back to file config. DB values take precedence when set (non-null).
  * @param {Object} config - Configuration object from loadConfig()
@@ -684,7 +752,10 @@ module.exports = {
   getRepoResetScript,
   getRepoPoolSize,
   getRepoPoolFetchInterval,
+  getRepoLoadSkills,
   resolvePoolConfig,
+  resolveLoadSkills,
+  buildCouncilProviderOverrides,
   resolveDbName,
   warnIfDevModeWithoutDbName,
   shouldSkipUpdateNotifier,

--- a/src/database.js
+++ b/src/database.js
@@ -20,7 +20,7 @@ function getDbPath() {
 /**
  * Current schema version - increment this when adding new migrations
  */
-const CURRENT_SCHEMA_VERSION = 42;
+const CURRENT_SCHEMA_VERSION = 43;
 
 /**
  * Database schema SQL statements
@@ -155,6 +155,7 @@ const SCHEMA_SQL = {
       pool_fetch_interval_minutes INTEGER,
       pool_fetch_started_at TEXT,
       pool_fetch_finished_at TEXT,
+      load_skills INTEGER,
       created_at TEXT DEFAULT CURRENT_TIMESTAMP,
       updated_at TEXT DEFAULT CURRENT_TIMESTAMP
     )
@@ -1830,6 +1831,20 @@ const MIGRATIONS = {
     } finally {
       db.pragma('foreign_keys = ON');
     }
+  },
+
+  43: (db) => {
+    console.log('Running migration to schema version 43: Add load_skills to repo_settings...');
+    const addColumnIfNotExists = (table, column, definition) => {
+      const tableInfo = db.prepare(`PRAGMA table_info(${table})`).all();
+      const columnExists = tableInfo.some(col => col.name === column);
+      if (!columnExists) {
+        db.prepare(`ALTER TABLE ${table} ADD COLUMN ${column} ${definition}`).run();
+        console.log(`  Added column ${column} to ${table}`);
+      }
+    };
+    addColumnIfNotExists('repo_settings', 'load_skills', 'INTEGER');
+    console.log('Migration to schema version 43 complete');
   }
 };
 
@@ -2765,7 +2780,7 @@ class RepoSettingsRepository {
    */
   async getRepoSettings(repository) {
     const row = await queryOne(this.db, `
-      SELECT id, repository, default_instructions, default_provider, default_model, default_council_id, default_tab, default_chat_instructions, local_path, auto_branch_review, pool_size, pool_fetch_interval_minutes, created_at, updated_at
+      SELECT id, repository, default_instructions, default_provider, default_model, default_council_id, default_tab, default_chat_instructions, local_path, auto_branch_review, pool_size, pool_fetch_interval_minutes, load_skills, created_at, updated_at
       FROM repo_settings
       WHERE repository = ?
     `, [repository]);
@@ -2822,7 +2837,7 @@ class RepoSettingsRepository {
    * @returns {Promise<Object>} Saved settings object
    */
   async saveRepoSettings(repository, settings) {
-    const { default_instructions, default_provider, default_model, default_council_id, default_tab, default_chat_instructions, local_path, pool_size, pool_fetch_interval_minutes } = settings;
+    const { default_instructions, default_provider, default_model, default_council_id, default_tab, default_chat_instructions, local_path, pool_size, pool_fetch_interval_minutes, load_skills } = settings;
     const now = new Date().toISOString();
 
     // Check if settings already exist
@@ -2841,6 +2856,7 @@ class RepoSettingsRepository {
             local_path = ?,
             pool_size = ?,
             pool_fetch_interval_minutes = ?,
+            load_skills = ?,
             updated_at = ?
         WHERE repository = ?
       `, [
@@ -2853,6 +2869,7 @@ class RepoSettingsRepository {
         local_path !== undefined ? local_path : existing.local_path,
         pool_size !== undefined ? pool_size : existing.pool_size,
         pool_fetch_interval_minutes !== undefined ? pool_fetch_interval_minutes : existing.pool_fetch_interval_minutes,
+        load_skills !== undefined ? load_skills : existing.load_skills,
         now,
         repository
       ]);
@@ -2868,14 +2885,15 @@ class RepoSettingsRepository {
         local_path: local_path !== undefined ? local_path : existing.local_path,
         pool_size: pool_size !== undefined ? pool_size : existing.pool_size,
         pool_fetch_interval_minutes: pool_fetch_interval_minutes !== undefined ? pool_fetch_interval_minutes : existing.pool_fetch_interval_minutes,
+        load_skills: load_skills !== undefined ? load_skills : existing.load_skills,
         updated_at: now
       };
     } else {
       // Insert new settings
       const result = await run(this.db, `
-        INSERT INTO repo_settings (repository, default_instructions, default_provider, default_model, default_council_id, default_tab, default_chat_instructions, local_path, pool_size, pool_fetch_interval_minutes, created_at, updated_at)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-      `, [repository, default_instructions || null, default_provider || null, default_model || null, default_council_id || null, default_tab || null, default_chat_instructions || null, local_path || null, pool_size ?? null, pool_fetch_interval_minutes ?? null, now, now]);
+        INSERT INTO repo_settings (repository, default_instructions, default_provider, default_model, default_council_id, default_tab, default_chat_instructions, local_path, pool_size, pool_fetch_interval_minutes, load_skills, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `, [repository, default_instructions || null, default_provider || null, default_model || null, default_council_id || null, default_tab || null, default_chat_instructions || null, local_path || null, pool_size ?? null, pool_fetch_interval_minutes ?? null, load_skills ?? null, now, now]);
 
       return {
         id: result.lastID,
@@ -2889,6 +2907,7 @@ class RepoSettingsRepository {
         local_path: local_path || null,
         pool_size: pool_size ?? null,
         pool_fetch_interval_minutes: pool_fetch_interval_minutes ?? null,
+        load_skills: load_skills ?? null,
         created_at: now,
         updated_at: now
       };

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,6 @@
 // Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
 const fs = require('fs');
-const { loadConfig, getConfigDir, getGitHubToken, showWelcomeMessage, resolveDbName, resolveRepoOptions, resolvePoolConfig, getRepoResetScript } = require('./config');
+const { loadConfig, getConfigDir, getGitHubToken, showWelcomeMessage, resolveDbName, resolveRepoOptions, resolvePoolConfig, getRepoResetScript, resolveLoadSkills } = require('./config');
 const { initializeDatabase, run, queryOne, query, migrateExistingWorktrees, WorktreeRepository, ReviewRepository, RepoSettingsRepository, GitHubReviewRepository, WorktreePoolRepository } = require('./database');
 const { PRArgumentParser } = require('./github/parser');
 const { GitHubClient } = require('./github/client');
@@ -879,8 +879,12 @@ async function performHeadlessReview(args, config, db, flags, options, externalP
 
     // Run AI analysis
     console.log('Running AI analysis (all 3 levels)...');
-    const model = flags.model || process.env.PAIR_REVIEW_MODEL || 'opus';
-    const analyzer = new Analyzer(db, model);
+    const cliProvider = repoSettings?.default_provider || config.default_provider || config.provider || 'claude';
+    const model = flags.model || process.env.PAIR_REVIEW_MODEL || repoSettings?.default_model || config.default_model || config.model || 'opus';
+    const providerLoadSkills = config.providers?.[cliProvider]?.load_skills;
+    const loadSkills = resolveLoadSkills(config, repository, repoSettings, providerLoadSkills);
+    const providerOverrides = { load_skills: loadSkills };
+    const analyzer = new Analyzer(db, model, cliProvider, providerOverrides);
 
     let analysisSummary = null;
     try {

--- a/src/routes/analyses.js
+++ b/src/routes/analyses.js
@@ -494,6 +494,8 @@ async function launchCouncilAnalysis(db, modeContext, councilConfig, councilId, 
     config: modeConfig,
     excludePrevious,
     serverPort,
+    providerOverrides = {},
+    providerOverridesMap = null,
     hookContext = {},
   } = modeContext;
 
@@ -585,7 +587,7 @@ async function launchCouncilAnalysis(db, modeContext, councilConfig, councilId, 
       }).catch(err => { logger.warn(`Analysis hook failed: ${err.message}`); });
     }
 
-    const analyzer = new Analyzer(db, 'council', 'council');
+    const analyzer = new Analyzer(db, 'council', 'council', providerOverrides, providerOverridesMap);
 
     logger.section(`Council Analysis Request (${configType}) - ${logLabel}`);
     logger.log('API', `Repository: ${repository}`, 'magenta');

--- a/src/routes/chat.js
+++ b/src/routes/chat.js
@@ -21,6 +21,7 @@ const ws = require('../ws');
 const { fireHooks, hasHooks } = require('../hooks/hook-runner');
 const { buildChatStartedPayload, buildChatResumedPayload, buildChatHookContext, getCachedUser } = require('../hooks/payloads');
 const { resolveFormat } = require('../utils/comment-formatter');
+const { resolveLoadSkills } = require('../config');
 
 /**
  * Fire a chat hook event (non-blocking). Skips async work when no hooks are configured.
@@ -227,6 +228,22 @@ async function getChatInstructions(db, review) {
 }
 
 /**
+ * Resolve load_skills for a chat session based on repo settings and config.
+ * @param {Object} db - Database instance
+ * @param {Object} review - Review record
+ * @param {Object} config - App config
+ * @param {string} provider - Chat provider ID (e.g. 'pi')
+ * @returns {Promise<boolean|undefined>} Resolved load_skills, or undefined if no repo override
+ */
+async function getRepoLoadSkillsForChat(db, review, config, provider) {
+  if (!review || !review.repository) return undefined;
+  const repoSettingsRepo = new RepoSettingsRepository(db);
+  const repoSettings = await repoSettingsRepo.getRepoSettings(review.repository);
+  const providerLoadSkills = config.chat_providers?.[provider]?.load_skills;
+  return resolveLoadSkills(config, review.repository, repoSettings, providerLoadSkills);
+}
+
+/**
  * Create a new chat session
  */
 router.post('/api/chat/session', async (req, res) => {
@@ -316,6 +333,10 @@ router.post('/api/chat/session', async (req, res) => {
       ? sessionPreamble + '\n\n' + initialContext
       : sessionPreamble;
 
+    // Resolve load_skills from repo settings, falling back to provider config
+    const loadSkillsConfig = req.app.get('config') || {};
+    const loadSkills = await getRepoLoadSkillsForChat(db, review, loadSkillsConfig, provider);
+
     const session = await chatSessionManager.createSession({
       provider,
       model,
@@ -323,7 +344,8 @@ router.post('/api/chat/session', async (req, res) => {
       contextCommentId: contextCommentId || null,
       systemPrompt: finalSystemPrompt,
       cwd: resolvedCwd,
-      initialContext: initialContextWithPort
+      initialContext: initialContextWithPort,
+      loadSkills
     });
 
     logger.info(`Chat session created: ${session.id} (provider=${provider})`);
@@ -398,9 +420,10 @@ router.post('/api/chat/session/:id/message', async (req, res) => {
 
       const systemPrompt = buildChatPrompt({ review, prData, chatInstructions, commentFormatTemplate: fmtConfig.template });
       const cwd = await resolveReviewCwd(db, review);
+      const loadSkills = await getRepoLoadSkillsForChat(db, review, config, session.provider);
 
       try {
-        await chatSessionManager.resumeSession(sessionId, { systemPrompt, cwd });
+        await chatSessionManager.resumeSession(sessionId, { systemPrompt, cwd, loadSkills });
         unregisterChatBroadcast(sessionId);
         registerChatBroadcast(chatSessionManager, sessionId, req.socket.localPort);
         logger.info(`[ChatRoute] Auto-resumed session ${sessionId} for message delivery`);
@@ -540,8 +563,9 @@ router.post('/api/chat/session/:id/resume', async (req, res) => {
 
     const systemPrompt = buildChatPrompt({ review, prData, chatInstructions, commentFormatTemplate: fmtConfig.template });
     const cwd = await resolveReviewCwd(db, review);
+    const loadSkills = await getRepoLoadSkillsForChat(db, review, config, session.provider);
 
-    await chatSessionManager.resumeSession(sessionId, { systemPrompt, cwd });
+    await chatSessionManager.resumeSession(sessionId, { systemPrompt, cwd, loadSkills });
     unregisterChatBroadcast(sessionId);
     const serverPort = req.socket.localPort;
     registerChatBroadcast(chatSessionManager, sessionId, serverPort);

--- a/src/routes/config.js
+++ b/src/routes/config.js
@@ -100,7 +100,8 @@ router.get('/api/repos/:owner/:repo/settings', async (req, res) => {
         default_tab: null,
         default_chat_instructions: null,
         pool_size: null,
-        pool_fetch_interval_minutes: null
+        pool_fetch_interval_minutes: null,
+        load_skills: null
       });
     }
 
@@ -115,6 +116,7 @@ router.get('/api/repos/:owner/:repo/settings', async (req, res) => {
       default_chat_instructions: settings.default_chat_instructions,
       pool_size: settings.pool_size ?? null,
       pool_fetch_interval_minutes: settings.pool_fetch_interval_minutes ?? null,
+      load_skills: settings.load_skills ?? null,
       created_at: settings.created_at,
       updated_at: settings.updated_at
     });
@@ -134,12 +136,12 @@ router.get('/api/repos/:owner/:repo/settings', async (req, res) => {
 router.post('/api/repos/:owner/:repo/settings', async (req, res) => {
   try {
     const { owner, repo } = req.params;
-    const { default_instructions, default_provider, default_model, local_path, default_council_id, default_tab, default_chat_instructions, pool_size, pool_fetch_interval_minutes } = req.body;
+    const { default_instructions, default_provider, default_model, local_path, default_council_id, default_tab, default_chat_instructions, pool_size, pool_fetch_interval_minutes, load_skills } = req.body;
     const repository = normalizeRepository(owner, repo);
     const db = req.app.get('db');
 
     // Validate that at least one setting is provided
-    if (default_instructions === undefined && default_provider === undefined && default_model === undefined && local_path === undefined && default_council_id === undefined && default_tab === undefined && default_chat_instructions === undefined && pool_size === undefined && pool_fetch_interval_minutes === undefined) {
+    if (default_instructions === undefined && default_provider === undefined && default_model === undefined && local_path === undefined && default_council_id === undefined && default_tab === undefined && default_chat_instructions === undefined && pool_size === undefined && pool_fetch_interval_minutes === undefined && load_skills === undefined) {
       return res.status(400).json({
         error: 'At least one setting must be provided'
       });
@@ -155,7 +157,8 @@ router.post('/api/repos/:owner/:repo/settings', async (req, res) => {
       default_tab,
       default_chat_instructions,
       pool_size,
-      pool_fetch_interval_minutes
+      pool_fetch_interval_minutes,
+      load_skills
     });
 
     logger.info(`Saved repo settings for ${repository}`);
@@ -173,6 +176,7 @@ router.post('/api/repos/:owner/:repo/settings', async (req, res) => {
         default_chat_instructions: settings.default_chat_instructions,
         pool_size: settings.pool_size ?? null,
         pool_fetch_interval_minutes: settings.pool_fetch_interval_minutes ?? null,
+        load_skills: settings.load_skills ?? null,
         updated_at: settings.updated_at
       }
     });

--- a/src/routes/executable-analysis.js
+++ b/src/routes/executable-analysis.js
@@ -234,7 +234,8 @@ async function runExecutableAnalysis(req, res, params, shared, callbacks) {
     reviewId, review, selectedProvider, selectedModel,
     repoInstructions, requestInstructions,
     runId, analysisId, repository, reviewType, headSha,
-    extraInitialStatus
+    extraInitialStatus,
+    providerOverrides = {}
   } = params;
 
   const {
@@ -332,7 +333,7 @@ async function runExecutableAnalysis(req, res, params, shared, callbacks) {
   (async () => {
     const tmpDir = await fsPromises.mkdtemp(path.join(os.tmpdir(), 'pair-review-exec-'));
     try {
-      const provider = createProvider(selectedProvider, selectedModel);
+      const provider = createProvider(selectedProvider, selectedModel, providerOverrides);
 
       const executableContext = {
         ...buildContext(review, { selectedModel, requestInstructions }),

--- a/src/routes/local.js
+++ b/src/routes/local.js
@@ -24,7 +24,7 @@ const { broadcastReviewEvent } = require('../events/review-events');
 const { fireHooks, hasHooks } = require('../hooks/hook-runner');
 const { buildReviewStartedPayload, buildReviewLoadedPayload, buildAnalysisStartedPayload, buildAnalysisCompletedPayload, getCachedUser } = require('../hooks/payloads');
 const { mergeInstructions } = require('../utils/instructions');
-const { getGitHubToken } = require('../config');
+const { getGitHubToken, resolveLoadSkills, buildCouncilProviderOverrides } = require('../config');
 const { generateScopedDiff, computeScopedDigest, getBranchCommitCount, getFirstCommitSubject, detectAndBuildBranchInfo, findMergeBase, getCurrentBranch, getRepositoryName } = require('../local-review');
 const { STOPS, isValidScope, normalizeScope, reviewScope, includesBranch, DEFAULT_SCOPE } = require('../local-scope');
 const { getGeneratedFilePatterns } = require('../git/gitattributes');
@@ -1023,7 +1023,8 @@ router.get('/api/local/:reviewId/check-stale', async (req, res) => {
  */
 async function handleExecutableAnalysis(req, res, {
   reviewId, review, localPath, repository, selectedProvider, selectedModel,
-  repoInstructions, requestInstructions, combinedInstructions, runId, analysisId, reviewRepo
+  repoInstructions, requestInstructions, combinedInstructions, runId, analysisId, reviewRepo,
+  providerOverrides
 }) {
   return runExecutableAnalysis(req, res, {
     reviewId,
@@ -1036,7 +1037,8 @@ async function handleExecutableAnalysis(req, res, {
     analysisId,
     repository,
     reviewType: review.review_type || 'local',
-    headSha: review.local_head_sha
+    headSha: review.local_head_sha,
+    providerOverrides
   }, {
     activeAnalyses,
     reviewToAnalysisId,
@@ -1171,6 +1173,11 @@ router.post('/api/local/:reviewId/analyses', async (req, res) => {
     const runId = uuidv4();
     const analysisId = runId;
 
+    // Resolve load_skills across all config tiers
+    const providerLoadSkills = appConfig.providers?.[selectedProvider]?.load_skills;
+    const loadSkills = resolveLoadSkills(appConfig, repository, repoSettings, providerLoadSkills);
+    const providerOverrides = { load_skills: loadSkills };
+
     // Check if selected provider is an executable provider (external tool)
     const ProviderClass = getProviderClass(selectedProvider);
     if (ProviderClass?.isExecutable) {
@@ -1186,7 +1193,8 @@ router.post('/api/local/:reviewId/analyses', async (req, res) => {
         combinedInstructions,
         runId,
         analysisId,
-        reviewRepo
+        reviewRepo,
+        providerOverrides
       });
     }
 
@@ -1258,7 +1266,7 @@ router.post('/api/local/:reviewId/analyses', async (req, res) => {
     }
 
     // Create analyzer instance with provider and model
-    const analyzer = new Analyzer(db, selectedModel, selectedProvider);
+    const analyzer = new Analyzer(db, selectedModel, selectedProvider, providerOverrides);
 
     // Build local review metadata for the analyzer
     // The analyzer uses base_sha and head_sha for git diff commands
@@ -2051,7 +2059,6 @@ router.post('/api/local/:reviewId/analyses/council', async (req, res) => {
       scopeEnd: councilScopeEnd,
     };
 
-    const analyzer = new Analyzer(db, 'council', 'council');
     // Use the scope-aware helper so the file list matches the generated diff
     // (covers branch, staged, unstaged, and untracked stops as appropriate).
     const changedFiles = await getChangedFiles(localPath, {
@@ -2085,6 +2092,10 @@ router.post('/api/local/:reviewId/analyses/council', async (req, res) => {
     // Import launchCouncilAnalysis from analyses.js
     const analysesRouter = require('./analyses');
     const localCouncilConfig = req.app.get('config') || {};
+
+    const { providerOverrides: councilProviderOverrides, providerOverridesMap: councilProviderOverridesMap } =
+      buildCouncilProviderOverrides(localCouncilConfig, review.repository, repoSettings);
+
     const { analysisId, runId } = await analysesRouter.launchCouncilAnalysis(
       db,
       {
@@ -2099,6 +2110,8 @@ router.post('/api/local/:reviewId/analyses/council', async (req, res) => {
         config: localCouncilConfig,
         excludePrevious,
         serverPort: req.socket.localPort,
+        providerOverrides: councilProviderOverrides,
+        providerOverridesMap: councilProviderOverridesMap,
         hookContext: {
           mode: 'local',
           localContext: { path: localPath, branch: review.local_head_branch, headSha: review.local_head_sha },

--- a/src/routes/mcp.js
+++ b/src/routes/mcp.js
@@ -23,6 +23,7 @@ const {
   createProgressCallback
 } = require('./shared');
 const { safeParseJson } = require('../utils/safe-parse-json');
+const { resolveLoadSkills } = require('../config');
 
 // All valid tier values: canonical tiers + aliases (for Zod enum validation)
 const ALL_TIER_VALUES = /** @type {[string, ...string[]]} */ ([...TIERS, ...Object.keys(TIER_ALIASES)]);
@@ -595,8 +596,13 @@ function createMCPServer(db, options = {}) {
           broadcastProgress(analysisId, initialStatus);
           broadcastReviewEvent(reviewId, { type: 'review:analysis_started', analysisId });
 
+          // Resolve load_skills across all config tiers
+          const providerLoadSkills = config.providers?.[provider]?.load_skills;
+          const loadSkills = resolveLoadSkills(config, repository, repoSettings, providerLoadSkills);
+          const providerOverrides = { load_skills: loadSkills };
+
           // Create analyzer and launch asynchronously
-          const analyzer = new Analyzer(db, model, provider);
+          const analyzer = new Analyzer(db, model, provider, providerOverrides);
           const localMetadata = {
             id: reviewId,
             repository: review.repository,
@@ -747,7 +753,12 @@ function createMCPServer(db, options = {}) {
           broadcastProgress(analysisId, initialStatus);
           broadcastReviewEvent(review.id, { type: 'review:analysis_started', analysisId });
 
-          const analyzer = new Analyzer(db, model, provider);
+          // Resolve load_skills across all config tiers
+          const prProviderLoadSkills = config.providers?.[provider]?.load_skills;
+          const prLoadSkills = resolveLoadSkills(config, repository, repoSettings, prProviderLoadSkills);
+          const prProviderOverrides = { load_skills: prLoadSkills };
+
+          const analyzer = new Analyzer(db, model, provider, prProviderOverrides);
           const progressCallback = createProgressCallback(analysisId);
           const tier = resolveTier(args.tier);
 

--- a/src/routes/pr.js
+++ b/src/routes/pr.js
@@ -25,7 +25,7 @@ const Analyzer = require('../ai/analyzer');
 const { v4: uuidv4 } = require('uuid');
 const fs = require('fs').promises;
 const path = require('path');
-const { getGitHubToken, getWorktreeDisplayName } = require('../config');
+const { getGitHubToken, getWorktreeDisplayName, resolveLoadSkills, buildCouncilProviderOverrides } = require('../config');
 const logger = require('../utils/logger');
 const { buildDiffLineSet } = require('../utils/diff-annotator');
 const { broadcastReviewEvent } = require('../events/review-events');
@@ -1518,7 +1518,7 @@ router.post('/api/parse-pr-url', (req, res) => {
 async function handleExecutablePRAnalysis(req, res, {
   reviewId, review, prNumber, owner, repo, repository, worktreePath, prMetadata,
   selectedProvider, selectedModel, repoInstructions, requestInstructions,
-  combinedInstructions, runId, analysisId, reviewRepo, poolLifecycle
+  combinedInstructions, runId, analysisId, reviewRepo, poolLifecycle, providerOverrides
 }) {
   const prContext = {
     number: prNumber, owner, repo,
@@ -1539,7 +1539,8 @@ async function handleExecutablePRAnalysis(req, res, {
     reviewType: 'pr',
     headSha: prMetadata.head_sha,
     extraInitialStatus: { prNumber },
-    poolLifecycle
+    poolLifecycle,
+    providerOverrides
   }, {
     activeAnalyses,
     reviewToAnalysisId,
@@ -1651,7 +1652,7 @@ router.post('/api/pr/:owner/:repo/:number/analyses', async (req, res) => {
     const appConfig = req.app.get('config') || {};
     const globalInstructions = appConfig.globalInstructions || null;
 
-    const { provider, model, repoInstructions, combinedInstructions } = await withTransaction(db, async () => {
+    const { provider, model, repoInstructions, combinedInstructions, repoSettings: fetchedRepoSettings } = await withTransaction(db, async () => {
       const repoSettingsRepo = new RepoSettingsRepository(db);
       const fetchedRepoSettings = await repoSettingsRepo.getRepoSettings(repository);
 
@@ -1684,7 +1685,8 @@ router.post('/api/pr/:owner/:repo/:number/analyses', async (req, res) => {
         provider: selectedProvider,
         model: selectedModel,
         repoInstructions: fetchedRepoInstructions,
-        combinedInstructions: mergedInstructions
+        combinedInstructions: mergedInstructions,
+        repoSettings: fetchedRepoSettings
       };
     });
 
@@ -1692,6 +1694,11 @@ router.post('/api/pr/:owner/:repo/:number/analyses', async (req, res) => {
     const analysisId = runId;
 
     const { review } = await reviewRepo.getOrCreate({ prNumber, repository });
+
+    // Resolve load_skills across all config tiers
+    const providerLoadSkills = appConfig.providers?.[provider]?.load_skills;
+    const loadSkills = resolveLoadSkills(appConfig, repository, fetchedRepoSettings, providerLoadSkills);
+    const providerOverrides = { load_skills: loadSkills };
 
     // Check if selected provider is an executable provider (external tool)
     const ProviderClass = getProviderClass(provider);
@@ -1713,7 +1720,8 @@ router.post('/api/pr/:owner/:repo/:number/analyses', async (req, res) => {
         runId,
         analysisId,
         reviewRepo,
-        poolLifecycle: req.app.get('poolLifecycle')
+        poolLifecycle: req.app.get('poolLifecycle'),
+        providerOverrides
       });
     }
 
@@ -1783,7 +1791,7 @@ router.post('/api/pr/:owner/:repo/:number/analyses', async (req, res) => {
         }).catch(() => {});
       }
 
-      const analyzer = new Analyzer(req.app.get('db'), model, provider);
+      const analyzer = new Analyzer(req.app.get('db'), model, provider, providerOverrides);
 
       logger.section(`AI Analysis Request - PR #${prNumber}`);
       logger.log('API', `Repository: ${repository}`, 'magenta');
@@ -2041,6 +2049,10 @@ router.post('/api/pr/:owner/:repo/:number/analyses/council', async (req, res) =>
     }
 
     const prCouncilConfig = req.app.get('config') || {};
+
+    const { providerOverrides: councilProviderOverrides, providerOverridesMap: councilProviderOverridesMap } =
+      buildCouncilProviderOverrides(prCouncilConfig, repository, repoSettings);
+
     const { analysisId, runId } = await analysesRouter.launchCouncilAnalysis(
       db,
       {
@@ -2056,6 +2068,8 @@ router.post('/api/pr/:owner/:repo/:number/analyses/council', async (req, res) =>
         excludePrevious,
         serverPort: req.socket.localPort,
         poolLifecycle: req.app.get('poolLifecycle'),
+        providerOverrides: councilProviderOverrides,
+        providerOverridesMap: councilProviderOverridesMap,
         hookContext: {
           mode: 'pr',
           prContext: {

--- a/src/routes/stack-analysis.js
+++ b/src/routes/stack-analysis.js
@@ -19,7 +19,7 @@ const { normalizeRepository } = require('../utils/paths');
 const { mergeInstructions } = require('../utils/instructions');
 const { GitWorktreeManager } = require('../git/worktree');
 const { GitHubClient } = require('../github/client');
-const { getGitHubToken } = require('../config');
+const { getGitHubToken, resolveLoadSkills, buildCouncilProviderOverrides } = require('../config');
 const { setupStackPR } = require('../setup/stack-setup');
 const Analyzer = require('../ai/analyzer');
 const { getProviderClass, createProvider } = require('../ai/provider');
@@ -374,14 +374,24 @@ async function analyzeStackPR(deps, db, config, {
   let analysisResult;
 
   if (configType === 'council' || configType === 'advanced' || isCouncil) {
+    const { providerOverrides: councilProviderOverrides, providerOverridesMap: councilProviderOverridesMap } =
+      buildCouncilProviderOverrides(config, repository, repoSettings);
+
     analysisResult = await launchStackCouncilAnalysis(deps, db, config, {
       reviewId, worktreePath, prMetadata, prNum, owner, repo, repository,
       globalInstructions, repoInstructions, requestInstructions,
-      councilId, rawCouncilConfig, configType, onAnalysisIdReady
+      councilId, rawCouncilConfig, configType, onAnalysisIdReady,
+      providerOverrides: councilProviderOverrides,
+      providerOverridesMap: councilProviderOverridesMap
     });
   } else {
     let selectedProvider = reqProvider || repoSettings?.default_provider || config.default_provider || config.provider || 'claude';
     let selectedModel = reqModel || repoSettings?.default_model || config.default_model || config.model || 'opus';
+
+    // Resolve load_skills across all config tiers
+    const providerLoadSkills = config.providers?.[selectedProvider]?.load_skills;
+    const loadSkills = resolveLoadSkills(config, repository, repoSettings, providerLoadSkills);
+    const providerOverrides = { load_skills: loadSkills };
 
     const ProviderClass = deps.getProviderClass(selectedProvider);
 
@@ -389,14 +399,16 @@ async function analyzeStackPR(deps, db, config, {
       analysisResult = await launchStackExecutableAnalysis(deps, db, config, {
         reviewId, worktreePath, prMetadata, prNum, owner, repo, repository,
         selectedProvider, selectedModel,
-        repoInstructions, requestInstructions, onAnalysisIdReady
+        repoInstructions, requestInstructions, onAnalysisIdReady,
+        providerOverrides
       });
     } else {
       analysisResult = await launchStackSingleAnalysis(deps, db, config, {
         reviewId, worktreePath, prMetadata, prNum, owner, repo, repository,
         selectedProvider, selectedModel,
         globalInstructions, repoInstructions, requestInstructions,
-        reqTier, reqEnabledLevels, onAnalysisIdReady
+        reqTier, reqEnabledLevels, onAnalysisIdReady,
+        providerOverrides
       });
     }
   }
@@ -415,7 +427,8 @@ async function launchStackSingleAnalysis(deps, db, config, {
   reviewId, worktreePath, prMetadata, prNum, owner, repo, repository,
   selectedProvider, selectedModel,
   globalInstructions, repoInstructions, requestInstructions,
-  reqTier, reqEnabledLevels, onAnalysisIdReady
+  reqTier, reqEnabledLevels, onAnalysisIdReady,
+  providerOverrides = {}
 }) {
   const runId = uuidv4();
   const analysisId = runId;
@@ -462,7 +475,7 @@ async function launchStackSingleAnalysis(deps, db, config, {
   broadcastProgress(analysisId, initialStatus);
   broadcastReviewEvent(reviewId, { type: 'review:analysis_started', analysisId });
 
-  const analyzer = new deps.Analyzer(db, selectedModel, selectedProvider);
+  const analyzer = new deps.Analyzer(db, selectedModel, selectedProvider, providerOverrides);
   const progressCallback = createProgressCallback(analysisId);
 
   logger.info(`Stack analysis: starting single-model analysis for PR #${prNum} (${selectedProvider}/${selectedModel})`);
@@ -538,7 +551,9 @@ async function launchStackSingleAnalysis(deps, db, config, {
 async function launchStackCouncilAnalysis(deps, db, config, {
   reviewId, worktreePath, prMetadata, prNum, owner, repo, repository,
   globalInstructions, repoInstructions, requestInstructions,
-  councilId, rawCouncilConfig, configType, onAnalysisIdReady
+  councilId, rawCouncilConfig, configType, onAnalysisIdReady,
+  providerOverrides = {},
+  providerOverridesMap = null
 }) {
   let councilConfig;
   let resolvedConfigType = configType;
@@ -580,6 +595,8 @@ async function launchStackCouncilAnalysis(deps, db, config, {
       logLabel: `Stack PR #${prNum}`,
       initialStatusExtra: { prNumber: prNum, reviewType: 'pr' },
       config,
+      providerOverrides,
+      providerOverridesMap,
       hookContext: {
         mode: 'pr',
         prContext: {
@@ -623,7 +640,8 @@ async function launchStackCouncilAnalysis(deps, db, config, {
 async function launchStackExecutableAnalysis(deps, db, config, {
   reviewId, worktreePath, prMetadata, prNum, owner, repo, repository,
   selectedProvider, selectedModel,
-  repoInstructions, requestInstructions, onAnalysisIdReady
+  repoInstructions, requestInstructions, onAnalysisIdReady,
+  providerOverrides = {}
 }) {
   const runId = uuidv4();
   const analysisId = runId;
@@ -671,7 +689,8 @@ async function launchStackExecutableAnalysis(deps, db, config, {
     repository,
     reviewType: 'pr',
     headSha: prMetadata.head_sha,
-    extraInitialStatus: { prNumber: prNum }
+    extraInitialStatus: { prNumber: prNum },
+    providerOverrides
   }, {
     activeAnalyses,
     reviewToAnalysisId,

--- a/tests/integration/routes.test.js
+++ b/tests/integration/routes.test.js
@@ -3302,6 +3302,12 @@ describe('Repository Settings Endpoints', () => {
       expect(response.body.default_model).toBeNull();
     });
 
+    it('should return load_skills: null by default', async () => {
+      const res = await request(app).get('/api/repos/owner/repo/settings');
+      expect(res.status).toBe(200);
+      expect(res.body.load_skills).toBe(null);
+    });
+
     it('should return existing settings', async () => {
       const repoSettingsRepo = new RepoSettingsRepository(db);
       await repoSettingsRepo.saveRepoSettings('owner/repo', {
@@ -3360,6 +3366,36 @@ describe('Repository Settings Endpoints', () => {
 
       expect(response.status).toBe(200);
       expect(response.body.settings.default_instructions).toBe('Updated');
+    });
+
+    it('should save load_skills: 0 and GET retrieves it', async () => {
+      await request(app)
+        .post('/api/repos/owner/repo/settings')
+        .send({ load_skills: 0 });
+      const res = await request(app).get('/api/repos/owner/repo/settings');
+      expect(res.status).toBe(200);
+      expect(res.body.load_skills).toBe(0);
+    });
+
+    it('should save load_skills: 1', async () => {
+      await request(app)
+        .post('/api/repos/owner/repo/settings')
+        .send({ load_skills: 1 });
+      const res = await request(app).get('/api/repos/owner/repo/settings');
+      expect(res.status).toBe(200);
+      expect(res.body.load_skills).toBe(1);
+    });
+
+    it('should reset load_skills to null', async () => {
+      await request(app)
+        .post('/api/repos/owner/repo/settings')
+        .send({ load_skills: 1 });
+      await request(app)
+        .post('/api/repos/owner/repo/settings')
+        .send({ load_skills: null });
+      const res = await request(app).get('/api/repos/owner/repo/settings');
+      expect(res.status).toBe(200);
+      expect(res.body.load_skills).toBe(null);
     });
   });
 });
@@ -6172,6 +6208,55 @@ describe('Worktree Tiered Discovery', () => {
 
       const settings = await repoSettingsRepo.getRepoSettings('owner/repo');
       expect(settings.local_path).toBeNull();
+    });
+  });
+
+  describe('RepoSettingsRepository load_skills round-trip', () => {
+    it('saveRepoSettings preserves load_skills: 0', async () => {
+      const repoSettingsRepo = new RepoSettingsRepository(db);
+
+      await repoSettingsRepo.saveRepoSettings('owner/repo', { load_skills: 0 });
+
+      const settings = await repoSettingsRepo.getRepoSettings('owner/repo');
+      expect(settings.load_skills).toBe(0);
+    });
+
+    it('saveRepoSettings preserves load_skills: 1', async () => {
+      const repoSettingsRepo = new RepoSettingsRepository(db);
+
+      await repoSettingsRepo.saveRepoSettings('owner/repo', { load_skills: 1 });
+
+      const settings = await repoSettingsRepo.getRepoSettings('owner/repo');
+      expect(settings.load_skills).toBe(1);
+    });
+
+    it('saveRepoSettings defaults load_skills to null', async () => {
+      const repoSettingsRepo = new RepoSettingsRepository(db);
+
+      await repoSettingsRepo.saveRepoSettings('owner/repo', { default_instructions: 'test' });
+
+      const settings = await repoSettingsRepo.getRepoSettings('owner/repo');
+      expect(settings.load_skills).toBeNull();
+    });
+
+    it('saveRepoSettings can update load_skills on existing row', async () => {
+      const repoSettingsRepo = new RepoSettingsRepository(db);
+
+      await repoSettingsRepo.saveRepoSettings('owner/repo', { load_skills: 1 });
+      await repoSettingsRepo.saveRepoSettings('owner/repo', { load_skills: 0 });
+
+      const settings = await repoSettingsRepo.getRepoSettings('owner/repo');
+      expect(settings.load_skills).toBe(0);
+    });
+
+    it('saveRepoSettings can reset load_skills to null', async () => {
+      const repoSettingsRepo = new RepoSettingsRepository(db);
+
+      await repoSettingsRepo.saveRepoSettings('owner/repo', { load_skills: 1 });
+      await repoSettingsRepo.saveRepoSettings('owner/repo', { load_skills: null });
+
+      const settings = await repoSettingsRepo.getRepoSettings('owner/repo');
+      expect(settings.load_skills).toBeNull();
     });
   });
 

--- a/tests/unit/analyzer-consolidation.test.js
+++ b/tests/unit/analyzer-consolidation.test.js
@@ -472,3 +472,83 @@ describe('Consolidation helper methods (direct tests)', () => {
     });
   });
 });
+
+describe('Per-voice provider overrides (providerOverridesMap)', () => {
+  describe('Analyzer constructor stores providerOverridesMap', () => {
+    it('should store providerOverridesMap when provided', () => {
+      const map = { pi: { load_skills: false }, gemini: { timeout: 300000 } };
+      const a = new Analyzer({}, 'council', 'council', { load_skills: true }, map);
+      expect(a.providerOverridesMap).toBe(map);
+    });
+
+    it('should default providerOverridesMap to null when not provided', () => {
+      const a = new Analyzer({}, 'council', 'council', { load_skills: true });
+      expect(a.providerOverridesMap).toBeNull();
+    });
+
+    it('should store providerOverrides alongside providerOverridesMap', () => {
+      const shared = { load_skills: true };
+      const map = { pi: { load_skills: false } };
+      const a = new Analyzer({}, 'council', 'council', shared, map);
+      expect(a.providerOverrides).toBe(shared);
+      expect(a.providerOverridesMap).toBe(map);
+    });
+  });
+
+  describe('buildVoiceContext per-voice override logic (source verification)', () => {
+    /**
+     * Extract the body of buildVoiceContext for focused assertions.
+     */
+    const methodMatch = analyzerSource.match(
+      /function buildVoiceContext\(voice, idx, instructions, progressCallback, db, providerOverrides = \{\}, providerOverridesMap = null\)\s*\{([\s\S]*?)\nfunction /
+    );
+    // Fallback: match up to the next top-level function or class
+    const methodBody = methodMatch ? methodMatch[1] : '';
+
+    it('should extract the buildVoiceContext function body', () => {
+      expect(methodBody.length).toBeGreaterThan(50);
+    });
+
+    it('should accept providerOverridesMap as the 7th parameter', () => {
+      expect(analyzerSource).toContain(
+        'function buildVoiceContext(voice, idx, instructions, progressCallback, db, providerOverrides = {}, providerOverridesMap = null)'
+      );
+    });
+
+    it('should resolve effectiveOverrides from providerOverridesMap by voice.provider, falling back to shared providerOverrides', () => {
+      expect(methodBody).toContain("providerOverridesMap?.[voice.provider] || providerOverrides");
+    });
+
+    it('should pass effectiveOverrides (not providerOverrides) to new Analyzer for native voices', () => {
+      // The Analyzer constructor call for native voices should use effectiveOverrides
+      expect(methodBody).toMatch(/new Analyzer\(db, voice\.model, voice\.provider, effectiveOverrides\)/);
+    });
+
+    it('should pass effectiveOverrides (not providerOverrides) to createProvider for executable voices', () => {
+      expect(methodBody).toMatch(/createProvider\(voice\.provider, voice\.model, effectiveOverrides\)/);
+    });
+  });
+
+  describe('Council methods pass providerOverridesMap to buildVoiceContext (source verification)', () => {
+    it('runReviewerCentricCouncil single-voice path should pass this.providerOverridesMap', () => {
+      // Line ~2940: buildVoiceContext(voice, 0, instructions, progressCallback, this.db, this.providerOverrides, this.providerOverridesMap)
+      expect(analyzerSource).toContain(
+        'buildVoiceContext(voice, 0, instructions, progressCallback, this.db, this.providerOverrides, this.providerOverridesMap)'
+      );
+    });
+
+    it('runReviewerCentricCouncil multi-voice path should pass this.providerOverridesMap', () => {
+      // Line ~3042: buildVoiceContext(voice, idx, instructions, progressCallback, this.db, this.providerOverrides, this.providerOverridesMap)
+      expect(analyzerSource).toContain(
+        'buildVoiceContext(voice, idx, instructions, progressCallback, this.db, this.providerOverrides, this.providerOverridesMap)'
+      );
+    });
+
+    it('runCouncilAnalysis should use providerOverridesMap for per-voice overrides', () => {
+      // Line ~3418: providerOverrides: this.providerOverridesMap?.[voice.provider] || this.providerOverrides
+      expect(analyzerSource).toContain(
+        'providerOverrides: this.providerOverridesMap?.[voice.provider] || this.providerOverrides'
+      );
+    });
+  });
+});

--- a/tests/unit/chat/session-manager.test.js
+++ b/tests/unit/chat/session-manager.test.js
@@ -701,6 +701,57 @@ describe('ChatSessionManager', () => {
         try { fs.unlinkSync(sessionFilePath); } catch { /* ignore */ }
       }
     });
+
+    it('should pass loadSkills: false through to the bridge on resume', async () => {
+      const session = await manager.createSession({ provider: 'pi', reviewId: 1 });
+      const sessionFilePath = '/tmp/test-resume-load-skills.json';
+
+      const fs = require('fs');
+      fs.writeFileSync(sessionFilePath, '{}');
+
+      try {
+        db.prepare('UPDATE chat_sessions SET agent_session_id = ? WHERE id = ?')
+          .run(sessionFilePath, session.id);
+        await manager.closeSession(session.id);
+
+        await manager.resumeSession(session.id, {
+          systemPrompt: 'test',
+          cwd: '/tmp',
+          loadSkills: false
+        });
+
+        // The resumed bridge should have loadSkills: false, not undefined
+        const resumedBridge = _createdBridges[_createdBridges.length - 1];
+        expect(resumedBridge._constructorOptions.loadSkills).toBe(false);
+      } finally {
+        try { fs.unlinkSync(sessionFilePath); } catch { /* ignore */ }
+      }
+    });
+
+    it('should not set loadSkills when not provided on resume', async () => {
+      const session = await manager.createSession({ provider: 'pi', reviewId: 1 });
+      const sessionFilePath = '/tmp/test-resume-no-load-skills.json';
+
+      const fs = require('fs');
+      fs.writeFileSync(sessionFilePath, '{}');
+
+      try {
+        db.prepare('UPDATE chat_sessions SET agent_session_id = ? WHERE id = ?')
+          .run(sessionFilePath, session.id);
+        await manager.closeSession(session.id);
+
+        await manager.resumeSession(session.id, {
+          systemPrompt: 'test',
+          cwd: '/tmp'
+        });
+
+        // loadSkills should fall through to the provider def default (undefined here)
+        const resumedBridge = _createdBridges[_createdBridges.length - 1];
+        expect(resumedBridge._constructorOptions.loadSkills).toBeUndefined();
+      } finally {
+        try { fs.unlinkSync(sessionFilePath); } catch { /* ignore */ }
+      }
+    });
   });
 
   describe('getMRUSession', () => {

--- a/tests/unit/config.test.js
+++ b/tests/unit/config.test.js
@@ -5,7 +5,7 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 const childProcess = require('child_process');
-const { deepMerge, getGitHubToken, expandPath, resolveDbName, warnIfDevModeWithoutDbName, loadConfig, shouldSkipUpdateNotifier, _resetTokenCache, getRepoConfig, getRepoPath, getRepoCheckoutScript, getRepoWorktreeDirectory, getRepoWorktreeNameTemplate, getRepoCheckoutTimeout, resolveRepoOptions, getRepoResetScript, getRepoPoolSize, getRepoPoolFetchInterval, resolvePoolConfig, getWorktreeDisplayName, getConfigDir } = require('../../src/config');
+const { deepMerge, getGitHubToken, expandPath, resolveDbName, warnIfDevModeWithoutDbName, loadConfig, shouldSkipUpdateNotifier, _resetTokenCache, getRepoConfig, getRepoPath, getRepoCheckoutScript, getRepoWorktreeDirectory, getRepoWorktreeNameTemplate, getRepoCheckoutTimeout, resolveRepoOptions, getRepoResetScript, getRepoPoolSize, getRepoPoolFetchInterval, resolvePoolConfig, getWorktreeDisplayName, getConfigDir, getRepoLoadSkills, resolveLoadSkills, buildCouncilProviderOverrides } = require('../../src/config');
 
 describe('config.js', () => {
   describe('getGitHubToken', () => {
@@ -1658,6 +1658,102 @@ describe('config.js', () => {
 
     it('should return null for undefined input', () => {
       expect(getWorktreeDisplayName(undefined, {}, 'owner/repo')).toBeNull();
+    });
+  });
+
+  describe('getRepoLoadSkills', () => {
+    it('returns null when no repos config', () => {
+      expect(getRepoLoadSkills({}, 'owner/repo')).toBe(null);
+    });
+
+    it('returns null when repo not in config', () => {
+      expect(getRepoLoadSkills({ repos: {} }, 'owner/repo')).toBe(null);
+    });
+
+    it('returns true when set to true', () => {
+      expect(getRepoLoadSkills({ repos: { 'owner/repo': { load_skills: true } } }, 'owner/repo')).toBe(true);
+    });
+
+    it('returns false when set to false', () => {
+      expect(getRepoLoadSkills({ repos: { 'owner/repo': { load_skills: false } } }, 'owner/repo')).toBe(false);
+    });
+
+    it('returns null for non-boolean values', () => {
+      expect(getRepoLoadSkills({ repos: { 'owner/repo': { load_skills: 1 } } }, 'owner/repo')).toBe(null);
+    });
+  });
+
+  describe('resolveLoadSkills', () => {
+    it('returns true by default when nothing is set', () => {
+      expect(resolveLoadSkills({}, 'owner/repo', null)).toBe(true);
+    });
+
+    it('uses DB value (1) over everything', () => {
+      const config = { repos: { 'owner/repo': { load_skills: false } } };
+      expect(resolveLoadSkills(config, 'owner/repo', { load_skills: 1 }, false)).toBe(true);
+    });
+
+    it('uses DB value (0) over everything', () => {
+      const config = { repos: { 'owner/repo': { load_skills: true } } };
+      expect(resolveLoadSkills(config, 'owner/repo', { load_skills: 0 }, true)).toBe(false);
+    });
+
+    it('falls through DB null to repo JSON config', () => {
+      const config = { repos: { 'owner/repo': { load_skills: false } } };
+      expect(resolveLoadSkills(config, 'owner/repo', { load_skills: null }, true)).toBe(false);
+    });
+
+    it('falls through DB null + no repo config to provider config', () => {
+      expect(resolveLoadSkills({}, 'owner/repo', null, false)).toBe(false);
+    });
+
+    it('converts DB integer 0 to boolean false', () => {
+      // Critical: PiProvider checks !== false with strict equality
+      const result = resolveLoadSkills({}, 'owner/repo', { load_skills: 0 });
+      expect(result).toBe(false);
+      expect(result).not.toBe(0); // Must be boolean, not integer
+    });
+
+    it('converts DB integer 1 to boolean true', () => {
+      const result = resolveLoadSkills({}, 'owner/repo', { load_skills: 1 });
+      expect(result).toBe(true);
+      expect(result).not.toBe(1); // Must be boolean, not integer
+    });
+  });
+
+  describe('buildCouncilProviderOverrides', () => {
+    it('returns base overrides using tier 1+2 resolution', () => {
+      const { providerOverrides } = buildCouncilProviderOverrides({}, 'owner/repo', null);
+      expect(providerOverrides).toEqual({ load_skills: true }); // default
+    });
+
+    it('returns empty map when no providers configured', () => {
+      const { providerOverridesMap } = buildCouncilProviderOverrides({}, 'owner/repo', null);
+      expect(providerOverridesMap).toEqual({});
+    });
+
+    it('builds per-provider map with tier 3 resolution', () => {
+      const config = {
+        providers: {
+          pi: { load_skills: false },
+          claude: { load_skills: true },
+        }
+      };
+      const { providerOverrides, providerOverridesMap } = buildCouncilProviderOverrides(config, 'owner/repo', null);
+      // Base (no tier 3) defaults to true
+      expect(providerOverrides).toEqual({ load_skills: true });
+      // Per-provider includes tier 3
+      expect(providerOverridesMap.pi).toEqual({ load_skills: false });
+      expect(providerOverridesMap.claude).toEqual({ load_skills: true });
+    });
+
+    it('DB repo settings (tier 1) override per-provider tier 3', () => {
+      const config = { providers: { pi: { load_skills: false } } };
+      const repoSettings = { load_skills: 1 }; // DB says enabled
+      const { providerOverrides, providerOverridesMap } = buildCouncilProviderOverrides(config, 'owner/repo', repoSettings);
+      expect(providerOverrides).toEqual({ load_skills: true });
+      // Tier 1 (DB) takes precedence over tier 3 (provider)
+      expect(providerOverridesMap.pi).toEqual({ load_skills: true });
     });
   });
 });

--- a/tests/unit/executable-analysis.test.js
+++ b/tests/unit/executable-analysis.test.js
@@ -23,8 +23,8 @@ vi.mock('../../src/ai/provider', () => ({
   createProvider: vi.fn()
 }));
 vi.mock('../../src/database', () => ({
-  AnalysisRunRepository: vi.fn(),
-  CommentRepository: vi.fn()
+  AnalysisRunRepository: vi.fn(() => ({ create: vi.fn().mockResolvedValue({}) })),
+  CommentRepository: vi.fn(() => ({ batchInsert: vi.fn() }))
 }));
 vi.mock('../../src/hooks/hook-runner', () => ({
   fireHooks: vi.fn(),
@@ -59,8 +59,21 @@ const localReviewModule = require('../../src/local-review');
 const mockGenerateScopedDiff = vi.spyOn(localReviewModule, 'generateScopedDiff');
 const mockFindMergeBase = vi.spyOn(localReviewModule, 'findMergeBase');
 
+// Spy on provider and database modules (CJS requires need vi.spyOn, not vi.mock)
+const providerModule = require('../../src/ai/provider');
+const mockCreateProvider = vi.spyOn(providerModule, 'createProvider');
+
+const databaseModule = require('../../src/database');
+const mockAnalysisRunRepoCreate = vi.fn().mockResolvedValue({});
+vi.spyOn(databaseModule, 'AnalysisRunRepository').mockImplementation(function () {
+  this.create = mockAnalysisRunRepoCreate;
+});
+vi.spyOn(databaseModule, 'CommentRepository').mockImplementation(function () {
+  this.batchInsert = vi.fn();
+});
+
 // Import source module after all spies are set up
-const { generateDiffForExecutable, getChangedFiles } = require('../../src/routes/executable-analysis');
+const { generateDiffForExecutable, getChangedFiles, runExecutableAnalysis } = require('../../src/routes/executable-analysis');
 
 describe('generateDiffForExecutable', () => {
   beforeEach(() => {
@@ -547,5 +560,70 @@ describe('getChangedFiles', () => {
       // findMergeBase should NOT be called since baseBranch is null
       expect(mockFindMergeBase).not.toHaveBeenCalled();
     });
+  });
+});
+
+describe('runExecutableAnalysis', () => {
+  it('should pass providerOverrides to createProvider', async () => {
+    // Set up createProvider to return a minimal provider that will reject
+    // (we only care about the createProvider call args, not the full execution)
+    const mockProvider = {
+      resolvedModel: 'test-model',
+      model: 'test-model',
+      contextArgs: {},
+      execute: vi.fn().mockRejectedValue(new Error('test abort'))
+    };
+    mockCreateProvider.mockReturnValue(mockProvider);
+
+    const testOverrides = { load_skills: false };
+
+    const mockReq = {
+      app: {
+        get: vi.fn((key) => {
+          if (key === 'db') return {};
+          if (key === 'config') return {};
+          return null;
+        })
+      }
+    };
+    const mockRes = { json: vi.fn() };
+
+    const params = {
+      reviewId: 1,
+      review: { id: 1 },
+      selectedProvider: 'test-exec',
+      selectedModel: 'test-model',
+      repoInstructions: null,
+      requestInstructions: null,
+      runId: 'run-1',
+      analysisId: 'analysis-1',
+      repository: 'owner/repo',
+      reviewType: 'pr',
+      headSha: 'abc123',
+      extraInitialStatus: {},
+      providerOverrides: testOverrides
+    };
+
+    const shared = {
+      activeAnalyses: new Map(),
+      reviewToAnalysisId: new Map(),
+      broadcastProgress: vi.fn(),
+      broadcastReviewEvent: vi.fn(),
+      registerProcessForCancellation: vi.fn()
+    };
+
+    const callbacks = {
+      buildContext: vi.fn(() => ({ cwd: '/tmp/test' })),
+      buildHookPayload: vi.fn(() => ({})),
+      onSuccess: vi.fn(),
+      logLabel: 'Test'
+    };
+
+    await runExecutableAnalysis(mockReq, mockRes, params, shared, callbacks);
+
+    // The async IIFE runs after res.json(), so wait a tick for createProvider to be called
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    expect(mockCreateProvider).toHaveBeenCalledWith('test-exec', 'test-model', testOverrides);
   });
 });

--- a/tests/unit/provider-config.test.js
+++ b/tests/unit/provider-config.test.js
@@ -957,6 +957,49 @@ describe('Provider Configuration', () => {
     });
   });
 
+  describe('createProvider per-call overrides', () => {
+    beforeEach(() => {
+      applyConfigOverrides({ providers: {} });
+    });
+
+    it('passes per-call load_skills: false to PiProvider', () => {
+      const provider = createProvider('pi', 'default', { load_skills: false });
+      // PiProvider adds --no-skills when load_skills is false
+      expect(provider.baseArgs).toContain('--no-skills');
+    });
+
+    it('does not add --no-skills when load_skills is true', () => {
+      const provider = createProvider('pi', 'default', { load_skills: true });
+      expect(provider.baseArgs).not.toContain('--no-skills');
+    });
+
+    it('per-call override supersedes global config override', () => {
+      // Global config says load_skills: true
+      applyConfigOverrides({
+        providers: {
+          pi: {
+            load_skills: true
+          }
+        }
+      });
+      // Per-call override says load_skills: false
+      const provider = createProvider('pi', 'default', { load_skills: false });
+      expect(provider.baseArgs).toContain('--no-skills');
+    });
+
+    it('global config override applies when no per-call override', () => {
+      applyConfigOverrides({
+        providers: {
+          pi: {
+            load_skills: false
+          }
+        }
+      });
+      const provider = createProvider('pi', 'default');
+      expect(provider.baseArgs).toContain('--no-skills');
+    });
+  });
+
   describe('createAliasedProviderClass defaultTimeout forwarding', () => {
     it('should set defaultTimeout as static property on alias class', () => {
       const BaseClass = getProviderClass('claude');

--- a/tests/unit/stack-orchestrator.test.js
+++ b/tests/unit/stack-orchestrator.test.js
@@ -591,6 +591,81 @@ describe('executeStackAnalysis', () => {
   });
 });
 
+describe('providerOverrides forwarding in analyzeStackPR dispatch branches', () => {
+  it('single-model branch passes providerOverrides to Analyzer constructor', async () => {
+    const deps = createMockDeps();
+    const params = createDefaultParams(deps, {
+      prNumbers: [10],
+      config: { providers: { claude: { load_skills: false } } },
+    });
+    initActiveState(params.stackAnalysisId, params.prNumbers);
+
+    await executeStackAnalysis(params);
+
+    // Analyzer is called as constructor: new Analyzer(db, model, provider, providerOverrides)
+    expect(deps.Analyzer).toHaveBeenCalled();
+    const ctorArgs = deps.Analyzer.mock.calls[0];
+    // 4th arg is providerOverrides
+    expect(ctorArgs[3]).toEqual({ load_skills: false });
+  });
+
+  it('executable branch passes providerOverrides to runExecutableAnalysis', async () => {
+    const deps = createMockDeps({
+      getProviderClass: vi.fn().mockReturnValue({ isExecutable: true }),
+      runExecutableAnalysis: vi.fn().mockResolvedValue({ analysisId: 'a1', runId: 'r1' }),
+      waitForAnalysisCompletion: vi.fn().mockResolvedValue({ status: 'completed', suggestionsCount: 0 }),
+    });
+    const params = createDefaultParams(deps, {
+      prNumbers: [10],
+      config: { providers: { claude: { load_skills: false } } },
+    });
+    initActiveState(params.stackAnalysisId, params.prNumbers);
+
+    await executeStackAnalysis(params);
+
+    expect(deps.runExecutableAnalysis).toHaveBeenCalled();
+    const callArgs = deps.runExecutableAnalysis.mock.calls[0];
+    // 3rd arg is params object which should contain providerOverrides
+    expect(callArgs[2].providerOverrides).toEqual({ load_skills: false });
+  });
+
+  it('council branch passes both providerOverrides and providerOverridesMap to launchCouncilAnalysis', async () => {
+    const councilConfig = {
+      voices: [
+        { provider: 'claude', model: 'opus' },
+        { provider: 'pi', model: 'default' },
+      ],
+      levels: { 1: true, 2: true, 3: false },
+    };
+
+    vi.spyOn(databaseModule.CouncilRepository.prototype, 'getById').mockResolvedValue({
+      id: 'council-1',
+      config: councilConfig,
+      type: 'council',
+    });
+
+    const deps = createMockDeps({
+      launchCouncilAnalysis: vi.fn().mockResolvedValue({ analysisId: 'a1', runId: 'r1' }),
+    });
+    const params = createDefaultParams(deps, {
+      prNumbers: [10],
+      config: { providers: { pi: { load_skills: false } } },
+      analysisConfig: { configType: 'council', councilId: 'council-1' },
+    });
+    initActiveState(params.stackAnalysisId, params.prNumbers);
+
+    await executeStackAnalysis(params);
+
+    expect(deps.launchCouncilAnalysis).toHaveBeenCalled();
+    const callArgs = deps.launchCouncilAnalysis.mock.calls[0];
+    // 2nd arg is modeContext
+    const modeContext = callArgs[1];
+    expect(modeContext.providerOverrides).toEqual({ load_skills: true }); // base (no tier 3)
+    expect(modeContext.providerOverridesMap).toBeDefined();
+    expect(modeContext.providerOverridesMap.pi).toEqual({ load_skills: false }); // tier 3 for Pi
+  });
+});
+
 describe('estimateCouncilTimeout', () => {
   it('returns voice + consolidation + margin for voice-centric councils', () => {
     const config = {

--- a/tests/utils/schema.js
+++ b/tests/utils/schema.js
@@ -124,6 +124,7 @@ const SCHEMA_SQL = {
       pool_fetch_interval_minutes INTEGER,
       pool_fetch_started_at TEXT,
       pool_fetch_finished_at TEXT,
+      load_skills INTEGER,
       created_at TEXT DEFAULT CURRENT_TIMESTAMP,
       updated_at TEXT DEFAULT CURRENT_TIMESTAMP
     )


### PR DESCRIPTION
## Summary
- Adds a tiered `load_skills` configuration system (DB repo settings > repo JSON config > provider-level config > default) that controls whether AI providers load skill extensions during analysis
- Council mode resolves overrides per-voice via `providerOverridesMap` so mixed-provider councils respect provider-specific settings (e.g. `config.providers.pi.load_skills = false`)
- Adds a toggle in the repo settings UI and a new `load_skills` column in the `repo_settings` DB table
- Fixes: headless review now respects `repoSettings.default_provider` and `default_model`; resumed chat sessions preserve the resolved `load_skills` setting; removes unused Analyzer instance in local council path
- Extracts `buildCouncilProviderOverrides` helper to eliminate duplication across 3 route files

## Test plan
- [x] Unit tests for `resolveLoadSkills` and `buildCouncilProviderOverrides` in config.test.js
- [x] Unit tests for per-voice provider overrides in analyzer-consolidation.test.js
- [x] Unit tests for resumed session `loadSkills` forwarding in session-manager.test.js
- [x] Unit tests for `providerOverrides` threading in executable-analysis.test.js
- [x] Unit tests for override forwarding across all 3 stack analysis branches in stack-orchestrator.test.js
- [x] Integration route tests for `load_skills` in repo settings API
- [ ] Manual: toggle load_skills in repo settings UI, verify Pi analysis respects the setting

🤖 Generated with [Claude Code](https://claude.com/claude-code)