### PR TITLE
Fix Opus 4.6 CLI model IDs to use claude- prefix

### DIFF
--- a/.changeset/fix-opus-4-6-cli-model-id.md
+++ b/.changeset/fix-opus-4-6-cli-model-id.md
@@ -1,0 +1,7 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Fix Opus 4.6 model variants failing to launch
+
+The `opus`, `opus-4.6-low`, `opus-4.6-medium`, and `opus-4.6-1m` Claude provider entries were pinned to `opus-4-6` / `opus-4-6[1m]` CLI model IDs in 3.3.4, but the Claude CLI does not accept those bare aliases — only the fully-qualified `claude-opus-4-6` / `claude-opus-4-6[1m]` IDs work. Updated all four entries to use the prefixed IDs so these models actually run.

--- a/src/ai/claude-provider.js
+++ b/src/ai/claude-provider.js
@@ -34,7 +34,7 @@ const CLAUDE_MODELS = [
   {
     id: 'opus',
     aliases: ['opus-4.6-high'],
-    cli_model: 'opus-4-6',
+    cli_model: 'claude-opus-4-6',
     env: { CLAUDE_CODE_EFFORT_LEVEL: 'high' },
     name: 'Opus 4.6 High',
     tier: 'thorough',
@@ -65,7 +65,7 @@ const CLAUDE_MODELS = [
   },
   {
     id: 'opus-4.6-low',
-    cli_model: 'opus-4-6',
+    cli_model: 'claude-opus-4-6',
     env: { CLAUDE_CODE_EFFORT_LEVEL: 'low' },
     name: 'Opus 4.6 Low',
     tier: 'balanced',
@@ -76,7 +76,7 @@ const CLAUDE_MODELS = [
   },
   {
     id: 'opus-4.6-medium',
-    cli_model: 'opus-4-6',
+    cli_model: 'claude-opus-4-6',
     env: { CLAUDE_CODE_EFFORT_LEVEL: 'medium' },
     name: 'Opus 4.6 Medium',
     tier: 'balanced',
@@ -87,7 +87,7 @@ const CLAUDE_MODELS = [
   },
   {
     id: 'opus-4.6-1m',
-    cli_model: 'opus-4-6[1m]',
+    cli_model: 'claude-opus-4-6[1m]',
     name: 'Opus 4.6 1M',
     tier: 'balanced',
     tagline: 'Extended Context',

--- a/tests/unit/claude-provider.test.js
+++ b/tests/unit/claude-provider.test.js
@@ -231,11 +231,11 @@ describe('ClaudeProvider', () => {
 
     describe('cli_model resolution', () => {
       it('should resolve cli_model from built-in model definition', () => {
-        // opus-4.6-low has cli_model: 'opus-4-6' in built-in definition
+        // opus-4.6-low has cli_model: 'claude-opus-4-6' in built-in definition
         const provider = new ClaudeProvider('opus-4.6-low');
         const modelIdx = provider.args.indexOf('--model');
         expect(modelIdx).not.toBe(-1);
-        expect(provider.args[modelIdx + 1]).toBe('opus-4-6');
+        expect(provider.args[modelIdx + 1]).toBe('claude-opus-4-6');
       });
 
       it('should fall back to id when no cli_model is defined', () => {
@@ -284,11 +284,11 @@ describe('ClaudeProvider', () => {
         expect(provider.args[modelIdx + 1]).toBe('claude-opus-4-5-20251101');
       });
 
-      it('should resolve opus-4.6-1m to opus-4-6[1m] cli_model', () => {
+      it('should resolve opus-4.6-1m to claude-opus-4-6[1m] cli_model', () => {
         const provider = new ClaudeProvider('opus-4.6-1m');
         const modelIdx = provider.args.indexOf('--model');
         expect(modelIdx).not.toBe(-1);
-        expect(provider.args[modelIdx + 1]).toBe('opus-4-6[1m]');
+        expect(provider.args[modelIdx + 1]).toBe('claude-opus-4-6[1m]');
       });
     });
 
@@ -1164,7 +1164,7 @@ describe('ClaudeProvider', () => {
       const args = provider.buildArgsForModel('opus-4.6-low');
       const modelIdx = args.indexOf('--model');
       expect(modelIdx).not.toBe(-1);
-      expect(args[modelIdx + 1]).toBe('opus-4-6');
+      expect(args[modelIdx + 1]).toBe('claude-opus-4-6');
     });
 
     it('should fall back to id when no cli_model defined', () => {


### PR DESCRIPTION
## Summary
- The 3.3.4 release pinned the four Opus 4.6 variants (`opus`, `opus-4.6-low`, `opus-4.6-medium`, `opus-4.6-1m`) to bare aliases `opus-4-6` / `opus-4-6[1m]`, but the Claude CLI does not accept those — only the fully-qualified `claude-opus-4-6` / `claude-opus-4-6[1m]` IDs work, so the models failed to launch.
- Updated the `cli_model` fields in `src/ai/claude-provider.js` to use the prefixed IDs and adjusted the matching unit-test assertions.
- Added a patch-level changeset for the fix.

## Test plan
- [x] `vitest run tests/unit/claude-provider.test.js tests/unit/executable-provider.test.js` (195 passed)
- [x] Manual launch of Opus 4.6 model variant confirmed working

🤖 Generated with [Claude Code](https://claude.com/claude-code)