### PR TITLE
Add Codex reasoning-effort variants and Claude Opus 4.7 High

### DIFF
--- a/.changeset/claude-opus-4.7-high-variant.md
+++ b/.changeset/claude-opus-4.7-high-variant.md
@@ -1,0 +1,11 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Add Claude Opus 4.7 High variant and normalize XHigh display name
+
+- New `opus-4.7-high` model — Opus 4.7 pinned to `claude-opus-4-7` with
+  `CLAUDE_CODE_EFFORT_LEVEL=high`, parallel to the existing `opus-4.7-xhigh`.
+- Renamed the `opus-4.7-xhigh` display name from `Opus 4.7 xhigh` to
+  `Opus 4.7 XHigh` for consistency with the Codex provider's `XHigh` casing
+  and the existing `High`/`Low`/`Medium` capitalization on 4.6 variants.

--- a/.changeset/codex-gpt-5.5-and-reasoning-variants.md
+++ b/.changeset/codex-gpt-5.5-and-reasoning-variants.md
@@ -1,0 +1,20 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Add GPT-5.4 and GPT-5.5 high/xhigh reasoning variants to the Codex provider
+
+New Codex model options:
+- `gpt-5.4-high` / `gpt-5.4-xhigh` — GPT-5.4 with elevated reasoning effort
+- `gpt-5.5-high` / `gpt-5.5-xhigh` — GPT-5.5 with elevated reasoning effort
+
+Each variant passes its base model to `codex exec -m` and configures reasoning
+effort via `-c 'model_reasoning_effort="<level>"'`, so a variant ID like
+`gpt-5.5-xhigh` is never sent to Codex as a literal model name. Built-in
+`cli_model` and `extra_args` are honored by both the main analysis path and
+the extraction fallback.
+
+The bare `gpt-5.4` option (unspecified reasoning effort) has been removed
+from the picker in favor of these explicit variants. `gpt-5.4` still resolves
+as an alias of `gpt-5.4-high`, so previously saved results and councils that
+reference it continue to work.

