### PR TITLE
Fix review panel chat actions for comments

### DIFF
--- a/.changeset/review-panel-comment-chat.md
+++ b/.changeset/review-panel-comment-chat.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Add "Chat" actions for user-created comments in the review panel so they open chat with the comment context, matching adopted comments and inline comment chat behavior.

--- a/public/js/components/AIPanel.js
+++ b/public/js/components/AIPanel.js
@@ -793,38 +793,7 @@ class AIPanel {
         this.findingsList.querySelectorAll('.quick-action-chat').forEach(btn => {
             btn.addEventListener('click', (e) => {
                 e.stopPropagation(); // Prevent triggering item click
-                if (!window.chatPanel) return;
-
-                const findingId = btn.dataset.findingId ? parseInt(btn.dataset.findingId, 10) : null;
-                const commentId = btn.dataset.commentId ? parseInt(btn.dataset.commentId, 10) : null;
-                const file = btn.dataset.findingFile || '';
-                const title = btn.dataset.findingTitle || '';
-
-                // Build context from the finding data
-                let suggestionContext = { title, file };
-
-                if (findingId && this.findings) {
-                    const finding = this.findings.find(f => f.id === findingId);
-                    if (finding) {
-                        suggestionContext = {
-                            suggestionId: findingId ? String(findingId) : null,
-                            title: finding.title || title,
-                            body: finding.formattedBody || finding.body || '',
-                            type: finding.type || '',
-                            file: finding.file || file,
-                            line_start: finding.line_start || null,
-                            line_end: finding.line_end || null,
-                            side: 'RIGHT',
-                            reasoning: null
-                        };
-                    }
-                }
-
-                window.chatPanel.open({
-                    reviewId: window.prManager?.currentPR?.id,
-                    suggestionId: findingId ? String(findingId) : (commentId ? String(commentId) : undefined),
-                    suggestionContext
-                });
+                this.openQuickActionChat(btn);
             });
         });
 
@@ -885,6 +854,79 @@ class AIPanel {
         if (window.prManager?.restoreSuggestion) {
             window.prManager.restoreSuggestion(findingId);
         }
+    }
+
+    /**
+     * Handle chat button clicks from review panel quick actions.
+     * Suggestions use suggestionContext; comments use commentContext.
+     * @param {HTMLButtonElement} btn - The clicked chat button
+     */
+    openQuickActionChat(btn) {
+        if (!window.chatPanel) return;
+
+        const findingId = btn.dataset.findingId ? parseInt(btn.dataset.findingId, 10) : null;
+        const commentId = btn.dataset.commentId ? parseInt(btn.dataset.commentId, 10) : null;
+        const reviewId = window.prManager?.currentPR?.id;
+
+        const buildCommentContext = (comment, fallbackDataset = {}) => ({
+            commentId: comment?.id ? String(comment.id) : String(commentId),
+            body: comment?.body || '',
+            file: comment?.file || fallbackDataset.commentFile || '',
+            line_start: comment?.line_start ?? (fallbackDataset.commentLineStart ? parseInt(fallbackDataset.commentLineStart, 10) : null),
+            line_end: comment?.line_end ?? (fallbackDataset.commentLineEnd ? parseInt(fallbackDataset.commentLineEnd, 10) : null),
+            parentId: comment?.parent_id ?? (fallbackDataset.commentParentId ? parseInt(fallbackDataset.commentParentId, 10) : null),
+            source: 'user',
+            isFileLevel: comment?.is_file_level === 1 || comment?.is_file_level === true
+        });
+
+        if (commentId) {
+            const comment = this.comments?.find(c => c.id === commentId);
+
+            window.chatPanel.open({
+                reviewId,
+                commentContext: buildCommentContext(comment, btn.dataset)
+            });
+            return;
+        }
+
+        const file = btn.dataset.findingFile || '';
+        const title = btn.dataset.findingTitle || '';
+        let suggestionContext = { title, file };
+
+        if (findingId && this.findings) {
+            const finding = this.findings.find(f => f.id === findingId);
+            if (finding) {
+                if (finding.status === 'adopted') {
+                    const adoptedComment = this.comments?.find(c => c.parent_id === findingId && c.status !== 'inactive')
+                        || this.comments?.find(c => c.parent_id === findingId);
+                    if (adoptedComment) {
+                        window.chatPanel.open({
+                            reviewId,
+                            commentContext: buildCommentContext(adoptedComment)
+                        });
+                        return;
+                    }
+                }
+
+                suggestionContext = {
+                    suggestionId: String(findingId),
+                    title: finding.title || title,
+                    body: finding.formattedBody || finding.body || '',
+                    type: finding.type || '',
+                    file: finding.file || file,
+                    line_start: finding.line_start ?? null,
+                    line_end: finding.line_end ?? null,
+                    side: 'RIGHT',
+                    reasoning: null
+                };
+            }
+        }
+
+        window.chatPanel.open({
+            reviewId,
+            suggestionId: findingId ? String(findingId) : undefined,
+            suggestionContext
+        });
     }
 
     onFindingClick(item) {
@@ -1204,9 +1246,9 @@ class AIPanel {
         `;
         }
 
-        // Chat button for active and dismissed findings (upper-right corner)
+        // Chat button for all findings when chat is available
         let chatAction = '';
-        if (finding.status !== 'adopted' && document.documentElement.getAttribute('data-chat') === 'available') {
+        if (document.documentElement.getAttribute('data-chat') === 'available') {
             chatAction = `
             <div class="finding-chat-action">
                 <button class="quick-action-btn quick-action-chat" data-finding-id="${finding.id}" data-finding-file="${finding.file || ''}" data-finding-title="${this.escapeHtml(title)}" title="Chat" aria-label="Chat about suggestion">
@@ -1279,12 +1321,12 @@ class AIPanel {
             `;
         }
 
-        // Chat button for active AI-originated comments
+        // Chat button for active comments
         let chatAction = '';
-        if (!isDismissed && comment.parent_id && document.documentElement.getAttribute('data-chat') === 'available') {
+        if (!isDismissed && document.documentElement.getAttribute('data-chat') === 'available') {
             chatAction = `
             <div class="finding-chat-action">
-                <button class="quick-action-btn quick-action-chat" data-comment-id="${comment.id}" data-finding-file="${comment.file || ''}" data-finding-title="${this.escapeHtml(title)}" title="Chat" aria-label="Chat about comment">
+                <button class="quick-action-btn quick-action-chat" data-comment-id="${comment.id}" data-comment-file="${this.escapeHtml(comment.file || '')}" data-comment-line-start="${comment.line_start ?? ''}" data-comment-line-end="${comment.line_end ?? ''}" data-comment-parent-id="${comment.parent_id || ''}" title="Chat" aria-label="Chat about comment">
                     <svg viewBox="0 0 16 16" fill="currentColor" width="12" height="12"><path d="M1.75 1h8.5c.966 0 1.75.784 1.75 1.75v5.5A1.75 1.75 0 0 1 10.25 10H7.061l-2.574 2.573A1.458 1.458 0 0 1 2 11.543V10h-.25A1.75 1.75 0 0 1 0 8.25v-5.5C0 1.784.784 1 1.75 1ZM1.5 2.75v5.5c0 .138.112.25.25.25h1a.75.75 0 0 1 .75.75v2.19l2.72-2.72a.749.749 0 0 1 .53-.22h3.5a.25.25 0 0 0 .25-.25v-5.5a.25.25 0 0 0-.25-.25h-8.5a.25.25 0 0 0-.25.25Zm13 2a.25.25 0 0 0-.25-.25h-.5a.75.75 0 0 1 0-1.5h.5c.966 0 1.75.784 1.75 1.75v5.5A1.75 1.75 0 0 1 14.25 12H14v1.543a1.458 1.458 0 0 1-2.487 1.03L9.22 12.28a.749.749 0 0 1 .326-1.275.749.749 0 0 1 .734.215l2.22 2.22v-2.19a.75.75 0 0 1 .75-.75h1a.25.25 0 0 0 .25-.25Z"/></svg>
                 </button>
             </div>

--- a/tests/e2e/chat-lines.spec.js
+++ b/tests/e2e/chat-lines.spec.js
@@ -181,3 +181,78 @@ test.describe('Comment form Chat button', () => {
     await expect(chatFromCommentBtn).toBeHidden();
   });
 });
+
+test.describe('Review panel comment chat button', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/pr/test-owner/test-repo/1');
+    await waitForDiffToRender(page);
+  });
+
+  test.afterEach(async ({ page }) => {
+    await cleanupAllComments(page);
+  });
+
+  test('opens chat from a user-created review panel entry', async ({ page }) => {
+    await enableChat(page);
+
+    const lineNumberCell = page.locator('.d2h-code-linenumber').nth(0);
+    await lineNumberCell.hover();
+    const addCommentBtn = page.locator('.add-comment-btn').first();
+    await addCommentBtn.waitFor({ state: 'visible', timeout: 5000 });
+    await addCommentBtn.click();
+    await page.waitForSelector('.user-comment-form', { timeout: 5000 });
+
+    const commentText = 'Panel chat should use this user comment';
+    const commentTextarea = page.locator('.user-comment-form textarea');
+    await commentTextarea.fill(commentText);
+    await page.locator('.save-comment-btn').click();
+
+    await expect(page.locator('.user-comment-row')).toContainText(commentText);
+
+    await page.locator('#ai-panel-toggle').click();
+    await expect(page.locator('#ai-panel')).not.toHaveClass(/collapsed/);
+
+    await page.locator('.segment-btn[data-segment="comments"]').click();
+
+    const commentPanelItem = page.locator('.finding-item-wrapper', { hasText: commentText });
+    await expect(commentPanelItem).toBeAttached({ timeout: 5000 });
+
+    const panelChatBtn = commentPanelItem.locator('.quick-action-chat[data-comment-id]');
+    await expect(panelChatBtn).toBeAttached({ timeout: 5000 });
+    await panelChatBtn.click({ force: true });
+
+    await expect(page.locator('.chat-panel')).toBeVisible({ timeout: 5000 });
+    const contextCard = page.locator('.chat-panel__context-card[data-tooltip-body]');
+    await expect(contextCard).toBeVisible({ timeout: 3000 });
+    await expect(contextCard.locator('.chat-panel__context-title')).toContainText(commentText);
+  });
+
+  test('review-panel chat button is hidden when chat is disabled', async ({ page }) => {
+    await disableChat(page);
+
+    const lineNumberCell = page.locator('.d2h-code-linenumber').nth(0);
+    await lineNumberCell.hover();
+    const addCommentBtn = page.locator('.add-comment-btn').first();
+    await addCommentBtn.waitFor({ state: 'visible', timeout: 5000 });
+    await addCommentBtn.click();
+    await page.waitForSelector('.user-comment-form', { timeout: 5000 });
+
+    const commentText = 'Review panel chat should stay hidden';
+    const commentTextarea = page.locator('.user-comment-form textarea');
+    await commentTextarea.fill(commentText);
+    await page.locator('.save-comment-btn').click();
+
+    await expect(page.locator('.user-comment-row')).toContainText(commentText);
+
+    await page.locator('#ai-panel-toggle').click();
+    await expect(page.locator('#ai-panel')).not.toHaveClass(/collapsed/);
+
+    await page.locator('.segment-btn[data-segment="comments"]').click();
+
+    const commentPanelItem = page.locator('.finding-item-wrapper', { hasText: commentText });
+    await expect(commentPanelItem).toBeAttached({ timeout: 5000 });
+
+    const panelChatBtn = commentPanelItem.locator('.quick-action-chat[data-comment-id]');
+    await expect(panelChatBtn).toBeHidden();
+  });
+});

