### PR TITLE
Auto-merge case-duplicate repo_settings in migration 42

### DIFF
--- a/.changeset/migration-42-auto-merge.md
+++ b/.changeset/migration-42-auto-merge.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Auto-merge case-duplicate repo_settings rows during migration instead of blocking startup. Keeps the most recently updated row and writes a backup of removed rows to ~/.pair-review/.

--- a/plans/migration-42-auto-merge-duplicates.md
+++ b/plans/migration-42-auto-merge-duplicates.md
@@ -1,0 +1,49 @@
+# Migration 42: Auto-merge duplicate repo_settings instead of throwing
+
+## Context
+
+Migration 42 (`src/database.js:1769-1833`) adds `COLLATE NOCASE` to the `repo_settings.repository` column via a table rebuild. Currently, if case-duplicate rows exist (e.g., `Owner/Repo` and `owner/repo`), the migration **throws an error and blocks startup entirely**. This migration has never been released, so we can modify it in place.
+
+Users shouldn't be blocked from running pair-review over stale preference data they probably don't care about. Instead, we'll auto-merge duplicates by keeping the most recently updated row, log what was dropped, and write a backup file to `~/.pair-review/` so no data is truly lost.
+
+## Files to modify
+
+- `src/database.js` — Migration 42 (lines 1769-1833)
+- `tests/integration/database.test.js` — Add test coverage for migration 42
+
+## Implementation
+
+### 1. Modify migration 42 duplicate handling (`src/database.js`)
+
+Replace the current "detect dupes → throw" block (lines 1803-1807) with:
+
+1. **Detect duplicates** (same query as now)
+2. **If duplicates exist:**
+   a. For each duplicate group, query all rows, sort by `updated_at DESC`
+   b. Keep the first (newest) row, collect the rest as "to delete"
+   c. **Write backup file** to `~/.pair-review/migration-42-backup-<ISO-timestamp>.json` containing all deleted rows (use `getConfigDir()` — already imported)
+   d. **Log a warning** via `console.log` (matching existing migration logging convention — migrations do NOT use the logger utility) listing: which repos had duplicates, which rows were kept vs removed, and the backup file path
+   e. **Delete the duplicate rows** from the original table (before the INSERT...SELECT into the rebuild table)
+3. Proceed with the existing rebuild logic
+
+### 2. Add tests (`tests/integration/database.test.js`)
+
+Add a `describe('Migration 42')` block covering:
+
+- **Happy path**: No duplicates — migration completes, table has COLLATE NOCASE
+- **Duplicate resolution**: Insert case-duplicate rows, run migration, verify only the newest survives
+- **Backup file written**: Verify the backup JSON file is created in the config dir with correct contents
+- **Idempotency**: Migration doesn't fail if `repo_settings_rebuild` table already exists from a prior crash
+
+### Notes
+
+- Use `fs.writeFileSync` (not async) since migrations run synchronously in better-sqlite3
+- The `fs` import in database.js is currently `require('fs').promises` — will need to also get the sync API (or use `require('fs')` directly for `writeFileSync`)
+- Backup filename includes ISO timestamp to avoid collisions if somehow run multiple times
+- The `getConfigDir()` function is already imported in database.js line 5
+
+## Verification
+
+1. `npm test` — all existing tests pass
+2. New migration 42 tests pass with duplicate auto-merge behavior
+3. Manual sanity check: insert case-dupes into a test DB, run migration, verify backup file and merged result

--- a/src/database.js
+++ b/src/database.js
@@ -2,6 +2,7 @@
 const Database = require('better-sqlite3');
 const path = require('path');
 const fs = require('fs').promises;
+const fsSync = require('fs');
 const { getConfigDir } = require('./config');
 
 let dbPath = null;
