### PR TITLE
Add PORT env var support; migrate config.js logging

### DIFF
--- a/.changeset/port-env-var.md
+++ b/.changeset/port-env-var.md
@@ -1,0 +1,11 @@
+---
+"@in-the-loop-labs/pair-review": minor
+---
+
+Support `PORT` env var to override the configured port
+
+Setting `PORT` in the environment now overrides `config.port` from every config layer (managed, global, project, local). Invalid values (non-numeric or outside 1024–65535) fail fast with a clear error.
+
+This makes pair-review compatible with launchers that dynamically assign a port — notably Claude Code's Preview feature, whose `"autoPort": true` in `.claude/launch.json` picks a free port and injects it via `PORT`.
+
+Also migrated `console.error`/`console.log` calls in `src/config.js` to the project's `logger`, matching the existing logging convention.

--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,15 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "pair-review-local-debug",
+      "runtimeExecutable": "node",
+      "runtimeArgs": ["bin/pair-review.js", "--local", "--debug"],
+      "port": 7247,
+      "autoPort": true,
+      "env": {
+        "PAIR_REVIEW_NO_OPEN": "1"
+      }
+    }
+  ]
+}

--- a/src/config.js
+++ b/src/config.js
@@ -129,7 +129,7 @@ async function copyExampleConfig() {
   try {
     await fs.access(sourceExample);
     await fs.copyFile(sourceExample, CONFIG_EXAMPLE_FILE);
-    console.log(`Copied config.example.json to: ${CONFIG_EXAMPLE_FILE}`);
+    logger.info(`Copied config.example.json to: ${CONFIG_EXAMPLE_FILE}`);
     return true;
   } catch (error) {
     if (error.code === 'ENOENT') {
@@ -155,13 +155,13 @@ async function ensureConfigDir() {
     if (error.code === 'ENOENT') {
       try {
         await fs.mkdir(CONFIG_DIR, { recursive: true });
-        console.log(`Created config directory: ${CONFIG_DIR}`);
+        logger.info(`Created config directory: ${CONFIG_DIR}`);
         // Copy example config to new directory
         await copyExampleConfig();
         return true; // Directory was newly created
       } catch (mkdirError) {
         if (mkdirError.code === 'EACCES' || mkdirError.code === 'EPERM') {
-          console.error(`Cannot create configuration directory at ~/.pair-review/`);
+          logger.error(`Cannot create configuration directory at ~/.pair-review/`);
           process.exit(1);
         }
         throw mkdirError;
@@ -212,7 +212,7 @@ async function loadConfig() {
         // Optional files or managed-config-present: skip silently
       } else if (error instanceof SyntaxError) {
         if (source.required) {
-          console.error(`Invalid configuration file at ~/.pair-review/config.json`);
+          logger.error(`Invalid configuration file at ~/.pair-review/config.json`);
           process.exit(1);
         }
         logger.warn(`Malformed config at ${source.label}, skipping`);
@@ -236,9 +236,19 @@ async function loadConfig() {
     mergedConfig.repos = normalized;
   }
 
+  // PORT env var overrides all config layers (used by Preview and similar harnesses)
+  if (process.env.PORT) {
+    const envPort = Number(process.env.PORT);
+    if (!validatePort(envPort)) {
+      logger.error(`Invalid PORT env var "${process.env.PORT}" (must be an integer between 1024 and 65535)`);
+      process.exit(1);
+    }
+    mergedConfig.port = envPort;
+  }
+
   // Validate port
   if (!validatePort(mergedConfig.port)) {
-    console.error(`Invalid port number ${mergedConfig.port}`);
+    logger.error(`Invalid port number ${mergedConfig.port}`);
     process.exit(1);
   }
 
@@ -270,7 +280,7 @@ async function saveConfig(config) {
     await fs.writeFile(CONFIG_FILE, JSON.stringify(config, null, 2));
   } catch (error) {
     if (error.code === 'EACCES' || error.code === 'EPERM') {
-      console.error(`Cannot create configuration directory at ~/.pair-review/`);
+      logger.error(`Cannot create configuration directory at ~/.pair-review/`);
       process.exit(1);
     }
     throw error;

--- a/tests/unit/config.test.js
+++ b/tests/unit/config.test.js
@@ -1154,6 +1154,117 @@ describe('config.js', () => {
       warnSpy.mockRestore();
     });
 
+    describe('PORT env var', () => {
+      let originalPort;
+
+      beforeEach(() => {
+        originalPort = process.env.PORT;
+        delete process.env.PORT;
+      });
+
+      afterEach(() => {
+        if (originalPort !== undefined) {
+          process.env.PORT = originalPort;
+        } else {
+          delete process.env.PORT;
+        }
+      });
+
+      it('should override config.port when PORT env var is set', async () => {
+        process.env.PORT = '9999';
+        mockReadFile({
+          global: { port: 7247 },
+        });
+
+        const { config } = await loadConfig();
+
+        expect(config.port).toBe(9999);
+      });
+
+      it('should override all config layers including project local', async () => {
+        process.env.PORT = '4242';
+        mockReadFile({
+          global: { port: 1111 },
+          globalLocal: { port: 2222 },
+          project: { port: 3333 },
+          projectLocal: { port: 5555 },
+        });
+
+        const { config } = await loadConfig();
+
+        expect(config.port).toBe(4242);
+      });
+
+      it('should use config.port when PORT env var is not set', async () => {
+        mockReadFile({
+          global: { port: 7247 },
+        });
+
+        const { config } = await loadConfig();
+
+        expect(config.port).toBe(7247);
+      });
+
+      it('should coerce numeric string env value to integer', async () => {
+        process.env.PORT = '8080';
+        mockReadFile({
+          global: { port: 7247 },
+        });
+
+        const { config } = await loadConfig();
+
+        expect(config.port).toBe(8080);
+        expect(typeof config.port).toBe('number');
+      });
+
+      it('should exit with error for non-numeric PORT env var', async () => {
+        process.env.PORT = 'abc';
+        mockReadFile({
+          global: { port: 7247 },
+        });
+        const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+          throw new Error('process.exit called');
+        });
+        const logger = require('../../src/utils/logger');
+        const errorSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
+
+        await expect(loadConfig()).rejects.toThrow('process.exit called');
+        expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('Invalid PORT env var'));
+
+        exitSpy.mockRestore();
+        errorSpy.mockRestore();
+      });
+
+      it('should exit with error for out-of-range PORT env var', async () => {
+        process.env.PORT = '80';
+        mockReadFile({
+          global: { port: 7247 },
+        });
+        const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+          throw new Error('process.exit called');
+        });
+        const logger = require('../../src/utils/logger');
+        const errorSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
+
+        await expect(loadConfig()).rejects.toThrow('process.exit called');
+        expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('Invalid PORT env var'));
+
+        exitSpy.mockRestore();
+        errorSpy.mockRestore();
+      });
+
+      it('should ignore empty string PORT env var', async () => {
+        process.env.PORT = '';
+        mockReadFile({
+          global: { port: 7247 },
+        });
+
+        const { config } = await loadConfig();
+
+        expect(config.port).toBe(7247);
+      });
+    });
+
     it('should normalize monorepos key into repos when only monorepos is present', async () => {
       mockReadFile({
         global: {


### PR DESCRIPTION
## Summary

- Honor `process.env.PORT` as the highest-priority override for `config.port`. Validates range (1024–65535) and fails fast on invalid values.
- Makes pair-review compatible with launchers that assign a port dynamically — notably Claude Code's Preview feature with `"autoPort": true` in `.claude/launch.json`, which picks a free port and injects it via `PORT`.
- Migrates `console.error`/`console.log` calls in `src/config.js` to the project's `logger`, per the documented logging convention.
- Adds a `.claude/launch.json` preset for the Preview integration (uses `autoPort: true`).

## Test plan

- [x] Unit tests for PORT override, layering across config sources, no-op when unset, empty string, non-numeric, out-of-range (7 new tests in `tests/unit/config.test.js`).
- [x] Full `tests/unit/config.test.js` suite passes (178 tests).
- [x] End-to-end with Claude Preview: started app with configured port 7247 taken; Preview picked free port 61350, injected `PORT=61350`, app bound to 61350, UI rendered correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)