### PR TITLE
Show viewed state for files in the sidebar

### DIFF
--- a/.changeset/sidebar-viewed-indicator.md
+++ b/.changeset/sidebar-viewed-indicator.md
@@ -1,0 +1,7 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Show "viewed" state for files in the sidebar
+
+Files marked as viewed (and therefore collapsed in the diff panel) now display a gray filename and an eye-slash icon in the sidebar file list. The indicator updates in-place when viewed state is toggled, so the sidebar stays in sync with the diff panel without a full re-render.

--- a/public/css/pr.css
+++ b/public/css/pr.css
@@ -1075,6 +1075,25 @@
   font-style: italic;
 }
 
+.file-viewed-icon-wrapper {
+  display: inline-flex;
+  align-items: center;
+  flex-shrink: 0;
+  margin-right: 4px;
+}
+
+.file-viewed-icon {
+  color: var(--color-fg-muted, #8b949e);
+  vertical-align: middle;
+  flex-shrink: 0;
+}
+
+.file-item.viewed .file-name,
+.file-item.viewed.context-file-item .file-name {
+  color: var(--color-fg-muted, #8b949e);
+  font-style: italic;
+}
+
 /* Tree view styles */
 .tree-item {
   user-select: none;

--- a/public/js/local.js
+++ b/public/js/local.js
@@ -1508,11 +1508,12 @@ class LocalManager {
         fileCount: sortedFiles.length
       });
 
+      // Load viewed state before rendering so files can start collapsed
+      // and so the sidebar viewed indicator renders on first paint
+      await manager.loadViewedState();
+
       // Update file list sidebar
       manager.updateFileList(sortedFiles);
-
-      // Load viewed state before rendering so files can start collapsed
-      await manager.loadViewedState();
 
       // Render diff
       manager.renderDiff({ changed_files: sortedFiles });

--- a/public/js/pr.js
+++ b/public/js/pr.js
@@ -799,11 +799,12 @@ class PRManager {
           window.aiPanel.setFileOrder(this.canonicalFileOrder);
         }
 
+        // Load viewed state before rendering so files can start collapsed
+        // and so the sidebar viewed indicator renders on first paint
+        await this.loadViewedState();
+
         // Update sidebar with file list
         this.updateFileList(sortedFiles);
-
-        // Load viewed state before rendering so files can start collapsed
-        await this.loadViewedState();
 
         // Render diff using the existing renderDiff method
         this.renderDiff({ changed_files: sortedFiles });
@@ -2083,8 +2084,58 @@ class PRManager {
       }
     }
 
+    // Update sidebar file row to reflect viewed state
+    this.updateFileItemViewedState(filePath, isViewed);
+
     // Persist viewed state
     this.saveViewedState();
+  }
+
+  /**
+   * Build the eye-slash icon wrapper element used to mark a sidebar
+   * file row as viewed. Shared by the initial render and in-place updates
+   * so the markup and attributes stay in sync.
+   * @returns {HTMLSpanElement}
+   */
+  _createViewedIcon() {
+    const viewedIcon = document.createElement('span');
+    viewedIcon.className = 'file-viewed-icon-wrapper';
+    viewedIcon.title = 'Marked as viewed';
+    viewedIcon.setAttribute('aria-label', 'Marked as viewed');
+    viewedIcon.innerHTML = '<svg class="file-viewed-icon" viewBox="0 0 16 16" width="14" height="14" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M1.22 1.22a.75.75 0 0 1 1.06 0l12.5 12.5a.75.75 0 1 1-1.06 1.06l-1.82-1.82A7.44 7.44 0 0 1 8 14c-2.12 0-3.88-.81-5.26-1.94A13.13 13.13 0 0 1 .75 9.44a7.34 7.34 0 0 1-.51-.66.77.77 0 0 1 0-.84 12.52 12.52 0 0 1 .55-.72c.28-.34.66-.79 1.13-1.26L1.22 2.28a.75.75 0 0 1 0-1.06ZM4.5 5.56 6 7.06a2.5 2.5 0 0 0 2.94 2.94l1.22 1.22a4 4 0 0 1-5.66-5.66ZM8 3.5a4 4 0 0 1 3.98 4.46l3.04 3.04.1-.12c.36-.44.65-.87.87-1.22a.77.77 0 0 0 0-.84 13.13 13.13 0 0 0-2-2.62A7.44 7.44 0 0 0 8 2a7.4 7.4 0 0 0-2.3.36L7.1 3.78c.3-.18.62-.28.9-.28Z"/></svg>';
+    return viewedIcon;
+  }
+
+  /**
+   * Update the sidebar file row to reflect the viewed state.
+   * Adds/removes the .viewed class and injects/removes the eye-slash icon
+   * without re-rendering the whole file list.
+   * @param {string} filePath - Path of the file
+   * @param {boolean} isViewed - Whether the file is now viewed
+   */
+  updateFileItemViewedState(filePath, isViewed) {
+    const items = document.querySelectorAll('.file-item');
+    let item = null;
+    for (const candidate of items) {
+      if (candidate.dataset.path === filePath) {
+        item = candidate;
+        break;
+      }
+    }
+    if (!item) return;
+
+    const existingIcon = item.querySelector('.file-viewed-icon-wrapper');
+
+    if (isViewed) {
+      item.classList.add('viewed');
+      if (!existingIcon) {
+        const viewedIcon = this._createViewedIcon();
+        item.insertBefore(viewedIcon, item.firstChild);
+      }
+    } else {
+      item.classList.remove('viewed');
+      if (existingIcon) existingIcon.remove();
+    }
   }
 
   /**
@@ -4191,6 +4242,11 @@ class PRManager {
 
     if (file.generated) item.classList.add('generated');
     if (file.contextFile) item.classList.add('context-file-item');
+    if (this.viewedFiles && this.viewedFiles.has(file.fullPath)) {
+      item.classList.add('viewed');
+      const viewedIcon = this._createViewedIcon();
+      item.insertBefore(viewedIcon, item.firstChild);
+    }
     if (file.renamed && file.renamedFrom) {
       item.title = `Renamed from: ${file.renamedFrom}`;
       const renameIcon = document.createElement('span');

--- a/tests/unit/file-item-viewed-indicator.test.js
+++ b/tests/unit/file-item-viewed-indicator.test.js
@@ -1,0 +1,175 @@
+// Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+// @vitest-environment jsdom
+/**
+ * Unit tests for the sidebar file row's "viewed" indicator.
+ *
+ * When a file is marked as viewed, the sidebar row should:
+ *   - Gain the `.viewed` class (drives gray file-name color via CSS)
+ *   - Get an eye-slash icon prepended inside `.file-viewed-icon-wrapper`
+ *
+ * Covers both the initial render (`renderFileItem`) and in-place updates
+ * after a viewed toggle (`updateFileItemViewedState`).
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+
+const { PRManager } = require('../../public/js/pr.js');
+
+function createManager(viewedPaths = []) {
+  const manager = Object.create(PRManager.prototype);
+  manager.viewedFiles = new Set(viewedPaths);
+  return manager;
+}
+
+function makeFile(overrides = {}) {
+  return {
+    name: 'app.js',
+    fullPath: 'src/app.js',
+    status: 'modified',
+    additions: 5,
+    deletions: 2,
+    binary: false,
+    generated: false,
+    renamed: false,
+    renamedFrom: null,
+    contextFile: false,
+    ...overrides,
+  };
+}
+
+describe('file-item viewed indicator', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  describe('renderFileItem', () => {
+    it('adds .viewed class and eye-slash icon when file is in viewedFiles', () => {
+      const manager = createManager(['src/app.js']);
+      const item = manager.renderFileItem(makeFile());
+
+      expect(item.classList.contains('viewed')).toBe(true);
+
+      const icon = item.querySelector('.file-viewed-icon-wrapper');
+      expect(icon).not.toBeNull();
+      expect(icon.getAttribute('title')).toBe('Marked as viewed');
+      expect(icon.querySelector('svg.file-viewed-icon')).not.toBeNull();
+    });
+
+    it('prepends the viewed icon before other content (first child)', () => {
+      const manager = createManager(['src/app.js']);
+      const item = manager.renderFileItem(makeFile());
+
+      expect(item.firstChild.classList.contains('file-viewed-icon-wrapper')).toBe(true);
+    });
+
+    it('does not add .viewed class or icon when file is not in viewedFiles', () => {
+      const manager = createManager([]);
+      const item = manager.renderFileItem(makeFile());
+
+      expect(item.classList.contains('viewed')).toBe(false);
+      expect(item.querySelector('.file-viewed-icon-wrapper')).toBeNull();
+    });
+
+    it('marks context files as viewed when their path is in viewedFiles', () => {
+      const manager = createManager(['src/app.js']);
+      const item = manager.renderFileItem(makeFile({ contextFile: true }));
+
+      expect(item.classList.contains('viewed')).toBe(true);
+      expect(item.querySelector('.file-viewed-icon-wrapper')).not.toBeNull();
+    });
+
+    it('handles missing viewedFiles set without throwing', () => {
+      const manager = Object.create(PRManager.prototype);
+      manager.viewedFiles = undefined;
+
+      expect(() => manager.renderFileItem(makeFile())).not.toThrow();
+      const item = manager.renderFileItem(makeFile());
+      expect(item.classList.contains('viewed')).toBe(false);
+    });
+
+    it('coexists with rename icon — both icons are appended', () => {
+      const manager = createManager(['src/app.js']);
+      const item = manager.renderFileItem(makeFile({
+        renamed: true,
+        renamedFrom: 'src/old.js',
+      }));
+
+      expect(item.querySelector('.file-viewed-icon-wrapper')).not.toBeNull();
+      expect(item.querySelector('.file-rename-icon-wrapper')).not.toBeNull();
+      // Viewed icon should come first
+      expect(item.firstChild.classList.contains('file-viewed-icon-wrapper')).toBe(true);
+    });
+  });
+
+  describe('updateFileItemViewedState', () => {
+    it('adds class and icon when toggled to viewed', () => {
+      const manager = createManager([]);
+      const item = manager.renderFileItem(makeFile());
+      document.body.appendChild(item);
+
+      manager.updateFileItemViewedState('src/app.js', true);
+
+      expect(item.classList.contains('viewed')).toBe(true);
+      expect(item.querySelector('.file-viewed-icon-wrapper')).not.toBeNull();
+    });
+
+    it('removes class and icon when toggled to unviewed', () => {
+      const manager = createManager(['src/app.js']);
+      const item = manager.renderFileItem(makeFile());
+      document.body.appendChild(item);
+
+      manager.updateFileItemViewedState('src/app.js', false);
+
+      expect(item.classList.contains('viewed')).toBe(false);
+      expect(item.querySelector('.file-viewed-icon-wrapper')).toBeNull();
+    });
+
+    it('does not duplicate the icon if called twice with isViewed=true', () => {
+      const manager = createManager([]);
+      const item = manager.renderFileItem(makeFile());
+      document.body.appendChild(item);
+
+      manager.updateFileItemViewedState('src/app.js', true);
+      manager.updateFileItemViewedState('src/app.js', true);
+
+      const icons = item.querySelectorAll('.file-viewed-icon-wrapper');
+      expect(icons.length).toBe(1);
+    });
+
+    it('is a no-op when no matching sidebar row exists', () => {
+      const manager = createManager([]);
+      // No DOM element rendered — should not throw
+      expect(() =>
+        manager.updateFileItemViewedState('src/missing.js', true)
+      ).not.toThrow();
+    });
+
+    it('handles paths containing characters that need CSS-escape', () => {
+      const manager = createManager([]);
+      const trickyPath = 'src/weird[brackets].js';
+      const item = manager.renderFileItem(makeFile({ fullPath: trickyPath }));
+      document.body.appendChild(item);
+
+      manager.updateFileItemViewedState(trickyPath, true);
+
+      expect(item.classList.contains('viewed')).toBe(true);
+      expect(item.querySelector('.file-viewed-icon-wrapper')).not.toBeNull();
+    });
+
+    it('places viewed icon before rename icon when toggled on a renamed file', () => {
+      const manager = createManager([]);
+      const item = manager.renderFileItem(makeFile({
+        renamed: true,
+        renamedFrom: 'src/old.js',
+      }));
+      document.body.appendChild(item);
+
+      manager.updateFileItemViewedState('src/app.js', true);
+
+      const viewedIcon = item.querySelector('.file-viewed-icon-wrapper');
+      const renameIcon = item.querySelector('.file-rename-icon-wrapper');
+      const children = [...item.children];
+      expect(children.indexOf(viewedIcon)).toBeLessThan(children.indexOf(renameIcon));
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Files marked as viewed now show a gray italic filename and an eye-slash icon in the sidebar file list
- Indicator updates in-place on toggle and renders correctly on page load for both regular and context files
- Works in both PR mode and Local mode

## Test plan
- [x] Unit tests: 12/12 in `tests/unit/file-item-viewed-indicator.test.js`, full suite 5253/5253
- [x] E2E: 270/271 (one unrelated flaky Analysis History test)
- [ ] Manual: open a PR, mark a file as viewed via the diff-header checkbox, confirm the sidebar row goes gray + italic with an eye-slash icon, uncheck it, confirm the styling clears
- [ ] Manual: reload the page, confirm previously-viewed files render with the indicator on first paint
- [ ] Manual: repeat for a context file in a Local mode session
- [ ] Manual: repeat for a renamed file — viewed icon should sit before the rename icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)