@@ -1800,10 +1801,30 @@ const MIGRATIONS = {
         updated_at TEXT DEFAULT CURRENT_TIMESTAMP
       )`).run();
 
+      // Auto-merge case-duplicate repositories, keeping the most recently updated row.
       const dupes = db.prepare(`SELECT LOWER(repository) as repo, COUNT(*) as cnt FROM repo_settings GROUP BY LOWER(repository) HAVING cnt > 1`).all();
       if (dupes.length > 0) {
-        const names = dupes.map(d => d.repo).join(', ');
-        throw new Error(`Migration 42: case-duplicate repositories found: ${names}. Please resolve manually before upgrading.`);
+        const removedRows = [];
+        for (const { repo } of dupes) {
+          const rows = db.prepare(`SELECT * FROM repo_settings WHERE LOWER(repository) = ? ORDER BY julianday(updated_at) DESC, id DESC`).all(repo);
+          const kept = rows[0];
+          const discarded = rows.slice(1);
+          for (const row of discarded) {
+            removedRows.push(row);
+            db.prepare('DELETE FROM repo_settings WHERE id = ?').run(row.id);
+          }
+          console.warn(`  [migration 42] Case-duplicate repo "${repo}": kept id=${kept.id} (updated ${kept.updated_at}), removed ${discarded.length} older row(s)`);
+        }
+
+        // Write backup of removed rows to ~/.pair-review/ so no data is truly lost
+        try {
+          const backupPath = path.join(getConfigDir(), `migration-42-backup-${new Date().toISOString().replace(/[:.]/g, '-')}.json`);
+          fsSync.writeFileSync(backupPath, JSON.stringify(removedRows, null, 2));
+          console.warn(`  [migration 42] Backup of ${removedRows.length} removed row(s) written to ${backupPath}`);
+        } catch (backupErr) {
+          console.warn(`  [migration 42] Warning: could not write backup file: ${backupErr.message}`);
+          console.warn(`  [migration 42] Removed row data: ${JSON.stringify(removedRows)}`);
+        }
       }
 
       const cols = [
@@ -4929,5 +4950,7 @@ module.exports = {
   CouncilRepository,
   ContextFileRepository,
   generateWorktreeId,
-  migrateExistingWorktrees
+  migrateExistingWorktrees,
+  // Exported for testing only
+  _MIGRATIONS: MIGRATIONS
 };

--- a/tests/integration/database.test.js
+++ b/tests/integration/database.test.js
@@ -1,5 +1,5 @@
 // Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { createTestDatabase, closeTestDatabase, seedTestReview } from '../utils/schema';
 
 // Import database module functions and classes
@@ -19,6 +19,7 @@ const {
   ReviewRepository,
   AnalysisRunRepository,
   generateWorktreeId,
+  _MIGRATIONS: MIGRATIONS,
 } = database;
 
 // ============================================================================
@@ -2744,5 +2745,177 @@ describe('AnalysisRunRepository', () => {
       expect(children[0].levels_config).toBe('{"1":true,"2":true,"3":false}');
       expect(children[0].parent_run_id).toBe('parent-run');
     });
+  });
+});
+
+// ============================================================================
+// Migration 42 Tests: COLLATE NOCASE with auto-merge of case-duplicates
+// ============================================================================
+
+describe('Migration 42 - COLLATE NOCASE auto-merge', () => {
+  const fsSync = require('fs');
+  const path = require('path');
+  let db;
+
+  // Create a DB with the pre-migration-42 schema (repository column without COLLATE NOCASE)
+  function createPreMigration42Database() {
+    const Database = require('better-sqlite3');
+    const testDb = new Database(':memory:');
+    testDb.pragma('journal_mode = WAL');
+    testDb.pragma('foreign_keys = ON');
+
+    testDb.exec(`
+      CREATE TABLE IF NOT EXISTS repo_settings (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        repository TEXT NOT NULL UNIQUE,
+        default_instructions TEXT,
+        default_provider TEXT,
+        default_model TEXT,
+        default_council_id TEXT,
+        default_tab TEXT,
+        default_chat_instructions TEXT,
+        local_path TEXT,
+        auto_branch_review INTEGER DEFAULT 0,
+        pool_size INTEGER,
+        pool_fetch_interval_minutes INTEGER,
+        pool_fetch_started_at TEXT,
+        pool_fetch_finished_at TEXT,
+        created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+        updated_at TEXT DEFAULT CURRENT_TIMESTAMP
+      )
+    `);
+    return testDb;
+  }
+
+  afterEach(() => {
+    if (db) {
+      db.close();
+      db = null;
+    }
+    vi.restoreAllMocks();
+  });
+
+  it('should rebuild table without errors when there are no duplicates', () => {
+    db = createPreMigration42Database();
+    db.prepare(`INSERT INTO repo_settings (repository, updated_at) VALUES (?, ?)`).run('owner/repo', '2026-01-01T00:00:00Z');
+    db.prepare(`INSERT INTO repo_settings (repository, updated_at) VALUES (?, ?)`).run('other/repo', '2026-01-02T00:00:00Z');
+
+    MIGRATIONS[42](db);
+
+    const rows = db.prepare('SELECT * FROM repo_settings ORDER BY repository').all();
+    expect(rows).toHaveLength(2);
+
+    // Verify COLLATE NOCASE is in effect — inserting a case-variant should fail
+    expect(() => {
+      db.prepare(`INSERT INTO repo_settings (repository) VALUES (?)`).run('Owner/Repo');
+    }).toThrow();
+  });
+
+  it('should auto-merge case-duplicates keeping the most recently updated row', () => {
+    db = createPreMigration42Database();
+
+    // Insert case-duplicate rows with different updated_at timestamps
+    db.prepare(`INSERT INTO repo_settings (repository, default_provider, updated_at) VALUES (?, ?, ?)`).run('Owner/Repo', 'old-provider', '2026-01-01T00:00:00Z');
+    db.prepare(`INSERT INTO repo_settings (repository, default_provider, updated_at) VALUES (?, ?, ?)`).run('owner/repo', 'new-provider', '2026-03-15T00:00:00Z');
+    db.prepare(`INSERT INTO repo_settings (repository, default_provider, updated_at) VALUES (?, ?, ?)`).run('OWNER/REPO', 'oldest-provider', '2025-06-01T00:00:00Z');
+
+    // Mock fsSync.writeFileSync to capture the backup
+    const writeSpy = vi.spyOn(fsSync, 'writeFileSync').mockImplementation(() => {});
+
+    MIGRATIONS[42](db);
+
+    const rows = db.prepare('SELECT * FROM repo_settings').all();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].default_provider).toBe('new-provider');
+    // The kept row should be the one with the latest updated_at
+    expect(rows[0].repository).toBe('owner/repo');
+
+    // Verify backup was written
+    expect(writeSpy).toHaveBeenCalledOnce();
+    const [backupPath, backupContent] = writeSpy.mock.calls[0];
+    expect(backupPath).toMatch(/migration-42-backup-.*\.json$/);
+    const backup = JSON.parse(backupContent);
+    expect(backup).toHaveLength(2);
+    // The backup should contain the two removed rows
+    const backupProviders = backup.map(r => r.default_provider).sort();
+    expect(backupProviders).toEqual(['old-provider', 'oldest-provider']);
+  });
+
+  it('should write backup file with all removed row data', () => {
+    db = createPreMigration42Database();
+
+    db.prepare(`INSERT INTO repo_settings (repository, default_instructions, default_provider, updated_at) VALUES (?, ?, ?, ?)`).run(
+      'org/project', 'keep-these-instructions', 'claude', '2026-04-01T00:00:00Z'
+    );
+    db.prepare(`INSERT INTO repo_settings (repository, default_instructions, default_provider, updated_at) VALUES (?, ?, ?, ?)`).run(
+      'ORG/PROJECT', 'stale-instructions', 'gemini', '2026-01-01T00:00:00Z'
+    );
+
+    let capturedBackup;
+    vi.spyOn(fsSync, 'writeFileSync').mockImplementation((_path, content) => {
+      capturedBackup = JSON.parse(content);
+    });
+
+    MIGRATIONS[42](db);
+
+    expect(capturedBackup).toHaveLength(1);
+    expect(capturedBackup[0].default_instructions).toBe('stale-instructions');
+    expect(capturedBackup[0].default_provider).toBe('gemini');
+    expect(capturedBackup[0].repository).toBe('ORG/PROJECT');
+  });
+
+  it('should still succeed if backup file write fails', () => {
+    db = createPreMigration42Database();
+
+    db.prepare(`INSERT INTO repo_settings (repository, updated_at) VALUES (?, ?)`).run('a/b', '2026-01-01T00:00:00Z');
+    db.prepare(`INSERT INTO repo_settings (repository, updated_at) VALUES (?, ?)`).run('A/B', '2026-02-01T00:00:00Z');
+
+    vi.spyOn(fsSync, 'writeFileSync').mockImplementation(() => {
+      throw new Error('Permission denied');
+    });
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    // Should not throw even when backup write fails
+    MIGRATIONS[42](db);
+
+    const rows = db.prepare('SELECT * FROM repo_settings').all();
+    expect(rows).toHaveLength(1);
+
+    // Should log the removed row data as fallback
+    const fallbackCall = warnSpy.mock.calls.find(call => call[0].includes('Removed row data:'));
+    expect(fallbackCall).toBeDefined();
+  });
+
+  it('should handle idempotent rebuild if repo_settings_rebuild already exists', () => {
+    db = createPreMigration42Database();
+
+    db.prepare(`INSERT INTO repo_settings (repository, updated_at) VALUES (?, ?)`).run('some/repo', '2026-01-01T00:00:00Z');
+
+    // Simulate a leftover table from a previous crashed migration
+    db.exec(`CREATE TABLE repo_settings_rebuild (id INTEGER PRIMARY KEY, repository TEXT)`);
+
+    MIGRATIONS[42](db);
+
+    // Should succeed — the DROP TABLE IF EXISTS handles the leftover
+    const rows = db.prepare('SELECT * FROM repo_settings').all();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].repository).toBe('some/repo');
+  });
+
+  it('should break ties by id DESC when updated_at is identical', () => {
+    db = createPreMigration42Database();
+
+    const sameTime = '2026-01-01T00:00:00Z';
+    db.prepare(`INSERT INTO repo_settings (repository, default_provider, updated_at) VALUES (?, ?, ?)`).run('tie/repo', 'first-inserted', sameTime);
+    db.prepare(`INSERT INTO repo_settings (repository, default_provider, updated_at) VALUES (?, ?, ?)`).run('TIE/REPO', 'second-inserted', sameTime);
+
+    vi.spyOn(fsSync, 'writeFileSync').mockImplementation(() => {});
+
+    MIGRATIONS[42](db);
+
+    const rows = db.prepare('SELECT * FROM repo_settings').all();
+    expect(rows).toHaveLength(1);
+    // Higher ID (second inserted) should be kept since ORDER BY updated_at DESC, id DESC
+    expect(rows[0].default_provider).toBe('second-inserted');
   });
 });


### PR DESCRIPTION
## Summary
- Migration 42 previously threw an error blocking startup if case-duplicate `repo_settings` rows existed
- Now auto-merges duplicates by keeping the most recently updated row (using `julianday()` for format-independent timestamp comparison)
- Writes a backup JSON file of removed rows to `~/.pair-review/` with a terminal warning so no data is silently lost
- Adds 6 integration tests covering: happy path, duplicate merge, backup file, backup failure fallback, idempotency, and tie-breaking

## Test plan
- [x] All 199 database integration tests pass
- [x] Full test suite passes (6080 tests)
- [x] Manual test: inserted case-duplicate into real `scopes.db`, ran migration, verified correct row survived and backup written

🤖 Generated with [Claude Code](https://claude.com/claude-code)