### PR TITLE
Add `skip_bulk_fetch` repo option to skip the bulk git fetch on refresh

### DIFF
--- a/.changeset/skip-bulk-fetch.md
+++ b/.changeset/skip-bulk-fetch.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Add per-repo `skip_bulk_fetch` option that opts out of the unconditional `git fetch <remote> --prune` step during PR refresh. The targeted base-SHA and PR-head ref fetches still run, so diff inputs remain correct. Useful on very large monorepos where bulk fetching all refs/tags can take tens of minutes.

--- a/config.example.json
+++ b/config.example.json
@@ -247,7 +247,7 @@
   },
 
   "repos": {
-    "_comment": "Repository configurations (renamed from 'monorepos'; the old key still works). 'path' points to an existing local clone. 'checkout_script' runs after worktree creation. 'reset_script' runs when switching a pool worktree to a new PR. 'load_skills' controls whether AI providers load environment-level skills (default: true).",
+    "_comment": "Repository configurations (renamed from 'monorepos'; the old key still works). 'path' points to an existing local clone. 'checkout_script' runs after worktree creation. 'reset_script' runs when switching a pool worktree to a new PR. 'load_skills' controls whether AI providers load environment-level skills (default: true). 'skip_bulk_fetch' opts out of the unconditional `git fetch <remote> --prune` during refresh (default: false); the targeted base-SHA and PR-head ref fetches still run. Useful for very large monorepos where bulk fetching all refs/tags is prohibitively slow.",
     "owner/repo": {
       "path": "~/path/to/monorepo",
       "checkout_script": "my-repo-checkout $BASE_SHA $HEAD_BRANCH",
@@ -257,7 +257,8 @@
       "worktree_name_template": "{id}/src",
       "pool_size": 0,
       "pool_fetch_interval_minutes": null,
-      "load_skills": true
+      "load_skills": true,
+      "skip_bulk_fetch": false
     }
   }
 }

--- a/src/config.js
+++ b/src/config.js
@@ -529,6 +529,17 @@ function getRepoResetScript(config, repository) {
 }
 
 /**
+ * Gets whether updateWorktree should skip the bulk `git fetch <remote> --prune`
+ * @param {Object} config - Configuration object from loadConfig()
+ * @param {string} repository - Repository in "owner/repo" format
+ * @returns {boolean} - true if the bulk fetch should be skipped (default: false)
+ */
+function getRepoSkipBulkFetch(config, repository) {
+  const repoConfig = getRepoConfig(config, repository);
+  return repoConfig?.skip_bulk_fetch === true;
+}
+
+/**
  * Gets the configured pool size for a repository from file config only.
  * Prefer resolvePoolConfig() when DB repo_settings are available.
  * @param {Object} config - Configuration object from loadConfig()
@@ -761,6 +772,7 @@ module.exports = {
   getRepoCheckoutTimeout,
   resolveRepoOptions,
   getRepoResetScript,
+  getRepoSkipBulkFetch,
   getRepoPoolSize,
   getRepoPoolFetchInterval,
   getRepoLoadSkills,

--- a/src/git/worktree.js
+++ b/src/git/worktree.js
@@ -733,9 +733,11 @@ class GitWorktreeManager {
    * @param {string} repo - Repository name
    * @param {number} number - PR number
    * @param {Object} prData - PR data from GitHub API (for remote resolution)
+   * @param {Object} [options]
+   * @param {boolean} [options.skipBulkFetch=false] - Skip the bulk `git fetch <remote> --prune`; targeted base-SHA and PR-head fetches still run
    * @returns {Promise<string>} Path to updated worktree
    */
