### PR TITLE
Add single-port mode with version update notifications

### DIFF
--- a/.changeset/single-port-mode.md
+++ b/.changeset/single-port-mode.md
@@ -1,0 +1,14 @@
+---
+"@in-the-loop-labs/pair-review": minor
+---
+
+Add single-port mode: reuse one pair-review server across invocations
+
+By default, pair-review now uses a single server on its configured port (7247). A second invocation detects the running server via `/health`, opens the appropriate URL in the browser (PR, local, or landing page), and exits without touching the database or starting a second server. This keeps bookmarks, MCP configs, and user expectations stable instead of picking a new fallback port each time.
+
+When a newer CLI invocation hits an older running server, the older server surfaces a dismissible corner-card update banner in the web UI — "pair-review vX.Y.Z is available. Restart the server to update." — so users know to restart.
+
+New config key:
+- `single_port` — defaults to `true`. Set to `false` in `~/.pair-review/config.json` to restore the previous automatic-port-selection behavior (useful for running multiple dev instances simultaneously).
+
+Headless modes (`--ai-review`, `--ai-draft`) bypass delegation and continue to bind the configured port directly.

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "glob": "^13.0.6",
     "markdown-it": "^13.0.2",
     "open": "^9.1.0",
+    "semver": "^7.7.4",
     "simple-git": "^3.19.1",
     "update-notifier": "^5.1.0",
     "uuid": "^11.1.0",