--- a/tests/unit/ai-panel-collapse.test.js
+++ b/tests/unit/ai-panel-collapse.test.js
@@ -83,6 +83,7 @@ beforeEach(() => {
   global.document = {
     ...global.document,
     documentElement: {
+      getAttribute: vi.fn((name) => (name === 'data-chat' ? 'available' : null)),
       style: {
         setProperty: vi.fn(),
       },
@@ -90,6 +91,8 @@ beforeEach(() => {
   };
 
   global.window = {
+    chatPanel: { open: vi.fn() },
+    prManager: { currentPR: { id: 123 } },
     panelGroup: {
       _onReviewVisibilityChanged: vi.fn(),
     },
@@ -319,6 +322,327 @@ describe('AIPanel collapsed state persistence', () => {
       panel.clearAllFindings();
 
       expect(panel.currentIndex).toBe(-1);
+    });
+  });
+
+  describe('comment chat actions', () => {
+    it('renders a chat button for active user-originated comments', () => {
+      const panel = createTestPanel();
+
+      const html = panel.renderCommentItem({
+        id: 7,
+        body: 'Please tighten this check',
+        file: 'src/app.js',
+        line_start: 12,
+        status: 'active',
+      }, 0);
+
+      expect(html).toContain('quick-action-chat');
+      expect(html).toContain('data-comment-id="7"');
+    });
+
+    it('does not render a chat button for dismissed user comments', () => {
+      const panel = createTestPanel();
+
+      const html = panel.renderCommentItem({
+        id: 7,
+        body: 'Please tighten this check',
+        file: 'src/app.js',
+        line_start: 12,
+        status: 'inactive',
+      }, 0);
+
+      expect(html).not.toContain('quick-action-chat');
+    });
+
+    it('opens chat with commentContext for line-level user comments', () => {
+      const panel = createTestPanel({
+        comments: [{
+          id: 7,
+          body: 'Please tighten this check',
+          file: 'src/app.js',
+          line_start: 12,
+          line_end: 14,
+          status: 'active',
+          parent_id: null,
+        }],
+      });
+
+      panel.openQuickActionChat({
+        dataset: {
+          commentId: '7',
+        },
+      });
+
+      expect(window.chatPanel.open).toHaveBeenCalledWith({
+        reviewId: 123,
+        commentContext: {
+          commentId: '7',
+          body: 'Please tighten this check',
+          file: 'src/app.js',
+          line_start: 12,
+          line_end: 14,
+          parentId: null,
+          source: 'user',
+          isFileLevel: false,
+        },
+      });
+    });
+
+    it('opens chat with commentContext for file-level user comments', () => {
+      const panel = createTestPanel({
+        comments: [{
+          id: 9,
+          body: 'This file needs a follow-up pass',
+          file: 'src/app.js',
+          line_start: null,
+          line_end: null,
+          status: 'active',
+          is_file_level: 1,
+          parent_id: null,
+        }],
+      });
+
+      panel.openQuickActionChat({
+        dataset: {
+          commentId: '9',
+        },
+      });
+
+      expect(window.chatPanel.open).toHaveBeenCalledWith({
+        reviewId: 123,
+        commentContext: {
+          commentId: '9',
+          body: 'This file needs a follow-up pass',
+          file: 'src/app.js',
+          line_start: null,
+          line_end: null,
+          parentId: null,
+          source: 'user',
+          isFileLevel: true,
+        },
+      });
+    });
+
+    it('preserves parentId for adopted comments', () => {
+      const panel = createTestPanel({
+        comments: [{
+          id: 10,
+          body: 'Adjusted adopted comment text',
+          file: 'src/app.js',
+          line_start: 18,
+          line_end: 18,
+          status: 'active',
+          parent_id: 42,
+        }],
+      });
+
+      panel.openQuickActionChat({
+        dataset: {
+          commentId: '10',
+        },
+      });
+
+      expect(window.chatPanel.open).toHaveBeenCalledWith({
+        reviewId: 123,
+        commentContext: {
+          commentId: '10',
+          body: 'Adjusted adopted comment text',
+          file: 'src/app.js',
+          line_start: 18,
+          line_end: 18,
+          parentId: 42,
+          source: 'user',
+          isFileLevel: false,
+        },
+      });
+    });
+
+    it('normalizes empty dataset parentId to null for user comments', () => {
+      const panel = createTestPanel({
+        comments: [],
+      });
+
+      panel.openQuickActionChat({
+        dataset: {
+          commentId: '12',
+          commentFile: 'src/app.js',
+          commentLineStart: '5',
+          commentLineEnd: '5',
+          commentParentId: '',
+        },
+      });
+
+      expect(window.chatPanel.open).toHaveBeenCalledWith({
+        reviewId: 123,
+        commentContext: {
+          commentId: '12',
+          body: '',
+          file: 'src/app.js',
+          line_start: 5,
+          line_end: 5,
+          parentId: null,
+          source: 'user',
+          isFileLevel: false,
+        },
+      });
+    });
+
+    it('keeps suggestion chat behavior for AI findings', () => {
+      const panel = createTestPanel({
+        findings: [{
+          id: 5,
+          title: 'Null guard missing',
+          formattedBody: 'Check for null before accessing name',
+          type: 'bug',
+          file: 'src/app.js',
+          line_start: 21,
+          line_end: 21,
+        }],
+      });
+
+      panel.openQuickActionChat({
+        dataset: {
+          findingId: '5',
+          findingFile: 'src/app.js',
+          findingTitle: 'Null guard missing',
+        },
+      });
+
+      expect(window.chatPanel.open).toHaveBeenCalledWith({
+        reviewId: 123,
+        suggestionId: '5',
+        suggestionContext: {
+          suggestionId: '5',
+          title: 'Null guard missing',
+          body: 'Check for null before accessing name',
+          type: 'bug',
+          file: 'src/app.js',
+          line_start: 21,
+          line_end: 21,
+          side: 'RIGHT',
+          reasoning: null,
+        },
+      });
+    });
+
+    it('opens adopted findings as commentContext when linked comment exists', () => {
+      const panel = createTestPanel({
+        findings: [{
+          id: 42,
+          title: 'Original AI suggestion title',
+          formattedBody: 'Original AI suggestion body',
+          type: 'bug',
+          file: 'src/app.js',
+          line_start: 18,
+          line_end: 18,
+          status: 'adopted',
+        }],
+        comments: [{
+          id: 10,
+          body: 'Adjusted adopted comment text',
+          file: 'src/app.js',
+          line_start: 18,
+          line_end: 18,
+          status: 'active',
+          parent_id: 42,
+        }],
+      });
+
+      panel.openQuickActionChat({
+        dataset: {
+          findingId: '42',
+          findingFile: 'src/app.js',
+          findingTitle: 'Original AI suggestion title',
+        },
+      });
+
+      expect(window.chatPanel.open).toHaveBeenCalledWith({
+        reviewId: 123,
+        commentContext: {
+          commentId: '10',
+          body: 'Adjusted adopted comment text',
+          file: 'src/app.js',
+          line_start: 18,
+          line_end: 18,
+          parentId: 42,
+          source: 'user',
+          isFileLevel: false,
+        },
+      });
+    });
+
+    it('prefers the active adopted comment over inactive history for adopted findings', () => {
+      const panel = createTestPanel({
+        findings: [{
+          id: 42,
+          title: 'Original AI suggestion title',
+          formattedBody: 'Original AI suggestion body',
+          type: 'bug',
+          file: 'src/app.js',
+          line_start: 18,
+          line_end: 18,
+          status: 'adopted',
+        }],
+        comments: [{
+          id: 10,
+          body: 'Old dismissed adopted comment',
+          file: 'src/app.js',
+          line_start: 18,
+          line_end: 18,
+          status: 'inactive',
+          parent_id: 42,
+        }, {
+          id: 11,
+          body: 'Current active adopted comment',
+          file: 'src/app.js',
+          line_start: 18,
+          line_end: 18,
+          status: 'active',
+          parent_id: 42,
+        }],
+      });
+
+      panel.openQuickActionChat({
+        dataset: {
+          findingId: '42',
+          findingFile: 'src/app.js',
+          findingTitle: 'Original AI suggestion title',
+        },
+      });
+
+      expect(window.chatPanel.open).toHaveBeenCalledWith({
+        reviewId: 123,
+        commentContext: {
+          commentId: '11',
+          body: 'Current active adopted comment',
+          file: 'src/app.js',
+          line_start: 18,
+          line_end: 18,
+          parentId: 42,
+          source: 'user',
+          isFileLevel: false,
+        },
+      });
+    });
+  });
+
+  describe('finding chat actions', () => {
+    it('renders a chat button for adopted suggestions', () => {
+      const panel = createTestPanel();
+
+      const html = panel.renderFindingItem({
+        id: 11,
+        title: 'Use stricter validation',
+        body: 'Tighten the schema before persisting',
+        type: 'bug',
+        file: 'src/app.js',
+        line_start: 9,
+        status: 'adopted',
+      }, 0);
+
+      expect(html).toContain('quick-action-chat');
+      expect(html).toContain('data-finding-id="11"');
     });
   });
 });


### PR DESCRIPTION
## Summary
- add review-panel chat actions for user-created comments and adopted suggestions
- route adopted finding chat through the linked adopted comment when available
- add unit and e2e coverage for enabled and disabled chat states

## Testing
- pnpm test tests/unit/ai-panel-collapse.test.js
- pnpm test:e2e tests/e2e/chat-lines.spec.js