### PR TITLE
fix: stop persisting pair-review-base remote

### DIFF
--- a/.changeset/stop-persisting-base-remote.md
+++ b/.changeset/stop-persisting-base-remote.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Stop persisting the `pair-review-base` git remote and prefer existing remotes for PR fetches

--- a/src/git/worktree.js
+++ b/src/git/worktree.js
@@ -66,8 +66,9 @@ class GitWorktreeManager {
   /**
    * Resolve which git remote points to the given repository URLs.
    * Compares normalized URLs against all configured remotes. If no match is
-   * found, adds (or updates) a managed `pair-review-base` remote so that
-   * subsequent fetches target the correct repository (e.g. the base repo of a fork PR).
+   * found, falls back to an existing non-managed remote instead of mutating the
+   * repository's git config. This preserves proxy/mirror setups where the
+   * canonical fetch URL may differ from GitHub's clone URL.
    *
    * @param {Object} git - simple-git instance
    * @param {string} cloneUrl - HTTPS clone URL of the target repository
@@ -81,9 +82,7 @@ class GitWorktreeManager {
     const remoteOutput = await git.raw(['remote', '-v']);
 
     if (!remoteOutput || !remoteOutput.trim()) {
-      console.log(`No remotes found, adding ${MANAGED_REMOTE} remote for ${cloneUrl}`);
-      await git.addRemote(MANAGED_REMOTE, cloneUrl);
-      return MANAGED_REMOTE;
+      throw new Error(`No remotes configured — cannot resolve base repository for ${cloneUrl}`);
     }
 
     // Parse remote output into { name: url } map (fetch URLs only)
@@ -115,9 +114,16 @@ class GitWorktreeManager {
 
     const normalizedCloneUrl = normalizeUrl(cloneUrl);
     const normalizedSshUrl = sshUrl ? normalizeUrl(sshUrl) : '';
+    const remoteNames = Object.keys(remotes);
+    const fallbackRemote = remotes.origin
+      ? 'origin'
+      : remoteNames.find((name) => name !== MANAGED_REMOTE) || 'origin';
 
-    // Check each remote for a match
+    // Check each non-managed remote for a direct URL match
     for (const [name, url] of Object.entries(remotes)) {
+      if (name === MANAGED_REMOTE) {
+        continue;
+      }
       const normalizedRemoteUrl = normalizeUrl(url);
       if (normalizedRemoteUrl === normalizedCloneUrl ||
           (normalizedSshUrl && normalizedRemoteUrl === normalizedSshUrl)) {
@@ -126,16 +132,13 @@ class GitWorktreeManager {
       }
     }
 
-    // No match found — add or update the managed remote
-    if (remotes[MANAGED_REMOTE]) {
-      console.log(`Updating ${MANAGED_REMOTE} remote URL to ${cloneUrl}`);
-      await git.raw(['remote', 'set-url', MANAGED_REMOTE, cloneUrl]);
-    } else {
-      console.log(`Adding ${MANAGED_REMOTE} remote for ${cloneUrl}`);
-      await git.addRemote(MANAGED_REMOTE, cloneUrl);
-    }
-
-    return MANAGED_REMOTE;
+    console.warn(
+      `No configured remote matched ${cloneUrl}; using existing remote '${fallbackRemote}' without modifying git config`
+    );
+    // NOTE: For fork PRs this may return a remote that does not point to the
+    // base repository. Callers rely on fetchPRHead's SHA-fallback path and
+    // tolerant base-branch fetching to handle this without mutating git config.
+    return fallbackRemote;
   }
 
   /**

--- a/tests/unit/worktree-remote-resolution.test.js
+++ b/tests/unit/worktree-remote-resolution.test.js
@@ -98,12 +98,11 @@ describe('GitWorktreeManager remote resolution', () => {
       expect(mockGit.addRemote).not.toHaveBeenCalled();
     });
 
-    it('should add pair-review-base remote when no remote matches', async () => {
+    it('should fall back to origin when no remote matches', async () => {
       mockGit.raw.mockResolvedValue(
         'origin\thttps://github.com/fork-owner/repo.git (fetch)\n' +
         'origin\thttps://github.com/fork-owner/repo.git (push)\n'
       );
-      mockGit.addRemote.mockResolvedValue(undefined);
 
       const result = await manager.resolveRemoteForRepo(
         mockGit,
@@ -111,26 +110,17 @@ describe('GitWorktreeManager remote resolution', () => {
         'git@github.com:upstream-owner/repo.git'
       );
 
-      expect(result).toBe('pair-review-base');
-      expect(mockGit.addRemote).toHaveBeenCalledWith(
-        'pair-review-base',
-        'https://github.com/upstream-owner/repo.git'
-      );
+      expect(result).toBe('origin');
+      expect(mockGit.addRemote).not.toHaveBeenCalled();
     });
 
-    it('should use set-url when pair-review-base remote already exists', async () => {
-      mockGit.raw.mockImplementation(async (args) => {
-        if (args[0] === 'remote' && args[1] === '-v') {
-          return (
-            'origin\thttps://github.com/fork-owner/repo.git (fetch)\n' +
-            'origin\thttps://github.com/fork-owner/repo.git (push)\n' +
-            'pair-review-base\thttps://github.com/old-upstream/repo.git (fetch)\n' +
-            'pair-review-base\thttps://github.com/old-upstream/repo.git (push)\n'
-          );
-        }
-        // set-url call
-        return '';
-      });
+    it('should prefer origin over a stale pair-review-base remote', async () => {
+      mockGit.raw.mockResolvedValue(
+        'origin\thttps://proxy.example.com/owner/repo.git (fetch)\n' +
+        'origin\thttps://proxy.example.com/owner/repo.git (push)\n' +
+        'pair-review-base\thttps://github.com/old-upstream/repo.git (fetch)\n' +
+        'pair-review-base\thttps://github.com/old-upstream/repo.git (push)\n'
+      );
 
       const result = await manager.resolveRemoteForRepo(
         mockGit,
@@ -138,11 +128,9 @@ describe('GitWorktreeManager remote resolution', () => {
         ''
       );
 
-      expect(result).toBe('pair-review-base');
+      expect(result).toBe('origin');
       expect(mockGit.addRemote).not.toHaveBeenCalled();
-      expect(mockGit.raw).toHaveBeenCalledWith([
-        'remote', 'set-url', 'pair-review-base', 'https://github.com/new-upstream/repo.git'
-      ]);
+      expect(mockGit.raw).toHaveBeenCalledTimes(1);
     });
 
     it('should not produce false matches when sshUrl is null or empty', async () => {
@@ -166,24 +154,54 @@ describe('GitWorktreeManager remote resolution', () => {
         'https://github.com/different-owner/repo.git',
         ''
       );
-      expect(result2).toBe('pair-review-base');
+      expect(result2).toBe('origin');
     });
 
-    it('should add managed remote when remote output is empty', async () => {
-      mockGit.raw.mockResolvedValue('');
-      mockGit.addRemote.mockResolvedValue(undefined);
+    it('should fall back to first non-managed remote when origin is unavailable', async () => {
+      mockGit.raw.mockResolvedValue(
+        'upstream\tssh://git@proxy.example.com/owner/repo (fetch)\n' +
+        'upstream\tssh://git@proxy.example.com/owner/repo (push)\n' +
+        'pair-review-base\thttps://github.com/owner/repo.git (fetch)\n' +
+        'pair-review-base\thttps://github.com/owner/repo.git (push)\n'
+      );
+
+      const result = await manager.resolveRemoteForRepo(
+        mockGit,
+        'https://github.com/different-owner/repo.git',
+        ''
+      );
+
+      expect(result).toBe('upstream');
+      expect(mockGit.addRemote).not.toHaveBeenCalled();
+    });
+
+    it('should ignore pair-review-base even when its URL matches', async () => {
+      mockGit.raw.mockResolvedValue(
+        'origin\thttps://proxy.example.com/owner/repo.git (fetch)\n' +
+        'origin\thttps://proxy.example.com/owner/repo.git (push)\n' +
+        'pair-review-base\thttps://github.com/owner/repo.git (fetch)\n' +
+        'pair-review-base\thttps://github.com/owner/repo.git (push)\n'
+      );
 
       const result = await manager.resolveRemoteForRepo(
         mockGit,
         'https://github.com/owner/repo.git',
-        'git@github.com:owner/repo.git'
+        ''
       );
 
-      expect(result).toBe('pair-review-base');
-      expect(mockGit.addRemote).toHaveBeenCalledWith(
-        'pair-review-base',
-        'https://github.com/owner/repo.git'
-      );
+      expect(result).toBe('origin');
+      expect(mockGit.addRemote).not.toHaveBeenCalled();
+    });
+
+    it('should throw when remote output is empty', async () => {
+      mockGit.raw.mockResolvedValue('');
+
+      await expect(manager.resolveRemoteForRepo(
+        mockGit,
+        'https://github.com/owner/repo.git',
+        'git@github.com:owner/repo.git'
+      )).rejects.toThrow('No remotes configured');
+      expect(mockGit.addRemote).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
## Summary
- stop mutating repo git config by adding or updating `pair-review-base`
- prefer existing remotes and ignore stale `pair-review-base` entries so proxy/mirror setups stay in control
- fail fast when no remotes are configured, and cover the new behavior with focused unit tests

## Testing
- pnpm test tests/unit/worktree-remote-resolution.test.js
- pnpm test tests/unit/worktree-checkout.test.js