### PR TITLE
Add Claude Opus 4.7 xhigh model

### DIFF
--- a/.changeset/claude-opus-4-7-models.md
+++ b/.changeset/claude-opus-4-7-models.md
@@ -1,0 +1,7 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Add Claude Opus 4.7 (`opus-4.7-xhigh`) as a new built-in model
+
+Adds `opus-4.7-xhigh`, pinned to the `claude-opus-4-7` CLI model with `CLAUDE_CODE_EFFORT_LEVEL=xhigh` for the deepest analysis. Also pins the existing `opus`, `opus-4.6-low`, `opus-4.6-medium`, and `opus-4.6-1m` entries to explicit `opus-4-6` / `opus-4-6[1m]` CLI model IDs so they no longer drift when the CLI's `opus` alias updates. `opus` (Opus 4.6 High) remains the default.

--- a/config.example.json
+++ b/config.example.json
@@ -77,7 +77,7 @@
     },
 
     "claude": {
-      "_comment": "Override Claude's built-in configuration. Useful for custom paths, wrapper scripts, or additional arguments. Built-in models include haiku, sonnet, opus-4.5, opus-4.6-low, opus-4.6-medium, opus, and opus-4.6-1m. Use 'cli_model' to decouple the app-level model ID from the CLI --model argument. Use 'env' for model-specific environment variables.",
+      "_comment": "Override Claude's built-in configuration. Useful for custom paths, wrapper scripts, or additional arguments. Built-in models include haiku, sonnet, opus-4.5, opus-4.6-low, opus-4.6-medium, opus, opus-4.6-1m, and opus-4.7-xhigh. Use 'cli_model' to decouple the app-level model ID from the CLI --model argument. Use 'env' for model-specific environment variables.",
       "command": "claude",
       "extra_args": [],
       "env": {},

--- a/src/ai/claude-provider.js
+++ b/src/ai/claude-provider.js
@@ -21,6 +21,30 @@ const BIN_DIR = path.join(__dirname, '..', '..', 'bin');
  */
 const CLAUDE_MODELS = [
   {
+    id: 'opus-4.7-xhigh',
+    cli_model: 'claude-opus-4-7',
+    env: { CLAUDE_CODE_EFFORT_LEVEL: 'xhigh' },
+    name: 'Opus 4.7 xhigh',
+    tier: 'thorough',
+    tagline: 'Latest Gen',
+    description: 'Opus 4.7 (latest) with extra-high effort',
+    badge: 'Latest',
+    badgeClass: 'badge-power'
+  },
+  {
+    id: 'opus',
+    aliases: ['opus-4.6-high'],
+    cli_model: 'opus-4-6',
+    env: { CLAUDE_CODE_EFFORT_LEVEL: 'high' },
+    name: 'Opus 4.6 High',
+    tier: 'thorough',
+    tagline: 'Maximum Depth',
+    description: 'Opus 4.6 with high effort — deepest analysis',
+    badge: 'Most Thorough',
+    badgeClass: 'badge-power',
+    default: true
+  },
+  {
     id: 'haiku',
     name: 'Haiku 4.6',
     tier: 'fast',
@@ -41,7 +65,7 @@ const CLAUDE_MODELS = [
   },
   {
     id: 'opus-4.6-low',
-    cli_model: 'opus',
+    cli_model: 'opus-4-6',
     env: { CLAUDE_CODE_EFFORT_LEVEL: 'low' },
     name: 'Opus 4.6 Low',
     tier: 'balanced',
@@ -52,7 +76,7 @@ const CLAUDE_MODELS = [
   },
   {
     id: 'opus-4.6-medium',
-    cli_model: 'opus',
+    cli_model: 'opus-4-6',
     env: { CLAUDE_CODE_EFFORT_LEVEL: 'medium' },
     name: 'Opus 4.6 Medium',
     tier: 'balanced',
@@ -62,20 +86,8 @@ const CLAUDE_MODELS = [
     badgeClass: 'badge-power'
   },
   {
-    id: 'opus',
-    aliases: ['opus-4.6-high'],
-    env: { CLAUDE_CODE_EFFORT_LEVEL: 'high' },
-    name: 'Opus 4.6 High',
-    tier: 'thorough',
-    tagline: 'Maximum Depth',
-    description: 'Opus 4.6 with high effort — deepest analysis',
-    badge: 'Most Thorough',
-    badgeClass: 'badge-power',
-    default: true
-  },
-  {
     id: 'opus-4.6-1m',
-    cli_model: 'opus[1m]',
+    cli_model: 'opus-4-6[1m]',
     name: 'Opus 4.6 1M',
     tier: 'balanced',
     tagline: 'Extended Context',

--- a/src/main.js
+++ b/src/main.js
@@ -116,7 +116,8 @@ OPTIONS:
                             The web UI also starts for the human reviewer.
     --model <name>          Override the AI model. Claude Code is the default provider.
                             Available models: opus, sonnet, haiku (Claude Code);
-                            also: opus-4.5, opus-4.6-low, opus-4.6-medium, opus-4.6-1m
+                            also: opus-4.5, opus-4.6-low, opus-4.6-medium, opus-4.6-1m,
+                                  opus-4.7-xhigh
                             or use provider-specific models with Gemini/Codex
     --use-checkout          Use current directory instead of creating worktree
                             (automatic in GitHub Actions)

--- a/tests/unit/claude-provider.test.js
+++ b/tests/unit/claude-provider.test.js
@@ -63,7 +63,7 @@ describe('ClaudeProvider', () => {
     it('should return array of models with expected structure', () => {
       const models = ClaudeProvider.getModels();
       expect(Array.isArray(models)).toBe(true);
-      expect(models.length).toBe(7);
+      expect(models.length).toBe(8);
 
       // Check that we have haiku, sonnet, and opus variants
       const modelIds = models.map(m => m.id);
@@ -74,6 +74,7 @@ describe('ClaudeProvider', () => {
       expect(modelIds).toContain('opus-4.6-medium');
       expect(modelIds).toContain('opus');
       expect(modelIds).toContain('opus-4.6-1m');
+      expect(modelIds).toContain('opus-4.7-xhigh');
 
       // Check model structure - opus is now the default
       const opus = models.find(m => m.id === 'opus');
@@ -93,6 +94,8 @@ describe('ClaudeProvider', () => {
       expect(models.find(m => m.id === 'opus-4.5').tier).toBe('thorough');
       // opus itself is thorough
       expect(opus.tier).toBe('thorough');
+      // opus-4.7 xhigh is thorough
+      expect(models.find(m => m.id === 'opus-4.7-xhigh').tier).toBe('thorough');
     });
 
     it('should return install instructions', () => {
@@ -228,11 +231,11 @@ describe('ClaudeProvider', () => {
 
     describe('cli_model resolution', () => {
       it('should resolve cli_model from built-in model definition', () => {
-        // opus-4.6-low has cli_model: 'opus' in built-in definition
+        // opus-4.6-low has cli_model: 'opus-4-6' in built-in definition
         const provider = new ClaudeProvider('opus-4.6-low');
         const modelIdx = provider.args.indexOf('--model');
         expect(modelIdx).not.toBe(-1);
-        expect(provider.args[modelIdx + 1]).toBe('opus');
+        expect(provider.args[modelIdx + 1]).toBe('opus-4-6');
       });
 
       it('should fall back to id when no cli_model is defined', () => {
@@ -281,11 +284,11 @@ describe('ClaudeProvider', () => {
         expect(provider.args[modelIdx + 1]).toBe('claude-opus-4-5-20251101');
       });
 
-      it('should resolve opus-4.6-1m to opus[1m] cli_model', () => {
+      it('should resolve opus-4.6-1m to opus-4-6[1m] cli_model', () => {
         const provider = new ClaudeProvider('opus-4.6-1m');
         const modelIdx = provider.args.indexOf('--model');
         expect(modelIdx).not.toBe(-1);
-        expect(provider.args[modelIdx + 1]).toBe('opus[1m]');
+        expect(provider.args[modelIdx + 1]).toBe('opus-4-6[1m]');
       });
     });
 
@@ -335,6 +338,18 @@ describe('ClaudeProvider', () => {
       it('should have empty extraEnv for opus-4.5 (no built-in env)', () => {
         const provider = new ClaudeProvider('opus-4.5');
         expect(provider.extraEnv).toEqual({});
+      });
+
+      it('should include built-in env (xhigh) for opus-4.7-xhigh', () => {
+        const provider = new ClaudeProvider('opus-4.7-xhigh');
+        expect(provider.extraEnv).toEqual({ CLAUDE_CODE_EFFORT_LEVEL: 'xhigh' });
+      });
+
+      it('should resolve opus-4.7-xhigh to claude-opus-4-7 cli_model', () => {
+        const provider = new ClaudeProvider('opus-4.7-xhigh');
+        const modelIdx = provider.args.indexOf('--model');
+        expect(modelIdx).not.toBe(-1);
+        expect(provider.args[modelIdx + 1]).toBe('claude-opus-4-7');
       });
     });
 
@@ -1149,7 +1164,7 @@ describe('ClaudeProvider', () => {
       const args = provider.buildArgsForModel('opus-4.6-low');
       const modelIdx = args.indexOf('--model');
       expect(modelIdx).not.toBe(-1);
-      expect(args[modelIdx + 1]).toBe('opus');
+      expect(args[modelIdx + 1]).toBe('opus-4-6');
     });
 
     it('should fall back to id when no cli_model defined', () => {


### PR DESCRIPTION
## Summary
- Adds `opus-4.7-xhigh` as a new built-in Claude model, pinned to `claude-opus-4-7` with `CLAUDE_CODE_EFFORT_LEVEL=xhigh`
- Pins existing 4.6 variants (`opus`, `opus-4.6-low`, `opus-4.6-medium`, `opus-4.6-1m`) to explicit `opus-4-6` / `opus-4-6[1m]` CLI model IDs so they no longer drift when the CLI's `opus` alias updates
- Opus 4.6 High (`opus`) remains the default; 4.7 is opt-in

## Test plan
- [x] `pnpx vitest run tests/unit/claude-provider.test.js` — 118/118 passing
- [ ] Manually exercise `--model opus-4.7-xhigh` end-to-end once merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)