-  async updateWorktree(owner, repo, number, prData) {
+  async updateWorktree(owner, repo, number, prData, options = {}) {
     const prInfo = { owner, repo, number };
     const headSha = this.getPRHeadSha(prData);
     const worktreePath = await this.getWorktreePath(prInfo);
@@ -756,9 +758,15 @@ class GitWorktreeManager {
       const remote = await this.resolveRemoteForPR(worktreeGit, prData, prInfo);
 
       // Fetch the latest from the resolved remote (--prune removes stale
-      // tracking refs that would otherwise block fetch on ref hierarchy conflicts)
-      console.log(`Fetching latest changes from ${remote}...`);
-      await worktreeGit.fetch([remote, '--prune']);
+      // tracking refs that would otherwise block fetch on ref hierarchy conflicts).
+      // Opt out via skip_bulk_fetch on very large monorepos where this is too slow;
+      // the targeted base-SHA and PR-head ref fetches below still run.
+      if (options.skipBulkFetch) {
+        console.log(`Skipping bulk fetch from ${remote} (skip_bulk_fetch enabled)`);
+      } else {
+        console.log(`Fetching latest changes from ${remote}...`);
+        await worktreeGit.fetch([remote, '--prune']);
+      }
 
       await this.ensureBaseShaAvailable(worktreeGit, prData, remote);
 

--- a/src/git/worktree.js
+++ b/src/git/worktree.js
@@ -762,7 +762,23 @@ class GitWorktreeManager {
       // Opt out via skip_bulk_fetch on very large monorepos where this is too slow;
       // the targeted base-SHA and PR-head ref fetches below still run.
       if (options.skipBulkFetch) {
+      if (options.skipBulkFetch) {
         console.log(`Skipping bulk fetch from ${remote} (skip_bulk_fetch enabled)`);
+        // Still fetch only the PR's base branch so ensureBaseShaAvailable does not
+        // have to fall back to `git fetch <remote> <sha>`, which some Git servers
+        // and mirrors reject (they require uploadpack.allowReachableSHA1InWant).
+        // This mirrors the targeted fetch used in createWorktreeForPR.
+        if (prData?.base_branch) {
+          try {
+            await worktreeGit.fetch([remote, `+refs/heads/${prData.base_branch}:refs/remotes/${remote}/${prData.base_branch}`]);
+          } catch (fetchError) {
+            console.warn(`Targeted base-branch fetch failed, will rely on existing refs: ${fetchError.message}`);
+          }
+        }
+      } else {
+        console.log(`Fetching latest changes from ${remote}...`);
+        await worktreeGit.fetch([remote, '--prune']);
+      }
       } else {
         console.log(`Fetching latest changes from ${remote}...`);
         await worktreeGit.fetch([remote, '--prune']);

--- a/src/git/worktree.js
+++ b/src/git/worktree.js
@@ -762,7 +762,6 @@ class GitWorktreeManager {
       // Opt out via skip_bulk_fetch on very large monorepos where this is too slow;
       // the targeted base-SHA and PR-head ref fetches below still run.
       if (options.skipBulkFetch) {
-      if (options.skipBulkFetch) {
         console.log(`Skipping bulk fetch from ${remote} (skip_bulk_fetch enabled)`);
         // Still fetch only the PR's base branch so ensureBaseShaAvailable does not
         // have to fall back to `git fetch <remote> <sha>`, which some Git servers
@@ -775,10 +774,6 @@ class GitWorktreeManager {
             console.warn(`Targeted base-branch fetch failed, will rely on existing refs: ${fetchError.message}`);
           }
         }
-      } else {
-        console.log(`Fetching latest changes from ${remote}...`);
-        await worktreeGit.fetch([remote, '--prune']);
-      }
       } else {
         console.log(`Fetching latest changes from ${remote}...`);
         await worktreeGit.fetch([remote, '--prune']);

--- a/src/routes/pr.js
+++ b/src/routes/pr.js
@@ -25,7 +25,7 @@ const Analyzer = require('../ai/analyzer');
 const { v4: uuidv4 } = require('uuid');
 const fs = require('fs').promises;
 const path = require('path');
-const { getGitHubToken, getWorktreeDisplayName, resolveLoadSkills, buildCouncilProviderOverrides } = require('../config');
+const { getGitHubToken, getWorktreeDisplayName, resolveLoadSkills, buildCouncilProviderOverrides, getRepoSkipBulkFetch } = require('../config');
 const logger = require('../utils/logger');
 const { buildDiffLineSet } = require('../utils/diff-annotator');
 const { broadcastReviewEvent } = require('../events/review-events');
@@ -378,7 +378,13 @@ router.post('/api/pr/:owner/:repo/:number/refresh', async (req, res) => {
 
     // Update worktree with latest changes
     const worktreeManager = new GitWorktreeManager(db);
-    const worktreePath = await worktreeManager.updateWorktree(owner, repo, prNumber, prData);
+    const worktreePath = await worktreeManager.updateWorktree(
+      owner,
+      repo,
+      prNumber,
+      prData,
+      { skipBulkFetch: getRepoSkipBulkFetch(config, repository) }
+    );
 
     // Generate fresh diff and get changed files
     const diffPrData = {

--- a/tests/unit/config.test.js
+++ b/tests/unit/config.test.js
@@ -5,7 +5,7 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 const childProcess = require('child_process');
-const { deepMerge, getGitHubToken, expandPath, resolveDbName, warnIfDevModeWithoutDbName, loadConfig, shouldSkipUpdateNotifier, _resetTokenCache, getRepoConfig, getRepoPath, getRepoCheckoutScript, getRepoWorktreeDirectory, getRepoWorktreeNameTemplate, getRepoCheckoutTimeout, resolveRepoOptions, getRepoResetScript, getRepoPoolSize, getRepoPoolFetchInterval, resolvePoolConfig, getWorktreeDisplayName, getConfigDir, getRepoLoadSkills, resolveLoadSkills, buildCouncilProviderOverrides } = require('../../src/config');
+const { deepMerge, getGitHubToken, expandPath, resolveDbName, warnIfDevModeWithoutDbName, loadConfig, shouldSkipUpdateNotifier, _resetTokenCache, getRepoConfig, getRepoPath, getRepoCheckoutScript, getRepoWorktreeDirectory, getRepoWorktreeNameTemplate, getRepoCheckoutTimeout, resolveRepoOptions, getRepoResetScript, getRepoSkipBulkFetch, getRepoPoolSize, getRepoPoolFetchInterval, resolvePoolConfig, getWorktreeDisplayName, getConfigDir, getRepoLoadSkills, resolveLoadSkills, buildCouncilProviderOverrides } = require('../../src/config');
 
 describe('config.js', () => {
   describe('getGitHubToken', () => {
@@ -1487,6 +1487,38 @@ describe('config.js', () => {
         monorepos: { 'owner/repo': { reset_script: './legacy-reset.sh' } }
       };
       expect(getRepoResetScript(config, 'owner/repo')).toBe('./legacy-reset.sh');
+    });
+  });
+
+  describe('getRepoSkipBulkFetch', () => {
+    it('returns true when explicitly enabled', () => {
+      const config = {
+        repos: { 'owner/repo': { skip_bulk_fetch: true } }
+      };
+      expect(getRepoSkipBulkFetch(config, 'owner/repo')).toBe(true);
+    });
+
+    it('returns false when explicitly disabled', () => {
+      const config = {
+        repos: { 'owner/repo': { skip_bulk_fetch: false } }
+      };
+      expect(getRepoSkipBulkFetch(config, 'owner/repo')).toBe(false);
+    });
+
+    it('returns false when not configured', () => {
+      const config = { repos: { 'owner/repo': { path: '~/repo' } } };
+      expect(getRepoSkipBulkFetch(config, 'owner/repo')).toBe(false);
+    });
+
+    it('returns false for unconfigured repository', () => {
+      expect(getRepoSkipBulkFetch({}, 'owner/repo')).toBe(false);
+    });
+
+    it('only treats strict true as enabled (not truthy strings)', () => {
+      const config = {
+        repos: { 'owner/repo': { skip_bulk_fetch: 'yes' } }
+      };
+      expect(getRepoSkipBulkFetch(config, 'owner/repo')).toBe(false);
     });
   });
 

--- a/tests/unit/worktree-base-sha.test.js
+++ b/tests/unit/worktree-base-sha.test.js
@@ -98,6 +98,27 @@ describe('GitWorktreeManager base SHA availability', () => {
     expect(worktreeGit.checkout).toHaveBeenCalledWith(['refs/remotes/fork-remote/pr-42']);
   });
 
+  it('skips the bulk fetch when skipBulkFetch option is set', async () => {
+    const worktreeGit = createMockGit({
+      raw: vi.fn(async (args) => {
+        if (args[0] === 'cat-file') return 'commit\n';
+        return '';
+      }),
+      revparse: vi.fn().mockResolvedValue('head-sha\n'),
+    });
+
+    manager._gitFor = vi.fn().mockReturnValue(worktreeGit);
+
+    await manager.updateWorktree(
+      'owner', 'repo', 42,
+      { base_sha: 'base-sha', head_sha: 'head-sha' },
+      { skipBulkFetch: true }
+    );
+
+    expect(worktreeGit.fetch).not.toHaveBeenCalledWith(['fork-remote', '--prune']);
+    expect(worktreeGit.checkout).toHaveBeenCalledWith(['refs/remotes/fork-remote/pr-42']);
+  });
+
   it('uses nested REST-format SHAs during update verification', async () => {
     const worktreeGit = createMockGit({
       raw: vi.fn(async (args) => {

--- a/tests/unit/worktree-base-sha.test.js
+++ b/tests/unit/worktree-base-sha.test.js
@@ -116,6 +116,56 @@ describe('GitWorktreeManager base SHA availability', () => {
     );
 
     expect(worktreeGit.fetch).not.toHaveBeenCalledWith(['fork-remote', '--prune']);
+    expect(worktreeGit.fetch).not.toHaveBeenCalledWith(
+      expect.arrayContaining([expect.stringContaining('+refs/heads/')])
+    );
+    expect(worktreeGit.checkout).toHaveBeenCalledWith(['refs/remotes/fork-remote/pr-42']);
+  });
+
+  it('targets the base branch fetch when skipBulkFetch is set and base_branch is present', async () => {
+    const worktreeGit = createMockGit({
+      raw: vi.fn(async (args) => {
+        if (args[0] === 'cat-file') return 'commit\n';
+        return '';
+      }),
+      revparse: vi.fn().mockResolvedValue('head-sha\n'),
+    });
+
+    manager._gitFor = vi.fn().mockReturnValue(worktreeGit);
+
+    await manager.updateWorktree(
+      'owner', 'repo', 42,
+      { base_sha: 'base-sha', head_sha: 'head-sha', base_branch: 'main' },
+      { skipBulkFetch: true }
+    );
+
+    expect(worktreeGit.fetch).toHaveBeenCalledWith([
+      'fork-remote',
+      '+refs/heads/main:refs/remotes/fork-remote/main',
+    ]);
+    expect(worktreeGit.fetch).not.toHaveBeenCalledWith(['fork-remote', '--prune']);
+  });
+
+  it('continues when targeted base-branch fetch fails under skipBulkFetch', async () => {
+    const worktreeGit = createMockGit({
+      raw: vi.fn(async (args) => {
+        if (args[0] === 'cat-file') return 'commit\n';
+        return '';
+      }),
+      revparse: vi.fn().mockResolvedValue('head-sha\n'),
+    });
+    worktreeGit.fetch = vi.fn()
+      .mockRejectedValueOnce(new Error('ref hierarchy conflict'))
+      .mockResolvedValue(undefined);
+
+    manager._gitFor = vi.fn().mockReturnValue(worktreeGit);
+
+    await expect(manager.updateWorktree(
+      'owner', 'repo', 42,
+      { base_sha: 'base-sha', head_sha: 'head-sha', base_branch: 'main' },
+      { skipBulkFetch: true }
+    )).resolves.toBeDefined();
+
     expect(worktreeGit.checkout).toHaveBeenCalledWith(['refs/remotes/fork-remote/pr-42']);
   });
 


### PR DESCRIPTION
## Summary
- Adds a per-repo `skip_bulk_fetch` config option that skips the unconditional `git fetch <remote> --prune` in `updateWorktree`. Default is false so behavior is unchanged.
- The targeted `ensureBaseShaAvailable` and `fetchPRHead` calls still run, so diff inputs stay correct.
- Useful on very large monorepos where bulk fetching all refs and tags is prohibitively slow.

## Testing
- pnpm vitest run tests/unit/config.test.js tests/unit/worktree-base-sha.test.js