### PR TITLE
Fix stale base SHA handling in worktree refreshes

### DIFF
--- a/.changeset/worktree-base-sha-fetch.md
+++ b/.changeset/worktree-base-sha-fetch.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Fetch a PR worktree's missing base commit during refresh and update so diff generation keeps working after the worktree is reused.

--- a/src/git/worktree-pool-lifecycle.js
+++ b/src/git/worktree-pool-lifecycle.js
@@ -248,6 +248,8 @@ class WorktreePoolLifecycle {
         number: prInfo.prNumber,
       }, prData, { remote: remoteName });
 
+      await worktreeManager.ensureBaseShaAvailable(git, prData, remoteName);
+
       // Clean the working tree before switching PRs. Without this, untracked
       // files (build artifacts, generated code) from the previous PR leak into
       // the new checkout, and modified tracked files can cause checkout to fail.
@@ -257,7 +259,7 @@ class WorktreePoolLifecycle {
       await git.clean('f', ['-d']);
 
       // Checkout specific head SHA (stored SHA in restore mode, latest in fresh mode)
-      const targetSha = prData.head?.sha || prData.head_sha;
+      const targetSha = worktreeManager.getPRHeadSha(prData);
       if (targetSha) {
         await git.checkout([targetSha]);
       } else {
@@ -269,8 +271,8 @@ class WorktreePoolLifecycle {
         logger.info(`Executing reset script: ${options.resetScript}`);
         const headRef = prData.head?.ref || prData.head_branch || '';
         const baseRef = prData.base?.ref || prData.base_branch || '';
-        const headSha = prData.head?.sha || prData.head_sha || '';
-        const baseSha = prData.base?.sha || prData.base_sha || '';
+        const headSha = worktreeManager.getPRHeadSha(prData);
+        const baseSha = worktreeManager.getPRBaseSha(prData);
 
         const scriptEnv = {
           BASE_BRANCH: baseRef,
@@ -341,6 +343,13 @@ class WorktreePoolLifecycle {
         const git = this._simpleGit(poolEntry.path);
         const currentHead = (await git.revparse(['HEAD'])).trim();
         if (currentHead === targetSha) {
+          const worktreeManager = new this._GitWorktreeManager(this.db);
+          const remote = await worktreeManager.resolveRemoteForPR(git, prData, {
+            owner: prInfo.owner,
+            repo: prInfo.repo,
+            number: prInfo.prNumber,
+          });
+          await worktreeManager.ensureBaseShaAvailable(git, prData, remote);
           logger.info(`Pool worktree ${poolEntry.id} already at target SHA ${targetSha.slice(0, 8)}, skipping refresh`);
           await this._poolRepo.markInUse(poolEntry.id, prInfo.prNumber);
           return { worktreePath: poolEntry.path, worktreeId: poolEntry.id };

--- a/src/git/worktree.js
+++ b/src/git/worktree.js
@@ -10,6 +10,8 @@ const { normalizeRepository, resolveRenamedFile, resolveRenamedFileOld } = requi
 const { GIT_DIFF_FLAGS_ARRAY, GIT_DIFF_SUMMARY_FLAGS_ARRAY } = require('./diff-flags');
 const { spawn, execSync } = require('child_process');
 
+const MISSING_COMMIT_ERROR_CODE = 'PAIR_REVIEW_MISSING_COMMIT';
+
 /**
  * Git worktree manager for handling PR branch checkouts and diffs
  */
@@ -199,6 +201,136 @@ class GitWorktreeManager {
    */
   getPRHeadSha(prData) {
     return prData?.head?.sha || prData?.head_sha || '';
+  }
+
+  /**
+   * Extract the PR base SHA from either REST or stored PR metadata.
+   * @param {Object|null} prData
+   * @returns {string}
+   */
+  getPRBaseSha(prData) {
+    return prData?.base?.sha || prData?.base_sha || '';
+  }
+
+  /**
+   * Check whether the given commit object is already available locally.
+   * @param {Object} git - simple-git instance
+   * @param {string} sha
+   * @returns {Promise<boolean>}
+   */
+  async hasCommitLocally(git, sha) {
+    if (!sha) {
+      return false;
+    }
+
+    try {
+      const objectType = (await git.raw(['cat-file', '-t', sha])).trim();
+      return objectType === 'commit';
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Ensure a specific commit object exists locally, fetching it directly when needed.
+   * @param {Object} git - simple-git instance
+   * @param {string} sha
+   * @param {string} remote
+   * @param {string} label
+   * @returns {Promise<void>}
+   */
+  async ensureCommitAvailable(git, sha, remote, label = 'Commit') {
+    if (!sha) {
+      return;
+    }
+
+    if (await this.hasCommitLocally(git, sha)) {
+      return;
+    }
+
+    let fetchError = null;
+    try {
+      await git.raw(['fetch', remote, sha]);
+    } catch (error) {
+      fetchError = error;
+    }
+
+    if (await this.hasCommitLocally(git, sha)) {
+      return;
+    }
+
+    if (fetchError) {
+      const error = new Error(`${label} ${sha} is not available locally and fetch from ${remote} failed: ${fetchError.message}`);
+      error.code = MISSING_COMMIT_ERROR_CODE;
+      error.commitSha = sha;
+      error.commitLabel = label;
+      error.remote = remote;
+      error.cause = fetchError;
+      throw error;
+    }
+
+    const error = new Error(`${label} ${sha} is not available locally after fetch from ${remote}`);
+    error.code = MISSING_COMMIT_ERROR_CODE;
+    error.commitSha = sha;
+    error.commitLabel = label;
+    error.remote = remote;
+    throw error;
+  }
+
+  /**
+   * Ensure the PR base commit is available in the local repository before diffing.
+   * @param {Object} git - simple-git instance
+   * @param {Object|null} prData
+   * @param {string} remote
+   * @returns {Promise<void>}
+   */
+  async ensureBaseShaAvailable(git, prData, remote) {
+    const baseSha = this.getPRBaseSha(prData);
+    if (!baseSha) {
+      return;
+    }
+
+    console.log(`Ensuring base commit ${baseSha} is available...`);
+    await this.ensureCommitAvailable(git, baseSha, remote, 'Base SHA');
+  }
+
+  /**
+   * Fail with a targeted message when a required diff commit is missing locally.
+   * @param {Object} git - simple-git instance
+   * @param {string} sha
+   * @param {string} label
+   * @returns {Promise<void>}
+   */
+  async assertCommitAvailableLocally(git, sha, label = 'Commit') {
+    if (!sha) {
+      throw new Error(`${label} is required but missing from PR data`);
+    }
+
+    if (await this.hasCommitLocally(git, sha)) {
+      return;
+    }
+
+    const error = new Error(`${label} ${sha} is not available locally. Refresh the worktree to fetch the missing commit before generating the diff.`);
+    error.code = MISSING_COMMIT_ERROR_CODE;
+    error.commitSha = sha;
+    error.commitLabel = label;
+    throw error;
+  }
+
+  /**
+   * Preserve machine-checkable error metadata when wrapping lower-level git failures.
+   * @param {string} prefix
+   * @param {Error} error
+   * @returns {Error}
+   */
+  wrapError(prefix, error) {
+    const wrapped = new Error(`${prefix}: ${error.message}`);
+    if (error?.code) wrapped.code = error.code;
+    if (error?.commitSha) wrapped.commitSha = error.commitSha;
+    if (error?.commitLabel) wrapped.commitLabel = error.commitLabel;
+    if (error?.remote) wrapped.remote = error.remote;
+    if (error) wrapped.cause = error;
+    return wrapped;
   }
 
   /**
@@ -451,7 +583,7 @@ class GitWorktreeManager {
       await this.cleanupWorktree(worktreePath);
       
       // Create git instance for the source repository
-      const git = simpleGit(repositoryPath);
+      const git = this._gitFor(repositoryPath);
 
       // Resolve which remote points to the PR's base repository (handles forks)
       const remote = await this.resolveRemoteForPR(git, prData, prInfo);
@@ -490,7 +622,7 @@ class GitWorktreeManager {
       } else {
         // Without checkout_script: use worktreeSourcePath as cwd if provided
         // (to inherit sparse-checkout from existing worktree)
-        const worktreeAddGit = worktreeSourcePath ? simpleGit(worktreeSourcePath) : git;
+        const worktreeAddGit = worktreeSourcePath ? this._gitFor(worktreeSourcePath) : git;
         if (worktreeSourcePath) {
           console.log(`Creating worktree at ${worktreePath} from ${prData.base_branch} (inheriting sparse-checkout from ${worktreeSourcePath})...`);
         } else {
@@ -509,17 +641,10 @@ class GitWorktreeManager {
       }
       
       // Create git instance for the worktree
-      const worktreeGit = simpleGit(worktreePath);
-      
+      const worktreeGit = this._gitFor(worktreePath);
+
       // Ensure base SHA is available (in case base branch was force-pushed or rebased)
-      console.log(`Ensuring base commit ${prData.base_sha} is available...`);
-      try {
-        // Try to fetch the specific base SHA if it's not already available
-        await worktreeGit.raw(['fetch', remote, prData.base_sha]);
-      } catch (fetchError) {
-        // If fetch fails, the SHA might already be available locally
-        console.log(`Base SHA fetch not needed or already available: ${fetchError.message}`);
-      }
+      await this.ensureBaseShaAvailable(worktreeGit, prData, remote);
 
       // Fetch the PR head using PR refs when available, with a branch/SHA fallback
       console.log(`Fetching PR #${prInfo.number} head...`);
@@ -546,7 +671,7 @@ class GitWorktreeManager {
         const scriptEnv = {
           BASE_BRANCH: prData.base_branch,
           HEAD_BRANCH: headBranch,
-          BASE_SHA: prData.base_sha,
+          BASE_SHA: this.getPRBaseSha(prData),
           HEAD_SHA: this.getPRHeadSha(prData),
           PR_NUMBER: String(prInfo.number),
           WORKTREE_PATH: worktreePath
@@ -567,8 +692,8 @@ class GitWorktreeManager {
       
       // Verify we're at the correct commit
       const currentCommit = await worktreeGit.revparse(['HEAD']);
-      if (currentCommit.trim() !== prData.head_sha) {
-        console.warn(`Warning: Expected commit ${prData.head_sha}, but got ${currentCommit.trim()}`);
+      if (targetSha && currentCommit.trim() !== targetSha) {
+        console.warn(`Warning: Expected commit ${targetSha}, but got ${currentCommit.trim()}`);
       }
 
       // Store/update worktree record in database
@@ -598,7 +723,7 @@ class GitWorktreeManager {
         console.error('Error during cleanup:', cleanupError);
       }
       
-      throw new Error(`Failed to create git worktree: ${error.message}`);
+      throw this.wrapError('Failed to create git worktree', error);
     }
   }
 
@@ -612,7 +737,7 @@ class GitWorktreeManager {
    */
   async updateWorktree(owner, repo, number, prData) {
     const prInfo = { owner, repo, number };
-    const headSha = prData.head_sha;
+    const headSha = this.getPRHeadSha(prData);
     const worktreePath = await this.getWorktreePath(prInfo);
 
     try {
@@ -625,7 +750,7 @@ class GitWorktreeManager {
       console.log(`Updating worktree for PR #${number} at ${worktreePath}`);
 
       // Create git instance for the worktree
-      const worktreeGit = simpleGit(worktreePath);
+      const worktreeGit = this._gitFor(worktreePath);
 
       // Resolve which remote points to the PR's base repository (handles forks)
       const remote = await this.resolveRemoteForPR(worktreeGit, prData, prInfo);
@@ -635,17 +760,19 @@ class GitWorktreeManager {
       console.log(`Fetching latest changes from ${remote}...`);
       await worktreeGit.fetch([remote, '--prune']);
 
+      await this.ensureBaseShaAvailable(worktreeGit, prData, remote);
+
       // Fetch the PR head using PR refs when available, with a branch/SHA fallback
       console.log(`Fetching PR #${number} head...`);
       const fetchedHead = await this.fetchPRHead(worktreeGit, prInfo, prData, { remote });
 
       // Checkout to PR head commit
-      console.log(`Checking out to PR head commit ${headSha}...`);
+      console.log(`Checking out to PR head ${headSha || fetchedHead.checkoutTarget}...`);
       await worktreeGit.checkout([fetchedHead.checkoutTarget]);
 
       // Verify we're at the correct commit
       const currentCommit = await worktreeGit.revparse(['HEAD']);
-      if (currentCommit.trim() !== headSha) {
+      if (headSha && currentCommit.trim() !== headSha) {
         console.warn(`Warning: Expected commit ${headSha}, but got ${currentCommit.trim()}`);
       }
 
@@ -654,7 +781,7 @@ class GitWorktreeManager {
 
     } catch (error) {
       console.error('Error updating worktree:', error);
-      throw new Error(`Failed to update git worktree: ${error.message}`);
+      throw this.wrapError('Failed to update git worktree', error);
     }
   }
 
@@ -666,16 +793,21 @@ class GitWorktreeManager {
    */
   async generateUnifiedDiff(worktreePath, prData) {
     try {
-      console.log(`Generating diff between ${prData.base_sha} and ${prData.head_sha}...`);
+      const git = this._gitFor(worktreePath);
+      const baseSha = this.getPRBaseSha(prData);
+      const headSha = this.getPRHeadSha(prData);
 
-      const git = simpleGit(worktreePath);
+      console.log(`Generating diff between ${baseSha} and ${headSha}...`);
+
+      await this.assertCommitAvailableLocally(git, baseSha, 'Base SHA');
+      await this.assertCommitAvailableLocally(git, headSha, 'Head SHA');
 
       // Generate diff between base SHA and head SHA (not branch names)
       // This ensures we compare the exact commits from the PR, even if the base branch has moved
       // Defensive flags to normalize output regardless of user's git config
       // (see src/git/diff-flags.js for rationale)
       const diff = await git.diff([
-        `${prData.base_sha}...${prData.head_sha}`,
+        `${baseSha}...${headSha}`,
         '--unified=3',
         ...GIT_DIFF_FLAGS_ARRAY
       ]);
@@ -684,7 +816,7 @@ class GitWorktreeManager {
 
     } catch (error) {
       console.error('Error generating diff:', error);
-      throw new Error(`Failed to generate diff: ${error.message}`);
+      throw this.wrapError('Failed to generate diff', error);
     }
   }
 
@@ -696,12 +828,17 @@ class GitWorktreeManager {
    */
   async getChangedFiles(worktreePath, prData) {
     try {
-      const git = simpleGit(worktreePath);
+      const git = this._gitFor(worktreePath);
+      const baseSha = this.getPRBaseSha(prData);
+      const headSha = this.getPRHeadSha(prData);
+
+      await this.assertCommitAvailableLocally(git, baseSha, 'Base SHA');
+      await this.assertCommitAvailableLocally(git, headSha, 'Head SHA');
 
       // Get file changes with stats using base SHA and head SHA
       // This ensures we get the exact files changed in the PR, even if the base branch has moved
       const diffSummary = await git.diffSummary([
-        `${prData.base_sha}...${prData.head_sha}`,
+        `${baseSha}...${headSha}`,
         ...GIT_DIFF_SUMMARY_FLAGS_ARRAY
       ]);
 
@@ -728,7 +865,7 @@ class GitWorktreeManager {
 
     } catch (error) {
       console.error('Error getting changed files:', error);
-      throw new Error(`Failed to get changed files: ${error.message}`);
+      throw this.wrapError('Failed to get changed files', error);
     }
   }
 
@@ -779,7 +916,7 @@ class GitWorktreeManager {
    */
   async resolveOwningRepo(worktreePath) {
     try {
-      const git = simpleGit(worktreePath);
+      const git = this._gitFor(worktreePath);
       const commonDir = (await git.raw(['rev-parse', '--git-common-dir'])).trim();
       // commonDir is either a .git subdirectory (regular repos) or the bare repo root itself.
       // Only strip the last component when it's actually a .git directory.
@@ -977,7 +1114,7 @@ class GitWorktreeManager {
    */
   async hasLocalChanges(worktreePath) {
     try {
-      const git = simpleGit(worktreePath);
+      const git = this._gitFor(worktreePath);
       const status = await git.raw(['status', '--porcelain']);
       return status.trim().length > 0;
     } catch (error) {
@@ -1007,10 +1144,12 @@ class GitWorktreeManager {
         throw new Error(`Worktree has uncommitted changes. Please resolve manually at: ${worktreePath}`);
       }
 
-      const git = simpleGit(worktreePath);
+      const git = this._gitFor(worktreePath);
 
       // Resolve which remote points to the PR's base repository (handles forks)
       const remote = await this.resolveRemoteForPR(git, prData, prInfo);
+
+      await this.ensureBaseShaAvailable(git, prData, remote);
 
       // Fetch the latest PR head from remote
       console.log(`Fetching PR #${prNumber} head from ${remote}...`);
@@ -1035,7 +1174,7 @@ class GitWorktreeManager {
         throw error;
       }
       console.error('Error refreshing worktree:', error);
-      throw new Error(`Failed to refresh worktree: ${error.message}`);
+      throw this.wrapError('Failed to refresh worktree', error);
     }
   }
 
@@ -1314,4 +1453,4 @@ class GitWorktreeManager {
   }
 }
 
-module.exports = { GitWorktreeManager };
+module.exports = { GitWorktreeManager, MISSING_COMMIT_ERROR_CODE };

--- a/src/setup/pr-setup.js
+++ b/src/setup/pr-setup.js
@@ -12,7 +12,7 @@
  */
 
 const { run, queryOne, WorktreeRepository, RepoSettingsRepository, ReviewRepository } = require('../database');
-const { GitWorktreeManager } = require('../git/worktree');
+const { GitWorktreeManager, MISSING_COMMIT_ERROR_CODE } = require('../git/worktree');
 const { WorktreePoolLifecycle } = require('../git/worktree-pool-lifecycle');
 const { GitHubClient } = require('../github/client');
 const { normalizeRepository } = require('../utils/paths');
@@ -374,11 +374,24 @@ async function findRepositoryPath({ db, owner, repo, repository, prNumber, confi
  * Used to trigger fallback from restore mode to fresh setup.
  */
 function isShaNotFoundError(err) {
-  const msg = (err.message || '').toLowerCase();
-  return msg.includes('did not match any') ||
-         msg.includes('not a valid object') ||
-         msg.includes('reference is not a tree') ||
-         msg.includes('bad object');
+  let current = err;
+  while (current) {
+    if (current.code === MISSING_COMMIT_ERROR_CODE) {
+      return true;
+    }
+
+    const msg = (current.message || '').toLowerCase();
+    if (msg.includes('did not match any') ||
+        msg.includes('not a valid object') ||
+        msg.includes('reference is not a tree') ||
+        msg.includes('bad object')) {
+      return true;
+    }
+
+    current = current.cause;
+  }
+
+  return false;
 }
 
 /**

--- a/tests/unit/pr-setup.test.js
+++ b/tests/unit/pr-setup.test.js
@@ -1,0 +1,27 @@
+// Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from 'vitest';
+
+const { isShaNotFoundError } = require('../../src/setup/pr-setup');
+const { MISSING_COMMIT_ERROR_CODE } = require('../../src/git/worktree');
+
+describe('isShaNotFoundError', () => {
+  it('recognizes the stable missing-commit error code', () => {
+    const error = new Error('Base SHA deadbeef is not available locally');
+    error.code = MISSING_COMMIT_ERROR_CODE;
+
+    expect(isShaNotFoundError(error)).toBe(true);
+  });
+
+  it('recognizes missing-commit errors through wrapped causes', () => {
+    const cause = new Error('Base SHA deadbeef is not available locally');
+    cause.code = MISSING_COMMIT_ERROR_CODE;
+    const wrapped = new Error(`Failed to generate diff: ${cause.message}`);
+    wrapped.cause = cause;
+
+    expect(isShaNotFoundError(wrapped)).toBe(true);
+  });
+
+  it('does not match unrelated errors', () => {
+    expect(isShaNotFoundError(new Error('network timeout'))).toBe(false);
+  });
+});

--- a/tests/unit/worktree-base-sha.test.js
+++ b/tests/unit/worktree-base-sha.test.js
@@ -1,0 +1,217 @@
+// Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { GitWorktreeManager, MISSING_COMMIT_ERROR_CODE } = require('../../src/git/worktree');
+
+function createMockGit(overrides = {}) {
+  return {
+    fetch: vi.fn().mockResolvedValue(undefined),
+    raw: vi.fn().mockResolvedValue(''),
+    checkout: vi.fn().mockResolvedValue(undefined),
+    revparse: vi.fn().mockResolvedValue('head-sha\n'),
+    branch: vi.fn().mockResolvedValue(undefined),
+    diff: vi.fn().mockResolvedValue('diff --git a/file.js b/file.js'),
+    diffSummary: vi.fn().mockResolvedValue({ files: [] }),
+    ...overrides,
+  };
+}
+
+describe('GitWorktreeManager base SHA availability', () => {
+  let manager;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    manager = new GitWorktreeManager(null, { worktreeBaseDir: '/tmp/worktrees' });
+    manager.ensureWorktreeBaseDir = vi.fn().mockResolvedValue(undefined);
+    manager.cleanupWorktree = vi.fn().mockResolvedValue(undefined);
+    manager.resolveRemoteForPR = vi.fn().mockResolvedValue('fork-remote');
+    manager.fetchPRHead = vi.fn().mockResolvedValue({ checkoutTarget: 'refs/remotes/fork-remote/pr-42' });
+    manager.hasLocalChanges = vi.fn().mockResolvedValue(false);
+    manager.getWorktreePath = vi.fn().mockResolvedValue('/tmp/worktrees/existing');
+    manager.worktreeExists = vi.fn().mockResolvedValue(true);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('fetches the exact base SHA when creating a new worktree and the commit is missing locally', async () => {
+    const repoPath = '/tmp/repo';
+    const repoGit = createMockGit();
+    const worktreeGit = createMockGit({
+      raw: vi.fn(async (args) => {
+        if (args[0] === 'cat-file' && args[2] === 'base-sha') {
+          if (!worktreeGit._seenBaseFetch) {
+            throw new Error('missing');
+          }
+          return 'commit\n';
+        }
+        if (args[0] === 'fetch' && args[1] === 'fork-remote' && args[2] === 'base-sha') {
+          worktreeGit._seenBaseFetch = true;
+          return '';
+        }
+        return '';
+      }),
+      revparse: vi.fn().mockResolvedValue('head-sha\n'),
+    });
+    worktreeGit._seenBaseFetch = false;
+
+    manager._gitFor = vi.fn((dirPath) => (dirPath === repoPath ? repoGit : worktreeGit));
+
+    await manager.createWorktreeForPR(
+      { owner: 'owner', repo: 'repo', number: 42 },
+      { base_branch: 'main', base_sha: 'base-sha', head_sha: 'head-sha', head_branch: 'feature' },
+      repoPath
+    );
+
+    expect(worktreeGit.raw).toHaveBeenCalledWith(['fetch', 'fork-remote', 'base-sha']);
+  });
+
+  it('fetches the exact base SHA when updating an existing worktree', async () => {
+    const worktreeGit = createMockGit({
+      raw: vi.fn(async (args) => {
+        if (args[0] === 'cat-file' && args[2] === 'base-sha') {
+          if (!worktreeGit._seenBaseFetch) {
+            throw new Error('missing');
+          }
+          return 'commit\n';
+        }
+        if (args[0] === 'fetch' && args[1] === 'fork-remote' && args[2] === 'base-sha') {
+          worktreeGit._seenBaseFetch = true;
+          return '';
+        }
+        return '';
+      }),
+      revparse: vi.fn().mockResolvedValue('head-sha\n'),
+    });
+    worktreeGit._seenBaseFetch = false;
+
+    manager._gitFor = vi.fn().mockReturnValue(worktreeGit);
+
+    await manager.updateWorktree('owner', 'repo', 42, {
+      base_sha: 'base-sha',
+      head_sha: 'head-sha',
+    });
+
+    expect(worktreeGit.fetch).toHaveBeenCalledWith(['fork-remote', '--prune']);
+    expect(worktreeGit.raw).toHaveBeenCalledWith(['fetch', 'fork-remote', 'base-sha']);
+    expect(worktreeGit.checkout).toHaveBeenCalledWith(['refs/remotes/fork-remote/pr-42']);
+  });
+
+  it('uses nested REST-format SHAs during update verification', async () => {
+    const worktreeGit = createMockGit({
+      raw: vi.fn(async (args) => {
+        if (args[0] === 'cat-file') {
+          return 'commit\n';
+        }
+        return '';
+      }),
+      revparse: vi.fn().mockResolvedValue('nested-head-sha\n'),
+    });
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    manager._gitFor = vi.fn().mockReturnValue(worktreeGit);
+
+    await manager.updateWorktree('owner', 'repo', 42, {
+      base: { sha: 'nested-base-sha' },
+      head: { sha: 'nested-head-sha' },
+    });
+
+    expect(worktreeGit.checkout).toHaveBeenCalledWith(['refs/remotes/fork-remote/pr-42']);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('fetches the exact base SHA when refreshing an existing worktree record', async () => {
+    const worktreeGit = createMockGit({
+      raw: vi.fn(async (args) => {
+        if (args[0] === 'cat-file' && args[2] === 'base-sha') {
+          if (!worktreeGit._seenBaseFetch) {
+            throw new Error('missing');
+          }
+          return 'commit\n';
+        }
+        if (args[0] === 'fetch' && args[1] === 'fork-remote' && args[2] === 'base-sha') {
+          worktreeGit._seenBaseFetch = true;
+          return '';
+        }
+        return '';
+      }),
+    });
+    worktreeGit._seenBaseFetch = false;
+
+    manager._gitFor = vi.fn().mockReturnValue(worktreeGit);
+
+    await manager.refreshWorktree(
+      { id: 'wt-1', path: '/tmp/worktrees/existing' },
+      42,
+      { base_sha: 'base-sha', head_sha: 'head-sha' },
+      { owner: 'owner', repo: 'repo', number: 42 }
+    );
+
+    expect(worktreeGit.raw).toHaveBeenCalledWith(['fetch', 'fork-remote', 'base-sha']);
+    expect(worktreeGit.raw).toHaveBeenCalledWith(['reset', '--hard', 'refs/remotes/fork-remote/pr-42']);
+  });
+
+  it('fails with a targeted diff error when the base SHA is missing locally', async () => {
+    const worktreeGit = createMockGit({
+      raw: vi.fn(async (args) => {
+        if (args[0] === 'cat-file' && args[2] === 'base-sha') {
+          throw new Error('missing');
+        }
+        return 'commit\n';
+      }),
+    });
+
+    manager._gitFor = vi.fn().mockReturnValue(worktreeGit);
+
+    const error = await manager.generateUnifiedDiff('/tmp/worktrees/existing', {
+      base_sha: 'base-sha',
+      head_sha: 'head-sha',
+    }).catch((err) => err);
+
+    expect(error.message).toBe(
+      'Failed to generate diff: Base SHA base-sha is not available locally. Refresh the worktree to fetch the missing commit before generating the diff.'
+    );
+    expect(error.code).toBe(MISSING_COMMIT_ERROR_CODE);
+
+    expect(worktreeGit.diff).not.toHaveBeenCalled();
+  });
+
+  it('passes BASE_SHA to checkout scripts when PR data uses nested REST-format SHAs', async () => {
+    const repoPath = '/tmp/repo';
+    const repoGit = createMockGit();
+    const worktreeGit = createMockGit({
+      raw: vi.fn(async (args) => {
+        if (args[0] === 'cat-file') {
+          return 'commit\n';
+        }
+        return '';
+      }),
+      revparse: vi.fn().mockResolvedValue('nested-head\n'),
+    });
+
+    manager._gitFor = vi.fn((dirPath) => (dirPath === repoPath ? repoGit : worktreeGit));
+    manager.executeCheckoutScript = vi.fn().mockResolvedValue(undefined);
+
+    await manager.createWorktreeForPR(
+      { owner: 'owner', repo: 'repo', number: 42 },
+      {
+        base_branch: 'main',
+        base: { sha: 'nested-base', ref: 'main' },
+        head: { sha: 'nested-head', ref: 'feature' },
+      },
+      repoPath,
+      { checkoutScript: '/tmp/checkout.sh' }
+    );
+
+    expect(manager.executeCheckoutScript).toHaveBeenCalledWith(
+      '/tmp/checkout.sh',
+      expect.any(String),
+      expect.objectContaining({
+        BASE_SHA: 'nested-base',
+        HEAD_SHA: 'nested-head',
+      }),
+      undefined
+    );
+  });
+});

--- a/tests/unit/worktree-pool-lifecycle.test.js
+++ b/tests/unit/worktree-pool-lifecycle.test.js
@@ -18,7 +18,10 @@ function createMockDeps() {
     refreshWorktree: vi.fn().mockResolvedValue('/tmp/worktree/pair-review--abc'),
     executeCheckoutScript: vi.fn().mockResolvedValue(undefined),
     cleanupWorktree: vi.fn().mockResolvedValue(undefined),
+    ensureBaseShaAvailable: vi.fn().mockResolvedValue(undefined),
     resolveRemoteForPR: vi.fn().mockResolvedValue('origin'),
+    getPRHeadSha: vi.fn((data) => data?.head?.sha || data?.head_sha || ''),
+    getPRBaseSha: vi.fn((data) => data?.base?.sha || data?.base_sha || ''),
     fetchPRHead: vi.fn().mockResolvedValue({
       remote: 'origin',
       trackingRef: 'refs/remotes/origin/pr-123',
@@ -290,6 +293,10 @@ describe('WorktreePoolLifecycle', () => {
           checkoutTarget: 'abc123',
         });
       });
+      deps._mockWorktreeManagerInstance.ensureBaseShaAvailable.mockImplementation(() => {
+        callOrder.push('ensureBaseShaAvailable');
+        return Promise.resolve();
+      });
       deps._mockGit.reset.mockImplementation(() => { callOrder.push('reset'); return Promise.resolve(); });
       deps._mockGit.clean.mockImplementation(() => { callOrder.push('clean'); return Promise.resolve(); });
       deps._mockGit.checkout.mockImplementation(() => { callOrder.push('checkout'); return Promise.resolve(); });
@@ -299,7 +306,17 @@ describe('WorktreePoolLifecycle', () => {
 
       await lifecycle._switchPoolWorktree(poolEntry, worktreeRecord, prInfo, prData, options);
 
-      expect(callOrder).toEqual(['resolveRemoteForPR', 'fetchPRHead', 'reset', 'clean', 'checkout', 'switchPR', 'clearWorktree', 'markInUse']);
+      expect(callOrder).toEqual(['resolveRemoteForPR', 'fetchPRHead', 'ensureBaseShaAvailable', 'reset', 'clean', 'checkout', 'switchPR', 'clearWorktree', 'markInUse']);
+    });
+
+    it('ensures the base SHA is available before switching the pool worktree', async () => {
+      await lifecycle._switchPoolWorktree(poolEntry, worktreeRecord, prInfo, prData, options);
+
+      expect(deps._mockWorktreeManagerInstance.ensureBaseShaAvailable).toHaveBeenCalledWith(
+        deps._mockGit,
+        prData,
+        'origin'
+      );
     });
 
     it('runs executeCheckoutScript when resetScript is provided', async () => {
@@ -509,6 +526,16 @@ describe('WorktreePoolLifecycle', () => {
       const result = await lifecycle._refreshPoolWorktree(poolEntry, worktreeRecord, prInfo, prData);
 
       expect(deps._mockGit.revparse).toHaveBeenCalledWith(['HEAD']);
+      expect(deps._mockWorktreeManagerInstance.resolveRemoteForPR).toHaveBeenCalledWith(
+        deps._mockGit,
+        prData,
+        { owner: 'test', repo: 'repo', number: 123 }
+      );
+      expect(deps._mockWorktreeManagerInstance.ensureBaseShaAvailable).toHaveBeenCalledWith(
+        deps._mockGit,
+        prData,
+        'origin'
+      );
       // Should NOT call refreshWorktree -- early return
       expect(deps._mockWorktreeManagerInstance.refreshWorktree).not.toHaveBeenCalled();
       // Should still mark in_use


### PR DESCRIPTION
## Summary
- ensure PR base commits are fetched for worktree create, refresh, update, and pooled worktree reuse paths
- preserve a machine-checkable missing-commit error so restore mode can fall back to fresh PR metadata
- normalize base/head SHA accessors across worktree setup and add regression coverage for restore and pool fast paths

## Testing
- pnpm exec vitest run tests/unit/pr-setup.test.js tests/unit/worktree-base-sha.test.js tests/unit/worktree-pool-lifecycle.test.js
- pnpm exec vitest run tests/unit/worktree*.test.js