### PR TITLE
Fix analysis history selection after suggestion adoption

### DIFF
--- a/.changeset/analysis-run-selection-adopt.md
+++ b/.changeset/analysis-run-selection-adopt.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Keep the selected analysis run stable when reloading analysis history after adopting a suggestion from an older run.

--- a/public/js/modules/analysis-history.js
+++ b/public/js/modules/analysis-history.js
@@ -205,9 +205,11 @@ class AnalysisHistoryManager {
   /**
    * Load analysis runs from the API (initial load only)
    *
-   * This method is intended for initial page load and always selects the latest run.
-   * For refreshing after a new analysis completes, use refresh() instead, which has
-   * logic to optionally preserve the user's current selection.
+   * This method is intended for initial page load. On first load it selects the
+   * latest run; on subsequent calls it preserves the current selection when that
+   * run still exists. For refreshing after a new analysis completes, use
+   * refresh(), which has logic to optionally preserve the user's current
+   * selection while surfacing a new run indicator.
    *
    * @returns {Promise<Array>} The loaded runs
    */
@@ -227,11 +229,13 @@ class AnalysisHistoryManager {
       return [];
     }
 
-    // Always select the latest run (first in the list since they're ordered by date DESC)
-    // This ensures that after a new analysis completes, its results are displayed
     const latestRun = this.runs[0];
-    const shouldTriggerCallback = !this.selectedRunId || String(this.selectedRunId) !== String(latestRun.id);
-    await this.selectRun(latestRun.id, shouldTriggerCallback);
+    const currentRun = this.selectedRunId
+      ? this.runs.find(run => String(run.id) === String(this.selectedRunId))
+      : null;
+    const runToSelect = currentRun || latestRun;
+    const shouldTriggerCallback = String(this.selectedRunId) !== String(runToSelect.id);
+    await this.selectRun(runToSelect.id, shouldTriggerCallback);
 
     // Render the dropdown (after selecting so the selected state is correct)
     this.renderDropdown(this.runs);

--- a/tests/e2e/analysis-history.spec.js
+++ b/tests/e2e/analysis-history.spec.js
@@ -500,4 +500,63 @@ test.describe('Analysis History - Dropdown', () => {
     const firstItem = page.locator('#analysis-context-list .analysis-history-item:first-child');
     await expect(firstItem).toHaveClass(/selected/);
   });
+
+  test('should preserve the selected older run after adopting a suggestion', async ({ page }) => {
+    await page.goto('/pr/test-owner/test-repo/1');
+    await waitForDiffToRender(page);
+
+    await page.evaluate(() => window.aiPanel?.expand());
+
+    await seedAnalysis(page);
+    await seedAnalysis(page);
+    await reloadAnalysisHistory(page);
+
+    await page.locator('#analysis-context-selector').waitFor({ state: 'visible', timeout: 5000 });
+    await page.locator('#analysis-context-btn').click();
+
+    const secondItem = page.locator('#analysis-context-list .analysis-history-item').nth(1);
+    await expect(secondItem).toBeVisible({ timeout: 3000 });
+    const olderRunId = await secondItem.getAttribute('data-run-id');
+    expect(olderRunId).toBeTruthy();
+
+    await secondItem.click();
+
+    await page.waitForFunction(
+      (runId) => window.prManager?.selectedRunId === runId
+        && window.prManager?.analysisHistoryManager?.selectedRunId === runId,
+      olderRunId
+    );
+
+    const suggestion = page.locator('.ai-suggestion:not(.collapsed)').first();
+    await expect(suggestion).toBeVisible({ timeout: 5000 });
+    const suggestionId = await suggestion.getAttribute('data-suggestion-id');
+    expect(suggestionId).toBeTruthy();
+
+    await page.evaluate((id) => window.prManager?.adoptSuggestion(parseInt(id, 10)), suggestionId);
+
+    await page.waitForFunction(
+      (runId) => window.prManager?.selectedRunId === runId
+        && window.prManager?.analysisHistoryManager?.selectedRunId === runId,
+      olderRunId
+    );
+
+    await page.evaluate(async () => {
+      if (window.prManager?.analysisHistoryManager) {
+        await window.prManager.analysisHistoryManager.loadAnalysisRuns();
+      }
+    });
+
+    await page.waitForFunction(
+      (runId) => {
+        const manager = window.prManager;
+        return manager?.selectedRunId === runId
+          && manager?.analysisHistoryManager?.selectedRunId === runId;
+      },
+      olderRunId
+    );
+
+    await page.locator('#analysis-context-btn').click();
+    const selectedItem = page.locator('#analysis-context-list .analysis-history-item.selected');
+    await expect(selectedItem).toHaveAttribute('data-run-id', olderRunId);
+  });
 });

