### PR TITLE
Persist per-level analysis outcomes

### DIFF
--- a/.changeset/persist-level-outcomes.md
+++ b/.changeset/persist-level-outcomes.md
@@ -1,0 +1,15 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Persist per-level analysis outcomes and surface them in history
+
+The analysis-run history now shows which levels actually **succeeded** or **failed**, not just which were configured to run. A new `C` slot reflects the consolidation (orchestration) step, which previously had no indicator at all.
+
+- Success → green ✓
+- Failure → red ✗
+- Skipped → neutral grey middot (`·`), replacing the old grey ✗
+
+Outcomes are stored in a new `analysis_runs.level_outcomes` column (migration v44) so the information survives navigation and reloads. Legacy runs fall back to the existing `levels_config`-based rendering (enabled → success, disabled → skipped; no `C` slot, because historical consolidation outcome is unknown).
+
+Council parent runs display only the `C` slot, since per-level outcomes live on the per-reviewer child runs.

--- a/plans/persist-level-outcomes.md
+++ b/plans/persist-level-outcomes.md
@@ -1,0 +1,221 @@
+# Persist Per-Level Analysis Outcomes
+
+## Context
+
+The analysis-run history shows L1/L2/L3 indicators: green check if the level was configured to run, grey X at 0.5 opacity if it was skipped. The problem:
+
+1. The indicators only reflect **what was requested** (`levels_config`), not **what actually happened**. A level can fail at runtime and still render as a green check.
+2. Per-level outcome is computed in-memory (`levelResults` in [`src/ai/analyzer.js:459`](src/ai/analyzer.js:459)) and streamed over the progress socket, but **never persisted**. If you navigate away or refresh, the information is lost.
+3. Consolidation ("orchestration") is also a discrete step that can succeed or fail ([`analyzer.js:519`](src/ai/analyzer.js:519) try/catch with fallback), but isn't surfaced at all.
+
+Goal: persist a four-slot outcome record per run — L1, L2, L3, C — and display it with iconography that distinguishes success (green ✓), failure (red ✗), and skipped (neutral grey middot `·`). Legacy runs (no persisted outcome) fall back to the current `levels_config`-driven display using the new neutral middot for skipped.
+
+## Data Model
+
+New column on `analysis_runs`:
+
+```
+level_outcomes TEXT  -- JSON
+```
+
+Shape:
+
+```json
+{
+  "level1": "success" | "failed" | "skipped",
+  "level2": "success" | "failed" | "skipped",
+  "level3": "success" | "failed" | "skipped",
+  "consolidation": "success" | "failed" | "skipped"
+}
+```
+
+Keys are **optional**. A council **parent** run only writes `consolidation` (its L1/L2/L3 run on child reviewer runs). A council **child** run writes all four keys like a normal single run. The frontend renders only the keys that are present, so the parent shows just a `C` and children show `L1 L2 L3 C`.
+
+## Backend Changes
+
+### 1. Database migration — [`src/database.js`](src/database.js)
+
+Bump the schema version and add an idempotent migration that mirrors the existing `levels_config` pattern at [`database.js:966`](src/database.js:966):
+
+```js
+const hasLevelOutcomes = columnExists(db, 'analysis_runs', 'level_outcomes');
+if (!hasLevelOutcomes) {
+  try {
+    db.prepare(`ALTER TABLE analysis_runs ADD COLUMN level_outcomes TEXT`).run();
+  } catch (error) {
+    if (!error.message.includes('duplicate column name')) throw error;
+  }
+}
+```
+
+Also add `'level_outcomes'` to the update-field whitelists at [`database.js:4383`](src/database.js:4383), [`database.js:4411`](src/database.js:4411), and [`database.js:4449`](src/database.js:4449), and to the INSERT at [`database.js:4296`](src/database.js:4296). The column stores a JSON string; serialize on write, parse on read.
+
+### 2. Analyzer — [`src/ai/analyzer.js`](src/ai/analyzer.js)
+
+The hard work is already done. `levelResults` at line 459 already holds per-level `status`, and orchestration success/failure is already distinguishable (the try/catch at line 519; the `orchestrationFailed: true` return flag at line 625).
+
+**`analyzeAllLevels`** (line 326):
+- Derive `levelOutcomes` from `levelResults` just before each `analysisRunRepo.update(...)` call (lines 554, 609):
+  - `{ level1: levelResults.level1.status, level2: ..., level3: ..., consolidation: 'success' }` in the happy path.
+  - `consolidation: 'failed'` in the fallback path (line 609).
+- If a level's `status` is `'skipped'`, keep `'skipped'`. No `'running'` states leak because we're past `Promise.allSettled`.
+- Pass `levelOutcomes` into the `analysisRunRepo.update` call alongside `status` / `summary` / etc.
+- Add `levelOutcomes` to the returned object at lines 568 and 620 so callers can inspect it.
+
+**`runReviewerCentricCouncil`** (line 2834) and **`runCouncilAnalysis`** (line 3362):
+- **Child reviewer runs**: already invoke `analyzeAllLevels`; they'll pick up the new column via the existing update call. No changes needed in the child path.
+- **Parent council run**: at the end, when the parent's own cross-reviewer consolidation completes, update the parent row with `level_outcomes: { consolidation: 'success' }` (or `'failed'`). Grep these two functions for their existing `analysisRunRepo.update(parentRunId, { status: 'completed', ... })` call sites and add the field there.
+
+### 3. Route layer — [`src/routes/analyses.js`](src/routes/analyses.js)
+
+`enrichRun` at line 47 already parses `levels_config`. Add a parallel line:
+
+```js
+level_outcomes: run.level_outcomes ? JSON.parse(run.level_outcomes) : null,
+```
+
+No other route changes needed — the analyzer writes the column directly via `analysisRunRepo.update`, and the GET endpoint is the only consumer.
+
+### 4. Failure paths
+
+If the analyzer throws **before** `Promise.allSettled` runs (config errors, worktree errors), `levelResults` is never populated. The route-level error handlers (`catch` blocks in [`src/routes/pr.js`](src/routes/pr.js), [`src/routes/local.js`](src/routes/local.js), [`src/routes/analyses.js`](src/routes/analyses.js), [`src/routes/executable-analysis.js`](src/routes/executable-analysis.js), [`src/routes/stack-analysis.js`](src/routes/stack-analysis.js), [`src/routes/mcp.js`](src/routes/mcp.js)) that mark the run `status: 'failed'` should leave `level_outcomes` as `NULL`. The frontend falls back to `levels_config`-based rendering for null outcomes, which is correct behavior for "never ran".
+
+## Frontend Changes
+
+### 1. [`public/js/modules/analysis-history.js`](public/js/modules/analysis-history.js) — `renderLevelIndicators` (line 890)
+
+Rewrite to a two-mode function:
+
+```js
+renderLevelIndicators(run) {
+  const outcomes = run.level_outcomes;
+  const config = run.levels_config;
+
+  // Build slot list: [{ label, outcome }, ...]
+  const slots = [];
+  const addSlot = (label, outcome) => {
+    if (outcome) slots.push({ label, outcome });
+  };
+
+  if (outcomes) {
+    // New path: use persisted outcomes
+    addSlot('L1', outcomes.level1);
+    addSlot('L2', outcomes.level2);
+    addSlot('L3', outcomes.level3);
+    addSlot('C',  outcomes.consolidation);
+  } else if (config) {
+    // Legacy fallback: derive from config only. No failure state, no C slot.
+    for (const level of [1, 2, 3]) {
+      const enabled = Array.isArray(config)
+        ? config.includes(level)
+        : config[`level${level}`] !== false;
+      addSlot(`L${level}`, enabled ? 'success' : 'skipped');
+    }
+  } else {
+    return '';
+  }
+
+  const icon = { success: '\u2713', failed: '\u2717', skipped: '\u00B7' };
+  const cls  = { success: 'level-success', failed: 'level-failed', skipped: 'level-skipped' };
+
+  const html = slots
+    .map(s => `<span class="analysis-history-level ${cls[s.outcome]}">${s.label}${icon[s.outcome]}</span>`)
+    .join('');
+  return `<span class="analysis-history-levels">${html}</span>`;
+}
+```
+
+Key behaviors:
+- New runs with `level_outcomes`: 3–4 slots, tri-state icons.
+- Legacy runs: 3 slots (no `C`), green check for enabled, neutral middot for skipped. **No failure state** — we don't know.
+- Council parent run: only `C` slot (because only `consolidation` is set in `level_outcomes`).
+
+### 2. CSS — [`public/css/pr.css`](public/css/pr.css:8002)
+
+Replace `.level-on` / `.level-off` with three classes:
+
+```css
+.analysis-history-level.level-success {
+  color: var(--color-success, #22c55e);
+}
+
+.analysis-history-level.level-failed {
+  color: var(--color-danger, #ef4444);
+}
+
+.analysis-history-level.level-skipped {
+  color: var(--color-text-muted);
+  opacity: 0.5;
+}
+```
+
+Verify the correct danger-color CSS variable by grepping for existing usage (e.g., `--color-danger`, `--color-error`, `--color-red`) — reuse the project's established token, don't introduce a new one.
+
+## Tests
+
+### Schema updates (required per CLAUDE.md)
+
+- [`tests/e2e/global-setup.js:370`](tests/e2e/global-setup.js:370) — add `level_outcomes TEXT` to the test schema.
+- [`tests/integration/routes.test.js:2422`](tests/integration/routes.test.js:2422) — same.
+
+### New unit tests
+
+Add a test file (`tests/unit/analysis-history-level-indicators.test.js` or extend [`tests/unit/analysis-history.test.js`](tests/unit/analysis-history.test.js)) covering:
+
+1. All succeed → `L1✓ L2✓ L3✓ C✓`, all green.
+2. L2 failed → `L1✓ L2✗ L3✓ C✓`, L2 has `.level-failed`.
+3. L3 skipped by config → `L1✓ L2✓ L3· C✓`, L3 has `.level-skipped`.
+4. Consolidation failed → `L1✓ L2✓ L3✓ C✗`.
+5. Legacy run (`level_outcomes: null`, `levels_config: [1, 2]`) → `L1✓ L2✓ L3·`, no `C` slot.
+6. Council parent (`level_outcomes: { consolidation: 'success' }`) → only `C✓`.
+7. Empty run (no outcomes, no config) → returns `''`.
+
+### New analyzer unit tests
+
+Extend [`tests/unit/analyzer`-style tests](tests/unit) to assert `levelResults` → `levelOutcomes` mapping for: all-success, single-level-failure, all-skipped-except-one, orchestration-failure (fallback path).
+
+### Integration test
+
+Extend [`tests/integration/routes.test.js`](tests/integration/routes.test.js): insert an `analysis_runs` row with `level_outcomes` JSON, `GET /api/analyses/runs/:id`, assert the parsed object round-trips.
+
+### E2E test (optional but recommended)
+
+Extend [`tests/e2e/ai-analysis.spec.js`](tests/e2e/ai-analysis.spec.js) or create a sibling: verify the indicator badges render with the correct classes after a completed run.
+
+## Hazards
+
+> **Three analyzer paths** — per CLAUDE.md, `analyzeAllLevels`, `runReviewerCentricCouncil`, and `runCouncilAnalysis` must all be updated. `analyzeAllLevels` carries the bulk; the council paths need to populate `consolidation` on the **parent** run row at their own final-update site.
+>
+> **Six route-level error handlers** — [`pr.js`](src/routes/pr.js), [`local.js`](src/routes/local.js), [`analyses.js`](src/routes/analyses.js), [`executable-analysis.js`](src/routes/executable-analysis.js), [`stack-analysis.js`](src/routes/stack-analysis.js), [`mcp.js`](src/routes/mcp.js). Each has a `catch` block that marks the run failed. Leave `level_outcomes` as NULL in those paths; the frontend fallback renders correctly.
+>
+> **Migration idempotency** — follow the pattern at [`database.js:966`](src/database.js:966) exactly. Guard with `columnExists` AND catch `duplicate column name` for race safety. Also remember the update-field whitelist at three separate sites ([`4383`](src/database.js:4383), [`4411`](src/database.js:4411), [`4449`](src/database.js:4449)).
+>
+> **`levels_config` has two formats** (array from voice-centric, object from advanced). The legacy-fallback branch of `renderLevelIndicators` already handles both — preserve that when rewriting.
+>
+> **Legacy runs have no "C" data** — the fallback branch must not render a `C` slot when outcomes are absent. Rendering `C·` would imply consolidation was skipped, which is usually false.
+>
+> **Parent vs child council runs** — parent writes only `consolidation`; children write all four. Getting this wrong would either double-display `C` or lose per-level visibility on child runs.
+>
+> **Icon encoding** — middot is U+00B7 (`·`), not a regular period. Use `\u00B7` in source to avoid stray encoding drift.
+>
+> **CSS variable name** — verify the danger/error color token in use before committing to `--color-danger`.
+
+## Changeset
+
+Minor version bump. User-facing UI change with new persisted data. Add `.changeset/*.md` describing: "Analysis-run history now shows per-level success/failure status (previously only showed which levels were configured to run). Consolidation step is also surfaced."
+
+## Verification
+
+1. `pnpm test` — unit + integration tests pass, including the new ones.
+2. Start the app against an existing database; migration runs cleanly. Old runs still render with the legacy fallback (green checks / grey middots, no `C`).
+3. Run a fresh analysis. Assert the indicator shows `L1✓ L2✓ L3✓ C✓` (all green).
+4. Force a failure: temporarily inject a throw in `analyzeLevel2Isolated`. Run analysis, assert history row shows `L1✓ L2✗ L3✓ C✓`. Remove the injection.
+5. Run a council analysis. Parent row shows only `C✓`. Child reviewer rows show `L1✓ L2✓ L3✓ C✓`.
+6. `pnpm test:e2e` — E2E tests pass.
+
+## Out of Scope
+
+- Per-voice outcomes on the council parent (parent shows only `C`, per user decision).
+- Timing/duration per level.
+- Retry-failed-level UI.
+- Backfilling `level_outcomes` for existing runs.

