### PR TITLE
Fall back to PR head SHA fetch

### DIFF
--- a/.changeset/pr-head-sha-fallback.md
+++ b/.changeset/pr-head-sha-fallback.md
@@ -1,0 +1,4 @@
+"@in-the-loop-labs/pair-review": patch
+---
+
+Fall back to fetching a pull request head by commit SHA when the configured git remote does not expose GitHub `refs/pull/*` refs.

--- a/.changeset/pr-head-sha-fallback.md
+++ b/.changeset/pr-head-sha-fallback.md
@@ -1,3 +1,4 @@
+---
 "@in-the-loop-labs/pair-review": patch
 ---
 

--- a/src/git/worktree-pool-lifecycle.js
+++ b/src/git/worktree-pool-lifecycle.js
@@ -231,15 +231,22 @@ class WorktreePoolLifecycle {
     // Note: poolEntry was already atomically marked 'switching' by claimAvailable()
     try {
       const git = this._simpleGit(poolEntry.path);
+      const worktreeManager = new this._GitWorktreeManager(this.db);
 
       // Resolve the remote
-      const remotes = await git.getRemotes();
-      const remote = remotes.find(r => r.name === 'origin') || remotes[0];
-      const remoteName = remote ? remote.name : 'origin';
+      const remoteName = await worktreeManager.resolveRemoteForPR(git, prData, {
+        owner: prInfo.owner,
+        repo: prInfo.repo,
+        number: prInfo.prNumber,
+      });
 
-      // Fetch new PR refs (incremental -- cheap on a warm worktree)
+      // Fetch new PR refs (incremental -- cheap on a warm worktree) with fallback
       logger.info(`Fetching PR #${prInfo.prNumber} refs into pool worktree ${poolEntry.id}`);
-      await git.fetch([remoteName, `+refs/pull/${prInfo.prNumber}/head:refs/remotes/${remoteName}/pr-${prInfo.prNumber}`]);
+      const fetchedHead = await worktreeManager.fetchPRHead(git, {
+        owner: prInfo.owner,
+        repo: prInfo.repo,
+        number: prInfo.prNumber,
+      }, prData, { remote: remoteName });
 
       // Clean the working tree before switching PRs. Without this, untracked
       // files (build artifacts, generated code) from the previous PR leak into
@@ -254,7 +261,7 @@ class WorktreePoolLifecycle {
       if (targetSha) {
         await git.checkout([targetSha]);
       } else {
-        await git.checkout([`refs/remotes/${remoteName}/pr-${prInfo.prNumber}`]);
+        await git.checkout([fetchedHead.checkoutTarget]);
       }
 
       // Run reset_script if configured
@@ -273,7 +280,6 @@ class WorktreePoolLifecycle {
           PR_NUMBER: String(prInfo.prNumber),
           WORKTREE_PATH: poolEntry.path,
         };
-        const worktreeManager = new this._GitWorktreeManager();
         await worktreeManager.executeCheckoutScript(
           options.resetScript, poolEntry.path, scriptEnv, options.checkoutTimeout
         );
@@ -285,7 +291,6 @@ class WorktreePoolLifecycle {
 
       // Best-effort disk cleanup for deleted non-pool worktree directories
       if (deletedPaths && deletedPaths.length > 0) {
-        const worktreeManager = new this._GitWorktreeManager();
         for (const deletedPath of deletedPaths) {
           try {
             await worktreeManager.cleanupWorktree(deletedPath);

--- a/src/git/worktree.js
+++ b/src/git/worktree.js
@@ -171,6 +171,97 @@ class GitWorktreeManager {
   }
 
   /**
+   * Extract a PR number from either { number } or { prNumber } shapes.
+   * @param {Object|null} prInfo
+   * @returns {number|null}
+   */
+  getPRNumber(prInfo) {
+    if (!prInfo) return null;
+    return prInfo.number || prInfo.prNumber || null;
+  }
+
+  /**
+   * Extract the PR head branch name from either REST or stored PR metadata.
+   * @param {Object|null} prData
+   * @returns {string}
+   */
+  getPRHeadBranch(prData) {
+    return prData?.head?.ref || prData?.head_branch || '';
+  }
+
+  /**
+   * Extract the PR head SHA from either REST or stored PR metadata.
+   * @param {Object|null} prData
+   * @returns {string}
+   */
+  getPRHeadSha(prData) {
+    return prData?.head?.sha || prData?.head_sha || '';
+  }
+
+  /**
+   * Detect whether a fetch failed because the remote does not expose a PR ref.
+   * @param {Error} error
+   * @returns {boolean}
+   */
+  isMissingRemoteRefError(error) {
+    const message = String(error?.message || '').toLowerCase();
+    return message.includes('couldn\'t find remote ref') ||
+      message.includes('could not find remote ref') ||
+      message.includes('remote ref does not exist') ||
+      message.includes('fatal: invalid refspec');
+  }
+
+  /**
+   * Fetch a PR head into a stable tracking ref, falling back from GitHub PR
+   * refs to a direct SHA fetch when the git transport does not expose
+   * refs/pull/* (for example, alternate internal fetch backends).
+   *
+   * @param {Object} git - simple-git instance
+   * @param {Object} prInfo - PR info { owner, repo, number } or { prNumber }
+   * @param {Object} prData - PR data from GitHub API or stored metadata
+   * @param {Object} [options={}]
+   * @param {string|null} [options.remote] - Base repository remote to use for PR-ref fetch
+   * @returns {Promise<{remote: string, trackingRef: string|null, checkoutTarget: string}>}
+   */
+  async fetchPRHead(git, prInfo, prData, options = {}) {
+    const prNumber = this.getPRNumber(prInfo);
+    const headSha = this.getPRHeadSha(prData);
+    const baseRemote = options.remote || await this.resolveRemoteForPR(git, prData, prInfo);
+
+    if (!prNumber) {
+      throw new Error('Cannot fetch PR head without a PR number');
+    }
+
+    const prTrackingRef = `refs/remotes/${baseRemote}/pr-${prNumber}`;
+
+    try {
+      await git.fetch([baseRemote, `+refs/pull/${prNumber}/head:${prTrackingRef}`]);
+      return {
+        remote: baseRemote,
+        trackingRef: prTrackingRef,
+        checkoutTarget: prTrackingRef
+      };
+    } catch (prRefError) {
+      if (!this.isMissingRemoteRefError(prRefError)) {
+        throw prRefError;
+      }
+
+      console.warn(`PR ref fetch unavailable for PR #${prNumber} on remote ${baseRemote}, falling back to SHA fetch: ${prRefError.message}`);
+
+      if (!headSha) {
+        throw prRefError;
+      }
+
+      await git.raw(['fetch', baseRemote, headSha]);
+      return {
+        remote: baseRemote,
+        trackingRef: null,
+        checkoutTarget: headSha
+      };
+    }
+  }
+
+  /**
    * Execute a user-provided checkout script in the worktree.
    * The script receives PR context as environment variables and is responsible
    * for configuring sparse-checkout (or any other worktree setup).
@@ -427,20 +518,21 @@ class GitWorktreeManager {
         console.log(`Base SHA fetch not needed or already available: ${fetchError.message}`);
       }
 
-      // Fetch the PR head using GitHub's pull request refs (more reliable than branch names)
+      // Fetch the PR head using PR refs when available, with a branch/SHA fallback
       console.log(`Fetching PR #${prInfo.number} head...`);
-      await worktreeGit.fetch([remote, `+refs/pull/${prInfo.number}/head:refs/remotes/${remote}/pr-${prInfo.number}`]);
+      const fetchedHead = await this.fetchPRHead(worktreeGit, prInfo, prData, { remote });
 
       // Execute checkout script if configured (before checkout so sparse-checkout is set up)
       if (checkoutScript) {
         // Fetch the actual head branch by name (for checkout scripts that expect branch refs)
         // This may fail for fork PRs where the branch is in a different repo - that's okay
-        if (prData.head_branch) {
+        const headBranch = this.getPRHeadBranch(prData);
+        if (headBranch) {
           try {
-            console.log(`Fetching head branch ${prData.head_branch}...`);
-            await worktreeGit.fetch([remote, `+refs/heads/${prData.head_branch}:refs/remotes/${remote}/${prData.head_branch}`]);
+            console.log(`Fetching head branch ${headBranch}...`);
+            await worktreeGit.fetch([remote, `+refs/heads/${headBranch}:refs/remotes/${remote}/${headBranch}`]);
             // Create/update a local branch pointing to the fetched ref so tooling can reference it by name
-            await worktreeGit.branch(['-f', prData.head_branch, `${remote}/${prData.head_branch}`]);
+            await worktreeGit.branch(['-f', headBranch, `${remote}/${headBranch}`]);
           } catch (branchFetchError) {
             // Expected for fork PRs - the branch exists in the fork, not the base repo
             console.log(`Could not fetch head branch (may be from a fork): ${branchFetchError.message}`);
@@ -450,9 +542,9 @@ class GitWorktreeManager {
         console.log(`Executing checkout script: ${checkoutScript}`);
         const scriptEnv = {
           BASE_BRANCH: prData.base_branch,
-          HEAD_BRANCH: prData.head_branch,
+          HEAD_BRANCH: headBranch,
           BASE_SHA: prData.base_sha,
-          HEAD_SHA: prData.head_sha,
+          HEAD_SHA: this.getPRHeadSha(prData),
           PR_NUMBER: String(prInfo.number),
           WORKTREE_PATH: worktreePath
         };
@@ -461,13 +553,13 @@ class GitWorktreeManager {
       }
 
       // Checkout to PR head commit
-      const targetSha = prData.head_sha;
+      const targetSha = this.getPRHeadSha(prData);
       if (targetSha) {
         console.log(`Checking out to PR head commit ${targetSha}...`);
         await worktreeGit.checkout([targetSha]);
       } else {
-        console.log(`Checking out to PR head ref ${remote}/pr-${prInfo.number}...`);
-        await worktreeGit.checkout([`${remote}/pr-${prInfo.number}`]);
+        console.log(`Checking out to PR head ref ${fetchedHead.checkoutTarget}...`);
+        await worktreeGit.checkout([fetchedHead.checkoutTarget]);
       }
       
       // Verify we're at the correct commit
@@ -540,13 +632,13 @@ class GitWorktreeManager {
       console.log(`Fetching latest changes from ${remote}...`);
       await worktreeGit.fetch([remote, '--prune']);
 
-      // Fetch the PR head using GitHub's pull request refs
+      // Fetch the PR head using PR refs when available, with a branch/SHA fallback
       console.log(`Fetching PR #${number} head...`);
-      await worktreeGit.fetch([remote, `+refs/pull/${number}/head:refs/remotes/${remote}/pr-${number}`]);
+      const fetchedHead = await this.fetchPRHead(worktreeGit, prInfo, prData, { remote });
 
       // Checkout to PR head commit
       console.log(`Checking out to PR head commit ${headSha}...`);
-      await worktreeGit.checkout([`${remote}/pr-${number}`]);
+      await worktreeGit.checkout([fetchedHead.checkoutTarget]);
 
       // Verify we're at the correct commit
       const currentCommit = await worktreeGit.revparse(['HEAD']);
@@ -919,11 +1011,11 @@ class GitWorktreeManager {
 
       // Fetch the latest PR head from remote
       console.log(`Fetching PR #${prNumber} head from ${remote}...`);
-      await git.fetch([remote, `pull/${prNumber}/head`]);
+      const fetchedHead = await this.fetchPRHead(git, prInfo || { number: prNumber }, prData, { remote });
 
       // Reset to the fetched PR head
       console.log(`Resetting worktree to PR head...`);
-      await git.raw(['reset', '--hard', 'FETCH_HEAD']);
+      await git.raw(['reset', '--hard', fetchedHead.checkoutTarget]);
 
       // Update last_accessed_at in database
       if (this.worktreeRepo) {
@@ -977,13 +1069,13 @@ class GitWorktreeManager {
         ? await this.resolveRemoteForPR(git, prData, prInfo)
         : defaultRemote;
 
-      // 3. Fetch PR head into a persistent ref
-      console.log(`Fetching PR #${prNumber} head from ${remote} into refs/remotes/${remote}/pr-${prNumber}...`);
-      await git.fetch([remote, `+refs/pull/${prNumber}/head:refs/remotes/${remote}/pr-${prNumber}`]);
+      // 3. Fetch PR head into a persistent ref (or by SHA when refs are unavailable)
+      console.log(`Fetching PR #${prNumber} head from ${remote}...`);
+      const fetchedHead = await this.fetchPRHead(git, prInfo || { number: prNumber }, prData, { remote });
 
       // 4. Reset worktree to the fetched ref
-      console.log(`Resetting worktree to refs/remotes/${remote}/pr-${prNumber}...`);
-      await git.raw(['reset', '--hard', `refs/remotes/${remote}/pr-${prNumber}`]);
+      console.log(`Resetting worktree to ${fetchedHead.checkoutTarget}...`);
+      await git.raw(['reset', '--hard', fetchedHead.checkoutTarget]);
 
       // 5. Return the new HEAD SHA
       const headSha = (await git.revparse(['HEAD'])).trim();

--- a/tests/unit/worktree-checkout.test.js
+++ b/tests/unit/worktree-checkout.test.js
@@ -89,4 +89,34 @@ describe('GitWorktreeManager.checkoutBranch', () => {
     const fetchCall = mockGit.fetch.mock.calls[0][0];
     expect(fetchCall[1]).toBe('+refs/pull/77/head:refs/remotes/upstream/pr-77');
   });
+
+  it('should fall back to fetching the head SHA when PR refs are unavailable', async () => {
+    mockGit.fetch.mockRejectedValueOnce(new Error("fatal: couldn't find remote ref refs/pull/42/head"));
+
+    const sha = await manager.checkoutBranch('/tmp/worktree', 42, {
+      prData: {
+        head_sha: 'abc123def456',
+      }
+    });
+
+    expect(mockGit.fetch).toHaveBeenNthCalledWith(1, [
+      'upstream',
+      '+refs/pull/42/head:refs/remotes/upstream/pr-42',
+    ]);
+    expect(mockGit.raw).toHaveBeenNthCalledWith(1, [
+      'fetch', 'upstream', 'abc123def456',
+    ]);
+    expect(mockGit.raw).toHaveBeenNthCalledWith(2, [
+      'reset', '--hard', 'abc123def456',
+    ]);
+    expect(sha).toBe('abc123def456');
+  });
+
+  it('should propagate the error when PR refs are unavailable and no head_sha is provided', async () => {
+    mockGit.fetch.mockRejectedValueOnce(new Error("fatal: couldn't find remote ref refs/pull/42/head"));
+
+    await expect(
+      manager.checkoutBranch('/tmp/worktree', 42, { prData: {} })
+    ).rejects.toThrow("couldn't find remote ref");
+  });
 });

--- a/tests/unit/worktree-pool-lifecycle.test.js
+++ b/tests/unit/worktree-pool-lifecycle.test.js
@@ -18,6 +18,12 @@ function createMockDeps() {
     refreshWorktree: vi.fn().mockResolvedValue('/tmp/worktree/pair-review--abc'),
     executeCheckoutScript: vi.fn().mockResolvedValue(undefined),
     cleanupWorktree: vi.fn().mockResolvedValue(undefined),
+    resolveRemoteForPR: vi.fn().mockResolvedValue('origin'),
+    fetchPRHead: vi.fn().mockResolvedValue({
+      remote: 'origin',
+      trackingRef: 'refs/remotes/origin/pr-123',
+      checkoutTarget: 'abc123',
+    }),
   };
 
   // Must use function (not arrow) so it can be called with `new`
@@ -143,11 +149,13 @@ describe('WorktreePoolLifecycle', () => {
       expect(result.worktreeId).toBe('pair-review--xyz');
       // claimAvailable already marked as switching -- no separate markSwitching call
       expect(deps.poolRepo.markSwitching).not.toHaveBeenCalled();
-      // PR-specific refspec fetch — no --prune (only broad fetches get --prune)
-      expect(deps._mockGit.fetch).toHaveBeenCalledWith([
-        'origin',
-        '+refs/pull/123/head:refs/remotes/origin/pr-123',
-      ]);
+      expect(deps._mockWorktreeManagerInstance.resolveRemoteForPR).toHaveBeenCalled();
+      expect(deps._mockWorktreeManagerInstance.fetchPRHead).toHaveBeenCalledWith(
+        deps._mockGit,
+        { owner: 'test', repo: 'repo', number: 123 },
+        prData,
+        { remote: 'origin' }
+      );
       expect(deps._mockGit.checkout).toHaveBeenCalled();
     });
 
@@ -273,7 +281,15 @@ describe('WorktreePoolLifecycle', () => {
 
     it('executes operations in the correct order (markSwitching already done by claimAvailable)', async () => {
       const callOrder = [];
-      deps._mockGit.fetch.mockImplementation(() => { callOrder.push('fetch'); return Promise.resolve(); });
+      deps._mockWorktreeManagerInstance.resolveRemoteForPR.mockImplementation(() => { callOrder.push('resolveRemoteForPR'); return Promise.resolve('origin'); });
+      deps._mockWorktreeManagerInstance.fetchPRHead.mockImplementation(() => {
+        callOrder.push('fetchPRHead');
+        return Promise.resolve({
+          remote: 'origin',
+          trackingRef: 'refs/remotes/origin/pr-123',
+          checkoutTarget: 'abc123',
+        });
+      });
       deps._mockGit.reset.mockImplementation(() => { callOrder.push('reset'); return Promise.resolve(); });
       deps._mockGit.clean.mockImplementation(() => { callOrder.push('clean'); return Promise.resolve(); });
       deps._mockGit.checkout.mockImplementation(() => { callOrder.push('checkout'); return Promise.resolve(); });
@@ -283,7 +299,7 @@ describe('WorktreePoolLifecycle', () => {
 
       await lifecycle._switchPoolWorktree(poolEntry, worktreeRecord, prInfo, prData, options);
 
-      expect(callOrder).toEqual(['fetch', 'reset', 'clean', 'checkout', 'switchPR', 'clearWorktree', 'markInUse']);
+      expect(callOrder).toEqual(['resolveRemoteForPR', 'fetchPRHead', 'reset', 'clean', 'checkout', 'switchPR', 'clearWorktree', 'markInUse']);
     });
 
     it('runs executeCheckoutScript when resetScript is provided', async () => {
@@ -349,7 +365,7 @@ describe('WorktreePoolLifecycle', () => {
     });
 
     it('rolls back to available on failure', async () => {
-      deps._mockGit.fetch.mockRejectedValue(new Error('fetch failed'));
+      deps._mockWorktreeManagerInstance.fetchPRHead.mockRejectedValue(new Error('fetch failed'));
 
       await expect(lifecycle._switchPoolWorktree(poolEntry, worktreeRecord, prInfo, prData, options))
         .rejects.toThrow('fetch failed');
@@ -386,6 +402,11 @@ describe('WorktreePoolLifecycle', () => {
         head: { ref: 'feature-branch' },
         base: { ref: 'main' },
       };
+      deps._mockWorktreeManagerInstance.fetchPRHead.mockResolvedValue({
+        remote: 'origin',
+        trackingRef: 'refs/remotes/origin/pr-123',
+        checkoutTarget: 'refs/remotes/origin/pr-123',
+      });
 
       await lifecycle._switchPoolWorktree(poolEntry, worktreeRecord, prInfo, prDataNoSha, options);
 
@@ -991,4 +1012,3 @@ describe('WorktreePoolLifecycle', () => {
     });
   });
 });
-


### PR DESCRIPTION
## Summary
- try fetching GitHub PR refs first and fall back to fetching the PR head SHA from the same remote when refs/pull/* is unavailable
- route pool worktree switching through the same shared fetch helper so all PR checkout paths behave consistently
- add regression coverage for SHA fallback and missing-head-sha error propagation, plus a patch changeset

## Testing
- pnpm vitest run tests/unit/worktree-checkout.test.js tests/unit/worktree-pool-lifecycle.test.js
- pnpm vitest run tests/unit/worktree-checkout.test.js tests/unit/worktree-pool-lifecycle.test.js tests/unit/github-client.test.js