### PR TITLE
Fix diff context expansion accuracy

### DIFF
--- a/.changeset/fix-start-of-file-hunk-header.md
+++ b/.changeset/fix-start-of-file-hunk-header.md
@@ -1,0 +1,6 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Fix incorrect context expansion above the first PR diff hunk so revealed lines
+and hunk headers stay aligned with the rendered patch.

--- a/public/js/pr.js
+++ b/public/js/pr.js
@@ -2357,7 +2357,9 @@ class PRManager {
           type: 'context',
           oldNumber: lineNumber,
           newNumber: lineNumber + lineOffset,  // Apply offset for correct right-side line number
-          content: content || ''
+          // Expanded rows should follow the same contract as parsed diff context
+          // lines so DiffRenderer strips the synthetic diff marker, not real indent.
+          content: ' ' + (content || '')
         };
 
         const lineRow = this.renderDiffLine(fragment, lineData, fileName, null);
@@ -2469,7 +2471,9 @@ class PRManager {
           type: 'context',
           oldNumber: lineNumber,
           newNumber: lineNumber + lineOffset,  // Apply offset for correct right-side line number
-          content: content || ''
+          // Expanded rows should follow the same contract as parsed diff context
+          // lines so DiffRenderer strips the synthetic diff marker, not real indent.
+          content: ' ' + (content || '')
         };
 
         const lineRow = this.renderDiffLine(fragment, lineData, fileName, null);

--- a/src/git/diff-flags.js
+++ b/src/git/diff-flags.js
@@ -8,12 +8,13 @@
  * - --no-ext-diff: Disable external diff drivers (overrides diff.external)
  * - --src-prefix=a/ --dst-prefix=b/: Ensure consistent a/ b/ prefixes (overrides diff.noprefix / diff.mnemonicPrefix)
  * - --no-relative: Ensure paths are repo-root-relative (overrides diff.relative)
+ * - --full-index: Persist full blob IDs so diff snapshots remain durable over time
  */
 
 /**
  * String form for execSync / exec shell calls (e.g. `git diff ${GIT_DIFF_FLAGS} ...`).
  */
