### PR TITLE
Add Elixir syntax highlighting

### DIFF
--- a/.changeset/elixir-syntax-highlighting.md
+++ b/.changeset/elixir-syntax-highlighting.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": minor
+---
+
+Add syntax highlighting for Elixir `.ex` and `.exs` files in PR and local diff views.

--- a/public/js/modules/diff-renderer.js
+++ b/public/js/modules/diff-renderer.js
@@ -64,6 +64,9 @@ class DiffRenderer {
     // Ruby
     'rb': 'ruby',
     'erb': 'erb',
+    // Elixir
+    'ex': 'elixir',
+    'exs': 'elixir',
     // PHP
     'php': 'php',
     // Java/Kotlin/Scala

--- a/public/local.html
+++ b/public/local.html
@@ -562,6 +562,7 @@
 
     <!-- Highlight.js for syntax highlighting -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/languages/elixir.min.js"></script>
 
     <!-- Markdown-it Library for rendering markdown in comments -->
     <script src="https://cdn.jsdelivr.net/npm/markdown-it@13.0.2/dist/markdown-it.min.js"></script>

--- a/public/pr.html
+++ b/public/pr.html
@@ -358,6 +358,7 @@
 
     <!-- Highlight.js for syntax highlighting -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/languages/elixir.min.js"></script>
 
     <!-- Markdown-it Library for rendering markdown in comments -->
     <script src="https://cdn.jsdelivr.net/npm/markdown-it@13.0.2/dist/markdown-it.min.js"></script>

--- a/tests/unit/diff-renderer.test.js
+++ b/tests/unit/diff-renderer.test.js
@@ -596,6 +596,13 @@ describe('DiffRenderer', () => {
     });
   });
 
+  describe('detectLanguage', () => {
+    it('detects Elixir source and script files', () => {
+      expect(DiffRenderer.detectLanguage('lib/pair_review.ex')).toBe('elixir');
+      expect(DiffRenderer.detectLanguage('mix.exs')).toBe('elixir');
+    });
+  });
+
   describe('normalizeFilePath', () => {
     it('iteratively strips interleaved leading slashes and ./ segments', () => {
       expect(DiffRenderer.normalizeFilePath('/./src/foo.js')).toBe('src/foo.js');


### PR DESCRIPTION
Closes https://github.com/in-the-loop-labs/pair-review/issues/485

## Summary
- Add Elixir extension mapping for `.ex` and `.exs` files in diff syntax highlighting
- Load the highlight.js Elixir language bundle in both PR and local review views
- Add unit coverage for Elixir language detection


<img width="1920" height="932" alt="image" src="https://github.com/user-attachments/assets/022fa7cb-c6a0-4fb8-bb13-b989038eae1e" />
 

## Tests
- PASS: `pnpm exec vitest run tests/unit/diff-renderer.test.js`
- PASS: `pnpm test -- tests/unit/diff-renderer.test.js`


- Co-authored by GPT 5.5, reviewed tophatted manually