--- a/plans/single-port-mode.md
+++ b/plans/single-port-mode.md
@@ -1,0 +1,238 @@
+# Single-Port Mode
+
+## Context
+
+pair-review currently picks the next available port when its configured port is busy (`findAvailablePort` tries up to 20 sequential ports). This creates unpredictable ports that break bookmarks, MCP configs, and user expectations. Multiple servers can also contend on the same SQLite database.
+
+**Goal**: By default, pair-review uses one port. A second invocation delegates to the running server by opening the appropriate URL in the browser, then exits. A config escape hatch (`single_port: false`) preserves the current multi-server behavior for development.
+
+Additionally, when a newer version invokes an older running server, the server notifies the user that an update is available.
+
+---
+
+## Startup Flow (single_port: true)
+
+```
+pair-review <args>
+  │
+  ├─ Early exits (--mcp, --help, --version, --configure, --register) → unchanged
+  │
+  ├─ Load config, parseArgs
+  │
+  ├─ Headless mode (--ai-review, --ai-draft)? → skip single-port, proceed normally
+  │
+  ├─ config.single_port === false? → skip single-port, proceed normally
+  │
+  ├─ GET http://localhost:{port}/health (2s timeout)
+  │   │
+  │   ├─ ECONNREFUSED → no server running
+  │   │   └─ Start server on exact port (no fallback). EADDRINUSE = hard fail.
+  │   │
+  │   ├─ Response has service: 'pair-review'
+  │   │   ├─ Construct URL for mode (PR / local / landing page)
+  │   │   ├─ If our version > server version → POST /api/notify-update
+  │   │   ├─ Open browser to URL
+  │   │   └─ exit(0)
+  │   │
+  │   └─ Response without service: 'pair-review' (or non-JSON)
+  │       └─ Hard fail: "Port {port} is in use by another service"
+  │
+```
+
+---
+
+## Changes
+
+### 1. Add `single_port` to config defaults
+**File**: `src/config.js`
+- Add `single_port: true` to `DEFAULT_CONFIG` (after `port`)
+
+### 2. Create `src/single-port.js` — detection and delegation
+New module with three exports, using the `_deps` injection pattern from `src/protocol-handler.js`:
+
+**`detectRunningServer(port, _deps)`**
+- Uses Node `http.get` to hit `http://localhost:{port}/health` with 2s timeout
+- Returns `{ running: false }` on ECONNREFUSED/timeout
+- Returns `{ running: true, isPairReview: true, version }` if response has `service: 'pair-review'`
+- Returns `{ running: true, isPairReview: false }` otherwise
+
+**`notifyVersion(port, currentVersion, _deps)`**
+- POST to `http://localhost:{port}/api/notify-update` with `{ version: currentVersion }`
+- Fire-and-forget (don't block on response)
+
+**`buildDelegationUrl(port, mode, context)`**
+- `mode: 'pr'` → `http://localhost:{port}/pr/{owner}/{repo}/{number}[?analyze=true]`
+- `mode: 'local'` → `http://localhost:{port}/local?path={encodeURIComponent(path)}[&analyze=true]`
+- `mode: 'server'` → `http://localhost:{port}/`
+- Returns the URL string
+
+### 3. Restructure `main()` in `src/main.js`
+The detection must happen **after** parseArgs (to know the mode) but **before** initializeDatabase (delegating process should not touch the DB).
+
+**Move up**: `parseArgs()` call and flag processing currently at line 454. Move to immediately after `loadConfig()` (line 435). `parseArgs` is pure — no DB or config dependency.
+
+**Insert single-port block** between parseArgs and DB init:
+```
+if (config.single_port !== false && !flags.aiReview && !flags.aiDraft) {
+  const result = await detectRunningServer(config.port);
+  if (result.running && result.isPairReview) {
+    // Construct URL based on mode
+    // - PR args present: parse with PRArgumentParser, build /pr/... URL
+    // - flags.local: build /local?path=... URL  
+    // - no args: build / URL
+    // Notify version if ours is newer (semver comparison)
+    // Open browser
+    // exit(0)
+  }
+  if (result.running && !result.isPairReview) {
+    throw new Error(`Port ${config.port} is in use by another service. ...`);
+  }
+  // Not running — proceed to start server normally
+}
+```
+
+**PR argument parsing for delegation**: Use `PRArgumentParser` to extract owner/repo/number. `parsePRUrl()` is synchronous for URL inputs. `parsePRArguments()` (async, reads git remote) needed for bare PR numbers. Neither requires DB.
+
+**Query params**: Pass `?analyze=true` when `flags.ai` is set. For local mode, also pass `&analyze=true`.
+
+### 4. Bypass `findAvailablePort` when single_port is true
+**File**: `src/server.js`
+
+In `startServer()`, after the port is determined (~line 368):
+```js
+let port;
+if (config.single_port !== false) {
+  port = config.port;
+  // Listen directly — EADDRINUSE is a hard failure
+} else {
+  port = await findAvailablePort(app, config.port);
+}
+```
+
+When single_port is true and `EADDRINUSE` fires on `app.listen()`, improve the error message:
+"Port {port} is already in use. A pair-review server may already be running, or another service is using this port."
+
+### 5. Enhance `/health` endpoint
+**File**: `src/server.js` (~line 298)
+
+```js
+app.get('/health', (req, res) => {
+  res.json({
+    status: 'ok',
+    service: 'pair-review',
+    version: require('../package.json').version,
+    timestamp: new Date().toISOString()
+  });
+});
+```
+
+### 6. Version notification endpoint + in-memory state
+**File**: `src/routes/config.js`
+
+**Module-level state** — a plain string, not an object. Monotonically increases
+for the life of the process:
+```js
+let pendingUpdateVersion = null;
+```
+
+**New endpoint**: `POST /api/notify-update`
+- Accepts `{ version }`
+- 400 if invalid semver
+- Compares with own version via `semver.gt(req.body.version, version)`; if not
+  strictly newer → `{ notified: false, reason: 'not_newer' }`
+- If `pendingUpdateVersion` is already set and incoming is not strictly newer
+  than it → `{ notified: false, reason: 'not_newer_than_pending' }`
+- Otherwise: `pendingUpdateVersion = incomingVersion`, log, return
+  `{ ok: true, notified: true }`
+
+**Version-based suppression, not time-based.** There is no 24h timer. Three
+cases are handled by version comparison alone:
+- `incoming == pending`  → suppressed (nothing new to say)
+- `incoming  > pending`  → accepted (genuinely newer)
+- `incoming  < pending`  → suppressed (downgrade — user already knows)
+
+This is clock-skew robust and makes tests deterministic (no fake timers).
+
+**Augment `GET /api/config`** response:
+- Add `pending_update: pendingUpdateVersion`
+
+**Test-only export**: `module.exports._resetPendingUpdate = () => { pendingUpdateVersion = null }`
+— used by integration tests to reset module-level state between cases.
+
+### 7. Frontend: UpdateBanner component
+**New file**: `public/js/components/UpdateBanner.js`
+
+A persistent, dismissible corner-card notification. Single delivery path —
+fetch `/api/config` in the constructor and show the banner if `pending_update`
+is set. No WebSocket coupling, no global `window._pairReviewConfig`, no event
+listener on the window.
+
+- Fetches `/api/config` in constructor (Promise chain, `.catch(() => {})`
+  swallows network errors because the banner is non-critical)
+- Shows: "pair-review v{version} is available. Restart the server to update."
+- Positioned as a compact corner card: `top: 16px; left: 16px; max-width: 360px`,
+  rounded corners, drop shadow matching the `.toast` aesthetic
+- Dismiss button removes it; dismissal stored in `sessionStorage` keyed by
+  version so a newer version re-shows
+- Class declared at file scope (no IIFE) with `module.exports = { UpdateBanner }`
+  for unit-test access, matching the convention of other components
+
+### 8. Include UpdateBanner in HTML pages
+**Files**: `public/pr.html`, `public/local.html`, `public/index.html`, `public/setup.html`
+
+Add `<script src="/js/components/UpdateBanner.js"></script>` on every page that
+should surface update notifications. Because the component fetches `/api/config`
+itself, no wiring from page-specific JS is required.
+
+### 9. Add `semver` as direct dependency
+Currently available as transitive dep via `update-notifier`. Add explicitly for reliability:
+```
+npm install semver
+```
+
+---
+
+## Hazards
+
+**`main()` restructuring — parseArgs ordering**: Moving `parseArgs` before DB init changes the order of operations. `parseArgs` is pure (parses argv, returns flags/prArgs). No dependency on DB or pool. `applyConfigOverrides(config)` at line 474 also has no DB dependency. Safe to move both. Everything from `initializeDatabase` through `poolLifecycle.resetAndRehydrate` stays after the single-port check.
+
+**`startServer()` called from 4 places**: `handlePullRequest`, `startServerOnly`, `handleLocalReview` (in local-review.js), and `performHeadlessReview`. The `findAvailablePort` bypass affects all four. MCP mode starts server via `startMCPStdio` (line 329) — handled before single-port check, so unaffected. Headless modes bypass single-port detection but still call `startServer`; when `single_port: true`, they'll bind to the exact port. This is intentional — headless modes typically run in CI where no other server is running. If they DO conflict, the improved EADDRINUSE message guides the user.
+
+**`handleLocalReview` has its own config + DB init**: `local-review.js:714-723` calls `loadConfig()` and `initializeDatabase()` independently. When delegating, `handleLocalReview` is never called. When NOT delegating (port is free), the normal flow calls it and its internal DB init is fine (same DB, same config).
+
+**Local mode env vars and in-memory diffs**: `handleLocalReview` sets `PAIR_REVIEW_LOCAL_*` env vars and stores diff data in `localReviewDiffs` Map. When delegating, none of this happens — the existing server's web UI setup flow (via `POST /api/local/start` in `src/routes/local.js`) handles diff generation server-side.
+
+**TOCTOU race**: Between health check confirming port is free and `app.listen()`, another process could grab the port. Window is <1s. Mitigated by clear EADDRINUSE error message. Not worth a retry mechanism.
+
+**Pull-only update delivery**: Update notifications are delivered exclusively via `GET /api/config` — there is no WebSocket push path. An already-open tab will not see a new banner the instant `POST /api/notify-update` fires; the banner appears on next page load or new tab. For a "restart to update" notification this tradeoff is correct — restart is disruptive, so instant delivery has no meaningful value over next-page-load delivery, and the single code path is much simpler to reason about and test.
+
+**`pendingUpdateVersion` is in-memory, monotonic**: Resets on server restart. Correct — a restart either IS the update (running version is now newer) or loses no information (the next notifier re-populates it). Only ever increases during a process's lifetime, so downgrades are impossible by construction.
+
+---
+
+## Verification
+
+1. **Unit tests** (`tests/unit/single-port.test.js`):
+   - `detectRunningServer`: mock HTTP responses for each case (ECONNREFUSED, pair-review response, non-pair-review response, timeout)
+   - `buildDelegationUrl`: all mode/flag combinations
+   - `notifyVersion`: verify POST body and fire-and-forget behavior
+   - Version comparison edge cases (same version, older, newer, pre-release)
+
+2. **Integration tests** (`tests/integration/routes.test.js`):
+   - `GET /health` returns `service: 'pair-review'` and `version`
+   - `POST /api/notify-update`: 400 on invalid/missing/empty version
+   - `POST /api/notify-update`: `{ notified: false, reason: 'not_newer' }` when version ≤ running
+   - `POST /api/notify-update`: newer version is accepted and visible via `GET /api/config` `pending_update`
+   - Version-aware suppression: same version suppressed, strictly-newer accepted, downgrade suppressed (monotonic `pendingUpdateVersion`)
+   - Use the `_resetPendingUpdate()` test helper exported from `src/routes/config.js` in `beforeEach` to isolate module-level state
+
+3. **Manual E2E**:
+   - Start `pair-review` (server starts on 7247)
+   - Run `pair-review https://github.com/owner/repo/pull/123` — should open URL on existing server and exit
+   - Run `pair-review --local` — should open local URL on existing server and exit
+   - Run `pair-review` with no args — should open landing page on existing server and exit
+   - Kill server, run again — should start fresh
+   - Set `single_port: false` in config — should use port fallback behavior
+   - Modify package.json version to simulate newer, run against older server — verify update banner appears
+
+4. **E2E tests**: Update existing E2E tests if any exercise server startup or port behavior

--- a/plans/single-port-mode.md
+++ b/plans/single-port-mode.md
@@ -198,6 +198,10 @@ npm install semver
 
 **`startServer()` called from 4 places**: `handlePullRequest`, `startServerOnly`, `handleLocalReview` (in local-review.js), and `performHeadlessReview`. The `findAvailablePort` bypass affects all four. MCP mode starts server via `startMCPStdio` (line 329) — handled before single-port check, so unaffected. Headless modes bypass single-port detection but still call `startServer`; when `single_port: true`, they'll bind to the exact port. This is intentional — headless modes typically run in CI where no other server is running. If they DO conflict, the improved EADDRINUSE message guides the user.
 
+**MCP mode cannot delegate**: `mcp-stdio.js` bypasses the delegation check (early exit in `main.js`) and calls `startServer` directly, because the stdio transport owns the process and cannot hand off to another server. With `single_port: true` as the default, MCP would crash with EADDRINUSE whenever a regular pair-review server is already running on `config.port`. Fix: an env var bridge — `mcp-stdio.js` sets `PAIR_REVIEW_SINGLE_PORT=false` before calling `startServer`, and `startServer` honors it by flipping `config.single_port` after `loadConfig()`. This matches the existing `PAIR_REVIEW_YOLO` bridge pattern (`src/ai/provider.js`) and avoids threading a new parameter through every `startServer` caller. Longer-term, MCP should probably become a pure HTTP client to a running pair-review server (or be replaced by a skill), but that is a separate change.
+
+**Post-startup server errors**: The old `server.on('error')` handler inside the `new Promise` constructor only called `reject()`. Once `listening` fires and the promise settles, subsequent `error` events on the server — specifically accept-loop errors like `EMFILE`/`ENFILE` from file descriptor exhaustion — become silent no-ops (rejecting an already-settled promise does nothing). Per-request errors go through Express middleware and are unaffected; per-socket errors fire on the socket, not the server. Fix: make the startup handler `.once('error', ...)` so it detaches after firing, then attach a second `.on('error', ...)` post-resolve that logs but does not `process.exit` (the pre-this-PR code did exit, which was too aggressive for transient errors).
+
 **`handleLocalReview` has its own config + DB init**: `local-review.js:714-723` calls `loadConfig()` and `initializeDatabase()` independently. When delegating, `handleLocalReview` is never called. When NOT delegating (port is free), the normal flow calls it and its internal DB init is fine (same DB, same config).
 
 **Local mode env vars and in-memory diffs**: `handleLocalReview` sets `PAIR_REVIEW_LOCAL_*` env vars and stores diff data in `localReviewDiffs` Map. When delegating, none of this happens — the existing server's web UI setup flow (via `POST /api/local/start` in `src/routes/local.js`) handles diff generation server-side.
@@ -217,6 +221,12 @@ npm install semver
    - `buildDelegationUrl`: all mode/flag combinations
    - `notifyVersion`: verify POST body and fire-and-forget behavior
    - Version comparison edge cases (same version, older, newer, pre-release)
+   - `attemptDelegation`: assert `prArgs` are forwarded verbatim to `PRArgumentParser` (catches argument-drop regressions)
+
+   **Unit tests** (`tests/unit/update-banner.test.js`, `@vitest-environment jsdom`):
+   - Constructor fetch chain: pending_update present → banner appended; missing → no banner; fetch rejects → no banner, no throw; non-ok response → no banner
+   - `show()` guards: empty/null version, already-dismissed-in-session, idempotent same-version, replace-for-different-version
+   - `dismiss()` lifecycle: banner removed from DOM, sessionStorage written, MutationObserver disconnected, newer version re-shows after prior dismissal
 
 2. **Integration tests** (`tests/integration/routes.test.js`):
    - `GET /health` returns `service: 'pair-review'` and `version`

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       open:
         specifier: ^9.1.0
         version: 9.1.0
+      semver:
+        specifier: ^7.7.4
+        version: 7.7.4
       simple-git:
         specifier: ^3.19.1
         version: 3.35.2

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -31,7 +31,13 @@
     --color-warning-bg: #fffae6;
     --color-warning-border: #ffc552;
     --color-warning-text: #7d4e00;
-    
+
+    --color-info-bg: #eff6ff;
+    --color-info-border: #bfdbfe;
+    --color-info-accent: #3b82f6;
+    --color-info-text: #1e3a8a;
+    --color-info-text-muted: #3b5998;
+
     --color-selection: #fff5b1;
     --color-selection-num: #ffeb3b;
     
@@ -72,7 +78,13 @@
     --color-warning-bg: #3d2e00;
     --color-warning-border: #9e6a03;
     --color-warning-text: #e3b341;
-    
+
+    --color-info-bg: #152033;
+    --color-info-border: #2d4a7a;
+    --color-info-accent: #4a90e2;
+    --color-info-text: #cfe0f5;
+    --color-info-text-muted: #8aa9cf;
+
     --color-selection: #3d3300;
     --color-selection-num: #4d4000;
     

--- a/public/index.html
+++ b/public/index.html
@@ -1488,6 +1488,7 @@
 
     <script src="/js/ws-client.js"></script>
     <script src="/js/components/Toast.js"></script>
+    <script src="/js/components/UpdateBanner.js"></script>
     <script src="/js/index.js"></script>
 </body>
 </html>

--- a/public/js/components/UpdateBanner.js
+++ b/public/js/components/UpdateBanner.js
@@ -1,0 +1,125 @@
+// Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+/**
+ * UpdateBanner Component
+ * Shows a persistent, dismissible corner-card notification when a newer
+ * version of pair-review is available. Single delivery path: on construction,
+ * fetch /api/config and show the banner if a pending_update exists.
+ */
+
+const DISMISS_KEY = 'update-banner-dismissed';
+
+class UpdateBanner {
+  constructor() {
+    this._banner = null;
+    this._version = null;
+
+    // Single path: fetch current config at construction; show banner if a
+    // pending update exists. No event listener, no WebSocket coupling.
+    // `fetch()` returns a Promise; `.then()` chains async steps; the final
+    // `.catch()` swallows network errors because the banner is non-critical.
+    fetch('/api/config')
+      .then(r => (r.ok ? r.json() : null))
+      .then(config => {
+        if (config && config.pending_update) this.show(config.pending_update);
+      })
+      .catch(() => { /* non-critical */ });
+  }
+
+  /**
+   * Show the update banner for the given version.
+   * No-op if already showing or dismissed for this version.
+   * @param {string} version
+   */
+  show(version) {
+    if (!version) return;
+
+    // Already dismissed for this version in this session
+    if (sessionStorage.getItem(DISMISS_KEY) === version) return;
+
+    // Already showing this version
+    if (this._banner && this._version === version) return;
+
+    // Remove any existing banner (e.g., for an older version)
+    this._remove();
+
+    this._version = version;
+
+    const banner = document.createElement('div');
+    banner.setAttribute('data-update-banner', '');
+    Object.assign(banner.style, {
+      position: 'fixed',
+      top: '16px',
+      left: '16px',
+      zIndex: '1000',
+      maxWidth: '360px',
+      background: 'var(--color-attention-subtle)',
+      border: '1px solid var(--color-attention-muted)',
+      borderRadius: '8px',
+      boxShadow: '0 4px 12px rgba(0, 0, 0, 0.15)',
+      color: 'var(--color-attention-fg)',
+      padding: '12px 14px',
+      fontSize: '13px',
+      lineHeight: '1.4',
+      display: 'flex',
+      alignItems: 'flex-start',
+      gap: '10px'
+    });
+
+    const text = document.createElement('span');
+    text.textContent = `pair-review v${version} is available. Restart the server to update.`;
+    text.style.flex = '1';
+
+    const dismissBtn = document.createElement('button');
+    dismissBtn.textContent = '\u00d7';
+    dismissBtn.setAttribute('aria-label', 'Dismiss');
+    Object.assign(dismissBtn.style, {
+      background: 'none',
+      border: 'none',
+      cursor: 'pointer',
+      color: 'var(--color-attention-fg)',
+      fontSize: '18px',
+      padding: '0',
+      lineHeight: '1',
+      flexShrink: '0',
+      opacity: '0.7'
+    });
+    dismissBtn.addEventListener('click', () => this.dismiss());
+
+    banner.appendChild(text);
+    banner.appendChild(dismissBtn);
+    document.body.appendChild(banner);
+    this._banner = banner;
+  }
+
+  /** Dismiss the banner and remember the choice for this session. */
+  dismiss() {
+    if (this._version) {
+      sessionStorage.setItem(DISMISS_KEY, this._version);
+    }
+    this._remove();
+  }
+
+  /** @private */
+  _remove() {
+    if (this._banner && this._banner.parentNode) {
+      this._banner.parentNode.removeChild(this._banner);
+    }
+    this._banner = null;
+  }
+}
+
+// Singleton init (browser only)
+if (typeof window !== 'undefined' && !window.updateBanner) {
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', () => {
+      window.updateBanner = new UpdateBanner();
+    });
+  } else {
+    window.updateBanner = new UpdateBanner();
+  }
+}
+
+// CommonJS export for unit tests
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { UpdateBanner };
+}