-const GIT_DIFF_FLAGS = '--no-color --no-ext-diff --src-prefix=a/ --dst-prefix=b/ --no-relative';
+const GIT_DIFF_FLAGS = '--no-color --no-ext-diff --src-prefix=a/ --dst-prefix=b/ --no-relative --full-index';
 
 /**
  * Array form for simple-git .diff() calls (full diff output including file content).
@@ -23,7 +24,8 @@ const GIT_DIFF_FLAGS_ARRAY = [
   '--no-ext-diff',
   '--src-prefix=a/',
   '--dst-prefix=b/',
-  '--no-relative'
+  '--no-relative',
+  '--full-index'
 ];
 
 /**

--- a/src/routes/pr.js
+++ b/src/routes/pr.js
@@ -982,14 +982,14 @@ router.get('/api/file-content-original/:fileName(*)', async (req, res) => {
         const git = simpleGit(worktreePath);
         for (const contentSpec of contentSpecs) {
           try {
-          const content = await git.show([contentSpec.gitSpec]);
-          const lines = content.split('\n');
+            const content = await git.show([contentSpec.gitSpec]);
+            const lines = content.split('\n');
 
-          return res.json({
-            fileName,
-            lines,
-            totalLines: lines.length
-          });
+            return res.json({
+              fileName,
+              lines,
+              totalLines: lines.length
+            });
           } catch (gitError) {
             // Fall through to the next git-based source before reading HEAD.
             logger.debug(`Could not read file ${fileName} from ${contentSpec.source}: ${gitError.message}`);

--- a/src/routes/pr.js
+++ b/src/routes/pr.js
@@ -45,6 +45,7 @@ const {
   registerProcess: registerProcessForCancellation
 } = require('./shared');
 const { safeParseJson } = require('../utils/safe-parse-json');
+const { resolveOriginalFileContentSpecs } = require('../utils/diff-file-content');
 const { validateCouncilConfig, normalizeCouncilConfig } = require('./councils');
 const { TIERS, TIER_ALIASES, VALID_TIERS, resolveTier } = require('../ai/prompts/config');
 const { getProviderClass, createProvider } = require('../ai/provider');
@@ -961,44 +962,37 @@ router.get('/api/file-content-original/:fileName(*)', async (req, res) => {
       });
     }
 
-    // Get base_sha from the stored PR data
-    // Context expansion needs content from the BASE version (old lines), not HEAD
+    // Prefer the exact blob from the cached diff snapshot. If that is unavailable,
+    // fall back to repo-wide base_sha and finally the worktree filesystem.
     const repository = normalizeRepository(owner, repo);
     const prRecord = await queryOne(db, `
       SELECT pr_data FROM pr_metadata
       WHERE pr_number = ? AND repository = ? COLLATE NOCASE
     `, [prNumber, repository]);
 
-    let baseSha = null;
-    if (prRecord?.pr_data) {
-      try {
-        const prData = JSON.parse(prRecord.pr_data);
-        baseSha = prData.base_sha;
-      } catch (parseError) {
-        console.warn('Could not parse pr_data for base_sha:', parseError.message);
-      }
+    const prData = safeParseJson(prRecord?.pr_data, null);
+    if (prRecord?.pr_data && !prData) {
+      logger.warn('Could not parse pr_data for file-content route');
     }
 
-    // If we have base_sha, use git show to get the BASE version of the file
-    // This is critical for correct line number mapping during context expansion
-    if (baseSha) {
-      try {
-        const git = simpleGit(worktreePath);
-        // git show base_sha:path/to/file returns the file content at that commit
-        const content = await git.show([`${baseSha}:${fileName}`]);
-        const lines = content.split('\n');
+    const contentSpecs = resolveOriginalFileContentSpecs(prData, fileName);
 
-        return res.json({
-          fileName,
-          lines,
-          totalLines: lines.length
-        });
-      } catch (gitError) {
-        // Fall through to filesystem read if git show fails for any reason:
-        // - File might not exist at base_sha (new file)
-        // - Worktree might not be a valid git repo (test environment)
-        // - Git command might fail for other reasons
-        logger.debug(`Could not read file ${fileName} from base commit: ${gitError.message}, falling back to HEAD`);
+    if (contentSpecs.length > 0) {
+      const git = simpleGit(worktreePath);
+      for (const contentSpec of contentSpecs) {
+        try {
+          const content = await git.show([contentSpec.gitSpec]);
+          const lines = content.split('\n');
+
+          return res.json({
+            fileName,
+            lines,
+            totalLines: lines.length
+          });
+        } catch (gitError) {
+          // Fall through to the next git-based source before reading HEAD.
+          logger.debug(`Could not read file ${fileName} from ${contentSpec.source}: ${gitError.message}`);
+        }
       }
     }
 

--- a/src/routes/pr.js
+++ b/src/routes/pr.js
@@ -978,9 +978,10 @@ router.get('/api/file-content-original/:fileName(*)', async (req, res) => {
     const contentSpecs = resolveOriginalFileContentSpecs(prData, fileName);
 
     if (contentSpecs.length > 0) {
-      const git = simpleGit(worktreePath);
-      for (const contentSpec of contentSpecs) {
-        try {
+      try {
+        const git = simpleGit(worktreePath);
+        for (const contentSpec of contentSpecs) {
+          try {
           const content = await git.show([contentSpec.gitSpec]);
           const lines = content.split('\n');
 
@@ -989,10 +990,13 @@ router.get('/api/file-content-original/:fileName(*)', async (req, res) => {
             lines,
             totalLines: lines.length
           });
-        } catch (gitError) {
-          // Fall through to the next git-based source before reading HEAD.
-          logger.debug(`Could not read file ${fileName} from ${contentSpec.source}: ${gitError.message}`);
+          } catch (gitError) {
+            // Fall through to the next git-based source before reading HEAD.
+            logger.debug(`Could not read file ${fileName} from ${contentSpec.source}: ${gitError.message}`);
+          }
         }
+      } catch (gitError) {
+        logger.debug(`Could not initialize git for ${worktreePath}: ${gitError.message}`);
       }
     }
 

--- a/src/routes/reviews.js
+++ b/src/routes/reviews.js
@@ -21,6 +21,7 @@ const { GitWorktreeManager } = require('../git/worktree');
 const { normalizeRepository } = require('../utils/paths');
 const { resolveFormat, formatAdoptedComment: formatComment } = require('../utils/comment-formatter');
 const { safeParseJson } = require('../utils/safe-parse-json');
+const { resolveOriginalFileContentSpecs } = require('../utils/diff-file-content');
 
 const router = express.Router();
 
@@ -1012,32 +1013,31 @@ router.get('/api/reviews/:reviewId/file-content/:fileName(*)', validateReviewId,
       return res.status(404).json({ error: 'Worktree not found for this PR. The PR may need to be reloaded.' });
     }
 
-    // Get base_sha from stored PR data
+    // Prefer the exact blob from the cached diff snapshot. If that is unavailable,
+    // fall back to repo-wide base_sha and finally the worktree filesystem.
     const normalizedRepo = normalizeRepository(owner, repo);
     const prRecord = await queryOne(db, `
       SELECT pr_data FROM pr_metadata
       WHERE pr_number = ? AND repository = ? COLLATE NOCASE
     `, [prNumber, normalizedRepo]);
 
-    let baseSha = null;
-    if (prRecord?.pr_data) {
-      try {
-        const prData = JSON.parse(prRecord.pr_data);
-        baseSha = prData.base_sha;
-      } catch (parseError) {
-        logger.warn('Could not parse pr_data for base_sha:', parseError.message);
-      }
+    const prData = safeParseJson(prRecord?.pr_data, null);
+    if (prRecord?.pr_data && !prData) {
+      logger.warn('Could not parse pr_data for file-content route');
     }
 
-    // Try git show for BASE version (correct line numbers for diff)
-    if (baseSha) {
-      try {
-        const git = simpleGit(worktreePath);
-        const content = await git.show([`${baseSha}:${fileName}`]);
-        const lines = content.split('\n');
-        return res.json({ fileName, lines, totalLines: lines.length });
-      } catch (gitError) {
-        logger.debug(`Could not read file ${fileName} from base commit: ${gitError.message}, falling back to HEAD`);
+    const contentSpecs = resolveOriginalFileContentSpecs(prData, fileName);
+
+    if (contentSpecs.length > 0) {
+      const git = simpleGit(worktreePath);
+      for (const contentSpec of contentSpecs) {
+        try {
+          const content = await git.show([contentSpec.gitSpec]);
+          const lines = content.split('\n');
+          return res.json({ fileName, lines, totalLines: lines.length });
+        } catch (gitError) {
+          logger.debug(`Could not read file ${fileName} from ${contentSpec.source}: ${gitError.message}`);
+        }
       }
     }
 

--- a/src/routes/reviews.js
+++ b/src/routes/reviews.js
@@ -1029,15 +1029,19 @@ router.get('/api/reviews/:reviewId/file-content/:fileName(*)', validateReviewId,
     const contentSpecs = resolveOriginalFileContentSpecs(prData, fileName);
 
     if (contentSpecs.length > 0) {
-      const git = simpleGit(worktreePath);
-      for (const contentSpec of contentSpecs) {
-        try {
-          const content = await git.show([contentSpec.gitSpec]);
-          const lines = content.split('\n');
-          return res.json({ fileName, lines, totalLines: lines.length });
-        } catch (gitError) {
-          logger.debug(`Could not read file ${fileName} from ${contentSpec.source}: ${gitError.message}`);
+      try {
+        const git = simpleGit(worktreePath);
+        for (const contentSpec of contentSpecs) {
+          try {
+            const content = await git.show([contentSpec.gitSpec]);
+            const lines = content.split('\n');
+            return res.json({ fileName, lines, totalLines: lines.length });
+          } catch (gitError) {
+            logger.debug(`Could not read file ${fileName} from ${contentSpec.source}: ${gitError.message}`);
+          }
         }
+      } catch (gitError) {
+        logger.debug(`Could not initialize git for ${worktreePath}: ${gitError.message}`);
       }
     }
 

--- a/src/utils/diff-file-content.js
+++ b/src/utils/diff-file-content.js
@@ -1,0 +1,110 @@
+// Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+/**
+ * Helpers for resolving file content directly from a cached diff snapshot.
+ *
+ * The diff's `index <old>..<new>` line is more precise than a repo-wide
+ * `base_sha` because it identifies the exact blob used for that file in the
+ * rendered patch, even if cached PR metadata drifts.
+ */
+
+function parseDiffGitPaths(headerLine) {
+  if (!headerLine.startsWith('diff --git ')) {
+    return null;
+  }
+
+  const rest = headerLine.slice('diff --git '.length);
+  const quotedMatch = rest.match(/^"a\/(.+)" "b\/(.+)"$/);
+  if (quotedMatch) {
+    return {
+      oldPath: quotedMatch[1].replace(/\\"/g, '"'),
+      newPath: quotedMatch[2].replace(/\\"/g, '"')
+    };
+  }
+
+  const plainMatch = rest.match(/^a\/(.+?) b\/(.+)$/);
+  if (!plainMatch) {
+    return null;
+  }
+
+  return {
+    oldPath: plainMatch[1],
+    newPath: plainMatch[2]
+  };
+}
+
+function findFileBlobInfoInDiff(diffText, fileName) {
+  if (!diffText || !fileName) {
+    return null;
+  }
+
+  const lines = diffText.split('\n');
+  let matchedPaths = null;
+
+  for (const line of lines) {
+    if (line.startsWith('diff --git ')) {
+      const paths = parseDiffGitPaths(line);
+      matchedPaths = paths && (paths.oldPath === fileName || paths.newPath === fileName)
+        ? paths
+        : null;
+      continue;
+    }
+
+    if (!matchedPaths || !line.startsWith('index ')) {
+      continue;
+    }
+
+    const match = line.match(/^index ([0-9a-f]+)\.\.([0-9a-f]+)(?: \d+)?$/i);
+    if (!match) {
+      return null;
+    }
+
+    return {
+      ...matchedPaths,
+      oldBlob: match[1],
+      newBlob: match[2]
+    };
+  }
+
+  return null;
+}
+
+function isZeroObjectId(objectId) {
+  return typeof objectId === 'string' && /^0+$/.test(objectId);
+}
+
+function resolveOriginalFileContentSpecs(prData, fileName) {
+  if (!prData || typeof prData !== 'object') {
+    return [];
+  }
+
+  const blobInfo = findFileBlobInfoInDiff(prData.diff, fileName);
+  const specs = [];
+
+  if (blobInfo?.oldBlob && !isZeroObjectId(blobInfo.oldBlob)) {
+    specs.push({
+      gitSpec: blobInfo.oldBlob,
+      source: 'diff blob'
+    });
+  }
+
+  if (prData.base_sha) {
+    const originalPath = blobInfo?.oldPath || fileName;
+    specs.push({
+      gitSpec: `${prData.base_sha}:${originalPath}`,
+      source: 'base commit'
+    });
+  }
+
+  return specs;
+}
+
+function resolveOriginalFileContentSpec(prData, fileName) {
+  return resolveOriginalFileContentSpecs(prData, fileName)[0] || null;
+}
+
+module.exports = {
+  findFileBlobInfoInDiff,
+  parseDiffGitPaths,
+  resolveOriginalFileContentSpecs,
+  resolveOriginalFileContentSpec
+};

--- a/tests/integration/review-file-content.test.js
+++ b/tests/integration/review-file-content.test.js
@@ -1,0 +1,174 @@
+// Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { execSync } from 'child_process';
+import express from 'express';
+import nodeFs from 'fs';
+import os from 'os';
+import path from 'path';
+import request from 'supertest';
+import { createTestDatabase, closeTestDatabase } from '../utils/schema';
+
+const fsPromises = require('fs').promises;
+const { run } = require('../../src/database');
+const { GitWorktreeManager } = require('../../src/git/worktree');
+const reviewsRoutes = require('../../src/routes/reviews');
+
+function createTestApp(db) {
+  const app = express();
+  app.use(express.json());
+  app.set('db', db);
+  app.use('/', reviewsRoutes);
+  return app;
+}
+
+describe('GET /api/reviews/:reviewId/file-content/:fileName', () => {
+  let db;
+  let app;
+  let readFileSpy;
+
+  beforeEach(async () => {
+    db = await createTestDatabase();
+    app = createTestApp(db);
+    readFileSpy = vi.spyOn(fsPromises, 'readFile');
+  });
+
+  afterEach(async () => {
+    readFileSpy?.mockRestore();
+    vi.restoreAllMocks();
+    if (db) {
+      await closeTestDatabase(db);
+    }
+  });
+
+  it('prefers the diff blob over a stale base_sha in PR mode', async () => {
+    const tempRepo = nodeFs.mkdtempSync(path.join(os.tmpdir(), 'pair-review-file-content-'));
+
+    try {
+      execSync('git init -b main', { cwd: tempRepo, stdio: 'pipe' });
+      execSync('git config user.email "test@test.com"', { cwd: tempRepo, stdio: 'pipe' });
+      execSync('git config user.name "Test User"', { cwd: tempRepo, stdio: 'pipe' });
+
+      const relativeFile = 'src/file.js';
+      const repoFile = path.join(tempRepo, relativeFile);
+      nodeFs.mkdirSync(path.dirname(repoFile), { recursive: true });
+
+      nodeFs.writeFileSync(repoFile, 'stale line 1\nstale line 2\nshared line\n');
+      execSync(`git add ${relativeFile}`, { cwd: tempRepo, stdio: 'pipe' });
+      execSync('git commit -m "stale base"', { cwd: tempRepo, stdio: 'pipe' });
+      const staleBaseSha = execSync('git rev-parse HEAD', { cwd: tempRepo, encoding: 'utf8' }).trim();
+
+      nodeFs.writeFileSync(repoFile, 'correct old 1\ncorrect old 2\nshared line\n');
+      execSync(`git add ${relativeFile}`, { cwd: tempRepo, stdio: 'pipe' });
+      execSync('git commit -m "real base"', { cwd: tempRepo, stdio: 'pipe' });
+      const actualBaseSha = execSync('git rev-parse HEAD', { cwd: tempRepo, encoding: 'utf8' }).trim();
+
+      nodeFs.writeFileSync(repoFile, 'correct new 1\ncorrect old 2\nshared line\nadded line\n');
+      execSync(`git add ${relativeFile}`, { cwd: tempRepo, stdio: 'pipe' });
+      execSync('git commit -m "head"', { cwd: tempRepo, stdio: 'pipe' });
+      const headSha = execSync('git rev-parse HEAD', { cwd: tempRepo, encoding: 'utf8' }).trim();
+      const diff = execSync(`git diff --unified=3 ${actualBaseSha}...${headSha} -- ${relativeFile}`, {
+        cwd: tempRepo,
+        encoding: 'utf8'
+      });
+
+      const prData = JSON.stringify({
+        state: 'open',
+        diff,
+        changed_files: [{ file: relativeFile, additions: 2, deletions: 1 }],
+        base_sha: staleBaseSha,
+        head_sha: headSha
+      });
+
+      await run(db, `
+        INSERT INTO pr_metadata (pr_number, repository, title, description, author, base_branch, head_branch, pr_data)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+      `, [10, 'owner/repo', 'Test PR', 'Description', 'user', 'main', 'feature', prData]);
+
+      const reviewResult = await run(db, `
+        INSERT INTO reviews (pr_number, repository, status, created_at, updated_at)
+        VALUES (?, ?, 'draft', datetime('now'), datetime('now'))
+      `, [10, 'owner/repo']);
+
+      vi.spyOn(GitWorktreeManager.prototype, 'getWorktreePath').mockResolvedValue(tempRepo);
+      vi.spyOn(GitWorktreeManager.prototype, 'worktreeExists').mockResolvedValue(true);
+
+      const response = await request(app)
+        .get(`/api/reviews/${reviewResult.lastID}/file-content/${encodeURIComponent(relativeFile)}`);
+
+      expect(response.status).toBe(200);
+      expect(response.body.lines.slice(0, 3)).toEqual([
+        'correct old 1',
+        'correct old 2',
+        'shared line'
+      ]);
+      expect(response.body.lines[0]).not.toBe('stale line 1');
+      expect(readFileSpy).not.toHaveBeenCalled();
+    } finally {
+      nodeFs.rmSync(tempRepo, { recursive: true, force: true });
+    }
+  });
+
+  it('falls back from an unusable diff blob to base_sha content before reading HEAD', async () => {
+    const tempRepo = nodeFs.mkdtempSync(path.join(os.tmpdir(), 'pair-review-file-content-'));
+
+    try {
+      execSync('git init -b main', { cwd: tempRepo, stdio: 'pipe' });
+      execSync('git config user.email "test@test.com"', { cwd: tempRepo, stdio: 'pipe' });
+      execSync('git config user.name "Test User"', { cwd: tempRepo, stdio: 'pipe' });
+
+      const relativeFile = 'src/file.js';
+      const repoFile = path.join(tempRepo, relativeFile);
+      nodeFs.mkdirSync(path.dirname(repoFile), { recursive: true });
+
+      nodeFs.writeFileSync(repoFile, 'correct old 1\ncorrect old 2\nshared line\n');
+      execSync(`git add ${relativeFile}`, { cwd: tempRepo, stdio: 'pipe' });
+      execSync('git commit -m "real base"', { cwd: tempRepo, stdio: 'pipe' });
+      const baseSha = execSync('git rev-parse HEAD', { cwd: tempRepo, encoding: 'utf8' }).trim();
+
+      nodeFs.writeFileSync(repoFile, 'correct new 1\ncorrect old 2\nshared line\nadded line\n');
+      execSync(`git add ${relativeFile}`, { cwd: tempRepo, stdio: 'pipe' });
+      execSync('git commit -m "head"', { cwd: tempRepo, stdio: 'pipe' });
+      const headSha = execSync('git rev-parse HEAD', { cwd: tempRepo, encoding: 'utf8' }).trim();
+
+      const prData = JSON.stringify({
+        state: 'open',
+        diff: [
+          `diff --git a/${relativeFile} b/${relativeFile}`,
+          'index deadbee..feedbee 100644',
+          `--- a/${relativeFile}`,
+          `+++ b/${relativeFile}`,
+          '@@ -1,3 +1,4 @@'
+        ].join('\n'),
+        changed_files: [{ file: relativeFile, additions: 2, deletions: 1 }],
+        base_sha: baseSha,
+        head_sha: headSha
+      });
+
+      await run(db, `
+        INSERT INTO pr_metadata (pr_number, repository, title, description, author, base_branch, head_branch, pr_data)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+      `, [11, 'owner/repo', 'Test PR', 'Description', 'user', 'main', 'feature', prData]);
+
+      const reviewResult = await run(db, `
+        INSERT INTO reviews (pr_number, repository, status, created_at, updated_at)
+        VALUES (?, ?, 'draft', datetime('now'), datetime('now'))
+      `, [11, 'owner/repo']);
+
+      vi.spyOn(GitWorktreeManager.prototype, 'getWorktreePath').mockResolvedValue(tempRepo);
+      vi.spyOn(GitWorktreeManager.prototype, 'worktreeExists').mockResolvedValue(true);
+
+      const response = await request(app)
+        .get(`/api/reviews/${reviewResult.lastID}/file-content/${encodeURIComponent(relativeFile)}`);
+
+      expect(response.status).toBe(200);
+      expect(response.body.lines.slice(0, 3)).toEqual([
+        'correct old 1',
+        'correct old 2',
+        'shared line'
+      ]);
+      expect(readFileSpy).not.toHaveBeenCalled();
+    } finally {
+      nodeFs.rmSync(tempRepo, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/unit/diff-file-content.test.js
+++ b/tests/unit/diff-file-content.test.js
@@ -1,0 +1,159 @@
+// Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+import { describe, it, expect } from 'vitest';
+
+const {
+  findFileBlobInfoInDiff,
+  parseDiffGitPaths,
+  resolveOriginalFileContentSpecs,
+  resolveOriginalFileContentSpec
+} = require('../../src/utils/diff-file-content');
+
+describe('diff-file-content', () => {
+  describe('parseDiffGitPaths', () => {
+    it('parses plain diff headers', () => {
+      expect(parseDiffGitPaths('diff --git a/src/file.js b/src/file.js')).toEqual({
+        oldPath: 'src/file.js',
+        newPath: 'src/file.js'
+      });
+    });
+
+    it('parses quoted diff headers', () => {
+      expect(parseDiffGitPaths('diff --git "a/src/file name.js" "b/src/file name.js"')).toEqual({
+        oldPath: 'src/file name.js',
+        newPath: 'src/file name.js'
+      });
+    });
+  });
+
+  describe('findFileBlobInfoInDiff', () => {
+    it('finds the blob IDs for a matching file', () => {
+      const diff = [
+        'diff --git a/src/file.js b/src/file.js',
+        'index abc1234..def5678 100644',
+        '--- a/src/file.js',
+        '+++ b/src/file.js',
+        '@@ -1 +1 @@',
+        '-old',
+        '+new'
+      ].join('\n');
+
+      expect(findFileBlobInfoInDiff(diff, 'src/file.js')).toEqual({
+        oldPath: 'src/file.js',
+        newPath: 'src/file.js',
+        oldBlob: 'abc1234',
+        newBlob: 'def5678'
+      });
+    });
+
+    it('matches renamed files by the new path', () => {
+      const diff = [
+        'diff --git a/src/old.js b/src/new.js',
+        'index aa11bb2..cc33dd4 100644',
+        '--- a/src/old.js',
+        '+++ b/src/new.js'
+      ].join('\n');
+
+      expect(findFileBlobInfoInDiff(diff, 'src/new.js')).toEqual({
+        oldPath: 'src/old.js',
+        newPath: 'src/new.js',
+        oldBlob: 'aa11bb2',
+        newBlob: 'cc33dd4'
+      });
+    });
+  });
+
+  describe('resolveOriginalFileContentSpec', () => {
+    it('prefers the diff blob over base_sha', () => {
+      const prData = {
+        base_sha: 'base123',
+        diff: [
+          'diff --git a/src/file.js b/src/file.js',
+          'index abc1234..def5678 100644'
+        ].join('\n')
+      };
+
+      expect(resolveOriginalFileContentSpec(prData, 'src/file.js')).toEqual({
+        gitSpec: 'abc1234',
+        source: 'diff blob'
+      });
+    });
+
+    it('falls back to base_sha when the file is missing from the diff', () => {
+      const prData = {
+        base_sha: 'base123',
+        diff: 'diff --git a/src/other.js b/src/other.js\nindex aaa1111..bbb2222 100644'
+      };
+
+      expect(resolveOriginalFileContentSpec(prData, 'src/file.js')).toEqual({
+        gitSpec: 'base123:src/file.js',
+        source: 'base commit'
+      });
+    });
+
+    it('falls back to base_sha when the diff represents a new file', () => {
+      const prData = {
+        base_sha: 'base123',
+        diff: [
+          'diff --git a/src/new.js b/src/new.js',
+          'new file mode 100644',
+          'index 0000000..def5678 100644'
+        ].join('\n')
+      };
+
+      expect(resolveOriginalFileContentSpec(prData, 'src/new.js')).toEqual({
+        gitSpec: 'base123:src/new.js',
+        source: 'base commit'
+      });
+    });
+  });
+
+  describe('resolveOriginalFileContentSpecs', () => {
+    it('returns diff blob first and base commit second', () => {
+      const prData = {
+        base_sha: 'base123',
+        diff: [
+          'diff --git a/src/file.js b/src/file.js',
+          'index abc1234..def5678 100644'
+        ].join('\n')
+      };
+
+      expect(resolveOriginalFileContentSpecs(prData, 'src/file.js')).toEqual([
+        { gitSpec: 'abc1234', source: 'diff blob' },
+        { gitSpec: 'base123:src/file.js', source: 'base commit' }
+      ]);
+    });
+
+    it('uses the old path for rename-aware base commit fallback', () => {
+      const prData = {
+        base_sha: 'base123',
+        diff: [
+          'diff --git a/src/old-name.js b/src/new-name.js',
+          'similarity index 100%',
+          'rename from src/old-name.js',
+          'rename to src/new-name.js',
+          'index aa11bb22..cc33dd44 100644'
+        ].join('\n')
+      };
+
+      expect(resolveOriginalFileContentSpecs(prData, 'src/new-name.js')).toEqual([
+        { gitSpec: 'aa11bb22', source: 'diff blob' },
+        { gitSpec: 'base123:src/old-name.js', source: 'base commit' }
+      ]);
+    });
+
+    it('still returns a base commit fallback for new files', () => {
+      const prData = {
+        base_sha: 'base123',
+        diff: [
+          'diff --git a/src/new.js b/src/new.js',
+          'new file mode 100644',
+          'index 0000000..def5678 100644'
+        ].join('\n')
+      };
+
+      expect(resolveOriginalFileContentSpecs(prData, 'src/new.js')).toEqual([
+        { gitSpec: 'base123:src/new.js', source: 'base commit' }
+      ]);
+    });
+  });
+});

--- a/tests/unit/diff-renderer.test.js
+++ b/tests/unit/diff-renderer.test.js
@@ -346,6 +346,25 @@ describe('DiffRenderer', () => {
         expect(header.remove).not.toHaveBeenCalled();
         expect(gap.insertAdjacentElement).toHaveBeenCalledWith('afterend', header);
       });
+
+      it('should relocate stranded header to the start-of-file gap boundary', () => {
+        // [gap(position=above)] [expanded code] [header with functionContext]
+        // After partial file-start expansion, the header should move up to the
+        // remaining gap boundary.
+        const gap = createMockRow('gap');
+        gap.expandControls = {
+          dataset: { position: 'above' }
+        };
+        const code = createMockRow('content');
+        const header = createMockRow('header', {
+          dataset: { functionContext: 'module Clients' }
+        });
+        const tbody = createMockTbody([gap, code, header]);
+
+        DiffRenderer.removeStrandedHunkHeaders(tbody);
+        expect(header.remove).not.toHaveBeenCalled();
+        expect(gap.insertAdjacentElement).toHaveBeenCalledWith('afterend', header);
+      });
     });
   });
 

--- a/tests/unit/executable-analysis.test.js
+++ b/tests/unit/executable-analysis.test.js
@@ -108,7 +108,7 @@ describe('generateDiffForExecutable', () => {
 
       const cmd = mockExec.mock.calls[0][0];
       expect(cmd).toContain('git diff');
-      expect(cmd).toContain('--no-color --no-ext-diff --src-prefix=a/ --dst-prefix=b/ --no-relative');
+      expect(cmd).toContain('--no-color --no-ext-diff --src-prefix=a/ --dst-prefix=b/ --no-relative --full-index');
       expect(cmd).toContain('abc123...def456');
     });
 
@@ -225,7 +225,7 @@ describe('generateDiffForExecutable', () => {
       );
 
       const cmd = mockExec.mock.calls[0][0];
-      expect(cmd).toBe('git diff --no-color --no-ext-diff --src-prefix=a/ --dst-prefix=b/ --no-relative');
+      expect(cmd).toBe('git diff --no-color --no-ext-diff --src-prefix=a/ --dst-prefix=b/ --no-relative --full-index');
     });
 
     it('appends diffArgs to fallback git diff', async () => {

--- a/tests/unit/file-start-gap-header.test.js
+++ b/tests/unit/file-start-gap-header.test.js
@@ -1,0 +1,269 @@
+// Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+// @vitest-environment jsdom
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+const { PRManager } = require('../../public/js/pr.js');
+
+function createTestPRManager(lines) {
+  const prManager = Object.create(PRManager.prototype);
+
+  prManager.fetchFileContent = vi.fn().mockResolvedValue({ lines });
+  prManager.renderDiffLine = vi.fn((container, lineData) => {
+    const row = document.createElement('tr');
+    row.className = 'd2h-cntx';
+    row.dataset.lineNumber = String(lineData.oldNumber);
+
+    const contentCell = document.createElement('td');
+    contentCell.className = 'd2h-code-line-ctn';
+    contentCell.textContent = lineData.content;
+    row.appendChild(contentCell);
+
+    container.appendChild(row);
+    return row;
+  });
+
+  return prManager;
+}
+
+function createGapRowElement(fileName, startLine, endLine, position, startLineNew) {
+  const row = document.createElement('tr');
+  row.className = 'context-expand-row';
+
+  const controls = {
+    dataset: {
+      fileName,
+      startLine: String(startLine),
+      endLine: String(endLine),
+      position,
+    }
+  };
+
+  if (startLineNew !== undefined && startLineNew !== null) {
+    controls.dataset.startLineNew = String(startLineNew);
+  }
+
+  row.expandControls = controls;
+  return row;
+}
+
+function createStartOfFileGapDOM({ gapStart, gapEnd, gapStartNew = 1, gapEndNew = gapEnd }) {
+  const table = document.createElement('table');
+  const tbody = document.createElement('tbody');
+  table.appendChild(tbody);
+  document.body.appendChild(table);
+
+  const gapRow = createGapRowElement('client.rb', gapStart, gapEnd, 'above', gapStartNew);
+  gapRow.expandControls.dataset.endLineNew = String(gapEndNew);
+
+  const boundaryHeader = document.createElement('tr');
+  boundaryHeader.className = 'd2h-info';
+  boundaryHeader.dataset.functionContext = 'module Clients';
+
+  const firstHunkRow = document.createElement('tr');
+  firstHunkRow.className = 'd2h-cntx';
+  firstHunkRow.dataset.lineNumber = '1507';
+
+  tbody.appendChild(gapRow);
+  tbody.appendChild(boundaryHeader);
+  tbody.appendChild(firstHunkRow);
+
+  return { tbody, gapRow, boundaryHeader, firstHunkRow, controls: gapRow.expandControls };
+}
+
+function createMockGapFactory() {
+  return vi.fn((fileName, startLine, endLine, _gapSize, position, _callback, startLineNew) =>
+    createGapRowElement(fileName, startLine, endLine, position, startLineNew)
+  );
+}
+
+describe('PRManager file-start gap header positioning', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    global.fetch = vi.fn();
+
+    window.GapCoordinates = {
+      getGapCoordinates: vi.fn()
+    };
+
+    window.HunkParser = {
+      EOF_SENTINEL: -1,
+      createGapRowElement: createMockGapFactory()
+    };
+
+    window.DiffRenderer = {
+      removeStrandedHunkHeaders: vi.fn(),
+      updateFunctionContextVisibility: vi.fn()
+    };
+
+    vi.spyOn(global, 'setTimeout').mockImplementation((callback) => {
+      callback();
+      return 0;
+    });
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+    vi.restoreAllMocks();
+  });
+
+  it('removes the first hunk header after expanding all from a file-start gap', async () => {
+    const prManager = createTestPRManager(['line 1', 'line 2', 'line 3']);
+    const { tbody, boundaryHeader, firstHunkRow, controls } = createStartOfFileGapDOM({
+      gapStart: 1,
+      gapEnd: 3
+    });
+
+    window.GapCoordinates.getGapCoordinates.mockReturnValue({
+      gapStart: 1,
+      gapEnd: 3,
+      gapStartNew: 1,
+      gapEndNew: 3,
+      offset: 0
+    });
+
+    window.DiffRenderer.removeStrandedHunkHeaders.mockImplementation(() => {
+      boundaryHeader.remove();
+    });
+
+    await prManager.expandGapContext(controls, 'all', 3);
+
+    expect(window.DiffRenderer.removeStrandedHunkHeaders).toHaveBeenCalledWith(tbody);
+    expect(tbody.contains(boundaryHeader)).toBe(false);
+    expect(firstHunkRow.previousElementSibling).not.toBe(boundaryHeader);
+    expect([...tbody.querySelectorAll('tr[data-line-number]')].map((row) => row.dataset.lineNumber)).toEqual([
+      '1',
+      '2',
+      '3',
+      '1507'
+    ]);
+  });
+
+  it('repositions the first hunk header to the new boundary after partial file-start expansion', async () => {
+    const prManager = createTestPRManager(['line 1', 'line 2', 'line 3', 'line 4', 'line 5']);
+    const { tbody, boundaryHeader, firstHunkRow, controls } = createStartOfFileGapDOM({
+      gapStart: 1,
+      gapEnd: 5
+    });
+
+    window.GapCoordinates.getGapCoordinates.mockReturnValue({
+      gapStart: 1,
+      gapEnd: 5,
+      gapStartNew: 1,
+      gapEndNew: 5,
+      offset: 0
+    });
+
+    window.DiffRenderer.removeStrandedHunkHeaders.mockImplementation(() => {
+      const gapRow = tbody.querySelector('tr.context-expand-row');
+      if (gapRow) {
+        gapRow.insertAdjacentElement('afterend', boundaryHeader);
+      }
+    });
+
+    await prManager.expandGapContext(controls, 'up', 2);
+
+    const gapRows = [...tbody.querySelectorAll('tr.context-expand-row')];
+
+    expect(window.DiffRenderer.removeStrandedHunkHeaders).toHaveBeenCalledWith(tbody);
+    expect(tbody.contains(boundaryHeader)).toBe(true);
+    expect(gapRows).toHaveLength(1);
+    expect(gapRows[0].expandControls.dataset.position).toBe('above');
+    expect(gapRows[0].nextElementSibling).toBe(boundaryHeader);
+    expect(boundaryHeader.nextElementSibling?.dataset.lineNumber).toBe('4');
+    expect([...tbody.querySelectorAll('tr[data-line-number]')].map((row) => row.dataset.lineNumber)).toEqual([
+      '4',
+      '5',
+      '1507'
+    ]);
+  });
+
+  it('repositions the first hunk header after expanding a range within a file-start gap', async () => {
+    const prManager = createTestPRManager(['line 1', 'line 2', 'line 3', 'line 4', 'line 5']);
+    const { tbody, gapRow, boundaryHeader, firstHunkRow, controls } = createStartOfFileGapDOM({
+      gapStart: 1,
+      gapEnd: 5
+    });
+
+    window.GapCoordinates.getGapCoordinates.mockReturnValue({
+      gapStart: 1,
+      gapEnd: 5,
+      gapStartNew: 1,
+      gapEndNew: 5,
+      offset: 0
+    });
+
+    window.DiffRenderer.removeStrandedHunkHeaders.mockImplementation(() => {
+      const gapRowAfterSplit = tbody.querySelector('tr.context-expand-row');
+      if (gapRowAfterSplit) {
+        gapRowAfterSplit.insertAdjacentElement('afterend', boundaryHeader);
+      }
+    });
+
+    await prManager.expandGapRange(gapRow, controls, 2, 3);
+
+    const gapRows = [...tbody.querySelectorAll('tr.context-expand-row')];
+
+    expect(window.DiffRenderer.removeStrandedHunkHeaders).toHaveBeenCalledWith(tbody);
+    expect(tbody.contains(boundaryHeader)).toBe(true);
+    expect(gapRows).toHaveLength(2);
+    expect(gapRows[0].expandControls.dataset.position).toBe('above');
+    expect(gapRows[1].expandControls.dataset.position).toBe('between');
+    expect(gapRows[0].nextElementSibling).toBe(boundaryHeader);
+    expect(firstHunkRow.previousElementSibling).not.toBe(boundaryHeader);
+    expect([...tbody.querySelectorAll('tr[data-line-number]')].map((row) => row.dataset.lineNumber)).toEqual([
+      '2',
+      '3',
+      '1507'
+    ]);
+  });
+
+  it('passes expanded context lines to the renderer with a synthetic context prefix', async () => {
+    const prManager = createTestPRManager(['  indented line', '    deeper indent', 'plain']);
+    const { controls } = createStartOfFileGapDOM({
+      gapStart: 1,
+      gapEnd: 3
+    });
+
+    window.GapCoordinates.getGapCoordinates.mockReturnValue({
+      gapStart: 1,
+      gapEnd: 3,
+      gapStartNew: 1,
+      gapEndNew: 3,
+      offset: 0
+    });
+
+    await prManager.expandGapContext(controls, 'all', 3);
+
+    const renderedContents = prManager.renderDiffLine.mock.calls.map(([, lineData]) => lineData.content);
+    expect(renderedContents).toEqual([
+      '   indented line',
+      '     deeper indent',
+      ' plain'
+    ]);
+  });
+
+  it('passes range-expanded context lines to the renderer with a synthetic context prefix', async () => {
+    const prManager = createTestPRManager(['zero', '  indented two', '    indented four', 'tail']);
+    const { gapRow, controls } = createStartOfFileGapDOM({
+      gapStart: 1,
+      gapEnd: 4
+    });
+
+    window.GapCoordinates.getGapCoordinates.mockReturnValue({
+      gapStart: 1,
+      gapEnd: 4,
+      gapStartNew: 1,
+      gapEndNew: 4,
+      offset: 0
+    });
+
+    await prManager.expandGapRange(gapRow, controls, 2, 3);
+
+    const renderedContents = prManager.renderDiffLine.mock.calls.map(([, lineData]) => lineData.content);
+    expect(renderedContents).toEqual([
+      '   indented two',
+      '     indented four'
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- resolve PR file-content expansion from the diff preimage blob before falling back to base commit content
- add a two-step git fallback, rename-aware base path handling, and full-index diff snapshots for durable stored metadata
- fix manual gap expansion so expanded context lines preserve indentation and add regression coverage for the backend and frontend cases

## Testing
- pnpm test tests/unit/diff-file-content.test.js tests/unit/executable-analysis.test.js tests/unit/file-start-gap-header.test.js tests/unit/diff-renderer.test.js tests/unit/hunk-parser.test.js
- pnpm exec vitest run tests/integration/review-file-content.test.js