### PR TITLE
Fix TanStack route path resolution

### DIFF
--- a/.changeset/tanstack-route-path-lookup.md
+++ b/.changeset/tanstack-route-path-lookup.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Normalize frontend diff file lookups so AI suggestions and file comment zones can resolve TanStack-style route paths and other equivalent path variants.

--- a/public/js/components/AIPanel.js
+++ b/public/js/components/AIPanel.js
@@ -965,20 +965,9 @@ class AIPanel {
     expandFileIfCollapsed(file) {
         if (!file) return false;
 
-        // Find the file wrapper - try exact match first, then partial match
-        let fileWrapper = document.querySelector(`[data-file-name="${file}"]`);
-
-        // Fallback: partial path match
-        if (!fileWrapper) {
-            const allWrappers = document.querySelectorAll('.d2h-file-wrapper');
-            for (const wrapper of allWrappers) {
-                const wrapperFile = wrapper.dataset.fileName;
-                if (wrapperFile && (wrapperFile.includes(file) || file.includes(wrapperFile))) {
-                    fileWrapper = wrapper;
-                    break;
-                }
-            }
-        }
+        const fileWrapper = window.prManager?.findFileElement
+            ? window.prManager.findFileElement(file)
+            : window.DiffRenderer?.findFileElement?.(file);
 
         if (!fileWrapper) return false;
 

--- a/public/js/modules/diff-renderer.js
+++ b/public/js/modules/diff-renderer.js
@@ -195,6 +195,88 @@ class DiffRenderer {
   }
 
   /**
+   * Normalize a file path for DOM matching.
+   *
+   * Frontend mirror of `normalizePath()` + `resolveRenamedFile()` from
+   * `src/utils/paths.js`. Browser code cannot `require()` the backend module,
+   * so the logic is duplicated here. Keep this function in sync with those two
+   * when modifying normalization rules, otherwise the frontend and backend
+   * will disagree on which paths are equivalent.
+   *
+   * @param {string} filePath - File path to normalize
+   * @returns {string} Normalized file path
+   */
+  static normalizeFilePath(filePath) {
+    if (typeof filePath !== 'string') return '';
+
+    let normalized = filePath.trim();
+    if (!normalized) return '';
+
+    // Resolve git rename syntax to the new path.
+    normalized = normalized.replace(/\{[^}]*\s*=>\s*([^}]*)\}/, '$1');
+    normalized = normalized.replace(/\/+/g, '/');
+
+    // Strip leading './' and '/' segments until the string stops changing.
+    // This mirrors normalizePath in src/utils/paths.js for interleaved cases
+    // like '/./src/foo.js'.
+    let prevLength;
+    do {
+      prevLength = normalized.length;
+
+      while (normalized.startsWith('./')) {
+        normalized = normalized.slice(2);
+      }
+
+      while (normalized.startsWith('/')) {
+        normalized = normalized.slice(1);
+      }
+    } while (normalized.length !== prevLength);
+
+    return normalized;
+  }
+
+  /**
+   * Check whether two file paths should be treated as the same DOM target.
+   * @param {string} left - First file path
+   * @param {string} right - Second file path
+   * @returns {boolean} True when the paths refer to the same file
+   */
+  static pathsMatch(left, right) {
+    const normalizedLeft = DiffRenderer.normalizeFilePath(left);
+    const normalizedRight = DiffRenderer.normalizeFilePath(right);
+
+    if (!normalizedLeft || !normalizedRight) return false;
+
+    return normalizedLeft === normalizedRight ||
+      normalizedLeft.endsWith(`/${normalizedRight}`) ||
+      normalizedRight.endsWith(`/${normalizedLeft}`);
+  }
+
+  /**
+   * Try a direct selector lookup for a file path.
+   * Falls back silently when CSS.escape is unavailable or the selector is invalid.
+   * @param {string} attribute - data attribute to match (without brackets)
+   * @param {string} filePath - File path to search for
+   * @returns {Element|null} Matching element if found
+   */
+  static queryFileElement(attribute, filePath) {
+    if (!filePath) {
+      return null;
+    }
+
+    const css = globalThis.CSS;
+    const escapedValue = css && typeof css.escape === 'function'
+      ? css.escape(filePath)
+      : filePath;
+
+    try {
+      return document.querySelector(`[${attribute}="${escapedValue}"]`);
+    } catch {
+      return null;
+    }
+  }
+
+  /**
    * Render a single diff line
    * @param {HTMLElement|DocumentFragment} container - Container to append to
    * @param {Object} line - Diff line data
@@ -696,18 +778,29 @@ class DiffRenderer {
    * @returns {Element|null} The file wrapper element or null if not found
    */
   static findFileElement(filePath) {
-    // Try exact match first
-    let fileElement = document.querySelector(`[data-file-name="${filePath}"]`);
-    if (fileElement) return fileElement;
+    const normalizedPath = DiffRenderer.normalizeFilePath(filePath);
 
-    fileElement = document.querySelector(`[data-file-path="${filePath}"]`);
-    if (fileElement) return fileElement;
+    // Try direct selector lookups first when we can safely escape the value.
+    const selectorCandidates = [filePath];
+    if (normalizedPath && normalizedPath !== filePath) {
+      selectorCandidates.push(normalizedPath);
+    }
 
-    // Try partial match for path segments
+    for (const candidate of selectorCandidates) {
+      let fileElement = DiffRenderer.queryFileElement('data-file-name', candidate);
+      if (fileElement) return fileElement;
+
+      fileElement = DiffRenderer.queryFileElement('data-file-path', candidate);
+      if (fileElement) return fileElement;
+    }
+
+    // Fall back to normalized iteration so special characters, rename syntax,
+    // and formatted variants still resolve to the rendered wrapper.
     const allFileWrappers = document.querySelectorAll('.d2h-file-wrapper');
     for (const wrapper of allFileWrappers) {
       const fileName = wrapper.dataset.fileName;
-      if (fileName && (fileName === filePath || fileName.endsWith('/' + filePath) || filePath.endsWith('/' + fileName))) {
+      const filePathAttr = wrapper.dataset.filePath;
+      if (DiffRenderer.pathsMatch(fileName, filePath) || DiffRenderer.pathsMatch(filePathAttr, filePath)) {
         return wrapper;
       }
     }

--- a/public/js/modules/file-comment-manager.js
+++ b/public/js/modules/file-comment-manager.js
@@ -1168,17 +1168,22 @@ class FileCommentManager {
    * @param {Array} suggestions - Array of file-level AI suggestions
    */
   loadFileComments(comments, suggestions) {
-    // Group by file
-    const commentsByFile = new Map();
-    const suggestionsByFile = new Map();
+    // Group by rendered file comments zone so path variants still attach to the
+    // correct file on initial load.
+    const commentsByZone = new Map();
+    const suggestionsByZone = new Map();
 
     if (comments) {
       for (const comment of comments) {
         if (comment.is_file_level === 1) {
-          if (!commentsByFile.has(comment.file)) {
-            commentsByFile.set(comment.file, []);
+          const zone = this.findZoneForFile(comment.file);
+          if (!zone) {
+            continue;
           }
-          commentsByFile.get(comment.file).push(comment);
+          if (!commentsByZone.has(zone)) {
+            commentsByZone.set(zone, []);
+          }
+          commentsByZone.get(zone).push(comment);
         }
       }
     }
@@ -1186,10 +1191,14 @@ class FileCommentManager {
     if (suggestions) {
       for (const suggestion of suggestions) {
         if (suggestion.is_file_level === 1) {
-          if (!suggestionsByFile.has(suggestion.file)) {
-            suggestionsByFile.set(suggestion.file, []);
+          const zone = this.findZoneForFile(suggestion.file);
+          if (!zone) {
+            continue;
           }
-          suggestionsByFile.get(suggestion.file).push(suggestion);
+          if (!suggestionsByZone.has(zone)) {
+            suggestionsByZone.set(zone, []);
+          }
+          suggestionsByZone.get(zone).push(suggestion);
         }
       }
     }
@@ -1197,7 +1206,6 @@ class FileCommentManager {
     // Find all file comment zones and populate them
     const zones = document.querySelectorAll('.file-comments-zone');
     for (const zone of zones) {
-      const fileName = zone.dataset.fileName;
       const container = zone.querySelector('.file-comments-container');
 
       // Selectively clear existing cards based on what we're about to reload
@@ -1221,8 +1229,8 @@ class FileCommentManager {
         }
       }
 
-      const fileComments = commentsByFile.get(fileName) || [];
-      const fileSuggestions = suggestionsByFile.get(fileName) || [];
+      const fileComments = commentsByZone.get(zone) || [];
+      const fileSuggestions = suggestionsByZone.get(zone) || [];
 
       // Display AI suggestions first
       for (const suggestion of fileSuggestions) {
@@ -1245,7 +1253,20 @@ class FileCommentManager {
    * @returns {HTMLElement|null} The zone element or null
    */
   findZoneForFile(fileName) {
-    return document.querySelector(`.file-comments-zone[data-file-name="${fileName}"]`);
+    const fileWrapper = window.DiffRenderer?.findFileElement
+      ? window.DiffRenderer.findFileElement(fileName)
+      : null;
+
+    if (fileWrapper) {
+      return fileWrapper.querySelector('.file-comments-zone');
+    }
+
+    try {
+      const escaped = globalThis.CSS?.escape ? CSS.escape(fileName) : fileName;
+      return document.querySelector(`.file-comments-zone[data-file-name="${escaped}"]`);
+    } catch {
+      return null;
+    }
   }
 
   /**

--- a/public/js/modules/suggestion-manager.js
+++ b/public/js/modules/suggestion-manager.js
@@ -161,6 +161,26 @@ class SuggestionManager {
   }
 
   /**
+   * Resolve a diff file wrapper for the provided path.
+   * @param {string} file - File path
+   * @returns {Element|null} Matching file wrapper
+   */
+  findFileElement(file) {
+    if (this.prManager?.findFileElement) {
+      return this.prManager.findFileElement(file);
+    }
+    if (window.DiffRenderer?.findFileElement) {
+      return window.DiffRenderer.findFileElement(file);
+    }
+    try {
+      const escaped = globalThis.CSS?.escape ? CSS.escape(file) : file;
+      return document.querySelector(`[data-file-name="${escaped}"]`);
+    } catch {
+      return null;
+    }
+  }
+
+  /**
    * Find suggestions that target lines currently hidden in gaps
    * @param {Array} suggestions - Array of suggestions
    * @returns {Array} Suggestions targeting hidden lines
@@ -176,9 +196,7 @@ class SuggestionManager {
       const side = suggestion.side || 'RIGHT';
 
       // Find the file wrapper
-      const fileElement = window.DiffRenderer ?
-        window.DiffRenderer.findFileElement(file) :
-        document.querySelector(`[data-file-name="${file}"]`);
+      const fileElement = this.findFileElement(file);
 
       if (!fileElement) {
         // File not in diff at all, not a hidden line issue
@@ -329,9 +347,7 @@ class SuggestionManager {
         const line = parseInt(lineStr);
 
         // Use helper method for file lookup
-        const fileElement = window.DiffRenderer ?
-          window.DiffRenderer.findFileElement(file) :
-          document.querySelector(`[data-file-name="${file}"]`);
+        const fileElement = this.findFileElement(file);
 
         if (!fileElement) {
           // This can happen when AI suggests a file path that doesn't exist in the diff

--- a/public/js/pr.js
+++ b/public/js/pr.js
@@ -2032,7 +2032,7 @@ class PRManager {
    * @param {string} filePath - Path of the file
    */
   toggleFileCollapse(filePath) {
-    const wrapper = document.querySelector(`[data-file-name="${filePath}"]`);
+    const wrapper = this.findFileElement(filePath);
     if (!wrapper) return;
 
     const isCollapsed = wrapper.classList.contains('collapsed');
@@ -2058,7 +2058,7 @@ class PRManager {
    * @param {boolean} isViewed - Whether the file is now viewed
    */
   toggleFileViewed(filePath, isViewed) {
-    const wrapper = document.querySelector(`[data-file-name="${filePath}"]`);
+    const wrapper = this.findFileElement(filePath);
 
     if (isViewed) {
       this.viewedFiles.add(filePath);
@@ -4359,7 +4359,7 @@ class PRManager {
   }
 
   scrollToFile(filePath) {
-    const fileWrapper = document.querySelector(`[data-file-name="${filePath}"]`);
+    const fileWrapper = this.findFileElement(filePath);
     if (fileWrapper) {
       fileWrapper.scrollIntoView({ behavior: 'smooth', block: 'start' });
     }

--- a/src/git/diff-flags.js
+++ b/src/git/diff-flags.js
@@ -30,12 +30,16 @@ const GIT_DIFF_FLAGS_ARRAY = [
 
 /**
  * Array form for simple-git .diffSummary() calls.
+ * Use --numstat so simple-git parses machine-readable output with exact file paths.
+ * The default --stat output is display-oriented and may abbreviate long paths,
+ * which breaks downstream matching for generated route files and similar cases.
  * Omits --src-prefix/--dst-prefix since diffSummary doesn't output file content with prefixes.
  */
 const GIT_DIFF_SUMMARY_FLAGS_ARRAY = [
   '--no-color',
   '--no-ext-diff',
-  '--no-relative'
+  '--no-relative',
+  '--numstat'
 ];
 
 module.exports = {

--- a/src/local-review.js
+++ b/src/local-review.js
@@ -1,5 +1,5 @@
 // Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
-const { execSync, exec } = require('child_process');
+const { execSync, exec, execFileSync } = require('child_process');
 const { promisify } = require('util');
 const crypto = require('crypto');
 const path = require('path');
@@ -15,7 +15,7 @@ const { initializeDatabase, ReviewRepository, RepoSettingsRepository } = require
 const { startServer } = require('./server');
 const { localReviewDiffs } = require('./routes/shared');
 const { getShaAbbrevLength } = require('./git/sha-abbrev');
-const { GIT_DIFF_FLAGS } = require('./git/diff-flags');
+const { GIT_DIFF_FLAGS, GIT_DIFF_FLAGS_ARRAY } = require('./git/diff-flags');
 const open = (...args) => process.env.PAIR_REVIEW_NO_OPEN ? Promise.resolve() : import('open').then(({ default: open }) => open(...args));
 
 // Design note: This module uses execSync for git commands despite async function signatures.
@@ -393,12 +393,23 @@ async function findMergeBase(repoPath, baseBranch) {
  * Generate diff output for untracked files using git diff --no-index.
  * @param {string} repoPath - Path to the git repository
  * @param {Array} untrackedFiles - Array from getUntrackedFiles()
- * @param {string} wFlag - Whitespace flag (e.g. ' -w' or '')
- * @param {string} [contextFlag=''] - Unified context flag (e.g. ' --unified=3')
- * @param {string} [extraArgsStr=''] - Additional git diff flags (e.g. ' --patience')
+ * @param {Object} [options]
+ * @param {boolean} [options.hideWhitespace=false] - Whether to pass -w
+ * @param {number} [options.contextLines=25] - Number of unified context lines
+ * @param {string[]} [options.extraArgs=[]] - Additional git diff flags
  * @returns {string} Combined diff text for untracked files
  */
-function generateUntrackedDiffs(repoPath, untrackedFiles, wFlag, contextFlag = '', extraArgsStr = '') {
+function generateUntrackedDiffs(repoPath, untrackedFiles, options = {}) {
+  const diffArgs = [
+    'diff',
+    '--no-index',
+    ...GIT_DIFF_FLAGS_ARRAY,
+    `--unified=${options.contextLines ?? 25}`,
+    ...(options.extraArgs || []),
+    ...(options.hideWhitespace ? ['-w'] : []),
+    '--',
+    '/dev/null'
+  ];
   let diff = '';
   for (const untracked of untrackedFiles) {
     if (!untracked.skipped) {
@@ -406,16 +417,21 @@ function generateUntrackedDiffs(repoPath, untrackedFiles, wFlag, contextFlag = '
         const filePath = path.join(repoPath, untracked.file);
         let fileDiff;
         try {
-          fileDiff = execSync(`git diff --no-index ${GIT_DIFF_FLAGS}${contextFlag}${extraArgsStr}${wFlag} -- /dev/null "${filePath}"`, {
+          fileDiff = execFileSync('git', [...diffArgs, filePath], {
             cwd: repoPath,
             encoding: 'utf8',
             stdio: ['pipe', 'pipe', 'pipe'],
             maxBuffer: 10 * 1024 * 1024
           });
         } catch (diffError) {
+          const diffStdout = typeof diffError?.stdout === 'string'
+            ? diffError.stdout
+            : Buffer.isBuffer(diffError?.stdout)
+              ? diffError.stdout.toString('utf8')
+              : null;
           if (diffError && typeof diffError === 'object' &&
-              diffError.status === GIT_DIFF_HAS_DIFFERENCES && typeof diffError.stdout === 'string') {
-            fileDiff = diffError.stdout;
+              diffError.status === GIT_DIFF_HAS_DIFFERENCES && diffStdout !== null) {
+            fileDiff = diffStdout;
           } else {
             throw diffError;
           }
@@ -552,7 +568,7 @@ async function generateScopedDiff(repoPath, scopeStart, scopeEnd, baseBranch, op
     const untrackedFiles = await getUntrackedFiles(repoPath);
     stats.untrackedFiles = untrackedFiles.length;
 
-    const untrackedDiff = generateUntrackedDiffs(repoPath, untrackedFiles, wFlag, contextFlag, extraArgsStr);
+    const untrackedDiff = generateUntrackedDiffs(repoPath, untrackedFiles, options);
     if (untrackedDiff) {
       if (diff) diff += '\n';
       diff += untrackedDiff;

--- a/src/routes/pr.js
+++ b/src/routes/pr.js
@@ -45,6 +45,7 @@ const {
   registerProcess: registerProcessForCancellation
 } = require('./shared');
 const { safeParseJson } = require('../utils/safe-parse-json');
+const { mergeChangedFilesWithDiff } = require('../utils/diff-file-list');
 const { resolveOriginalFileContentSpecs } = require('../utils/diff-file-content');
 const { validateCouncilConfig, normalizeCouncilConfig } = require('./councils');
 const { TIERS, TIER_ALIASES, VALID_TIERS, resolveTier } = require('../ai/prompts/config');
@@ -254,6 +255,8 @@ router.get('/api/pr/:owner/:repo/:number', async (req, res) => {
     }
 
     // Prepare response
+    const changedFiles = mergeChangedFilesWithDiff(extendedData.changed_files || [], extendedData.diff || '');
+
     // Use review.id instead of prMetadata.id to avoid ID collision with local mode
     const response = {
       success: true,
@@ -274,8 +277,8 @@ router.get('/api/pr/:owner/:repo/:number', async (req, res) => {
         shaAbbrevLength,
         created_at: prMetadata.created_at,
         updated_at: prMetadata.updated_at,
-        file_changes: extendedData.changed_files ? extendedData.changed_files.length : 0,
-        changed_files: extendedData.changed_files || [],
+        file_changes: changedFiles.length,
+        changed_files: changedFiles,
         additions: extendedData.additions || 0,
         deletions: extendedData.deletions || 0,
         diff_content: extendedData.diff || '',
@@ -759,6 +762,8 @@ router.get('/api/pr/:owner/:repo/:number/diff', async (req, res) => {
     let diffContent = prData.diff || '';
     let changedFiles = prData.changed_files || [];
 
+    let gitattributes = null;
+
     if (hideWhitespace && worktreeRecord && worktreeRecord.path) {
       try {
         const worktreePath = worktreeRecord.path;
@@ -774,7 +779,7 @@ router.get('/api/pr/:owner/:repo/:number/diff', async (req, res) => {
 
           const summaryArgs = [`${baseSha}...${headSha}`, ...GIT_DIFF_SUMMARY_FLAGS_ARRAY, '-w'];
           const diffSummary = await git.diffSummary(summaryArgs);
-          const gitattributes = await getGeneratedFilePatterns(worktreePath);
+          gitattributes = await getGeneratedFilePatterns(worktreePath);
           changedFiles = diffSummary.files.map(file => {
             const resolvedFile = resolveRenamedFile(file.file);
             const isRenamed = resolvedFile !== file.file;
@@ -799,15 +804,20 @@ router.get('/api/pr/:owner/:repo/:number/diff', async (req, res) => {
     } else if (worktreeRecord && worktreeRecord.path) {
       // Add generated flag to changed files based on .gitattributes
       try {
-        const gitattributes = await getGeneratedFilePatterns(worktreeRecord.path);
-        changedFiles = changedFiles.map(file => ({
-          ...file,
-          generated: gitattributes.isGenerated(file.file)
-        }));
+        gitattributes = await getGeneratedFilePatterns(worktreeRecord.path);
       } catch (error) {
         logger.warn(`Could not load .gitattributes: ${error.message}`);
         // Continue without generated flags
       }
+    }
+
+    changedFiles = mergeChangedFilesWithDiff(changedFiles, diffContent);
+
+    if (gitattributes) {
+      changedFiles = changedFiles.map(file => ({
+        ...file,
+        generated: gitattributes.isGenerated(file.file)
+      }));
     }
 
     // When diff was regenerated (whitespace), compute aggregate stats from

--- a/src/utils/diff-file-list.js
+++ b/src/utils/diff-file-list.js
@@ -3,8 +3,110 @@ const { promisify } = require('util');
 const { exec } = require('child_process');
 const { queryOne } = require('../database');
 const { GIT_DIFF_FLAGS } = require('../git/diff-flags');
+const { normalizePath, resolveRenamedFile } = require('./paths');
 
 const execPromise = promisify(exec);
+
+/**
+ * Parse a unified diff into a map of file path -> per-file patch.
+ * Uses the "b/" path from the diff header as the canonical file path.
+ *
+ * @param {string} diff - Full unified diff
+ * @returns {Map<string, string>} Map of file paths to full patch text
+ */
+function parseUnifiedDiffPatches(diff) {
+  const filePatchMap = new Map();
+  if (!diff) return filePatchMap;
+
+  const parts = diff.split(/(?=^diff --git )/m);
+
+  for (const part of parts) {
+    if (!part.trim()) continue;
+
+    const match = part.match(/^diff --git a\/(.+?) b\/(.+)$/m);
+    if (match) {
+      filePatchMap.set(match[2], part);
+    }
+  }
+
+  return filePatchMap;
+}
+
+/**
+ * Count additions and deletions inside a single patch body.
+ *
+ * @param {string} patch - Per-file patch text
+ * @returns {{ insertions: number, deletions: number }}
+ */
+function countPatchStats(patch) {
+  let insertions = 0;
+  let deletions = 0;
+
+  for (const line of patch.split('\n')) {
+    if (line.startsWith('+') && !line.startsWith('+++ ')) {
+      insertions++;
+    } else if (line.startsWith('-') && !line.startsWith('--- ')) {
+      deletions++;
+    }
+  }
+
+  return { insertions, deletions };
+}
+
+/**
+ * Merge changed_files metadata with the authoritative file list from the diff.
+ * This recovers files when cached changed_files were derived from abbreviated
+ * diff --stat output and no longer match the full patch headers.
+ *
+ * @param {Array<object|string>} changedFiles - Existing changed_files array
+ * @param {string} diff - Full unified diff
+ * @returns {Array<object|string>} Merged changed_files array
+ */
+function mergeChangedFilesWithDiff(changedFiles, diff) {
+  const patchMap = parseUnifiedDiffPatches(diff);
+  if (patchMap.size === 0) {
+    return Array.isArray(changedFiles) ? changedFiles : [];
+  }
+
+  // Drop cached `git diff --stat` ellipsis stubs once we have authoritative
+  // patch headers to recover the full file paths from.
+  const existing = (Array.isArray(changedFiles) ? changedFiles : []).filter(entry => {
+    const filePath = typeof entry === 'string' ? entry : entry?.file;
+    return filePath && !filePath.includes('...');
+  });
+
+  const normalizedExisting = new Set(existing.map(file => {
+    const filePath = typeof file === 'string' ? file : file?.file;
+    return normalizePath(resolveRenamedFile(filePath));
+  }).filter(Boolean));
+
+  const merged = [...existing];
+
+  for (const [filePath, patch] of patchMap.entries()) {
+    const normalizedPatchPath = normalizePath(resolveRenamedFile(filePath));
+    if (normalizedExisting.has(normalizedPatchPath)) {
+      continue;
+    }
+
+    const { insertions, deletions } = countPatchStats(patch);
+    const renameFrom = patch.match(/^rename from (.+)$/m)?.[1] || null;
+    const renameTo = patch.match(/^rename to (.+)$/m)?.[1] || null;
+    const binary = /^Binary files .* differ$/m.test(patch) || /^GIT binary patch$/m.test(patch);
+
+    merged.push({
+      file: filePath,
+      insertions,
+      deletions,
+      changes: insertions + deletions,
+      binary,
+      renamed: Boolean(renameFrom && renameTo),
+      renamedFrom: renameFrom
+    });
+    normalizedExisting.add(normalizedPatchPath);
+  }
+
+  return merged;
+}
 
 /**
  * Return the list of file paths that belong to the review's diff.
@@ -25,7 +127,9 @@ async function getDiffFileList(db, review) {
 
       if (prRecord?.pr_data) {
         const prData = JSON.parse(prRecord.pr_data);
-        return (prData.changed_files || []).map(f => f.file);
+        return mergeChangedFilesWithDiff(prData.changed_files || [], prData.diff || '')
+          .map(f => typeof f === 'string' ? f : f.file)
+          .filter(Boolean);
       }
     } catch {
       // parse / query error – fall through to empty list
@@ -55,4 +159,9 @@ async function getDiffFileList(db, review) {
   return [];
 }
 
-module.exports = { getDiffFileList };
+module.exports = {
+  getDiffFileList,
+  parseUnifiedDiffPatches,
+  countPatchStats,
+  mergeChangedFilesWithDiff
+};

--- a/src/utils/paths.js
+++ b/src/utils/paths.js
@@ -13,6 +13,8 @@
  * - Handles interleaved patterns like '/./src' by iterating
  * - Normalizes multiple consecutive slashes to single slash
  * - Does NOT modify case (paths are case-sensitive on most systems)
+ * - Frontend mirror lives in `DiffRenderer.normalizeFilePath`
+ *   (`public/js/modules/diff-renderer.js`); keep behavior in sync
  *
  * @param {string} filePath - The file path to normalize
  * @returns {string} Normalized path
@@ -159,6 +161,8 @@ function normalizeRepository(owner, repo) {
  *   "tests/{old.js => new.js}"      → "tests/new.js"
  *   "{old-dir => new-dir}/file.js"  → "new-dir/file.js"
  *   "a/{b => c}/d.js"              → "a/c/d.js"
+ * Frontend mirror lives in `DiffRenderer.normalizeFilePath`
+ * (`public/js/modules/diff-renderer.js`); keep behavior in sync.
  *
  * @param {string} fileName - File name possibly containing rename syntax
  * @returns {string} Resolved file name with the new path, or original if no rename syntax

--- a/tests/integration/routes.test.js
+++ b/tests/integration/routes.test.js
@@ -395,6 +395,48 @@ describe('PR Management Endpoints', () => {
       expect(response.body.stats.deletions).toBe(5);
     });
 
+    it('should recover full long file paths from diff headers when cached changed_files are abbreviated', async () => {
+      const longPath = 'areas/internal-services/meteorite/ui/app/frontend/src/routes/repos/$owner/$repo/pulls/$number/route.tsx';
+      const prData = JSON.stringify({
+        state: 'open',
+        diff: [
+          `diff --git a/${longPath} b/${longPath}`,
+          'index 1111111..2222222 100644',
+          `--- a/${longPath}`,
+          `+++ b/${longPath}`,
+          '@@ -1 +1,2 @@',
+          ' export const Route = {};',
+          '+Route.component = View;',
+          '+Route.loader = loader;'
+        ].join('\n'),
+        changed_files: [
+          { file: 'areas/internal-services/.../$number/route.tsx', insertions: 2, deletions: 0, changes: 2 }
+        ],
+        additions: 2,
+        deletions: 0,
+        html_url: 'https://github.com/owner/repo/pull/1',
+        base_sha: 'abc123',
+        head_sha: 'def456',
+        node_id: 'PR_node123'
+      });
+
+      await run(db, `
+        INSERT INTO pr_metadata (pr_number, repository, title, description, author, base_branch, head_branch, pr_data)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+      `, [1, 'owner/repo', 'Test PR', 'Desc', 'testuser', 'main', 'feature', prData]);
+      await insertTestWorktree(db, 1, 'owner/repo');
+
+      const response = await request(app)
+        .get('/api/pr/owner/repo/1/diff');
+
+      expect(response.status).toBe(200);
+      expect(response.body.changed_files).toEqual([
+        expect.objectContaining({ file: longPath, insertions: 2, deletions: 0, changes: 2 })
+      ]);
+      expect(response.body.changed_files).toHaveLength(1);
+      expect(response.body.stats.changed_files).toBe(1);
+    });
+
   });
 
   describe('GET /api/prs', () => {

--- a/tests/unit/diff-file-list.test.js
+++ b/tests/unit/diff-file-list.test.js
@@ -1,0 +1,90 @@
+// Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+import { describe, it, expect } from 'vitest';
+
+const {
+  parseUnifiedDiffPatches,
+  countPatchStats,
+  mergeChangedFilesWithDiff
+} = require('../../src/utils/diff-file-list');
+
+describe('diff-file-list utils', () => {
+  it('parses full file paths from unified diff headers', () => {
+    const diff = [
+      'diff --git a/src/short.js b/src/short.js',
+      'index 1111111..2222222 100644',
+      '--- a/src/short.js',
+      '+++ b/src/short.js',
+      '@@ -1 +1 @@',
+      '-old',
+      '+new',
+      'diff --git a/areas/internal-services/meteorite/ui/app/frontend/src/routes/repos/$owner/$repo/pulls/$number/route.tsx b/areas/internal-services/meteorite/ui/app/frontend/src/routes/repos/$owner/$repo/pulls/$number/route.tsx',
+      'index 3333333..4444444 100644',
+      '--- a/areas/internal-services/meteorite/ui/app/frontend/src/routes/repos/$owner/$repo/pulls/$number/route.tsx',
+      '+++ b/areas/internal-services/meteorite/ui/app/frontend/src/routes/repos/$owner/$repo/pulls/$number/route.tsx',
+      '@@ -1 +1 @@',
+      '-before',
+      '+after'
+    ].join('\n');
+
+    const patches = parseUnifiedDiffPatches(diff);
+
+    expect([...patches.keys()]).toEqual([
+      'src/short.js',
+      'areas/internal-services/meteorite/ui/app/frontend/src/routes/repos/$owner/$repo/pulls/$number/route.tsx'
+    ]);
+  });
+
+  it('counts patch additions and deletions without including file headers', () => {
+    const patch = [
+      'diff --git a/file.js b/file.js',
+      '--- a/file.js',
+      '+++ b/file.js',
+      '@@ -1,2 +1,3 @@',
+      ' context',
+      '-removed',
+      '+added',
+      '+also-added'
+    ].join('\n');
+
+    expect(countPatchStats(patch)).toEqual({ insertions: 2, deletions: 1 });
+  });
+
+  it('counts content lines that legitimately begin with +++ or ---', () => {
+    const patch = [
+      'diff --git a/file.js b/file.js',
+      '--- a/file.js',
+      '+++ b/file.js',
+      '@@ -1,2 +1,2 @@',
+      '---triple-minus-content',
+      '+++triple-plus-content'
+    ].join('\n');
+
+    expect(countPatchStats(patch)).toEqual({ insertions: 1, deletions: 1 });
+  });
+
+  it('merges missing diff files back into changed_files using full patch paths', () => {
+    const longPath = 'areas/internal-services/meteorite/ui/app/frontend/src/routes/repos/$owner/$repo/pulls/$number/route.tsx';
+    const diff = [
+      `diff --git a/${longPath} b/${longPath}`,
+      'index 3333333..4444444 100644',
+      `--- a/${longPath}`,
+      `+++ b/${longPath}`,
+      '@@ -1 +1,2 @@',
+      ' export const Route = {};',
+      '+Route.component = View;',
+      '+Route.loader = loader;'
+    ].join('\n');
+
+    const merged = mergeChangedFilesWithDiff([
+      { file: 'areas/internal-services/.../$number/route.tsx', insertions: 2, deletions: 0 }
+    ], diff);
+
+    expect(merged).toHaveLength(1);
+    expect(merged[0]).toMatchObject({
+      file: longPath,
+      insertions: 2,
+      deletions: 0,
+      changes: 2
+    });
+  });
+});

--- a/tests/unit/diff-renderer.test.js
+++ b/tests/unit/diff-renderer.test.js
@@ -531,6 +531,15 @@ describe('DiffRenderer', () => {
         expect(result).toBe(wrapper);
       });
 
+      it('should normalize TanStack-style route paths before matching wrappers', () => {
+        const tanstackPath = 'areas/internal-services/meteorite/ui/app/frontend/src/routes/repos/$owner/$repo/pulls/$number/route.tsx';
+        const wrapper = createMockWrapper(tanstackPath);
+        setupDocumentMock([wrapper]);
+
+        const result = DiffRenderer.findFileElement(`  ./${tanstackPath}  `);
+        expect(result).toBe(wrapper);
+      });
+
       it('should return null when no match found', () => {
         const wrapper = createMockWrapper('src/foo.js');
         setupDocumentMock([wrapper]);
@@ -570,6 +579,27 @@ describe('DiffRenderer', () => {
         const result = DiffRenderer.findFileElement('src/utils/helper.js');
         expect(result).toBe(wrapper);
       });
+
+      it('should fall back to wrapper iteration when selector lookup fails', () => {
+        const weirdPath = 'src/routes/repos/"quoted"/route.tsx';
+        const wrapper = createMockWrapper(weirdPath);
+        global.document = {
+          querySelector: vi.fn().mockImplementation(() => {
+            throw new Error('Invalid selector');
+          }),
+          querySelectorAll: vi.fn().mockReturnValue([wrapper])
+        };
+
+        const result = DiffRenderer.findFileElement(weirdPath);
+        expect(result).toBe(wrapper);
+      });
+    });
+  });
+
+  describe('normalizeFilePath', () => {
+    it('iteratively strips interleaved leading slashes and ./ segments', () => {
+      expect(DiffRenderer.normalizeFilePath('/./src/foo.js')).toBe('src/foo.js');
+      expect(DiffRenderer.normalizeFilePath('./../src/foo.js')).toBe('../src/foo.js');
     });
   });
 

--- a/tests/unit/file-comment-manager.test.js
+++ b/tests/unit/file-comment-manager.test.js
@@ -1,0 +1,81 @@
+// Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+import { describe, it, expect, afterEach, vi } from 'vitest';
+
+global.window = global.window || {};
+
+const { FileCommentManager } = require('../../public/js/modules/file-comment-manager.js');
+
+function createTestFileCommentManager() {
+  const fileCommentManager = Object.create(FileCommentManager.prototype);
+  fileCommentManager.prManager = {
+    currentPR: { id: 'test-review-1' }
+  };
+  return fileCommentManager;
+}
+
+describe('FileCommentManager.loadFileComments()', () => {
+  afterEach(() => {
+    delete global.document;
+    delete global.window.DiffRenderer;
+  });
+
+  it('resolves file-level items through findZoneForFile before rendering', () => {
+    const fileCommentManager = createTestFileCommentManager();
+    const container = {
+      querySelectorAll: vi.fn().mockReturnValue([])
+    };
+    const zone = {
+      dataset: { fileName: 'src/file.js' },
+      querySelector: vi.fn(selector => selector === '.file-comments-container' ? container : null)
+    };
+
+    global.document = {
+      querySelectorAll: vi.fn().mockReturnValue([zone])
+    };
+
+    fileCommentManager.findZoneForFile = vi.fn(file => file === './src/file.js' ? zone : null);
+    fileCommentManager.displayAISuggestion = vi.fn();
+    fileCommentManager.displayUserComment = vi.fn();
+    fileCommentManager.updateCommentCount = vi.fn();
+
+    const comment = { file: './src/file.js', is_file_level: 1, body: 'User comment' };
+    const suggestion = { file: './src/file.js', is_file_level: 1, body: 'AI suggestion' };
+
+    fileCommentManager.loadFileComments([comment], [suggestion]);
+
+    expect(fileCommentManager.findZoneForFile).toHaveBeenCalledWith('./src/file.js');
+    expect(fileCommentManager.displayAISuggestion).toHaveBeenCalledWith(zone, suggestion);
+    expect(fileCommentManager.displayUserComment).toHaveBeenCalledWith(zone, comment);
+    expect(fileCommentManager.updateCommentCount).toHaveBeenCalledWith(zone);
+  });
+});
+
+describe('FileCommentManager.findZoneForFile()', () => {
+  afterEach(() => {
+    delete global.document;
+    delete global.CSS;
+    delete global.window.DiffRenderer;
+  });
+
+  it('escapes CSS special characters in the fallback selector lookup', () => {
+    const fileCommentManager = createTestFileCommentManager();
+    const zone = { dataset: { fileName: 'src/routes/repos/"quoted"/route.tsx' } };
+    const file = 'src/routes/repos/"quoted"/route.tsx';
+
+    global.window.DiffRenderer = undefined;
+    global.CSS = {
+      escape: vi.fn(value => value.replace(/"/g, '\\"'))
+    };
+    global.document = {
+      querySelector: vi.fn().mockReturnValue(zone)
+    };
+
+    const result = fileCommentManager.findZoneForFile(file);
+
+    expect(global.CSS.escape).toHaveBeenCalledWith(file);
+    expect(global.document.querySelector).toHaveBeenCalledWith(
+      '.file-comments-zone[data-file-name="src/routes/repos/\\"quoted\\"/route.tsx"]'
+    );
+    expect(result).toBe(zone);
+  });
+});

--- a/tests/unit/local-review.test.js
+++ b/tests/unit/local-review.test.js
@@ -668,6 +668,48 @@ describe('generateScopedDiff', () => {
       expect(result.diff).toContain('file.txt');
       expect(result.diff).toContain('brand-new.txt');
     });
+
+    it('should preserve literal dollar-sign segments in untracked file paths', async () => {
+      const originalOwner = process.env.owner;
+      const originalRepo = process.env.repo;
+      const originalNumber = process.env.number;
+
+      process.env.owner = 'expanded-owner';
+      process.env.repo = 'expanded-repo';
+      process.env.number = 'expanded-number';
+
+      try {
+        const relativePath = 'src/routes/repos/$owner/$repo/pulls/$number/route.tsx';
+        await fs.mkdir(path.join(testDir, 'src/routes/repos/$owner/$repo/pulls/$number'), { recursive: true });
+        await fs.writeFile(path.join(testDir, relativePath), 'export const Route = {};\n');
+
+        const result = await generateScopedDiff(testDir, 'unstaged', 'untracked');
+
+        expect(result.diff).toContain(`diff --git a/${relativePath} b/${relativePath}`);
+        expect(result.diff).toContain(`+++ b/${relativePath}`);
+        expect(result.diff).not.toContain('expanded-owner');
+        expect(result.diff).not.toContain('expanded-repo');
+        expect(result.diff).not.toContain('expanded-number');
+      } finally {
+        if (originalOwner === undefined) {
+          delete process.env.owner;
+        } else {
+          process.env.owner = originalOwner;
+        }
+
+        if (originalRepo === undefined) {
+          delete process.env.repo;
+        } else {
+          process.env.repo = originalRepo;
+        }
+
+        if (originalNumber === undefined) {
+          delete process.env.number;
+        } else {
+          process.env.number = originalNumber;
+        }
+      }
+    });
   });
 
   describe('invalid scope rejection', () => {

--- a/tests/unit/suggestion-manager.test.js
+++ b/tests/unit/suggestion-manager.test.js
@@ -604,6 +604,36 @@ describe('SuggestionManager.getFileAndLineInfo()', () => {
   });
 });
 
+describe('SuggestionManager.findFileElement()', () => {
+  afterEach(() => {
+    delete global.document;
+    delete global.CSS;
+    delete global.window.DiffRenderer;
+  });
+
+  it('escapes CSS special characters in the fallback selector lookup', () => {
+    const suggestionManager = createTestSuggestionManager();
+    const wrapper = { dataset: { fileName: 'src/routes/repos/"quoted"/route.tsx' } };
+    const file = 'src/routes/repos/"quoted"/route.tsx';
+
+    global.window.DiffRenderer = undefined;
+    global.CSS = {
+      escape: vi.fn(value => value.replace(/"/g, '\\"'))
+    };
+    global.document = {
+      querySelector: vi.fn().mockReturnValue(wrapper)
+    };
+
+    const result = suggestionManager.findFileElement(file);
+
+    expect(global.CSS.escape).toHaveBeenCalledWith(file);
+    expect(global.document.querySelector).toHaveBeenCalledWith(
+      '[data-file-name="src/routes/repos/\\"quoted\\"/route.tsx"]'
+    );
+    expect(result).toBe(wrapper);
+  });
+});
+
 describe('SuggestionManager chat button event delegation', () => {
   let suggestionManager;
   let clickHandlers;

--- a/tests/unit/worktree-base-sha.test.js
+++ b/tests/unit/worktree-base-sha.test.js
@@ -214,4 +214,30 @@ describe('GitWorktreeManager base SHA availability', () => {
       undefined
     );
   });
+
+  it('uses --numstat when collecting changed files so long paths are not abbreviated', async () => {
+    const longPath = 'areas/internal-services/meteorite/ui/app/frontend/src/routes/repos/$owner/$repo/pulls/$number/route.tsx';
+    const worktreeGit = createMockGit({
+      diffSummary: vi.fn().mockResolvedValue({
+        files: [{ file: longPath, insertions: 12, deletions: 3, changes: 15, binary: false }]
+      })
+    });
+
+    manager._gitFor = vi.fn().mockReturnValue(worktreeGit);
+    manager.assertCommitAvailableLocally = vi.fn().mockResolvedValue(undefined);
+
+    const result = await manager.getChangedFiles('/tmp/worktrees/existing', {
+      base_sha: 'base-sha',
+      head_sha: 'head-sha'
+    });
+
+    expect(worktreeGit.diffSummary).toHaveBeenCalledWith([
+      'base-sha...head-sha',
+      '--no-color',
+      '--no-ext-diff',
+      '--no-relative',
+      '--numstat'
+    ]);
+    expect(result[0].file).toBe(longPath);
+  });
 });


### PR DESCRIPTION
## Summary
- recover full file paths from diff headers when cached PR `changed_files` entries were truncated, and drop stale `...` stat stubs once the full diff is available
- align frontend path normalization and file lookup behavior with the backend, including file-level comment/suggestion resolution and safer selector fallbacks
- preserve literal `$owner/$repo/$number` segments when generating local untracked-file diffs so TanStack route paths stay navigable in new reviews

## Testing
- `pnpm exec vitest run tests/unit/diff-renderer.test.js tests/unit/suggestion-manager.test.js tests/unit/file-comment-manager.test.js tests/unit/diff-file-list.test.js tests/unit/local-review.test.js tests/unit/worktree-base-sha.test.js tests/integration/routes.test.js`