### PR TITLE
Add 75m–120m options to analysis timeout selector

### DIFF
--- a/.changeset/extended-timeout-options.md
+++ b/.changeset/extended-timeout-options.md
@@ -1,0 +1,7 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Add 75m, 90m, 105m, and 120m options to analysis timeout selectors
+
+The analysis config dialog's timeout dropdowns (used in both Council and Advanced tabs) previously capped at 60m. Four longer options are now available for reviewers running deep analyses that exceed the old ceiling.

--- a/public/js/components/TimeoutSelect.js
+++ b/public/js/components/TimeoutSelect.js
@@ -39,6 +39,10 @@ class TimeoutSelect {
     { value: '1800000', label: '30m' },
     { value: '2700000', label: '45m' },
     { value: '3600000', label: '60m' },
+    { value: '4500000', label: '75m' },
+    { value: '5400000', label: '90m' },
+    { value: '6300000', label: '105m' },
+    { value: '7200000', label: '120m' },
   ];
 
   /**

--- a/tests/unit/TimeoutSelect.test.js
+++ b/tests/unit/TimeoutSelect.test.js
@@ -232,8 +232,8 @@ describe('TimeoutSelect', () => {
   // -- Static TIMEOUT_OPTIONS -----------------------------------------------
 
   describe('static TIMEOUT_OPTIONS', () => {
-    it('should be an array with 6 default entries', () => {
-      expect(TimeoutSelect.TIMEOUT_OPTIONS).toHaveLength(6);
+    it('should be an array with 10 default entries', () => {
+      expect(TimeoutSelect.TIMEOUT_OPTIONS).toHaveLength(10);
     });
 
     it('should have 600000 (10m) as the default selected value', () => {
@@ -245,7 +245,7 @@ describe('TimeoutSelect', () => {
 
     it('should contain expected timeout values', () => {
       const values = TimeoutSelect.TIMEOUT_OPTIONS.map(o => o.value);
-      expect(values).toEqual(['300000', '600000', '900000', '1800000', '2700000', '3600000']);
+      expect(values).toEqual(['300000', '600000', '900000', '1800000', '2700000', '3600000', '4500000', '5400000', '6300000', '7200000']);
     });
   });
 
@@ -261,7 +261,7 @@ describe('TimeoutSelect', () => {
     it('should create option buttons for each option', () => {
       const ts = new TimeoutSelect();
       const items = ts.el.querySelectorAll('.timeout-select-option');
-      expect(items).toHaveLength(6);
+      expect(items).toHaveLength(10);
     });
 
     it('should accept custom options', () => {
@@ -776,9 +776,9 @@ describe('TimeoutSelect', () => {
 
       const ts = TimeoutSelect.mount(mountSpan);
 
-      // Should have 6 options (from TIMEOUT_OPTIONS)
+      // Should have 10 options (from TIMEOUT_OPTIONS)
       const items = ts.el.querySelectorAll('.timeout-select-option');
-      expect(items).toHaveLength(6);
+      expect(items).toHaveLength(10);
       expect(ts.value).toBe('600000');
     });
 

--- a/tests/unit/config-tab-timeout.test.js
+++ b/tests/unit/config-tab-timeout.test.js
@@ -164,6 +164,10 @@ global.window.TimeoutSelect = {
     { value: '1800000', label: '30m' },
     { value: '2700000', label: '45m' },
     { value: '3600000', label: '60m' },
+    { value: '4500000', label: '75m' },
+    { value: '5400000', label: '90m' },
+    { value: '6300000', label: '105m' },
+    { value: '7200000', label: '120m' },
   ],
 };
 


### PR DESCRIPTION
## Summary
- Extend `TimeoutSelect.TIMEOUT_OPTIONS` with 75m, 90m, 105m, and 120m so the Council and Advanced config tabs can set longer analysis timeouts
- Update unit test fixtures (`TimeoutSelect.test.js`, `config-tab-timeout.test.js`) for the new option count and values
- Changeset: patch bump

## Test plan
- [x] `pnpm test` — all 6199 tests pass
- [ ] Manually open the Council config dialog and confirm the four new options appear and persist
- [ ] Manually open the Advanced config dialog and confirm the same

🤖 Generated with [Claude Code](https://claude.com/claude-code)