--- a/public/js/components/UpdateBanner.js
+++ b/public/js/components/UpdateBanner.js
@@ -11,6 +11,7 @@ const DISMISS_KEY = 'update-banner-dismissed';
 class UpdateBanner {
   constructor() {
     this._banner = null;
+    this._dismissBtn = null;
     this._version = null;
 
     // Single path: fetch current config at construction; show banner if a
@@ -44,6 +45,10 @@ class UpdateBanner {
 
     this._version = version;
 
+    // Theme-aware colors come from CSS custom properties (set in styles.css
+    // under :root and [data-theme="dark"]). The inline `var(..., fallback)`
+    // form keeps the banner readable even if the stylesheet hasn't loaded
+    // yet. No MutationObserver needed — CSS handles the theme switch.
     const banner = document.createElement('div');
     banner.setAttribute('data-update-banner', '');
     Object.assign(banner.style, {
@@ -52,22 +57,33 @@ class UpdateBanner {
       left: '16px',
       zIndex: '1000',
       maxWidth: '360px',
-      background: 'var(--color-attention-subtle)',
-      border: '1px solid var(--color-attention-muted)',
+      background: 'var(--color-info-bg, #eff6ff)',
+      border: '1px solid var(--color-info-border, #bfdbfe)',
+      borderLeft: '4px solid var(--color-info-accent, #3b82f6)',
       borderRadius: '8px',
       boxShadow: '0 4px 12px rgba(0, 0, 0, 0.15)',
-      color: 'var(--color-attention-fg)',
       padding: '12px 14px',
       fontSize: '13px',
       lineHeight: '1.4',
+      color: 'var(--color-info-text, #1e3a8a)',
       display: 'flex',
       alignItems: 'flex-start',
       gap: '10px'
     });
 
-    const text = document.createElement('span');
-    text.textContent = `pair-review v${version} is available. Restart the server to update.`;
+    // Two-line layout: headline + restart instruction on its own line.
+    const text = document.createElement('div');
     text.style.flex = '1';
+
+    const headline = document.createElement('div');
+    headline.textContent = `pair-review v${version} is available.`;
+
+    const instruction = document.createElement('div');
+    instruction.textContent = 'Restart the server to update.';
+    instruction.style.marginTop = '2px';
+
+    text.appendChild(headline);
+    text.appendChild(instruction);
 
     const dismissBtn = document.createElement('button');
     dismissBtn.textContent = '\u00d7';
@@ -75,13 +91,13 @@ class UpdateBanner {
     Object.assign(dismissBtn.style, {
       background: 'none',
       border: 'none',
+      color: 'var(--color-info-text-muted, #3b5998)',
       cursor: 'pointer',
-      color: 'var(--color-attention-fg)',
       fontSize: '18px',
       padding: '0',
       lineHeight: '1',
       flexShrink: '0',
-      opacity: '0.7'
+      opacity: '0.8'
     });
     dismissBtn.addEventListener('click', () => this.dismiss());
 
@@ -89,6 +105,7 @@ class UpdateBanner {
     banner.appendChild(dismissBtn);
     document.body.appendChild(banner);
     this._banner = banner;
+    this._dismissBtn = dismissBtn;
   }
 
   /** Dismiss the banner and remember the choice for this session. */
@@ -105,6 +122,7 @@ class UpdateBanner {
       this._banner.parentNode.removeChild(this._banner);
     }
     this._banner = null;
+    this._dismissBtn = null;
   }
 }
 

--- a/public/local.html
+++ b/public/local.html
@@ -591,6 +591,7 @@
     <!-- Components -->
     <script src="/js/components/TabTitle.js"></script>
     <script src="/js/components/Toast.js"></script>
+    <script src="/js/components/UpdateBanner.js"></script>
     <script src="/js/components/ConfirmDialog.js"></script>
     <script src="/js/components/TextInputDialog.js"></script>
     <script src="/js/components/AnalysisConfigModal.js"></script>

--- a/public/pr.html
+++ b/public/pr.html
@@ -387,6 +387,7 @@
     <!-- Components -->
     <script src="/js/components/TabTitle.js"></script>
     <script src="/js/components/Toast.js"></script>
+    <script src="/js/components/UpdateBanner.js"></script>
     <script src="/js/components/ConfirmDialog.js"></script>
     <script src="/js/components/TextInputDialog.js"></script>
     <script src="/js/components/AnalysisConfigModal.js"></script>

--- a/public/setup.html
+++ b/public/setup.html
@@ -528,6 +528,7 @@
 
     <!-- WebSocket client -->
     <script src="/js/ws-client.js"></script>
+    <script src="/js/components/UpdateBanner.js"></script>
     <script src="/js/utils/notification-sounds.js"></script>
 
     <script>

--- a/src/config.js
+++ b/src/config.js
@@ -19,6 +19,7 @@ const DEFAULT_CONFIG = {
   github_token: "",
   github_token_command: "gh auth token",  // Shell command whose stdout is used as the GitHub token
   port: 7247,
+  single_port: true,  // When true, reuse a single server on the configured port; new invocations delegate to the running server
   theme: "light",
   default_provider: "claude",  // AI provider: 'claude', 'gemini', 'codex', 'copilot', 'opencode', 'cursor-agent', 'pi'
   default_model: "opus",       // Model within the provider (e.g., 'opus' for Claude, 'gemini-2.5-pro' for Gemini)

--- a/src/main.js
+++ b/src/main.js
@@ -20,6 +20,7 @@ const { GIT_DIFF_FLAGS_ARRAY, GIT_DIFF_SUMMARY_FLAGS_ARRAY } = require('./git/di
 const { getEmoji: getCategoryEmoji } = require('./utils/category-emoji');
 const open = (...args) => process.env.PAIR_REVIEW_NO_OPEN ? Promise.resolve() : import('open').then(({default: open}) => open(...args));
 const { registerProtocolHandler, unregisterProtocolHandler } = require('./protocol-handler');
+const { attemptDelegation } = require('./single-port');
 
 let db = null;
 
@@ -431,26 +432,8 @@ AI PROVIDERS:
       showWelcomeMessage();
     }
 
-    // Initialize database
-    console.log('Initializing database...');
-    db = await initializeDatabase(resolveDbName(config));
-
-    // Migrate existing worktrees to database (if any)
-    const path = require('path');
-    const worktreeBaseDir = path.join(getConfigDir(), 'worktrees');
-    const migrationResult = await migrateExistingWorktrees(db, worktreeBaseDir);
-    if (migrationResult.migrated > 0) {
-      console.log(`Migrated ${migrationResult.migrated} existing worktrees to database`);
-    }
-    if (migrationResult.errors.length > 0) {
-      console.warn('Some worktrees could not be migrated:', migrationResult.errors);
-    }
-
-    // Reset stale pool entries, wire idle callbacks, and rehydrate preserved entries
-    const poolLifecycle = new WorktreePoolLifecycle(db, config);
-    await poolLifecycle.resetAndRehydrate();
-
-    // Parse command line arguments including flags
+    // Parse command line arguments including flags (before DB init so
+    // single-port delegation can skip DB entirely)
     const { prArgs, flags } = parseArgs(args);
 
     // Apply debug_stream from config if not already enabled by CLI flag
@@ -472,6 +455,36 @@ AI PROVIDERS:
     // startup, but headless paths (--ai-draft, --ai-review) never start the
     // server, so we must also apply here.
     applyConfigOverrides(config);
+
+    // Single-port delegation: if a pair-review server is already running on the
+    // configured port, delegate to it (open browser URL) and exit immediately.
+    // Skipped for: headless modes (no browser), single_port: false (dev mode).
+    if (config.single_port !== false && !flags.aiReview && !flags.aiDraft) {
+      const delegated = await attemptDelegation(config, flags, prArgs);
+      if (delegated) {
+        process.exit(0);
+      }
+      // Not delegated — no server running, proceed to start one
+    }
+
+    // Initialize database
+    console.log('Initializing database...');
+    db = await initializeDatabase(resolveDbName(config));
+
+    // Migrate existing worktrees to database (if any)
+    const path = require('path');
+    const worktreeBaseDir = path.join(getConfigDir(), 'worktrees');
+    const migrationResult = await migrateExistingWorktrees(db, worktreeBaseDir);
+    if (migrationResult.migrated > 0) {
+      console.log(`Migrated ${migrationResult.migrated} existing worktrees to database`);
+    }
+    if (migrationResult.errors.length > 0) {
+      console.warn('Some worktrees could not be migrated:', migrationResult.errors);
+    }
+
+    // Reset stale pool entries, wire idle callbacks, and rehydrate preserved entries
+    const poolLifecycle = new WorktreePoolLifecycle(db, config);
+    await poolLifecycle.resetAndRehydrate();
 
     // Check for local mode (review uncommitted local changes)
     if (flags.local) {

--- a/src/mcp-stdio.js
+++ b/src/mcp-stdio.js
@@ -45,6 +45,13 @@ async function startMCPStdio() {
     console.error(`[MCP] Warning: failed to load config, using defaults: ${err.message}`);
   }
 
+  // MCP mode needs its own Express server for stdio↔HTTP bridging and cannot
+  // delegate to a running pair-review instance (the stdio transport owns this
+  // process). Force auto-port selection to avoid EADDRINUSE when a regular
+  // pair-review server is already running on config.port.
+  // startServer (src/server.js) reads this env var and flips config.single_port.
+  process.env.PAIR_REVIEW_SINGLE_PORT = 'false';
+
   const db = await initializeDatabase(resolveDbName(config));
   const port = await startServer(db);
 

--- a/src/routes/config.js
+++ b/src/routes/config.js
@@ -22,10 +22,18 @@ const {
 const { normalizeRepository } = require('../utils/paths');
 const { isRunningViaNpx, getGitHubToken } = require('../config');
 const { version } = require('../../package.json');
+const semver = require('semver');
 const { getAllChatProviders, getAllCachedChatAvailability } = require('../chat/chat-providers');
 const logger = require('../utils/logger');
 
 const router = express.Router();
+
+// Module-level state: the most recent version we've been told about that's
+// newer than the running server. Plain string, not an object. `null` means
+// nothing is pending. Reset on process restart — which is fine because a
+// restart either IS the update (running version is now newer) or loses no
+// information (the next notifier will re-populate it).
+let pendingUpdateVersion = null;
 
 /**
  * Get user configuration (for frontend use)
@@ -71,8 +79,44 @@ router.get('/api/config', (req, res) => {
       icon: config.share.icon || null,
       label: config.share.label || null,
       description: config.share.description || null
-    } : null
+    } : null,
+    pending_update: pendingUpdateVersion
   });
+});
+
+/**
+ * Notify the running server that a newer version is available.
+ * Called by a newer CLI invocation delegating to this server.
+ * Stores state so browser tabs can pick it up via GET /api/config.
+ *
+ * Suppression is version-based, not time-based: a POST is accepted only
+ * when the incoming version is strictly newer than both the running version
+ * and any currently-pending version. This means `pendingUpdateVersion`
+ * monotonically increases for the life of the process.
+ */
+router.post('/api/notify-update', (req, res) => {
+  const incomingVersion = req.body?.version;
+  if (!incomingVersion || !semver.valid(incomingVersion)) {
+    return res.status(400).json({ error: 'Invalid version' });
+  }
+
+  if (!semver.gt(incomingVersion, version)) {
+    return res.json({ ok: true, notified: false, reason: 'not_newer' });
+  }
+
+  // Suppress unless the incoming version is STRICTLY newer than what's
+  // already pending. Handles three cases at once:
+  //   - incoming == pending  → suppressed (nothing new)
+  //   - incoming  > pending  → accepted (genuinely newer, falls through)
+  //   - incoming  < pending  → suppressed (downgrade — user already knows)
+  if (pendingUpdateVersion && !semver.gt(incomingVersion, pendingUpdateVersion)) {
+    return res.json({ ok: true, notified: false, reason: 'not_newer_than_pending' });
+  }
+
+  pendingUpdateVersion = incomingVersion;
+  logger.info(`New version available: ${incomingVersion} (running ${version})`);
+
+  res.json({ ok: true, notified: true });
 });
 
 /**
@@ -328,4 +372,14 @@ router.post('/api/providers/refresh-availability', async (req, res) => {
   }
 });
 
+/**
+ * Test-only helper: reset the in-memory pending-update state.
+ * Not exported from index — intended for use by integration tests that
+ * share the same module instance and need isolation between cases.
+ */
+function _resetPendingUpdate() {
+  pendingUpdateVersion = null;
+}
+
 module.exports = router;
+module.exports._resetPendingUpdate = _resetPendingUpdate;

--- a/src/server.js
+++ b/src/server.js
@@ -294,9 +294,14 @@ async function startServer(sharedDb = null, sharedPoolLifecycle = null) {
       res.sendFile(path.join(__dirname, '..', 'public', 'local.html'));
     });
 
-    // Health check endpoint
+    // Health check endpoint (also used by single-port detection)
     app.get('/health', (req, res) => {
-      res.json({ status: 'ok', timestamp: new Date().toISOString() });
+      res.json({
+        status: 'ok',
+        service: 'pair-review',
+        version: require('../package.json').version,
+        timestamp: new Date().toISOString()
+      });
     });
     
     // Store database instance, GitHub token, and config for routes
@@ -365,7 +370,9 @@ async function startServer(sharedDb = null, sharedPoolLifecycle = null) {
     });
     
     // Find available port and start server
-    const port = await findAvailablePort(app, config.port);
+    const port = config.single_port !== false
+      ? config.port  // single-port mode: use exact port, fail if unavailable
+      : await findAvailablePort(app, config.port);
 
     // Check provider availability before accepting requests so /api/config
     // returns accurate pi_available on the very first request (avoids race
@@ -381,14 +388,24 @@ async function startServer(sharedDb = null, sharedPoolLifecycle = null) {
       console.warn('Provider availability check failed:', err.message);
     }
 
-    server = app.listen(port, () => {
-      console.log(`Server running on http://localhost:${port}`);
-      attachWebSocket(server, db, poolLifecycle);
-    });
+    await new Promise((resolve, reject) => {
+      server = app.listen(port, () => {
+        console.log(`Server running on http://localhost:${port}`);
+        attachWebSocket(server, db, poolLifecycle);
+        resolve();
+      });
 
-    server.on('error', (error) => {
-      console.error('Server error:', error);
-      process.exit(1);
+      server.on('error', (error) => {
+        if (error.code === 'EADDRINUSE' && config.single_port !== false) {
+          reject(new Error(
+            `Port ${port} is already in use. A pair-review server may already be running, ` +
+            `or another service is using this port. ` +
+            `Set "single_port": false in ~/.pair-review/config.json to use automatic port selection.`
+          ));
+        } else {
+          reject(error);
+        }
+      });
     });
 
     // Return the actual port the server started on

--- a/src/server.js
+++ b/src/server.js
@@ -15,6 +15,19 @@ let server = null;
 let chatSessionManager = null;
 
 /**
+ * Apply env var overrides to config after loadConfig().
+ * Currently handles PAIR_REVIEW_SINGLE_PORT — a bridge for callers that
+ * need to force multi-port mode (e.g. mcp-stdio.js). Matches the
+ * PAIR_REVIEW_YOLO bridge pattern.
+ */
+function applyEnvOverrides(config) {
+  if (process.env.PAIR_REVIEW_SINGLE_PORT === 'false') {
+    config.single_port = false;
+  }
+  return config;
+}
+
+/**
  * Request logging middleware (disabled for cleaner output)
  */
 function requestLogger(req, res, next) {
@@ -93,6 +106,7 @@ async function startServer(sharedDb = null, sharedPoolLifecycle = null) {
   try {
     // Load configuration
     const { config } = await loadConfig();
+    applyEnvOverrides(config);
 
     // Apply provider configuration overrides (custom models, commands, etc.)
     applyConfigOverrides(config);
@@ -395,7 +409,10 @@ async function startServer(sharedDb = null, sharedPoolLifecycle = null) {
         resolve();
       });
 
-      server.on('error', (error) => {
+      // .once instead of .on: this handler detaches after firing exactly once,
+      // so the post-startup handler below doesn't double-handle EADDRINUSE/EACCES
+      // during the initial bind.
+      server.once('error', (error) => {
         if (error.code === 'EADDRINUSE' && config.single_port !== false) {
           reject(new Error(
             `Port ${port} is already in use. A pair-review server may already be running, ` +
@@ -406,6 +423,14 @@ async function startServer(sharedDb = null, sharedPoolLifecycle = null) {
           reject(error);
         }
       });
+    });
+
+    // Post-startup error handler. Express middleware handles request-level errors,
+    // so this only fires for lower-level issues like accept-loop failures (EMFILE,
+    // ENFILE from file descriptor exhaustion). Log but do NOT process.exit — the
+    // old code did that and it was too aggressive for transient errors.
+    server.on('error', (error) => {
+      console.error('Server error after startup:', error);
     });
 
     // Return the actual port the server started on
@@ -485,4 +510,4 @@ if (require.main === module) {
   startServer();
 }
 
-module.exports = { startServer };
+module.exports = { startServer, applyEnvOverrides };

--- a/src/single-port.js
+++ b/src/single-port.js
@@ -1,0 +1,190 @@
+// Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+const http = require('http');
+const semver = require('semver');
+const { PRArgumentParser } = require('./github/parser');
+const logger = require('./utils/logger');
+
+const HEALTH_TIMEOUT_MS = 2000;
+
+// Default dependencies (overridable for testing)
+const defaults = {
+  httpGet: http.get,
+  httpRequest: http.request,
+  logger,
+  open: (...args) => process.env.PAIR_REVIEW_NO_OPEN
+    ? Promise.resolve()
+    : import('open').then(({ default: open }) => open(...args)),
+  PRArgumentParser
+};
+
+/**
+ * Check if a pair-review server is already running on the given port.
+ * @param {number} port
+ * @param {object} [_deps] - Dependency overrides for testing
+ * @returns {Promise<{running: boolean, isPairReview?: boolean, version?: string}>}
+ */
+function detectRunningServer(port, _deps) {
+  const deps = { ...defaults, ..._deps };
+  return new Promise((resolve) => {
+    const req = deps.httpGet(`http://localhost:${port}/health`, { timeout: HEALTH_TIMEOUT_MS }, (res) => {
+      let data = '';
+      res.on('data', (chunk) => { data += chunk; });
+      res.on('end', () => {
+        try {
+          const body = JSON.parse(data);
+          if (body.service === 'pair-review') {
+            resolve({ running: true, isPairReview: true, version: body.version || null });
+          } else {
+            resolve({ running: true, isPairReview: false });
+          }
+        } catch {
+          resolve({ running: true, isPairReview: false });
+        }
+      });
+    });
+
+    req.on('error', () => {
+      resolve({ running: false });
+    });
+
+    req.on('timeout', () => {
+      req.destroy();
+      resolve({ running: false });
+    });
+  });
+}
+
+/**
+ * Notify the running server that a newer version is available.
+ * Fire-and-forget — does not block on response.
+ * @param {number} port
+ * @param {string} currentVersion - Version of the current CLI invocation
+ * @param {object} [_deps] - Dependency overrides for testing
+ */
+function notifyVersion(port, currentVersion, _deps) {
+  const deps = { ...defaults, ..._deps };
+  const payload = JSON.stringify({ version: currentVersion });
+  const req = deps.httpRequest({
+    hostname: 'localhost',
+    port,
+    path: '/api/notify-update',
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Content-Length': Buffer.byteLength(payload)
+    },
+    timeout: HEALTH_TIMEOUT_MS
+  }, () => { /* ignore response */ });
+
+  req.on('error', () => { /* fire and forget */ });
+  req.on('timeout', () => { req.destroy(); });
+  req.write(payload);
+  req.end();
+}
+
+/**
+ * Build the URL to delegate to an existing server.
+ * @param {number} port
+ * @param {'pr'|'local'|'server'} mode
+ * @param {object} context
+ * @param {string} [context.owner]
+ * @param {string} [context.repo]
+ * @param {number} [context.number]
+ * @param {string} [context.localPath]
+ * @param {boolean} [context.analyze] - Whether to trigger auto-analysis
+ * @returns {string} Full URL
+ */
+function buildDelegationUrl(port, mode, context = {}) {
+  const base = `http://localhost:${port}`;
+  if (mode === 'pr') {
+    let url = `${base}/pr/${context.owner}/${context.repo}/${context.number}`;
+    if (context.analyze) url += '?analyze=true';
+    return url;
+  }
+  if (mode === 'local') {
+    let url = `${base}/local?path=${encodeURIComponent(context.localPath)}`;
+    if (context.analyze) url += '&analyze=true';
+    return url;
+  }
+  return `${base}/`;
+}
+
+/**
+ * Parse PR arguments for URL construction without starting a server.
+ * Reuses PRArgumentParser — synchronous for URLs, async for bare numbers.
+ * @param {string[]} prArgs - Raw CLI PR arguments
+ * @param {object} [_deps] - Dependency overrides for testing
+ * @returns {Promise<{owner: string, repo: string, number: number}>}
+ */
+async function parsePRArgsForDelegation(prArgs, _deps) {
+  const deps = { ...defaults, ..._deps };
+  const parser = new deps.PRArgumentParser();
+  return parser.parsePRArguments(prArgs);
+}
+
+/**
+ * Attempt single-port delegation. Returns true if delegation happened (caller should exit).
+ * Returns false if no running server was found (caller should start normally).
+ * Throws if port is occupied by a non-pair-review service.
+ *
+ * @param {object} config - Loaded config
+ * @param {object} flags - Parsed CLI flags
+ * @param {string[]} prArgs - PR arguments from CLI
+ * @param {object} [_deps] - Dependency overrides for testing
+ * @returns {Promise<boolean>} true if delegated, false if should start fresh
+ */
+async function attemptDelegation(config, flags, prArgs, _deps) {
+  const deps = { ...defaults, ..._deps };
+  const port = config.port;
+
+  const result = await detectRunningServer(port, _deps);
+
+  if (result.running && !result.isPairReview) {
+    throw new Error(
+      `Port ${port} is in use by another service. ` +
+      `Either stop that service, or set a different port in ~/.pair-review/config.json`
+    );
+  }
+
+  if (!result.running) {
+    return false;
+  }
+
+  // Server is running — delegate to it
+  deps.logger.info(`Existing pair-review server detected on port ${port} (v${result.version})`);
+
+  // Determine mode and build URL
+  let url;
+  if (flags.local) {
+    const targetPath = require('path').resolve(flags.localPath || process.cwd());
+    url = buildDelegationUrl(port, 'local', { localPath: targetPath, analyze: flags.ai });
+  } else if (prArgs.length > 0) {
+    const prInfo = await parsePRArgsForDelegation(prArgs, _deps);
+    url = buildDelegationUrl(port, 'pr', { ...prInfo, analyze: flags.ai });
+  } else {
+    url = buildDelegationUrl(port, 'server');
+  }
+
+  // Notify running server of newer version if applicable
+  const currentVersion = require('../package.json').version;
+  if (result.version && semver.valid(currentVersion) && semver.valid(result.version)) {
+    if (semver.gt(currentVersion, result.version)) {
+      deps.logger.info(`Notifying server of newer version: ${currentVersion} > ${result.version}`);
+      notifyVersion(port, currentVersion, _deps);
+    }
+  }
+
+  // Open browser and exit
+  deps.logger.info(`Delegating to running server: ${url}`);
+  await deps.open(url);
+  return true;
+}
+
+module.exports = {
+  detectRunningServer,
+  notifyVersion,
+  buildDelegationUrl,
+  parsePRArgsForDelegation,
+  attemptDelegation,
+  HEALTH_TIMEOUT_MS
+};

--- a/src/single-port.js
+++ b/src/single-port.js
@@ -1,8 +1,10 @@
 // Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
 const http = require('http');
+const path = require('path');
 const semver = require('semver');
 const { PRArgumentParser } = require('./github/parser');
 const logger = require('./utils/logger');
+const { version: packageVersion } = require('../package.json');
 
 const HEALTH_TIMEOUT_MS = 2000;
 
@@ -156,7 +158,7 @@ async function attemptDelegation(config, flags, prArgs, _deps) {
   // Determine mode and build URL
   let url;
   if (flags.local) {
-    const targetPath = require('path').resolve(flags.localPath || process.cwd());
+    const targetPath = path.resolve(flags.localPath || process.cwd());
     url = buildDelegationUrl(port, 'local', { localPath: targetPath, analyze: flags.ai });
   } else if (prArgs.length > 0) {
     const prInfo = await parsePRArgsForDelegation(prArgs, _deps);
@@ -166,11 +168,10 @@ async function attemptDelegation(config, flags, prArgs, _deps) {
   }
 
   // Notify running server of newer version if applicable
-  const currentVersion = require('../package.json').version;
-  if (result.version && semver.valid(currentVersion) && semver.valid(result.version)) {
-    if (semver.gt(currentVersion, result.version)) {
-      deps.logger.info(`Notifying server of newer version: ${currentVersion} > ${result.version}`);
-      notifyVersion(port, currentVersion, _deps);
+  if (result.version && semver.valid(packageVersion) && semver.valid(result.version)) {
+    if (semver.gt(packageVersion, result.version)) {
+      deps.logger.info(`Notifying server of newer version: ${packageVersion} > ${result.version}`);
+      notifyVersion(port, packageVersion, _deps);
     }
   }
 

--- a/tests/integration/routes.test.js
+++ b/tests/integration/routes.test.js
@@ -3223,6 +3223,129 @@ describe('Config Endpoints', () => {
       expect(response.body.chat_enter_to_send).toBe(false);
     });
   });
+
+  describe('POST /api/notify-update', () => {
+    // The running server version is the package's own version.
+    const runningVersion = require('../../package.json').version;
+
+    beforeEach(() => {
+      // Reset the module-level pendingUpdateVersion so tests don't pollute
+      // each other. Safe: require() returns the same cached module instance
+      // that the route handler already holds a closure over.
+      require('../../src/routes/config')._resetPendingUpdate();
+    });
+
+    it('returns 400 for invalid semver', async () => {
+      const res = await request(app)
+        .post('/api/notify-update')
+        .send({ version: 'not-semver' });
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('Invalid version');
+    });
+
+    it('returns 400 for missing version', async () => {
+      const res = await request(app)
+        .post('/api/notify-update')
+        .send({});
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('Invalid version');
+    });
+
+    it('returns 400 for empty-string version', async () => {
+      const res = await request(app)
+        .post('/api/notify-update')
+        .send({ version: '' });
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('Invalid version');
+    });
+
+    it('returns notified:false when version is not newer', async () => {
+      // 0.0.1 is clearly older than any plausible running version
+      const res = await request(app)
+        .post('/api/notify-update')
+        .send({ version: '0.0.1' });
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ ok: true, notified: false, reason: 'not_newer' });
+    });
+
+    it('returns notified:false when version equals running', async () => {
+      const res = await request(app)
+        .post('/api/notify-update')
+        .send({ version: runningVersion });
+      expect(res.status).toBe(200);
+      expect(res.body.notified).toBe(false);
+      expect(res.body.reason).toBe('not_newer');
+    });
+
+    it('accepts a newer version and exposes it via GET /api/config', async () => {
+      const postRes = await request(app)
+        .post('/api/notify-update')
+        .send({ version: '999.0.0' });
+      expect(postRes.status).toBe(200);
+      expect(postRes.body).toEqual({ ok: true, notified: true });
+
+      const configRes = await request(app).get('/api/config');
+      expect(configRes.body.pending_update).toBe('999.0.0');
+    });
+
+    it('suppresses repeat POST of the same pending version', async () => {
+      // First POST succeeds
+      const first = await request(app)
+        .post('/api/notify-update')
+        .send({ version: '999.0.0' });
+      expect(first.body).toEqual({ ok: true, notified: true });
+
+      // Second POST of the same version is suppressed
+      const second = await request(app)
+        .post('/api/notify-update')
+        .send({ version: '999.0.0' });
+      expect(second.status).toBe(200);
+      expect(second.body.notified).toBe(false);
+      expect(second.body.reason).toBe('not_newer_than_pending');
+
+      // pending_update is still the same
+      const configRes = await request(app).get('/api/config');
+      expect(configRes.body.pending_update).toBe('999.0.0');
+    });
+
+    it('accepts a strictly newer version even when one is already pending', async () => {
+      // First: v999.0.0 becomes pending
+      await request(app).post('/api/notify-update').send({ version: '999.0.0' });
+
+      // Then: v999.1.0 should escape suppression and replace pending
+      const res = await request(app)
+        .post('/api/notify-update')
+        .send({ version: '999.1.0' });
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ ok: true, notified: true });
+
+      const configRes = await request(app).get('/api/config');
+      expect(configRes.body.pending_update).toBe('999.1.0');
+    });
+
+    it('suppresses a downgrade when a newer version is already pending', async () => {
+      // First: v999.1.0 becomes pending
+      await request(app).post('/api/notify-update').send({ version: '999.1.0' });
+
+      // Then: v999.0.0 is older than pending but still newer than running.
+      // Should be suppressed — user already knows about the newer version.
+      const res = await request(app)
+        .post('/api/notify-update')
+        .send({ version: '999.0.0' });
+      expect(res.status).toBe(200);
+      expect(res.body.notified).toBe(false);
+      expect(res.body.reason).toBe('not_newer_than_pending');
+
+      // pending_update is unchanged — monotonic behavior
+      const configRes = await request(app).get('/api/config');
+      expect(configRes.body.pending_update).toBe('999.1.0');
+    });
+
+    it('GET /api/config returns null pending_update before any notification', async () => {
+      const res = await request(app).get('/api/config');
+      expect(res.body.pending_update).toBeNull();
+    });
+  });
 });
 
 // ============================================================================

--- a/tests/unit/server-env-overrides.test.js
+++ b/tests/unit/server-env-overrides.test.js
@@ -1,0 +1,87 @@
+// Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+/**
+ * Unit tests for applyEnvOverrides — the small helper that bridges
+ * PAIR_REVIEW_SINGLE_PORT (and future env vars) into the loaded config
+ * object. Extracted from startServer() so it can be tested in isolation
+ * without spinning up Express, the database, or any other real deps.
+ *
+ * Contract: only the literal string "false" flips config.single_port to
+ * false. Any other value (unset, "true", "1", empty string, etc.) leaves
+ * the existing value untouched. Matches the PAIR_REVIEW_YOLO bridge.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+const { applyEnvOverrides } = require('../../src/server.js');
+
+describe('applyEnvOverrides', () => {
+  let savedSinglePortEnv;
+
+  beforeEach(() => {
+    savedSinglePortEnv = process.env.PAIR_REVIEW_SINGLE_PORT;
+    delete process.env.PAIR_REVIEW_SINGLE_PORT;
+  });
+
+  afterEach(() => {
+    if (savedSinglePortEnv === undefined) {
+      delete process.env.PAIR_REVIEW_SINGLE_PORT;
+    } else {
+      process.env.PAIR_REVIEW_SINGLE_PORT = savedSinglePortEnv;
+    }
+  });
+
+  describe('PAIR_REVIEW_SINGLE_PORT bridge', () => {
+    it('flips config.single_port to false when env var is the literal string "false"', () => {
+      process.env.PAIR_REVIEW_SINGLE_PORT = 'false';
+      const config = { single_port: true };
+      applyEnvOverrides(config);
+      expect(config.single_port).toBe(false);
+    });
+
+    it('preserves single_port=true when env var is unset', () => {
+      const config = { single_port: true };
+      applyEnvOverrides(config);
+      expect(config.single_port).toBe(true);
+    });
+
+    it('preserves single_port=false when env var is unset', () => {
+      const config = { single_port: false };
+      applyEnvOverrides(config);
+      expect(config.single_port).toBe(false);
+    });
+
+    it('preserves existing value when env var is "true"', () => {
+      process.env.PAIR_REVIEW_SINGLE_PORT = 'true';
+      const config = { single_port: true };
+      applyEnvOverrides(config);
+      expect(config.single_port).toBe(true);
+    });
+
+    it('preserves existing value when env var is "1"', () => {
+      process.env.PAIR_REVIEW_SINGLE_PORT = '1';
+      const config = { single_port: true };
+      applyEnvOverrides(config);
+      expect(config.single_port).toBe(true);
+    });
+
+    it('preserves existing value when env var is an empty string', () => {
+      process.env.PAIR_REVIEW_SINGLE_PORT = '';
+      const config = { single_port: true };
+      applyEnvOverrides(config);
+      expect(config.single_port).toBe(true);
+    });
+
+    it('does not flip when env var is "False" (case-sensitive contract)', () => {
+      process.env.PAIR_REVIEW_SINGLE_PORT = 'False';
+      const config = { single_port: true };
+      applyEnvOverrides(config);
+      expect(config.single_port).toBe(true);
+    });
+  });
+
+  it('returns the same config object it was given (chainable)', () => {
+    const config = { single_port: true };
+    const result = applyEnvOverrides(config);
+    expect(result).toBe(config);
+  });
+});

--- a/tests/unit/single-port.test.js
+++ b/tests/unit/single-port.test.js
@@ -1,5 +1,5 @@
 // Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 
 const {
   detectRunningServer,
@@ -80,16 +80,22 @@ function mockHttpRequest(capture = {}) {
 }
 
 function createMockDeps(overrides = {}) {
+  // Static field captures args across fresh instances, since production code
+  // calls `new deps.PRArgumentParser()` each time.
+  class MockPRArgumentParser {
+    async parsePRArguments(args) {
+      MockPRArgumentParser.lastArgs = args;
+      return { owner: 'test-owner', repo: 'test-repo', number: parseInt(args[0]) || 42 };
+    }
+  }
+  MockPRArgumentParser.lastArgs = null;
+
   return {
     httpGet: mockHttpGetSuccess({ status: 'ok', service: 'pair-review', version: '3.2.0' }),
     httpRequest: mockHttpRequest(),
     logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
     open: vi.fn().mockResolvedValue(undefined),
-    PRArgumentParser: class {
-      async parsePRArguments(args) {
-        return { owner: 'test-owner', repo: 'test-repo', number: parseInt(args[0]) || 42 };
-      }
-    },
+    PRArgumentParser: MockPRArgumentParser,
     ...overrides
   };
 }
@@ -253,13 +259,17 @@ describe('attemptDelegation', () => {
 
   it('delegates PR mode and opens browser', async () => {
     const deps = createMockDeps();
+    const prArgs = ['https://github.com/acme/widgets/pull/99'];
     const result = await attemptDelegation(
       baseConfig,
       { ai: false },
-      ['https://github.com/acme/widgets/pull/99'],
+      prArgs,
       deps
     );
     expect(result).toBe(true);
+    // Verify prArgs were forwarded verbatim to PRArgumentParser (guards against
+    // production code accidentally passing an empty array or dropping the args).
+    expect(deps.PRArgumentParser.lastArgs).toEqual(prArgs);
     expect(deps.open).toHaveBeenCalledWith(
       expect.stringContaining('/pr/test-owner/test-repo/')
     );

--- a/tests/unit/single-port.test.js
+++ b/tests/unit/single-port.test.js
@@ -1,0 +1,344 @@
+// Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const {
+  detectRunningServer,
+  notifyVersion,
+  buildDelegationUrl,
+  attemptDelegation,
+  HEALTH_TIMEOUT_MS
+} = require('../../src/single-port');
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Create a mock http.get that resolves with the given JSON body. */
+function mockHttpGetSuccess(body) {
+  return (url, opts, cb) => {
+    const res = {
+      on(event, handler) {
+        if (event === 'data') handler(JSON.stringify(body));
+        if (event === 'end') handler();
+        return res;
+      }
+    };
+    cb(res);
+    const req = {
+      on() { return req; },
+      destroy() {}
+    };
+    return req;
+  };
+}
+
+/** Create a mock http.get that emits an error (e.g. ECONNREFUSED). */
+function mockHttpGetError(code = 'ECONNREFUSED') {
+  return (_url, _opts, _cb) => {
+    const req = {
+      on(event, handler) {
+        if (event === 'error') {
+          const err = new Error(code);
+          err.code = code;
+          handler(err);
+        }
+        return req;
+      },
+      destroy() {}
+    };
+    return req;
+  };
+}
+
+/** Create a mock http.get that times out. */
+function mockHttpGetTimeout() {
+  return (_url, _opts, _cb) => {
+    const req = {
+      on(event, handler) {
+        if (event === 'timeout') handler();
+        return req;
+      },
+      destroy() {}
+    };
+    return req;
+  };
+}
+
+/** Create a mock http.request (for POST). Returns the written data via capture. */
+function mockHttpRequest(capture = {}) {
+  return (opts, cb) => {
+    capture.opts = opts;
+    if (cb) cb({ on() {} });
+    const req = {
+      on() { return req; },
+      write(data) { capture.body = data; return req; },
+      end() { return req; },
+      destroy() {}
+    };
+    return req;
+  };
+}
+
+function createMockDeps(overrides = {}) {
+  return {
+    httpGet: mockHttpGetSuccess({ status: 'ok', service: 'pair-review', version: '3.2.0' }),
+    httpRequest: mockHttpRequest(),
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    open: vi.fn().mockResolvedValue(undefined),
+    PRArgumentParser: class {
+      async parsePRArguments(args) {
+        return { owner: 'test-owner', repo: 'test-repo', number: parseInt(args[0]) || 42 };
+      }
+    },
+    ...overrides
+  };
+}
+
+// ---------------------------------------------------------------------------
+// detectRunningServer
+// ---------------------------------------------------------------------------
+
+describe('detectRunningServer', () => {
+  it('returns running=true, isPairReview=true when service is pair-review', async () => {
+    const deps = createMockDeps();
+    const result = await detectRunningServer(7247, deps);
+    expect(result).toEqual({ running: true, isPairReview: true, version: '3.2.0' });
+  });
+
+  it('returns running=true, isPairReview=false for non-pair-review service', async () => {
+    const deps = createMockDeps({
+      httpGet: mockHttpGetSuccess({ status: 'ok' })
+    });
+    const result = await detectRunningServer(7247, deps);
+    expect(result).toEqual({ running: true, isPairReview: false });
+  });
+
+  it('returns running=false on ECONNREFUSED', async () => {
+    const deps = createMockDeps({
+      httpGet: mockHttpGetError('ECONNREFUSED')
+    });
+    const result = await detectRunningServer(7247, deps);
+    expect(result).toEqual({ running: false });
+  });
+
+  it('returns running=false on timeout', async () => {
+    const deps = createMockDeps({
+      httpGet: mockHttpGetTimeout()
+    });
+    const result = await detectRunningServer(7247, deps);
+    expect(result).toEqual({ running: false });
+  });
+
+  it('returns isPairReview=false for non-JSON response', async () => {
+    const httpGet = (_url, _opts, cb) => {
+      const res = {
+        on(event, handler) {
+          if (event === 'data') handler('not json');
+          if (event === 'end') handler();
+          return res;
+        }
+      };
+      cb(res);
+      const req = { on() { return req; }, destroy() {} };
+      return req;
+    };
+    const deps = createMockDeps({ httpGet });
+    const result = await detectRunningServer(7247, deps);
+    expect(result).toEqual({ running: true, isPairReview: false });
+  });
+
+  it('handles missing version field gracefully', async () => {
+    const deps = createMockDeps({
+      httpGet: mockHttpGetSuccess({ status: 'ok', service: 'pair-review' })
+    });
+    const result = await detectRunningServer(7247, deps);
+    expect(result).toEqual({ running: true, isPairReview: true, version: null });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildDelegationUrl
+// ---------------------------------------------------------------------------
+
+describe('buildDelegationUrl', () => {
+  it('builds PR URL', () => {
+    const url = buildDelegationUrl(7247, 'pr', { owner: 'acme', repo: 'widgets', number: 42 });
+    expect(url).toBe('http://localhost:7247/pr/acme/widgets/42');
+  });
+
+  it('builds PR URL with analyze flag', () => {
+    const url = buildDelegationUrl(7247, 'pr', { owner: 'acme', repo: 'widgets', number: 42, analyze: true });
+    expect(url).toBe('http://localhost:7247/pr/acme/widgets/42?analyze=true');
+  });
+
+  it('builds local URL', () => {
+    const url = buildDelegationUrl(7247, 'local', { localPath: '/home/user/project' });
+    expect(url).toBe('http://localhost:7247/local?path=%2Fhome%2Fuser%2Fproject');
+  });
+
+  it('builds local URL with analyze flag', () => {
+    const url = buildDelegationUrl(7247, 'local', { localPath: '/home/user/project', analyze: true });
+    expect(url).toBe('http://localhost:7247/local?path=%2Fhome%2Fuser%2Fproject&analyze=true');
+  });
+
+  it('encodes special characters in local path', () => {
+    const url = buildDelegationUrl(7247, 'local', { localPath: '/path with spaces/dir' });
+    expect(url).toContain(encodeURIComponent('/path with spaces/dir'));
+  });
+
+  it('builds server landing URL', () => {
+    const url = buildDelegationUrl(7247, 'server');
+    expect(url).toBe('http://localhost:7247/');
+  });
+
+  it('builds server URL for unknown mode', () => {
+    const url = buildDelegationUrl(8080, 'unknown');
+    expect(url).toBe('http://localhost:8080/');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// notifyVersion
+// ---------------------------------------------------------------------------
+
+describe('notifyVersion', () => {
+  it('sends POST with version in body', () => {
+    const capture = {};
+    const deps = createMockDeps({ httpRequest: mockHttpRequest(capture) });
+    notifyVersion(7247, '3.3.0', deps);
+    expect(capture.opts.method).toBe('POST');
+    expect(capture.opts.port).toBe(7247);
+    expect(capture.opts.path).toBe('/api/notify-update');
+    expect(JSON.parse(capture.body)).toEqual({ version: '3.3.0' });
+  });
+
+  it('does not throw on request error', () => {
+    const deps = createMockDeps({
+      httpRequest: () => {
+        const req = {
+          on(event, handler) { if (event === 'error') handler(new Error('fail')); return req; },
+          write() { return req; },
+          end() { return req; },
+          destroy() {}
+        };
+        return req;
+      }
+    });
+    expect(() => notifyVersion(7247, '3.3.0', deps)).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// attemptDelegation
+// ---------------------------------------------------------------------------
+
+describe('attemptDelegation', () => {
+  const baseConfig = { port: 7247, single_port: true };
+
+  it('returns false when no server is running', async () => {
+    const deps = createMockDeps({
+      httpGet: mockHttpGetError('ECONNREFUSED')
+    });
+    const result = await attemptDelegation(baseConfig, {}, [], deps);
+    expect(result).toBe(false);
+  });
+
+  it('throws when port is used by non-pair-review service', async () => {
+    const deps = createMockDeps({
+      httpGet: mockHttpGetSuccess({ status: 'ok' })
+    });
+    await expect(attemptDelegation(baseConfig, {}, [], deps))
+      .rejects.toThrow('Port 7247 is in use by another service');
+  });
+
+  it('delegates PR mode and opens browser', async () => {
+    const deps = createMockDeps();
+    const result = await attemptDelegation(
+      baseConfig,
+      { ai: false },
+      ['https://github.com/acme/widgets/pull/99'],
+      deps
+    );
+    expect(result).toBe(true);
+    expect(deps.open).toHaveBeenCalledWith(
+      expect.stringContaining('/pr/test-owner/test-repo/')
+    );
+  });
+
+  it('delegates local mode and opens browser', async () => {
+    const deps = createMockDeps();
+    const result = await attemptDelegation(
+      baseConfig,
+      { local: true, localPath: '/tmp/project' },
+      [],
+      deps
+    );
+    expect(result).toBe(true);
+    expect(deps.open).toHaveBeenCalledWith(
+      expect.stringContaining('/local?path=')
+    );
+  });
+
+  it('delegates server-only mode and opens browser', async () => {
+    const deps = createMockDeps();
+    const result = await attemptDelegation(baseConfig, {}, [], deps);
+    expect(result).toBe(true);
+    expect(deps.open).toHaveBeenCalledWith('http://localhost:7247/');
+  });
+
+  it('appends ?analyze=true when flags.ai is set for PR mode', async () => {
+    const deps = createMockDeps();
+    await attemptDelegation(baseConfig, { ai: true }, ['42'], deps);
+    expect(deps.open).toHaveBeenCalledWith(
+      expect.stringContaining('?analyze=true')
+    );
+  });
+
+  it('appends analyze param when flags.ai is set for local mode', async () => {
+    const deps = createMockDeps();
+    await attemptDelegation(
+      baseConfig,
+      { local: true, localPath: '/tmp', ai: true },
+      [],
+      deps
+    );
+    expect(deps.open).toHaveBeenCalledWith(
+      expect.stringContaining('&analyze=true')
+    );
+  });
+
+  it('notifies version when current is newer than running server', async () => {
+    const capture = {};
+    const deps = createMockDeps({
+      httpGet: mockHttpGetSuccess({ status: 'ok', service: 'pair-review', version: '1.0.0' }),
+      httpRequest: mockHttpRequest(capture)
+    });
+    await attemptDelegation(baseConfig, {}, [], deps);
+    expect(capture.body).toBeDefined();
+    const body = JSON.parse(capture.body);
+    // Should contain the current package.json version
+    expect(body.version).toBeDefined();
+  });
+
+  it('does not notify version when current equals running server', async () => {
+    const capture = {};
+    // Use the actual package.json version so they match
+    const { version } = require('../../package.json');
+    const deps = createMockDeps({
+      httpGet: mockHttpGetSuccess({ status: 'ok', service: 'pair-review', version }),
+      httpRequest: mockHttpRequest(capture)
+    });
+    await attemptDelegation(baseConfig, {}, [], deps);
+    expect(capture.body).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// HEALTH_TIMEOUT_MS
+// ---------------------------------------------------------------------------
+
+describe('constants', () => {
+  it('exports HEALTH_TIMEOUT_MS', () => {
+    expect(HEALTH_TIMEOUT_MS).toBe(2000);
+  });
+});

--- a/tests/unit/update-banner.test.js
+++ b/tests/unit/update-banner.test.js
@@ -1,0 +1,194 @@
+// Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+// @vitest-environment jsdom
+/**
+ * Unit tests for UpdateBanner component.
+ *
+ * UpdateBanner fetches /api/config in its constructor and shows a
+ * corner-card notification if `pending_update` is set. These tests pin the
+ * constructor fetch chain, show() guards, and dismiss() lifecycle.
+ *
+ * jsdom notes:
+ * - The jsdom environment provides a real DOM, so we do not stub
+ *   document/sessionStorage/MutationObserver manually.
+ * - The module-level singleton init at the bottom of UpdateBanner.js runs at
+ *   import time (because jsdom defines `window`). We stub fetch BEFORE the
+ *   first require so the singleton's fetch call is a harmless no-op.
+ * - Each test creates its own UpdateBanner instance and asserts directly —
+ *   the singleton is ignored.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+// Stub fetch BEFORE requiring the module. The module-load-time singleton init
+// calls fetch('/api/config'), and jsdom's `window` is always defined, so we
+// must have a safe mock in place before import.
+global.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) });
+
+const { UpdateBanner } = require('../../public/js/components/UpdateBanner.js');
+
+const DISMISS_KEY = 'update-banner-dismissed';
+
+/** Flush the fetch -> .then() -> .then() promise chain used by the constructor. */
+async function flushFetchChain() {
+  // setImmediate runs after all microtasks, so any chain of .then()s scheduled
+  // in the constructor will have completed by the time this resolves.
+  await new Promise(resolve => setImmediate(resolve));
+}
+
+beforeEach(() => {
+  // Fresh fetch mock per test (default: empty config, no pending_update).
+  global.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) });
+
+  // Reset DOM and sessionStorage between tests.
+  document.body.innerHTML = '';
+  document.documentElement.removeAttribute('data-theme');
+  sessionStorage.clear();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('UpdateBanner', () => {
+  describe('constructor fetch-on-load', () => {
+    it('appends banner when /api/config returns pending_update', async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ pending_update: '3.3.0' })
+      });
+
+      new UpdateBanner();
+      await flushFetchChain();
+
+      const el = document.querySelector('[data-update-banner]');
+      expect(el).not.toBeNull();
+      expect(el.textContent).toContain('3.3.0');
+      expect(el.textContent).toContain('Restart the server');
+    });
+
+    it('does not append banner when /api/config lacks pending_update', async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({})
+      });
+
+      new UpdateBanner();
+      await flushFetchChain();
+
+      expect(document.querySelector('[data-update-banner]')).toBeNull();
+    });
+
+    it('does not append banner when fetch rejects', async () => {
+      global.fetch = vi.fn().mockRejectedValue(new Error('network down'));
+
+      // Must not throw — the banner is non-critical, errors are swallowed.
+      expect(() => new UpdateBanner()).not.toThrow();
+      await flushFetchChain();
+
+      expect(document.querySelector('[data-update-banner]')).toBeNull();
+    });
+
+    it('does not append banner when response is non-ok', async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        json: async () => ({ pending_update: '3.3.0' })
+      });
+
+      new UpdateBanner();
+      await flushFetchChain();
+
+      expect(document.querySelector('[data-update-banner]')).toBeNull();
+    });
+  });
+
+  describe('show() guards', () => {
+    it('is a no-op when called with empty version', async () => {
+      const ub = new UpdateBanner();
+      await flushFetchChain();
+
+      ub.show('');
+      ub.show(null);
+      ub.show(undefined);
+
+      expect(document.querySelector('[data-update-banner]')).toBeNull();
+    });
+
+    it('is a no-op when this version was already dismissed in session', async () => {
+      sessionStorage.setItem(DISMISS_KEY, '3.3.0');
+
+      const ub = new UpdateBanner();
+      await flushFetchChain();
+
+      ub.show('3.3.0');
+
+      expect(document.querySelector('[data-update-banner]')).toBeNull();
+    });
+
+    it('is idempotent when called twice with the same version', async () => {
+      const ub = new UpdateBanner();
+      await flushFetchChain();
+
+      ub.show('3.3.0');
+      ub.show('3.3.0');
+
+      const banners = document.querySelectorAll('[data-update-banner]');
+      expect(banners.length).toBe(1);
+    });
+
+    it('replaces the old banner when called with a newer version', async () => {
+      const ub = new UpdateBanner();
+      await flushFetchChain();
+
+      ub.show('3.3.0');
+      const first = document.querySelector('[data-update-banner]');
+      expect(first.textContent).toContain('3.3.0');
+
+      ub.show('3.4.0');
+      const banners = document.querySelectorAll('[data-update-banner]');
+      expect(banners.length).toBe(1);
+      expect(banners[0].textContent).toContain('3.4.0');
+      // The old banner node should no longer be attached to the DOM.
+      expect(first.parentNode).toBeNull();
+    });
+  });
+
+  describe('dismiss() lifecycle', () => {
+    it('removes the banner from the DOM and writes sessionStorage', async () => {
+      const ub = new UpdateBanner();
+      await flushFetchChain();
+
+      ub.show('3.3.0');
+      expect(document.querySelector('[data-update-banner]')).not.toBeNull();
+
+      ub.dismiss();
+
+      expect(document.querySelector('[data-update-banner]')).toBeNull();
+      expect(sessionStorage.getItem(DISMISS_KEY)).toBe('3.3.0');
+    });
+
+    it('dismiss button click removes the banner', async () => {
+      const ub = new UpdateBanner();
+      await flushFetchChain();
+      ub.show('3.3.0');
+      const btn = document.querySelector('[data-update-banner] button');
+      btn.click();
+      expect(document.querySelector('[data-update-banner]')).toBeNull();
+      expect(sessionStorage.getItem(DISMISS_KEY)).toBe('3.3.0');
+    });
+
+    it('re-shows the banner for a newer version after a previous dismissal', async () => {
+      const ub = new UpdateBanner();
+      await flushFetchChain();
+
+      ub.show('3.3.0');
+      ub.dismiss();
+      expect(document.querySelector('[data-update-banner]')).toBeNull();
+
+      // A newer version is not suppressed by the old dismissal.
+      ub.show('3.4.0');
+      const el = document.querySelector('[data-update-banner]');
+      expect(el).not.toBeNull();
+      expect(el.textContent).toContain('3.4.0');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Default pair-review to a single server on its configured port. Second invocations detect a running server via `/health` and delegate by opening the appropriate URL (PR / local / landing), then exit without touching the DB. Escape hatch: `single_port: false` in config.
- When a newer CLI hits an older running server, it POSTs `/api/notify-update`. Server stores the pending version (monotonic, version-based suppression — no time-based logic, no WebSocket push) and surfaces a dismissible corner-card banner on next page load via `GET /api/config`'s `pending_update` field.
- Headless modes (`--ai-review`, `--ai-draft`) bypass delegation and bind the configured port directly. MCP stdio mode uses a `PAIR_REVIEW_SINGLE_PORT=false` env bridge (matching the existing `PAIR_REVIEW_YOLO` pattern) so it never crashes with EADDRINUSE when a regular server is already running.

Design doc: `plans/single-port-mode.md`.

## Test plan

- [ ] `npm test` — unit + integration
- [ ] Start `pair-review`, run `pair-review <pr-url>` in another shell → should open URL on existing server and exit without starting a second process
- [ ] Run `pair-review --local` against running server → opens local URL, exits
- [ ] Run `pair-review` with no args against running server → opens landing page, exits
- [ ] Kill server, run again → starts fresh
- [ ] Set `single_port: false` → multi-port fallback behavior restored
- [ ] Bump `package.json` version, run CLI against older running server → update banner appears on next page load, dismissal persists per-version in sessionStorage
- [ ] `--mcp` while a regular server is running → MCP starts cleanly, does not crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)