--- a/public/css/pr.css
+++ b/public/css/pr.css
@@ -8003,11 +8003,15 @@ body.resizing * {
   padding: 0 2px;
 }
 
-.analysis-history-level.level-on {
+.analysis-history-level.level-success {
   color: var(--color-success, #22c55e);
 }
 
-.analysis-history-level.level-off {
+.analysis-history-level.level-failed {
+  color: var(--color-danger, #d1242f);
+}
+
+.analysis-history-level.level-skipped {
   color: var(--color-text-muted);
   opacity: 0.5;
 }

--- a/public/js/modules/analysis-history.js
+++ b/public/js/modules/analysis-history.js
@@ -502,7 +502,7 @@ class AnalysisHistoryManager {
     `;
 
     // Level indicators in preview
-    if (run.levels_config) {
+    if (run.levels_config || run.level_outcomes) {
       html += `
       <div class="analysis-preview-row">
         <span class="analysis-preview-label">Levels</span>
@@ -883,31 +883,56 @@ class AnalysisHistoryManager {
   }
 
   /**
-   * Render level indicators (L1/L2/L3) based on levels_config.
-   * @param {Object} run - Analysis run object with optional levels_config
+   * Render level indicators (L1/L2/L3/C) with tri-state outcomes
+   * (success / failed / skipped).
+   *
+   * Prefers persisted `level_outcomes` when available. Falls back to
+   * `levels_config` for legacy runs — in which case enabled levels render
+   * as success, disabled as skipped, and the consolidation slot is omitted
+   * (we have no historical data for it).
+   *
+   * @param {Object} run - Analysis run object
    * @returns {string} HTML string for level indicators
    */
   renderLevelIndicators(run) {
-    const levelsConfig = run.levels_config;
-    if (!levelsConfig) return '';
+    const outcomes = run.level_outcomes;
+    const config = run.levels_config;
 
-    // levels_config can be:
-    // - An array like [1, 2] (voice-centric: enabled levels)
-    // - An object like { level1: true, level2: true, level3: false } (advanced)
-    const levels = [1, 2, 3];
-    const indicators = levels.map(level => {
-      let enabled;
-      if (Array.isArray(levelsConfig)) {
-        enabled = levelsConfig.includes(level);
-      } else {
-        const key = `level${level}`;
-        enabled = levelsConfig[key] !== false;
+    const slots = [];
+    const addSlot = (label, outcome) => {
+      if (outcome) slots.push({ label, outcome });
+    };
+
+    if (outcomes) {
+      addSlot('L1', outcomes.level1);
+      addSlot('L2', outcomes.level2);
+      addSlot('L3', outcomes.level3);
+      addSlot('C', outcomes.consolidation);
+    } else if (config) {
+      // Legacy fallback: derive from config only. No failure state, no C slot.
+      // levels_config can be an array (voice-centric: enabled levels) or an
+      // object (advanced: per-level boolean).
+      for (const level of [1, 2, 3]) {
+        const enabled = Array.isArray(config)
+          ? config.includes(level)
+          : config[`level${level}`] !== false;
+        addSlot(`L${level}`, enabled ? 'success' : 'skipped');
       }
-      const cls = enabled ? 'level-on' : 'level-off';
-      const icon = enabled ? '\u2713' : '\u2717';
-      return `<span class="analysis-history-level ${cls}">L${level}${icon}</span>`;
-    });
-    return `<span class="analysis-history-levels">${indicators.join('')}</span>`;
+    } else {
+      return '';
+    }
+
+    const icon = { success: '\u2713', failed: '\u2717', skipped: '\u00B7' };
+    const cls = {
+      success: 'level-success',
+      failed: 'level-failed',
+      skipped: 'level-skipped'
+    };
+
+    const html = slots
+      .map(s => `<span class="analysis-history-level ${cls[s.outcome] || ''}">${s.label}${icon[s.outcome] || ''}</span>`)
+      .join('');
+    return `<span class="analysis-history-levels">${html}</span>`;
   }
 
   /**

--- a/src/ai/analyzer.js
+++ b/src/ai/analyzer.js
@@ -550,13 +550,22 @@ class Analyzer {
           throw new CancellationError('Analysis was cancelled');
         }
 
+        // Build per-level outcome record for persistence and UI
+        const levelOutcomes = {
+          level1: levelResults.level1.status,
+          level2: levelResults.level2.status,
+          level3: levelResults.level3.status,
+          consolidation: 'success'
+        };
+
         // Update analysis_run record with completion data
         try {
           await analysisRunRepo.update(runId, {
             status: 'completed',
             summary: orchestrationResult.summary,
             totalSuggestions: finalSuggestions.length,
-            filesAnalyzed: validFiles.length
+            filesAnalyzed: validFiles.length,
+            levelOutcomes
           });
           logger.info(`${logPrefix}Updated analysis_run record to completed: ${finalSuggestions.length} suggestions, ${validFiles.length} files`);
         } catch (updateError) {
@@ -569,6 +578,7 @@ class Analyzer {
           runId,
           suggestions: finalSuggestions,
           levelResults,
+          levelOutcomes,
           summary: orchestrationResult.summary
         };
 
@@ -603,6 +613,14 @@ class Analyzer {
           throw new CancellationError('Analysis was cancelled');
         }
 
+        // Build per-level outcome record (consolidation failed, fallback path used)
+        const levelOutcomes = {
+          level1: levelResults.level1.status,
+          level2: levelResults.level2.status,
+          level3: levelResults.level3.status,
+          consolidation: 'failed'
+        };
+
         // Update analysis_run record with completion data (even though orchestration failed)
         const fallbackSummary = `Analysis complete (consolidation failed): ${finalFallbackSuggestions.length} suggestions`;
         try {
@@ -610,7 +628,8 @@ class Analyzer {
             status: 'completed',
             summary: fallbackSummary,
             totalSuggestions: finalFallbackSuggestions.length,
-            filesAnalyzed: validFiles.length
+            filesAnalyzed: validFiles.length,
+            levelOutcomes
           });
           logger.info(`${logPrefix}Updated analysis_run record to completed (fallback): ${finalFallbackSuggestions.length} suggestions`);
         } catch (updateError) {
@@ -621,6 +640,7 @@ class Analyzer {
           runId,
           suggestions: finalFallbackSuggestions,
           levelResults,
+          levelOutcomes,
           summary: fallbackSummary,
           orchestrationFailed: true
         };
@@ -2973,7 +2993,8 @@ File-level suggestions should NOT have a line number. They apply to the entire f
             status: 'completed',
             summary: result.summary,
             totalSuggestions: finalSuggestions.length,
-            filesAnalyzed: validFiles.length
+            filesAnalyzed: validFiles.length,
+            levelOutcomes: { consolidation: 'skipped' }
           });
         } catch (err) {
           logger.warn(`[ReviewerCouncil] Failed to update parent run: ${err.message}`);
@@ -2982,7 +3003,8 @@ File-level suggestions should NOT have a line number. They apply to the entire f
         return {
           runId: parentRunId,
           suggestions: finalSuggestions,
-          summary: result.summary || `Review council complete: ${finalSuggestions.length} suggestions`
+          summary: result.summary || `Review council complete: ${finalSuggestions.length} suggestions`,
+          levelOutcomes: { consolidation: 'skipped' }
         };
       }
 
@@ -3012,7 +3034,8 @@ File-level suggestions should NOT have a line number. They apply to the entire f
       return {
         runId: parentRunId,
         suggestions: result.suggestions,
-        summary: result.summary || `Review council complete: ${result.suggestions?.length || 0} suggestions`
+        summary: result.summary || `Review council complete: ${result.suggestions?.length || 0} suggestions`,
+        levelOutcomes: result.levelOutcomes
       };
     }
 
@@ -3085,7 +3108,8 @@ File-level suggestions should NOT have a line number. They apply to the entire f
             await analysisRunRepo.update(childRunId, {
               status: 'completed',
               summary: result.summary,
-              totalSuggestions: validatedSuggestions.length
+              totalSuggestions: validatedSuggestions.length,
+              levelOutcomes: { consolidation: 'skipped' }
             });
           } catch (err) {
             logger.warn(`[ReviewerCouncil] Failed to update child run ${childRunId}: ${err.message}`);
@@ -3217,7 +3241,8 @@ File-level suggestions should NOT have a line number. They apply to the entire f
           status: 'completed',
           summary: singleResult.summary,
           totalSuggestions: finalSuggestions.length,
-          filesAnalyzed: validFiles.length
+          filesAnalyzed: validFiles.length,
+          levelOutcomes: { consolidation: 'skipped' }
         });
       } catch (err) {
         logger.warn(`[ReviewerCouncil] Failed to update parent run: ${err.message}`);
@@ -3226,7 +3251,8 @@ File-level suggestions should NOT have a line number. They apply to the entire f
       return {
         runId: parentRunId,
         suggestions: finalSuggestions,
-        summary: singleResult.summary || `Review council complete: ${finalSuggestions.length} suggestions`
+        summary: singleResult.summary || `Review council complete: ${finalSuggestions.length} suggestions`,
+        levelOutcomes: { consolidation: 'skipped' }
       };
     }
 
@@ -3295,7 +3321,8 @@ File-level suggestions should NOT have a line number. They apply to the entire f
           status: 'completed',
           summary,
           totalSuggestions: finalSuggestions.length,
-          filesAnalyzed: validFiles.length
+          filesAnalyzed: validFiles.length,
+          levelOutcomes: { consolidation: 'success' }
         });
       } catch (err) {
         logger.warn(`[ReviewerCouncil] Failed to update parent run: ${err.message}`);
@@ -3306,7 +3333,8 @@ File-level suggestions should NOT have a line number. They apply to the entire f
       return {
         runId: parentRunId,
         suggestions: finalSuggestions,
-        summary
+        summary,
+        levelOutcomes: { consolidation: 'success' }
       };
     } catch (error) {
       logger.error(`[ReviewerCouncil] Cross-reviewer consolidation failed: ${error.message}`);
@@ -3324,7 +3352,8 @@ File-level suggestions should NOT have a line number. They apply to the entire f
           status: 'completed',
           summary: fallbackSummary,
           totalSuggestions: fallbackSuggestions.length,
-          filesAnalyzed: validFiles.length
+          filesAnalyzed: validFiles.length,
+          levelOutcomes: { consolidation: 'failed' }
         });
       } catch (err) {
         logger.warn(`[ReviewerCouncil] Failed to update parent run: ${err.message}`);
@@ -3334,7 +3363,8 @@ File-level suggestions should NOT have a line number. They apply to the entire f
         runId: parentRunId,
         suggestions: fallbackSuggestions,
         summary: fallbackSummary,
-        orchestrationFailed: true
+        orchestrationFailed: true,
+        levelOutcomes: { consolidation: 'failed' }
       };
     }
   }
@@ -3523,7 +3553,8 @@ File-level suggestions should NOT have a line number. They apply to the entire f
       return {
         runId,
         suggestions: finalSuggestions,
-        summary: bestVoiceSummary || `Council analysis complete: ${finalSuggestions.length} suggestions from single reviewer`
+        summary: bestVoiceSummary || `Council analysis complete: ${finalSuggestions.length} suggestions from single reviewer`,
+        levelOutcomes: { consolidation: 'skipped' }
       };
     }
 
@@ -3636,7 +3667,8 @@ File-level suggestions should NOT have a line number. They apply to the entire f
       return {
         runId,
         suggestions: finalSuggestions,
-        summary: orchestrationResult.summary
+        summary: orchestrationResult.summary,
+        levelOutcomes: { consolidation: 'success' }
       };
     } catch (error) {
       logger.error(`[Council] Cross-level consolidation failed: ${error.message}`);
@@ -3657,7 +3689,8 @@ File-level suggestions should NOT have a line number. They apply to the entire f
         runId,
         suggestions: finalFallback,
         summary: `Council analysis complete (consolidation failed): ${finalFallback.length} suggestions`,
-        orchestrationFailed: true
+        orchestrationFailed: true,
+        levelOutcomes: { consolidation: 'failed' }
       };
     }
   }

--- a/src/database.js
+++ b/src/database.js
@@ -21,7 +21,7 @@ function getDbPath() {
 /**
  * Current schema version - increment this when adding new migrations
  */
-const CURRENT_SCHEMA_VERSION = 43;
+const CURRENT_SCHEMA_VERSION = 44;
 
 /**
  * Database schema SQL statements
@@ -184,6 +184,7 @@ const SCHEMA_SQL = {
       parent_run_id TEXT,
       config_type TEXT DEFAULT 'single',
       levels_config TEXT,
+      level_outcomes TEXT,
       scope_start TEXT,
       scope_end TEXT,
       FOREIGN KEY (review_id) REFERENCES reviews(id) ON DELETE CASCADE
@@ -1866,6 +1867,25 @@ const MIGRATIONS = {
     };
     addColumnIfNotExists('repo_settings', 'load_skills', 'INTEGER');
     console.log('Migration to schema version 43 complete');
+  },
+
+  44: (db) => {
+    console.log('Running migration to schema version 44: Add level_outcomes to analysis_runs...');
+    const hasLevelOutcomes = columnExists(db, 'analysis_runs', 'level_outcomes');
+    if (!hasLevelOutcomes) {
+      try {
+        db.prepare(`ALTER TABLE analysis_runs ADD COLUMN level_outcomes TEXT`).run();
+        console.log('  Added level_outcomes column to analysis_runs');
+      } catch (error) {
+        if (!error.message.includes('duplicate column name')) {
+          throw error;
+        }
+        console.log('  Column level_outcomes already exists (race condition)');
+      }
+    } else {
+      console.log('  Column level_outcomes already exists');
+    }
+    console.log('Migration to schema version 44 complete');
   }
 };
 
@@ -4348,6 +4368,11 @@ class AnalysisRunRepository {
       params.push(updates.diff);
     }
 
+    if (updates.levelOutcomes !== undefined) {
+      setClauses.push('level_outcomes = ?');
+      params.push(updates.levelOutcomes === null ? null : JSON.stringify(updates.levelOutcomes));
+    }
+
     if (setClauses.length === 0) {
       return false;
     }
@@ -4380,7 +4405,7 @@ class AnalysisRunRepository {
     const columns = [
       'id', 'review_id', 'provider', 'model', 'tier', 'custom_instructions', 'global_instructions', 'repo_instructions', 'request_instructions',
       'head_sha', 'summary', 'status', 'total_suggestions', 'files_analyzed', 'started_at', 'completed_at',
-      'parent_run_id', 'config_type', 'levels_config'
+      'parent_run_id', 'config_type', 'levels_config', 'level_outcomes'
     ];
     if (includeDiff) {
       columns.splice(columns.indexOf('head_sha') + 1, 0, 'diff'); // Insert diff after head_sha
@@ -4408,7 +4433,7 @@ class AnalysisRunRepository {
     const columns = [
       'id', 'review_id', 'provider', 'model', 'tier', 'custom_instructions', 'global_instructions', 'repo_instructions', 'request_instructions',
       'head_sha', 'summary', 'status', 'total_suggestions', 'files_analyzed', 'started_at', 'completed_at',
-      'parent_run_id', 'config_type', 'levels_config'
+      'parent_run_id', 'config_type', 'levels_config', 'level_outcomes'
     ];
     if (includeDiff) {
       columns.splice(columns.indexOf('head_sha') + 1, 0, 'diff'); // Insert diff after head_sha
@@ -4446,7 +4471,7 @@ class AnalysisRunRepository {
     const columns = [
       'id', 'review_id', 'provider', 'model', 'tier', 'custom_instructions', 'global_instructions', 'repo_instructions', 'request_instructions',
       'head_sha', 'summary', 'status', 'total_suggestions', 'files_analyzed', 'started_at', 'completed_at',
-      'parent_run_id', 'config_type', 'levels_config'
+      'parent_run_id', 'config_type', 'levels_config', 'level_outcomes'
     ];
     if (includeDiff) {
       columns.splice(columns.indexOf('head_sha') + 1, 0, 'diff'); // Insert diff after head_sha
@@ -4473,7 +4498,7 @@ class AnalysisRunRepository {
     return query(this.db, `
       SELECT id, review_id, provider, model, tier, custom_instructions, global_instructions, repo_instructions, request_instructions,
              head_sha, summary, status, total_suggestions, files_analyzed, started_at, completed_at,
-             parent_run_id, config_type, levels_config
+             parent_run_id, config_type, levels_config, level_outcomes
       FROM analysis_runs
       WHERE parent_run_id = ?
       ORDER BY started_at ASC
@@ -4971,5 +4996,6 @@ module.exports = {
   generateWorktreeId,
   migrateExistingWorktrees,
   // Exported for testing only
-  _MIGRATIONS: MIGRATIONS
+  _MIGRATIONS: MIGRATIONS,
+  MIGRATIONS
 };

--- a/src/routes/analyses.js
+++ b/src/routes/analyses.js
@@ -42,13 +42,14 @@ const router = express.Router();
 
 /**
  * Enrich a raw analysis run record for API responses.
- * Applies backward-compatible tier fallback and parses levels_config JSON.
+ * Applies backward-compatible tier fallback and parses JSON columns.
  */
 function enrichRun(run) {
   if (!run) return null;
   return {
     ...run,
     levels_config: run.levels_config ? JSON.parse(run.levels_config) : null,
+    level_outcomes: run.level_outcomes ? JSON.parse(run.level_outcomes) : null,
     tier: run.tier ?? (run.provider && run.model ? getTierForModel(run.provider, run.model) : null)
   };
 }
@@ -625,6 +626,7 @@ async function launchCouncilAnalysis(db, modeContext, councilConfig, councilId, 
           status: 'completed',
           summary: result.summary,
           totalSuggestions: result.suggestions.length,
+          ...(result.levelOutcomes ? { levelOutcomes: result.levelOutcomes } : {}),
           ...runUpdateExtra
         });
       } catch (updateError) {

--- a/tests/integration/database.test.js
+++ b/tests/integration/database.test.js
@@ -39,6 +39,12 @@ describe('Database Initialization', () => {
     }
   });
 
+  it('CURRENT_SCHEMA_VERSION matches the highest migration key', () => {
+    const { CURRENT_SCHEMA_VERSION, MIGRATIONS } = require('../../src/database');
+    const maxMigration = Math.max(...Object.keys(MIGRATIONS).map(Number));
+    expect(CURRENT_SCHEMA_VERSION).toBe(maxMigration);
+  });
+
   it('should create all required tables', async () => {
     const tables = await query(db, `
       SELECT name FROM sqlite_master
@@ -2254,6 +2260,54 @@ describe('AnalysisRunRepository', () => {
 
       const updated = await analysisRunRepo.update(runId, {});
       expect(updated).toBe(false);
+    });
+
+    it('should persist levelOutcomes as JSON and round-trip via getById', async () => {
+      const runId = 'test-run-level-outcomes';
+      await analysisRunRepo.create({ id: runId, reviewId: testReview.id });
+
+      const outcomes = {
+        level1: 'success',
+        level2: 'failed',
+        level3: 'skipped',
+        consolidation: 'success'
+      };
+
+      const updated = await analysisRunRepo.update(runId, {
+        status: 'completed',
+        levelOutcomes: outcomes
+      });
+      expect(updated).toBe(true);
+
+      const retrieved = await analysisRunRepo.getById(runId);
+      expect(retrieved.level_outcomes).toBe(JSON.stringify(outcomes));
+      expect(JSON.parse(retrieved.level_outcomes)).toEqual(outcomes);
+    });
+
+    it('should persist a council-parent levelOutcomes with only consolidation', async () => {
+      const runId = 'test-run-council-parent';
+      await analysisRunRepo.create({ id: runId, reviewId: testReview.id });
+
+      await analysisRunRepo.update(runId, {
+        status: 'completed',
+        levelOutcomes: { consolidation: 'failed' }
+      });
+
+      const retrieved = await analysisRunRepo.getById(runId);
+      expect(JSON.parse(retrieved.level_outcomes)).toEqual({ consolidation: 'failed' });
+    });
+
+    it('should clear levelOutcomes when null is provided', async () => {
+      const runId = 'test-run-clear-outcomes';
+      await analysisRunRepo.create({ id: runId, reviewId: testReview.id });
+
+      await analysisRunRepo.update(runId, {
+        levelOutcomes: { level1: 'success' }
+      });
+      await analysisRunRepo.update(runId, { levelOutcomes: null });
+
+      const retrieved = await analysisRunRepo.getById(runId);
+      expect(retrieved.level_outcomes).toBeNull();
     });
   });
 

--- a/tests/unit/analysis-history.test.js
+++ b/tests/unit/analysis-history.test.js
@@ -1602,45 +1602,132 @@ describe('AnalysisHistoryManager', () => {
       });
     });
 
-    it('should return empty string when no levels_config', () => {
+    it('should return empty string when no outcomes and no config', () => {
       expect(manager.renderLevelIndicators({})).toBe('');
       expect(manager.renderLevelIndicators({ levels_config: null })).toBe('');
+      expect(manager.renderLevelIndicators({ level_outcomes: null, levels_config: null })).toBe('');
     });
 
-    it('should render all levels enabled from array format', () => {
+    // --- Legacy fallback (levels_config only, no level_outcomes) ---
+
+    it('renders enabled levels as success and disabled as skipped (array format)', () => {
       const html = manager.renderLevelIndicators({ levels_config: [1, 2, 3] });
       expect(html).toContain('L1\u2713');
       expect(html).toContain('L2\u2713');
       expect(html).toContain('L3\u2713');
-      // All should have level-on class
-      expect(html).not.toContain('level-off');
+      expect(html).toContain('level-success');
+      expect(html).not.toContain('level-skipped');
+      expect(html).not.toContain('level-failed');
     });
 
-    it('should render partial levels from array format', () => {
+    it('renders partial enabled levels with middot for skipped (array format)', () => {
       const html = manager.renderLevelIndicators({ levels_config: [1, 2] });
-      expect(html).toContain('level-on');
-      expect(html).toContain('level-off');
-      // L3 should be off
-      expect(html).toContain('L3\u2717');
+      expect(html).toContain('L1\u2713');
+      expect(html).toContain('L2\u2713');
+      expect(html).toContain('L3\u00B7');
+      expect(html).toContain('level-success');
+      expect(html).toContain('level-skipped');
+      expect(html).not.toContain('level-failed');
     });
 
-    it('should render levels from object format', () => {
+    it('renders levels from object format with middot for disabled', () => {
       const html = manager.renderLevelIndicators({
         levels_config: { level1: true, level2: true, level3: false }
       });
       expect(html).toContain('L1\u2713');
       expect(html).toContain('L2\u2713');
-      expect(html).toContain('L3\u2717');
+      expect(html).toContain('L3\u00B7');
+      expect(html).toContain('level-skipped');
     });
 
-    it('should treat missing keys in object format as enabled', () => {
+    it('treats missing keys in object format as enabled', () => {
       const html = manager.renderLevelIndicators({
         levels_config: { level1: true }
       });
-      // level2 and level3 keys are missing, so treated as enabled (not false)
       expect(html).toContain('L1\u2713');
       expect(html).toContain('L2\u2713');
       expect(html).toContain('L3\u2713');
+    });
+
+    it('legacy fallback does not emit a C slot', () => {
+      const html = manager.renderLevelIndicators({ levels_config: [1, 2, 3] });
+      expect(html).not.toContain('>C');
+    });
+
+    // --- New path (level_outcomes present) ---
+
+    it('renders all-success with green checks and a C slot', () => {
+      const html = manager.renderLevelIndicators({
+        level_outcomes: {
+          level1: 'success', level2: 'success', level3: 'success',
+          consolidation: 'success'
+        }
+      });
+      expect(html).toContain('L1\u2713');
+      expect(html).toContain('L2\u2713');
+      expect(html).toContain('L3\u2713');
+      expect(html).toContain('C\u2713');
+      expect(html).not.toContain('level-failed');
+      expect(html).not.toContain('level-skipped');
+    });
+
+    it('renders a failed level with red X', () => {
+      const html = manager.renderLevelIndicators({
+        level_outcomes: {
+          level1: 'success', level2: 'failed', level3: 'success',
+          consolidation: 'success'
+        }
+      });
+      expect(html).toContain('L2\u2717');
+      expect(html).toContain('level-failed');
+      // L2 failed should carry the failed class
+      expect(html).toMatch(/level-failed[^<]*L2\u2717/);
+    });
+
+    it('renders a skipped level with a middot, not an X', () => {
+      const html = manager.renderLevelIndicators({
+        level_outcomes: {
+          level1: 'success', level2: 'success', level3: 'skipped',
+          consolidation: 'success'
+        }
+      });
+      expect(html).toContain('L3\u00B7');
+      expect(html).toContain('level-skipped');
+      expect(html).not.toContain('L3\u2717');
+    });
+
+    it('renders a failed consolidation with red X on the C slot', () => {
+      const html = manager.renderLevelIndicators({
+        level_outcomes: {
+          level1: 'success', level2: 'success', level3: 'success',
+          consolidation: 'failed'
+        }
+      });
+      expect(html).toContain('C\u2717');
+      expect(html).toMatch(/level-failed[^<]*C\u2717/);
+    });
+
+    it('council parent with only consolidation renders just a C slot', () => {
+      const html = manager.renderLevelIndicators({
+        level_outcomes: { consolidation: 'success' }
+      });
+      expect(html).toContain('C\u2713');
+      expect(html).not.toContain('L1');
+      expect(html).not.toContain('L2');
+      expect(html).not.toContain('L3');
+    });
+
+    it('prefers level_outcomes over legacy levels_config when both are present', () => {
+      const html = manager.renderLevelIndicators({
+        levels_config: [1, 2, 3],
+        level_outcomes: {
+          level1: 'success', level2: 'failed', level3: 'skipped',
+          consolidation: 'success'
+        }
+      });
+      expect(html).toContain('L2\u2717');
+      expect(html).toContain('L3\u00B7');
+      expect(html).toContain('C\u2713');
     });
   });
 });

--- a/tests/utils/schema.js
+++ b/tests/utils/schema.js
@@ -152,6 +152,7 @@ const SCHEMA_SQL = {
       parent_run_id TEXT,
       config_type TEXT DEFAULT 'single',
       levels_config TEXT,
+      level_outcomes TEXT,
       scope_start TEXT,
       scope_end TEXT,
       FOREIGN KEY (review_id) REFERENCES reviews(id) ON DELETE CASCADE


### PR DESCRIPTION
## Summary

- Analysis-run history now distinguishes success / failure / skipped per level, not just "configured to run"
- New `C` slot for the consolidation step (previously had no indicator)
- Outcomes persist to a new `analysis_runs.level_outcomes` column (migration v44) so they survive reloads

## Iconography

- success → green ✓
- failure → red ✗
- skipped → neutral grey middot (`·`), replacing the old grey ✗

## Behavior notes

- Legacy runs fall back to `levels_config`-based rendering (enabled → success, disabled → skipped; no `C` slot, since historical consolidation outcome is unknown)
- Council parent runs display only the `C` slot — per-level outcomes live on per-reviewer child runs
- Executable voices (Codex, etc.) persist `{consolidation: 'skipped'}` so they render consistently alongside level-based voices

## Test plan

- [x] Unit tests: 8 new `renderLevelIndicators` cases covering all tri-state combinations, legacy fallback, and council parent
- [x] Integration tests: 3 new DB round-trip cases (JSON serialization, council-parent-only shape, NULL clearing)
- [x] Schema invariant test: `CURRENT_SCHEMA_VERSION` must equal highest migration key (catches "forgot to bump the constant" bug)
- [x] Full suite: 6210/6210 passing
- [x] E2E: 270 passed (1 unrelated flake on retry)
- [ ] Manual smoke: start app against fresh DB, run analysis, confirm `L1✓ L2✓ L3✓ C✓` renders
- [ ] Manual smoke: run analysis against old DB, confirm migration v44 runs and legacy runs render with middot for skipped
- [ ] Manual smoke: council analysis — parent row shows only `C✓`, children show full `L1 L2 L3 C`

🤖 Generated with [Claude Code](https://claude.com/claude-code)