--- a/config.example.json
+++ b/config.example.json
@@ -77,7 +77,7 @@
     },
 
     "claude": {
-      "_comment": "Override Claude's built-in configuration. Useful for custom paths, wrapper scripts, or additional arguments. Built-in models include haiku, sonnet, opus-4.5, opus-4.6-low, opus-4.6-medium, opus, opus-4.6-1m, and opus-4.7-xhigh. Use 'cli_model' to decouple the app-level model ID from the CLI --model argument. Use 'env' for model-specific environment variables.",
+      "_comment": "Override Claude's built-in configuration. Useful for custom paths, wrapper scripts, or additional arguments. Built-in models include haiku, sonnet, opus-4.5, opus-4.6-low, opus-4.6-medium, opus, opus-4.6-1m, opus-4.7-high, and opus-4.7-xhigh. Use 'cli_model' to decouple the app-level model ID from the CLI --model argument. Use 'env' for model-specific environment variables.",
       "command": "claude",
       "extra_args": [],
       "env": {},

--- a/public/js/repo-settings.js
+++ b/public/js/repo-settings.js
@@ -157,7 +157,9 @@ class RepoSettingsPage {
           const newProvider = this.providers[newProviderId];
 
           if (oldProvider && newProvider) {
-            const currentModel = oldProvider.models.find(m => m.id === this.currentSettings.default_model);
+            // Match by id or alias so legacy model IDs still resolve their tier
+            // when the user switches providers.
+            const currentModel = this.findModelWithAliases(oldProvider, this.currentSettings.default_model);
             if (currentModel) {
               const matchingModel = newProvider.models.find(m => m.tier === currentModel.tier);
               const defaultModel = newProvider.models.find(m => m.default);
@@ -620,6 +622,22 @@ class RepoSettingsPage {
   }
 
   /**
+   * Look up a model by ID within a provider, matching both canonical `id` and
+   * `aliases`. Historical repo settings may still reference legacy model IDs
+   * (e.g. `gpt-5.4` before reasoning-effort variants were introduced); those
+   * must still resolve to the canonical model so the UI shows the correct
+   * selection instead of silently falling back to the provider default.
+   *
+   * @param {Object} provider - Provider object with a `models` array
+   * @param {string} modelId - Model ID to look up (may be an alias)
+   * @returns {Object|undefined} Matching model definition, or undefined if not found
+   */
+  findModelWithAliases(provider, modelId) {
+    if (!provider || !provider.models || !modelId) return undefined;
+    return provider.models.find(m => m.id === modelId || m.aliases?.includes(modelId));
+  }
+
+  /**
    * Render model select dropdown for the currently selected provider
    */
   renderModelSelect() {
@@ -654,9 +672,10 @@ class RepoSettingsPage {
       return;
     }
 
-    // Find the selected model, fall back to default or first
+    // Find the selected model, fall back to default or first. Match aliases
+    // so legacy model IDs still render the canonical card.
     const modelId = this.currentSettings.default_model;
-    const model = provider.models.find(m => m.id === modelId)
+    const model = this.findModelWithAliases(provider, modelId)
       || provider.models.find(m => m.default)
       || provider.models[0];
 
@@ -691,7 +710,9 @@ class RepoSettingsPage {
     if (!provider) {
       return { providerName: providerId || 'Unknown', modelName: modelId || 'Unknown' };
     }
-    const model = provider.models?.find(m => m.id === modelId);
+    // Match aliases so historical council/voice configs that stored a legacy
+    // model ID still show the canonical model's display name.
+    const model = this.findModelWithAliases(provider, modelId);
     return {
       providerName: provider.name,
       modelName: model ? model.name : (modelId || 'Unknown')
@@ -1166,11 +1187,20 @@ class RepoSettingsPage {
     this.selectProvider(providerId);
     this.renderProviderSelect();
 
-    // Validate saved model exists in current provider
+    // Validate saved model exists in current provider. Match aliases so legacy
+    // model IDs (e.g. `gpt-5.4` recorded before reasoning-effort variants) keep
+    // resolving to the canonical model; if matched via alias, canonicalize the
+    // stored ID so the dropdown selects the right option and the next save
+    // writes the canonical ID back.
     const provider = this.providers[this.selectedProvider];
     if (provider) {
-      const modelExists = provider.models.some(m => m.id === this.currentSettings.default_model);
-      if (!modelExists) {
+      const matchedModel = this.findModelWithAliases(provider, this.currentSettings.default_model);
+      if (matchedModel) {
+        if (matchedModel.id !== this.currentSettings.default_model) {
+          this.currentSettings.default_model = matchedModel.id;
+          this.originalSettings.default_model = matchedModel.id;
+        }
+      } else {
         const fallbackModel = provider.models.find(m => m.default) || provider.models[0];
         if (fallbackModel) {
           this.currentSettings.default_model = fallbackModel.id;

--- a/src/ai/claude-provider.js
+++ b/src/ai/claude-provider.js
@@ -24,10 +24,21 @@ const CLAUDE_MODELS = [
     id: 'opus-4.7-xhigh',
     cli_model: 'claude-opus-4-7',
     env: { CLAUDE_CODE_EFFORT_LEVEL: 'xhigh' },
-    name: 'Opus 4.7 xhigh',
+    name: 'Opus 4.7 XHigh',
     tier: 'thorough',
     tagline: 'Latest Gen',
     description: 'Opus 4.7 (latest) with extra-high effort',
+    badge: 'Latest',
+    badgeClass: 'badge-power'
+  },
+  {
+    id: 'opus-4.7-high',
+    cli_model: 'claude-opus-4-7',
+    env: { CLAUDE_CODE_EFFORT_LEVEL: 'high' },
+    name: 'Opus 4.7 High',
+    tier: 'thorough',
+    tagline: 'Latest Gen',
+    description: 'Opus 4.7 (latest) with high effort',
     badge: 'Latest',
     badgeClass: 'badge-power'
   },

--- a/src/ai/codex-provider.js
+++ b/src/ai/codex-provider.js
@@ -23,30 +23,64 @@ const BIN_DIR = path.join(__dirname, '..', '..', 'bin');
  * Based on OpenAI Codex Models guide (developers.openai.com/codex/models)
  * - gpt-5.4-nano: Cheapest model ($0.20/$1.25 per MTok), good for surface scans
  * - gpt-5.4-mini: Fast with 400k context ($0.75/$4.50 per MTok)
- * - gpt-5.4: Flagship model combining coding, reasoning, and agentic workflows
  * - gpt-5.3-codex: Industry-leading coding model for complex engineering tasks
+ * - gpt-5.4 / gpt-5.5: Exposed only via -high / -xhigh reasoning variants so the
+ *   selected effort level is always explicit.
+ *
+ * Reasoning-effort variants (-high / -xhigh) use `cli_model` to pass the base
+ * model ID to `codex exec -m` and add `-c model_reasoning_effort="..."` via
+ * extra_args so Codex picks up the effort level through its config override.
  *
  * Deprecated (April 2026): gpt-5.1-codex-mini, gpt-5.1-codex-max, gpt-5.1-codex
  */
 const CODEX_MODELS = [
   {
-    id: 'gpt-5.4-nano',
-    name: 'GPT-5.4 Nano',
-    tier: 'fast',
-    tagline: 'Cheapest',
-    description: 'Ultra-low-cost surface scans for style issues, obvious bugs, and lint-level feedback.',
-    badge: 'Cheapest',
-    badgeClass: 'badge-speed'
-  },
-  {
-    id: 'gpt-5.4-mini',
-    name: 'GPT-5.4 Mini',
-    tier: 'balanced',
-    tagline: 'Best Balance',
-    description: 'Fast reviews with 400k context—good balance of speed and capability for everyday PR review.',
+    id: 'gpt-5.4-high',
+    // Alias keeps results/councils saved under the previous bare `gpt-5.4`
+    // model ID resolving to the now-explicit high-effort variant.
+    aliases: ['gpt-5.4'],
+    cli_model: 'gpt-5.4',
+    extra_args: ['-c', 'model_reasoning_effort="high"'],
+    name: 'GPT-5.4 High',
+    tier: 'thorough',
+    tagline: 'Deep Review',
+    description: 'GPT-5.4 with high reasoning effort for complex multi-file reviews, architectural consistency, and subtle behavioral regressions.',
     badge: 'Recommended',
     badgeClass: 'badge-recommended',
     default: true
+  },
+  {
+    id: 'gpt-5.4-xhigh',
+    cli_model: 'gpt-5.4',
+    extra_args: ['-c', 'model_reasoning_effort="xhigh"'],
+    name: 'GPT-5.4 XHigh',
+    tier: 'thorough',
+    tagline: 'Max Depth',
+    description: 'GPT-5.4 with extra-high reasoning effort for difficult reviews that need broad context, careful tradeoff analysis, and deeper issue validation.',
+    badge: 'Extra High',
+    badgeClass: 'badge-power'
+  },
+  {
+    id: 'gpt-5.5-high',
+    cli_model: 'gpt-5.5',
+    extra_args: ['-c', 'model_reasoning_effort="high"'],
+    name: 'GPT-5.5 High',
+    tier: 'thorough',
+    tagline: 'Latest Deep',
+    description: 'Latest-generation GPT model with high reasoning effort for demanding PR reviews, strong code understanding, and careful cross-file analysis.',
+    badge: 'High Effort',
+    badgeClass: 'badge-power'
+  },
+  {
+    id: 'gpt-5.5-xhigh',
+    cli_model: 'gpt-5.5',
+    extra_args: ['-c', 'model_reasoning_effort="xhigh"'],
+    name: 'GPT-5.5 XHigh',
+    tier: 'thorough',
+    tagline: 'Frontier Depth',
+    description: 'GPT-5.5 with extra-high reasoning effort for the hardest reviews: architecture, concurrency, security-sensitive changes, and large codebase context.',
+    badge: 'Max Reasoning',
+    badgeClass: 'badge-power'
   },
   {
     id: 'gpt-5.3-codex',
@@ -58,13 +92,22 @@ const CODEX_MODELS = [
     badgeClass: 'badge-power'
   },
   {
-    id: 'gpt-5.4',
-    name: 'GPT-5.4',
-    tier: 'thorough',
-    tagline: 'Latest Gen',
-    description: 'Flagship model combining coding, reasoning, and agentic workflows for complex architectural reviews.',
-    badge: 'Most Thorough',
-    badgeClass: 'badge-power'
+    id: 'gpt-5.4-mini',
+    name: 'GPT-5.4 Mini',
+    tier: 'balanced',
+    tagline: 'Best Balance',
+    description: 'Fast reviews with 400k context—good balance of speed and capability for everyday PR review.',
+    badge: 'Fast',
+    badgeClass: 'badge-speed'
+  },
+  {
+    id: 'gpt-5.4-nano',
+    name: 'GPT-5.4 Nano',
+    tier: 'fast',
+    tagline: 'Cheapest',
+    description: 'Ultra-low-cost surface scans for style issues, obvious bugs, and lint-level feedback.',
+    badge: 'Cheapest',
+    badgeClass: 'badge-speed'
   }
 ];
 
@@ -78,7 +121,7 @@ class CodexProvider extends AIProvider {
    * @param {Object} configOverrides.env - Additional environment variables
    * @param {Object[]} configOverrides.models - Custom model definitions
    */
-  constructor(model = 'gpt-5.4-mini', configOverrides = {}) {
+  constructor(model = 'gpt-5.4-high', configOverrides = {}) {
     super(model);
 
     // Command precedence: ENV > config > default
@@ -127,25 +170,68 @@ class CodexProvider extends AIProvider {
     // same two-tier pattern as chat-providers.js: args replaces, extra_args appends.
     const defaultShellEnvArgs = ['-c', 'allow_login_shell=false', '-c', 'shell_environment_policy.include_only=["PATH","HOME","USER","GH_TOKEN","GITHUB_TOKEN"]'];
     const configArgs = configOverrides.args || defaultShellEnvArgs;
-    const baseArgs = ['exec', '-m', model, '--json', ...sandboxArgs, ...configArgs, '-'];
-    const providerArgs = configOverrides.extra_args || [];
-    const modelConfig = configOverrides.models?.find(m => m.id === model);
-    const modelArgs = modelConfig?.extra_args || [];
 
-    // Merge env: provider env + model env
-    this.extraEnv = {
-      ...(configOverrides.env || {}),
-      ...(modelConfig?.env || {})
-    };
+    // Resolve cli_model + extra_args + env from built-in model, provider config,
+    // and per-model config. This is what lets reasoning variants like
+    // gpt-5.4-high pass `-m gpt-5.4` plus `-c model_reasoning_effort="high"`.
+    const { cliModel, extraArgs, env } = this._resolveModelConfig(model);
+
+    // IMPORTANT: `-` (stdin marker) must come LAST, after any extra_args.
+    // Reasoning variants contribute `-c model_reasoning_effort="..."` via
+    // extraArgs; if '-' were placed inside baseArgs those flags would land
+    // after the positional stdin marker and be ignored. `buildArgsForModel`
+    // enforces the same invariant for the extraction path.
+    const baseArgs = ['exec', '-m', cliModel, '--json', ...sandboxArgs, ...configArgs];
+
+    this.extraEnv = env;
 
     if (this.useShell) {
       // In shell mode, build full command string with args
-      this.command = `${codexCmd} ${quoteShellArgs([...baseArgs, ...providerArgs, ...modelArgs]).join(' ')}`;
+      this.command = `${codexCmd} ${quoteShellArgs([...baseArgs, ...extraArgs, '-']).join(' ')}`;
       this.args = [];
     } else {
       this.command = codexCmd;
-      this.args = [...baseArgs, ...providerArgs, ...modelArgs];
+      this.args = [...baseArgs, ...extraArgs, '-'];
     }
+  }
+
+  /**
+   * Resolve model configuration by looking up built-in and config override definitions.
+   * Produces the CLI model ID (for `-m`), merged extra_args, and merged env.
+   *
+   * Precedence for cli_model: config model > built-in model > modelId.
+   * `cli_model` lets reasoning-effort variants (e.g. `gpt-5.4-high`) pass the
+   * base model (`gpt-5.4`) to `codex exec -m` while adding reasoning overrides
+   * via extra_args.
+   *
+   * @param {string} modelId
+   * @returns {{ builtIn: Object|undefined, configModel: Object|undefined, cliModel: string, extraArgs: string[], env: Object }}
+   * @private
+   */
+  _resolveModelConfig(modelId) {
+    const configOverrides = this.configOverrides || {};
+
+    const builtIn = CODEX_MODELS.find(m => m.id === modelId || (m.aliases && m.aliases.includes(modelId)));
+    const configModel = configOverrides.models?.find(m => m.id === modelId);
+
+    const cliModel = configModel?.cli_model !== undefined
+      ? configModel.cli_model
+      : (builtIn?.cli_model !== undefined ? builtIn.cli_model : modelId);
+
+    // Three-way merge for extra_args: built-in model → provider config → per-model config
+    const builtInArgs = builtIn?.extra_args || [];
+    const providerArgs = configOverrides.extra_args || [];
+    const configModelArgs = configModel?.extra_args || [];
+    const extraArgs = [...builtInArgs, ...providerArgs, ...configModelArgs];
+
+    // Three-way merge for env: built-in model → provider config → per-model config
+    const env = {
+      ...(builtIn?.env || {}),
+      ...(configOverrides.env || {}),
+      ...(configModel?.env || {})
+    };
+
+    return { builtIn, configModel, cliModel, extraArgs, env };
   }
 
   /**
@@ -572,17 +658,16 @@ class CodexProvider extends AIProvider {
    * @returns {string[]} Complete args array for the CLI
    */
   buildArgsForModel(model) {
+    // Resolve cli_model + merged extra_args so reasoning-effort variants behave
+    // the same for extraction as they do for the main analysis call.
+    const { cliModel, extraArgs } = this._resolveModelConfig(model);
+
     // Base args for extraction (read-only sandbox, no shell access needed)
     // Note: '-' (stdin marker) must come LAST, after any extra_args
-    const baseArgs = ['exec', '-m', model, '--json', '--sandbox', 'read-only', '--full-auto'];
-    // Provider-level extra_args (from configOverrides)
-    const providerArgs = this.configOverrides?.extra_args || [];
-    // Model-specific extra_args (from the model config for the given model)
-    const modelConfig = this.configOverrides?.models?.find(m => m.id === model);
-    const modelArgs = modelConfig?.extra_args || [];
+    const baseArgs = ['exec', '-m', cliModel, '--json', '--sandbox', 'read-only', '--full-auto'];
 
     // Append stdin marker '-' at the end after all other args
-    return [...baseArgs, ...providerArgs, ...modelArgs, '-'];
+    return [...baseArgs, ...extraArgs, '-'];
   }
 
   /**
@@ -598,20 +683,25 @@ class CodexProvider extends AIProvider {
 
     // Build args consistently using the shared method, applying provider and model extra_args
     const args = this.buildArgsForModel(model);
+    // Surface merged env (built-in + provider + per-model) so the extraction
+    // spawn matches the contract used by other providers.
+    const { env } = this._resolveModelConfig(model);
 
     if (useShell) {
       return {
         command: `${codexCmd} ${quoteShellArgs(args).join(' ')}`,
         args: [],
         useShell: true,
-        promptViaStdin: true
+        promptViaStdin: true,
+        env
       };
     }
     return {
       command: codexCmd,
       args,
       useShell: false,
-      promptViaStdin: true
+      promptViaStdin: true,
+      env
     };
   }
 
@@ -700,7 +790,7 @@ class CodexProvider extends AIProvider {
   }
 
   static getDefaultModel() {
-    return 'gpt-5.4-mini';
+    return 'gpt-5.4-high';
   }
 
   static getInstallInstructions() {

--- a/src/ai/index.js
+++ b/src/ai/index.js
@@ -21,7 +21,8 @@ const {
   inferModelDefaults,
   resolveDefaultModel,
   prettifyModelId,
-  createAliasedProviderClass
+  createAliasedProviderClass,
+  getTierForModel
 } = require('./provider');
 
 // Load the availability checking module
@@ -73,6 +74,7 @@ module.exports = {
   inferModelDefaults,
   resolveDefaultModel,
   prettifyModelId,
+  getTierForModel,
 
   // Provider factories
   createExecutableProviderClass,

--- a/src/ai/provider.js
+++ b/src/ai/provider.js
@@ -738,8 +738,11 @@ async function testProviderAvailability(providerId, timeout = 10000) {
 }
 
 /**
- * Get tier for a specific model from a provider
- * Queries the provider's model definitions (or config overrides) to find the tier
+ * Get tier for a specific model from a provider.
+ * Queries the provider's model definitions (or config overrides) to find the tier.
+ * Matches against both the canonical model `id` and any `aliases` so legacy
+ * model IDs (e.g. `gpt-5.4` before reasoning-effort variants were introduced)
+ * still resolve their tier for historical analysis runs.
  * @param {string} providerId - Provider ID (e.g., 'claude', 'gemini')
  * @param {string} modelId - Model ID (e.g., 'sonnet', 'gemini-2.5-pro')
  * @returns {string|null} Tier name or null if provider or model not found
@@ -754,7 +757,7 @@ function getTierForModel(providerId, modelId) {
   const overrides = providerConfigOverrides.get(providerId);
   const models = mergeModels(ProviderClass.getModels(), overrides?.models);
 
-  const model = models.find(m => m.id === modelId);
+  const model = models.find(m => m.id === modelId || m.aliases?.includes(modelId));
   return model?.tier || null;
 }
 

--- a/src/main.js
+++ b/src/main.js
@@ -117,7 +117,7 @@ OPTIONS:
     --model <name>          Override the AI model. Claude Code is the default provider.
                             Available models: opus, sonnet, haiku (Claude Code);
                             also: opus-4.5, opus-4.6-low, opus-4.6-medium, opus-4.6-1m,
-                                  opus-4.7-xhigh
+                                  opus-4.7-high, opus-4.7-xhigh
                             or use provider-specific models with Gemini/Codex
     --use-checkout          Use current directory instead of creating worktree
                             (automatic in GitHub Actions)

--- a/tests/unit/claude-provider.test.js
+++ b/tests/unit/claude-provider.test.js
@@ -63,7 +63,7 @@ describe('ClaudeProvider', () => {
     it('should return array of models with expected structure', () => {
       const models = ClaudeProvider.getModels();
       expect(Array.isArray(models)).toBe(true);
-      expect(models.length).toBe(8);
+      expect(models.length).toBe(9);
 
       // Check that we have haiku, sonnet, and opus variants
       const modelIds = models.map(m => m.id);
@@ -74,6 +74,7 @@ describe('ClaudeProvider', () => {
       expect(modelIds).toContain('opus-4.6-medium');
       expect(modelIds).toContain('opus');
       expect(modelIds).toContain('opus-4.6-1m');
+      expect(modelIds).toContain('opus-4.7-high');
       expect(modelIds).toContain('opus-4.7-xhigh');
 
       // Check model structure - opus is now the default
@@ -94,8 +95,16 @@ describe('ClaudeProvider', () => {
       expect(models.find(m => m.id === 'opus-4.5').tier).toBe('thorough');
       // opus itself is thorough
       expect(opus.tier).toBe('thorough');
-      // opus-4.7 xhigh is thorough
-      expect(models.find(m => m.id === 'opus-4.7-xhigh').tier).toBe('thorough');
+      // opus-4.7 high/xhigh are thorough and pinned to claude-opus-4-7
+      for (const id of ['opus-4.7-high', 'opus-4.7-xhigh']) {
+        const model = models.find(m => m.id === id);
+        expect(model.tier).toBe('thorough');
+        expect(model.cli_model).toBe('claude-opus-4-7');
+      }
+      // Display name is consistent with other effort variants (High/Low/Medium/XHigh)
+      expect(models.find(m => m.id === 'opus-4.7-xhigh').name).toBe('Opus 4.7 XHigh');
+      expect(models.find(m => m.id === 'opus-4.7-high').name).toBe('Opus 4.7 High');
+      expect(models.find(m => m.id === 'opus-4.7-high').env).toEqual({ CLAUDE_CODE_EFFORT_LEVEL: 'high' });
     });
 
     it('should return install instructions', () => {
@@ -347,6 +356,18 @@ describe('ClaudeProvider', () => {
 
       it('should resolve opus-4.7-xhigh to claude-opus-4-7 cli_model', () => {
         const provider = new ClaudeProvider('opus-4.7-xhigh');
+        const modelIdx = provider.args.indexOf('--model');
+        expect(modelIdx).not.toBe(-1);
+        expect(provider.args[modelIdx + 1]).toBe('claude-opus-4-7');
+      });
+
+      it('should include built-in env (high) for opus-4.7-high', () => {
+        const provider = new ClaudeProvider('opus-4.7-high');
+        expect(provider.extraEnv).toEqual({ CLAUDE_CODE_EFFORT_LEVEL: 'high' });
+      });
+
+      it('should resolve opus-4.7-high to claude-opus-4-7 cli_model', () => {
+        const provider = new ClaudeProvider('opus-4.7-high');
         const modelIdx = provider.args.indexOf('--model');
         expect(modelIdx).not.toBe(-1);
         expect(provider.args[modelIdx + 1]).toBe('claude-opus-4-7');

--- a/tests/unit/codex-provider.test.js
+++ b/tests/unit/codex-provider.test.js
@@ -53,30 +53,61 @@ describe('CodexProvider', () => {
       expect(CodexProvider.getProviderId()).toBe('codex');
     });
 
-    it('should return gpt-5.4-mini as default model', () => {
-      expect(CodexProvider.getDefaultModel()).toBe('gpt-5.4-mini');
+    it('should return gpt-5.4-high as default model', () => {
+      expect(CodexProvider.getDefaultModel()).toBe('gpt-5.4-high');
     });
 
     it('should return array of models with expected structure', () => {
       const models = CodexProvider.getModels();
       expect(Array.isArray(models)).toBe(true);
-      expect(models.length).toBe(4);
+      expect(models.length).toBe(7);
 
       // Check that we have the expected model IDs
       const modelIds = models.map(m => m.id);
       expect(modelIds).toContain('gpt-5.4-nano');
       expect(modelIds).toContain('gpt-5.4-mini');
       expect(modelIds).toContain('gpt-5.3-codex');
-      expect(modelIds).toContain('gpt-5.4');
+      expect(modelIds).toContain('gpt-5.4-high');
+      expect(modelIds).toContain('gpt-5.4-xhigh');
+      expect(modelIds).toContain('gpt-5.5-high');
+      expect(modelIds).toContain('gpt-5.5-xhigh');
+      // Bare gpt-5.4 / gpt-5.5 (unspecified reasoning effort) are not
+      // exposed as picker entries — users pick an explicit -high / -xhigh
+      // variant. `gpt-5.4` is kept as an alias of gpt-5.4-high so previously
+      // saved results/councils still resolve.
+      expect(modelIds).not.toContain('gpt-5.4');
+      expect(modelIds).not.toContain('gpt-5.5');
 
-      // Check model structure
-      const defaultModel = models.find(m => m.id === 'gpt-5.4-mini');
+      const high54 = models.find(m => m.id === 'gpt-5.4-high');
+      expect(high54.aliases).toContain('gpt-5.4');
+
+      // Check model structure — default is now gpt-5.4-high (explicit reasoning)
+      const defaultModel = models.find(m => m.default === true);
       expect(defaultModel).toMatchObject({
-        id: 'gpt-5.4-mini',
-        name: 'GPT-5.4 Mini',
-        tier: 'balanced',
+        id: 'gpt-5.4-high',
+        name: 'GPT-5.4 High',
+        tier: 'thorough',
         default: true
       });
+      // Only one entry should carry default: true
+      expect(models.filter(m => m.default === true).length).toBe(1);
+    });
+
+    it('reasoning-effort variants should declare cli_model and -c reasoning effort', () => {
+      const models = CodexProvider.getModels();
+      const variants = [
+        { id: 'gpt-5.4-high', cliModel: 'gpt-5.4', effort: 'high' },
+        { id: 'gpt-5.4-xhigh', cliModel: 'gpt-5.4', effort: 'xhigh' },
+        { id: 'gpt-5.5-high', cliModel: 'gpt-5.5', effort: 'high' },
+        { id: 'gpt-5.5-xhigh', cliModel: 'gpt-5.5', effort: 'xhigh' }
+      ];
+      for (const v of variants) {
+        const model = models.find(m => m.id === v.id);
+        expect(model, `missing model ${v.id}`).toBeDefined();
+        expect(model.cli_model).toBe(v.cliModel);
+        expect(model.extra_args).toEqual(['-c', `model_reasoning_effort="${v.effort}"`]);
+        expect(model.tier).toBe('thorough');
+      }
     });
 
     it('should return install instructions', () => {
@@ -89,7 +120,7 @@ describe('CodexProvider', () => {
   describe('constructor', () => {
     it('should create instance with default model', () => {
       const provider = new CodexProvider();
-      expect(provider.model).toBe('gpt-5.4-mini');
+      expect(provider.model).toBe('gpt-5.4-high');
     });
 
     it('should create instance with specified model', () => {
@@ -154,6 +185,88 @@ describe('CodexProvider', () => {
         ]
       });
       expect(provider.args).toContain('--special-flag');
+    });
+
+    describe('reasoning-effort variants', () => {
+      it('should pass cli_model to -m and append -c model_reasoning_effort for gpt-5.4-high', () => {
+        const provider = new CodexProvider('gpt-5.4-high');
+        // -m should receive the base cli_model, not the variant id
+        const mIdx = provider.args.indexOf('-m');
+        expect(mIdx).toBeGreaterThanOrEqual(0);
+        expect(provider.args[mIdx + 1]).toBe('gpt-5.4');
+        expect(provider.args).not.toContain('gpt-5.4-high');
+
+        // -c 'model_reasoning_effort="high"' must appear as adjacent args
+        const effortIdx = provider.args.indexOf('model_reasoning_effort="high"');
+        expect(effortIdx).toBeGreaterThanOrEqual(1);
+        expect(provider.args[effortIdx - 1]).toBe('-c');
+      });
+
+      it('should use xhigh effort for gpt-5.4-xhigh', () => {
+        const provider = new CodexProvider('gpt-5.4-xhigh');
+        const mIdx = provider.args.indexOf('-m');
+        expect(provider.args[mIdx + 1]).toBe('gpt-5.4');
+        const effortIdx = provider.args.indexOf('model_reasoning_effort="xhigh"');
+        expect(effortIdx).toBeGreaterThanOrEqual(1);
+        expect(provider.args[effortIdx - 1]).toBe('-c');
+      });
+
+      it('should pass gpt-5.5 as base model for gpt-5.5-high variant', () => {
+        const provider = new CodexProvider('gpt-5.5-high');
+        const mIdx = provider.args.indexOf('-m');
+        expect(provider.args[mIdx + 1]).toBe('gpt-5.5');
+        expect(provider.args).toContain('model_reasoning_effort="high"');
+      });
+
+      it('should pass gpt-5.5 as base model for gpt-5.5-xhigh variant', () => {
+        const provider = new CodexProvider('gpt-5.5-xhigh');
+        const mIdx = provider.args.indexOf('-m');
+        expect(provider.args[mIdx + 1]).toBe('gpt-5.5');
+        expect(provider.args).toContain('model_reasoning_effort="xhigh"');
+      });
+
+      it('should place stdin marker `-` AFTER reasoning extra_args in non-shell mode', () => {
+        // Regression: `-` is the positional stdin marker for `codex exec`.
+        // It must appear after `-c model_reasoning_effort="..."` or the
+        // reasoning override is silently ignored.
+        const provider = new CodexProvider('gpt-5.4-high');
+        const dashIdx = provider.args.lastIndexOf('-');
+        const effortIdx = provider.args.indexOf('model_reasoning_effort="high"');
+        expect(dashIdx).toBe(provider.args.length - 1);
+        expect(effortIdx).toBeLessThan(dashIdx);
+      });
+
+      it('should place stdin marker `-` AFTER reasoning extra_args in shell mode', () => {
+        process.env.PAIR_REVIEW_CODEX_CMD = 'devx codex';
+        const provider = new CodexProvider('gpt-5.4-high');
+        // In shell mode, args are baked into the command string
+        expect(provider.useShell).toBe(true);
+        const effortPos = provider.command.indexOf('model_reasoning_effort=');
+        const stdinPos = provider.command.lastIndexOf(' -');
+        expect(effortPos).toBeGreaterThanOrEqual(0);
+        expect(stdinPos).toBeGreaterThan(effortPos);
+        expect(provider.command.endsWith(' -')).toBe(true);
+      });
+
+      it('should treat legacy "gpt-5.4" model ID as an alias of gpt-5.4-high', () => {
+        const provider = new CodexProvider('gpt-5.4');
+        // this.model reflects what the caller asked for (unchanged)
+        expect(provider.model).toBe('gpt-5.4');
+        // but the resolved CLI args match the gpt-5.4-high variant
+        const mIdx = provider.args.indexOf('-m');
+        expect(provider.args[mIdx + 1]).toBe('gpt-5.4');
+        expect(provider.args).toContain('model_reasoning_effort="high"');
+      });
+
+      it('getExtractionConfig should also apply cli_model + reasoning effort', () => {
+        const provider = new CodexProvider('gpt-5.4-mini');
+        const config = provider.getExtractionConfig('gpt-5.5-xhigh');
+        const mIdx = config.args.indexOf('-m');
+        expect(config.args[mIdx + 1]).toBe('gpt-5.5');
+        expect(config.args).toContain('model_reasoning_effort="xhigh"');
+        // stdin marker stays at the very end
+        expect(config.args[config.args.length - 1]).toBe('-');
+      });
     });
 
     it('should use config command over default', () => {
@@ -436,6 +549,71 @@ describe('CodexProvider', () => {
     });
   });
 
+  describe('buildArgsForModel', () => {
+    it('should resolve cli_model for gpt-5.4-high variant', () => {
+      // Reasoning variants pass the base model to `-m` and add effort via
+      // `-c model_reasoning_effort="..."`, with the stdin marker `-` last.
+      const provider = new CodexProvider('gpt-5.4-mini');
+      const args = provider.buildArgsForModel('gpt-5.4-high');
+      const mIdx = args.indexOf('-m');
+      expect(mIdx).toBeGreaterThanOrEqual(0);
+      expect(args[mIdx + 1]).toBe('gpt-5.4');
+      const effortIdx = args.indexOf('model_reasoning_effort="high"');
+      expect(effortIdx).toBeGreaterThanOrEqual(1);
+      expect(args[effortIdx - 1]).toBe('-c');
+      expect(args[args.length - 1]).toBe('-');
+    });
+
+    it('should resolve legacy `gpt-5.4` alias to the high-effort variant shape', () => {
+      // Alias keeps historical analysis runs recorded under bare `gpt-5.4`
+      // executable against the canonical gpt-5.4-high configuration.
+      const provider = new CodexProvider('gpt-5.4-mini');
+      const args = provider.buildArgsForModel('gpt-5.4');
+      const mIdx = args.indexOf('-m');
+      expect(args[mIdx + 1]).toBe('gpt-5.4');
+      expect(args).toContain('model_reasoning_effort="high"');
+      expect(args[args.length - 1]).toBe('-');
+    });
+
+    it('should use read-only sandbox for extraction (distinct from workspace-write)', () => {
+      const provider = new CodexProvider('gpt-5.4-mini');
+      const args = provider.buildArgsForModel('gpt-5.4-mini');
+      const sandboxIdx = args.indexOf('--sandbox');
+      expect(sandboxIdx).toBeGreaterThanOrEqual(0);
+      expect(args[sandboxIdx + 1]).toBe('read-only');
+      expect(args).toContain('--full-auto');
+      // Extraction must not inherit the constructor's workspace-write mode
+      expect(args).not.toContain('workspace-write');
+    });
+
+    it('should respect config cli_model override (config > built-in > modelId)', () => {
+      // Documents the precedence chain in _resolveModelConfig: a per-model
+      // config `cli_model` beats the built-in `cli_model` (which is
+      // `gpt-5.4` for the high variant).
+      const provider = new CodexProvider('gpt-5.4-high', {
+        models: [
+          { id: 'gpt-5.4-high', cli_model: 'custom-model' }
+        ]
+      });
+      const args = provider.buildArgsForModel('gpt-5.4-high');
+      const mIdx = args.indexOf('-m');
+      expect(mIdx).toBeGreaterThanOrEqual(0);
+      expect(args[mIdx + 1]).toBe('custom-model');
+      expect(args).not.toContain('gpt-5.4');
+    });
+
+    it('should NOT add reasoning effort args for bare gpt-5.5 (no alias by design)', () => {
+      // Intentional: `gpt-5.5-high` deliberately has no `aliases: ['gpt-5.5']`
+      // because gpt-5.5 is brand new — there is no legacy data recorded under
+      // the bare model ID to preserve. Adding an alias later would silently
+      // change the meaning of `gpt-5.5` for any consumer that stored it.
+      const provider = new CodexProvider('gpt-5.4-mini');
+      const args = provider.buildArgsForModel('gpt-5.5');
+      const effortArg = args.find(a => typeof a === 'string' && a.startsWith('model_reasoning_effort='));
+      expect(effortArg).toBeUndefined();
+    });
+  });
+
   describe('getExtractionConfig', () => {
     it('should return correct config for default command', () => {
       const provider = new CodexProvider();
@@ -459,6 +637,30 @@ describe('CodexProvider', () => {
       expect(config.useShell).toBe(true);
       expect(config.command).toContain('docker run codex');
       expect(config.args).toEqual([]);
+    });
+
+    it('should include merged env in return value (matches provider contract)', () => {
+      // env is merged built-in → provider → per-model. Extraction spawn
+      // must receive it so reasoning/env-driven variants (claude-style
+      // effort envs, user config env, etc.) take effect.
+      const provider = new CodexProvider('gpt-5.4-mini', {
+        env: { PROVIDER_VAR: 'p' },
+        models: [
+          { id: 'gpt-5.4-nano', env: { MODEL_VAR: 'm' } }
+        ]
+      });
+      const config = provider.getExtractionConfig('gpt-5.4-nano');
+      expect(config.env).toEqual({ PROVIDER_VAR: 'p', MODEL_VAR: 'm' });
+    });
+
+    it('should include env in shell-mode return value', () => {
+      process.env.PAIR_REVIEW_CODEX_CMD = 'docker run codex';
+      const provider = new CodexProvider('gpt-5.4-mini', {
+        env: { FROM_PROVIDER: '1' }
+      });
+      const config = provider.getExtractionConfig('gpt-5.4-nano');
+      expect(config.useShell).toBe(true);
+      expect(config.env).toEqual({ FROM_PROVIDER: '1' });
     });
   });
 

--- a/tests/unit/provider-config.test.js
+++ b/tests/unit/provider-config.test.js
@@ -19,7 +19,8 @@ import {
   getRegisteredProviderIds,
   getProviderClass,
   createProvider,
-  createAliasedProviderClass
+  createAliasedProviderClass,
+  getTierForModel
 } from '../../src/ai/index.js';
 
 describe('Provider Configuration', () => {
@@ -188,6 +189,33 @@ describe('Provider Configuration', () => {
       ];
 
       expect(resolveDefaultModel(models)).toBe('model-a');
+    });
+  });
+
+  describe('getTierForModel', () => {
+    beforeEach(() => {
+      // Clear any existing overrides so built-in model definitions are used
+      applyConfigOverrides({ providers: {} });
+    });
+
+    it('should resolve tier by canonical model id', () => {
+      expect(getTierForModel('codex', 'gpt-5.4-high')).toBe('thorough');
+    });
+
+    it('should resolve tier via aliases for legacy model ids', () => {
+      // Regression: `gpt-5.4` was the pre-migration model ID stored in the
+      // analysis_runs table before reasoning-effort variants existed.
+      // It must keep resolving to 'thorough' via the alias on `gpt-5.4-high`
+      // so historical runs get their tier backfilled correctly.
+      expect(getTierForModel('codex', 'gpt-5.4')).toBe('thorough');
+    });
+
+    it('should return null for unknown models', () => {
+      expect(getTierForModel('codex', 'completely-unknown-model')).toBeNull();
+    });
+
+    it('should return null for unknown providers', () => {
+      expect(getTierForModel('nonexistent-provider', 'any-model')).toBeNull();
     });
   });
 


### PR DESCRIPTION
## Summary
- Codex: new `gpt-5.4-high` (default) / `-xhigh` and `gpt-5.5-high` / `-xhigh` variants that pass the base model via `-m` and set reasoning effort through `-c 'model_reasoning_effort="..."'`. The bare `gpt-5.4` picker entry is dropped but kept as an alias of `gpt-5.4-high`, so pre-existing analysis runs and council configs keep resolving.
- Claude: add Opus 4.7 High alongside the existing XHigh variant and normalize the XHigh display-name casing for consistency with the rest of the picker.
- Fix a latent stdin-marker bug in `CodexProvider` where `-` lived inside `baseArgs`, causing reasoning `-c` flags from `extra_args` to land after the positional stdin marker and be silently ignored. `CodexProvider.getExtractionConfig` now also surfaces merged env.
- Extend alias resolution beyond the execution path: `getTierForModel` and the repo-settings UI now resolve aliases, so historical tier backfills and saved `default_model` values don't get silently reset to the provider default.

## Test plan
- [x] `npx vitest run tests/unit/codex-provider.test.js` — 73 pass, including new `buildArgsForModel` and stdin-placement regression coverage.
- [x] `npx vitest run tests/unit/claude-provider.test.js` — 120 pass, including Opus 4.7 High env / `cli_model` / display-name assertions.
- [x] `npx vitest run tests/unit/provider-config.test.js` — new `getTierForModel` block covering canonical id, alias, unknown model, unknown provider.
- [x] `pnpm test` — full suite (148 files / 6281 tests) green.
- [ ] Manual: open the Settings UI on a repo whose saved `default_model` is `gpt-5.4` and confirm the dropdown shows `GPT-5.4 High` without flipping the value on save.

🤖 Generated with [Claude Code](https://claude.com/claude-code)