--- a/tests/unit/analysis-history.test.js
+++ b/tests/unit/analysis-history.test.js
@@ -1257,6 +1257,101 @@ describe('AnalysisHistoryManager', () => {
     });
   });
 
+  describe('loadAnalysisRuns()', () => {
+    it('should select the latest run on first load', async () => {
+      const onSelectionChange = vi.fn();
+      const manager = new AnalysisHistoryManager({
+        reviewId: 1,
+        mode: 'pr',
+        onSelectionChange
+      });
+      manager.init();
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          runs: [
+            { id: 'latest-run', model: 'opus', provider: 'claude' },
+            { id: 'older-run', model: 'sonnet', provider: 'claude' }
+          ]
+        })
+      });
+
+      await manager.loadAnalysisRuns();
+
+      expect(manager.selectedRunId).toBe('latest-run');
+      expect(onSelectionChange).toHaveBeenCalledWith(
+        'latest-run',
+        expect.objectContaining({ id: 'latest-run' })
+      );
+    });
+
+    it('should preserve an existing older selection when reloading runs', async () => {
+      const onSelectionChange = vi.fn();
+      const manager = new AnalysisHistoryManager({
+        reviewId: 1,
+        mode: 'pr',
+        onSelectionChange
+      });
+      manager.init();
+
+      manager.runs = [
+        { id: 'latest-run', model: 'opus', provider: 'claude' },
+        { id: 'older-run', model: 'sonnet', provider: 'claude' }
+      ];
+      manager.selectedRunId = 'older-run';
+      manager.selectedRun = manager.runs[1];
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          runs: [
+            { id: 'latest-run', model: 'opus', provider: 'claude' },
+            { id: 'older-run', model: 'sonnet', provider: 'claude' }
+          ]
+        })
+      });
+
+      await manager.loadAnalysisRuns();
+
+      expect(manager.selectedRunId).toBe('older-run');
+      expect(manager.selectedRun).toEqual(expect.objectContaining({ id: 'older-run' }));
+      expect(onSelectionChange).not.toHaveBeenCalled();
+    });
+
+    it('should fall back to latest when the previous selection no longer exists', async () => {
+      const onSelectionChange = vi.fn();
+      const manager = new AnalysisHistoryManager({
+        reviewId: 1,
+        mode: 'pr',
+        onSelectionChange
+      });
+      manager.init();
+
+      manager.runs = [{ id: 'removed-run', model: 'sonnet', provider: 'claude' }];
+      manager.selectedRunId = 'removed-run';
+      manager.selectedRun = manager.runs[0];
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          runs: [
+            { id: 'latest-run', model: 'opus', provider: 'claude' },
+            { id: 'older-run', model: 'haiku', provider: 'claude' }
+          ]
+        })
+      });
+
+      await manager.loadAnalysisRuns();
+
+      expect(manager.selectedRunId).toBe('latest-run');
+      expect(onSelectionChange).toHaveBeenCalledWith(
+        'latest-run',
+        expect.objectContaining({ id: 'latest-run' })
+      );
+    });
+  });
+
   describe('clearNewRunIndicator()', () => {
     it('should be called when user selects the new run', async () => {
       const manager = new AnalysisHistoryManager({


### PR DESCRIPTION
## Summary
- preserve the selected analysis run when analysis history is reloaded and the selected run still exists
- add unit coverage for first-load selection, preserved older selection, and fallback-to-latest behavior
- tighten the analysis-history E2E regression so it reloads history after adoption and verifies the older run stays selected in state and UI

## Testing
- pnpm test tests/unit/analysis-history.test.js
- pnpm test:e2e tests/e2e/analysis-history.spec.js *(not runnable here because Playwright Chromium is not installed in this environment)*