### PR TITLE
Fix worktree pool UI settings precedence

### DIFF
--- a/.changeset/fix-worktree-pool-ui-settings.md
+++ b/.changeset/fix-worktree-pool-ui-settings.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Fix worktree pool setup to honor UI repository pool settings before config-file values and adopt existing non-pool worktrees using the effective pool capacity.

--- a/src/config.js
+++ b/src/config.js
@@ -222,19 +222,19 @@ async function loadConfig() {
     }
   }
 
-  // Normalize legacy monorepos key into repos (monorepos values are overridden by repos)
-  if (mergedConfig.monorepos) {
-    mergedConfig.repos = deepMerge(mergedConfig.monorepos, mergedConfig.repos);
-  }
-
-  // Normalize repo keys to lowercase to match the database's COLLATE NOCASE identity
-  if (mergedConfig.repos) {
-    const normalized = {};
-    for (const [key, value] of Object.entries(mergedConfig.repos)) {
-      normalized[key.toLowerCase()] = value;
+  // Normalize legacy monorepos into one canonical repos map. Lowercase both
+  // sides before merging so JS object identity matches DB COLLATE NOCASE.
+  const lowercaseKeys = (obj) => {
+    const out = {};
+    for (const [key, value] of Object.entries(obj || {})) {
+      out[key.toLowerCase()] = value;
     }
-    mergedConfig.repos = normalized;
-  }
+    return out;
+  };
+  const lowerMonorepos = lowercaseKeys(mergedConfig.monorepos);
+  const lowerRepos = lowercaseKeys(mergedConfig.repos);
+  mergedConfig.repos = deepMerge(lowerMonorepos, lowerRepos);
+  delete mergedConfig.monorepos;
 
   // PORT env var overrides all config layers (used by Preview and similar harnesses)
   if (process.env.PORT) {
@@ -424,12 +424,15 @@ function expandPath(p) {
  * @returns {object|null}
  */
 function getRepoConfig(config, repository) {
+  const key = String(repository).toLowerCase();
   const reposSection = config.repos || {};
-  const entry = reposSection[repository];
-  if (entry) return entry;
+  const repoEntry = reposSection[key] || reposSection[repository] || Object.entries(reposSection)
+    .find(([repoName]) => repoName.toLowerCase() === key)?.[1];
+  if (repoEntry) return repoEntry;
 
   const legacySection = config.monorepos || {};
-  return legacySection[repository] || null;
+  return legacySection[key] || legacySection[repository] || Object.entries(legacySection)
+    .find(([repoName]) => repoName.toLowerCase() === key)?.[1] || null;
 }
 
 /**

--- a/src/database.js
+++ b/src/database.js
@@ -3002,6 +3002,20 @@ class RepoSettingsRepository {
   }
 
   /**
+   * List repositories with pool settings stored in the database.
+   * Includes rows with a fetch interval only so callers can resolve complete
+   * pool configuration with file fallback through resolvePoolConfig().
+   * @returns {Promise<Array<{repository: string, pool_size: number|null, pool_fetch_interval_minutes: number|null}>>}
+   */
+  async findPoolConfiguredRepoSettings() {
+    return await query(this.db, `
+      SELECT repository, pool_size, pool_fetch_interval_minutes
+      FROM repo_settings
+      WHERE pool_size IS NOT NULL OR pool_fetch_interval_minutes IS NOT NULL
+    `);
+  }
+
+  /**
    * Delete settings for a repository
    * @param {string} repository - Repository in owner/repo format
    * @returns {Promise<boolean>} True if settings were deleted

--- a/src/git/worktree-pool-lifecycle.js
+++ b/src/git/worktree-pool-lifecycle.js
@@ -3,11 +3,11 @@
 
 const fs = require('fs');
 const logger = require('../utils/logger');
-const { WorktreePoolRepository, WorktreeRepository, generateWorktreeId } = require('../database');
+const { WorktreePoolRepository, WorktreeRepository, RepoSettingsRepository, generateWorktreeId } = require('../database');
 const { GitWorktreeManager } = require('./worktree');
 const { WorktreePoolUsageTracker } = require('./worktree-pool-usage');
 const { normalizeRepository } = require('../utils/paths');
-const { getRepoPoolSize } = require('../config');
+const { resolvePoolConfig } = require('../config');
 
 /**
  * Consolidates the worktree pool state machine: absorbs WorktreePoolManager
@@ -25,6 +25,7 @@ class WorktreePoolLifecycle {
     const defaults = {
       poolRepo: new WorktreePoolRepository(db),
       worktreeRepo: new WorktreeRepository(db),
+      repoSettingsRepo: new RepoSettingsRepository(db),
       usageTracker: new WorktreePoolUsageTracker(),
       fs: fs,
       simpleGit: require('simple-git'),
@@ -36,6 +37,7 @@ class WorktreePoolLifecycle {
     this.config = config;
     this._poolRepo = deps.poolRepo;
     this._worktreeRepo = deps.worktreeRepo;
+    this._repoSettingsRepo = deps.repoSettingsRepo;
     this._usageTracker = deps.usageTracker;
     this._fs = deps.fs;
     this._simpleGit = deps.simpleGit;
@@ -628,11 +630,20 @@ class WorktreePoolLifecycle {
    * @private
    */
   async _adoptExistingWorktrees() {
-    const repos = this.config.repos || {};
+    const config = this.config || {};
+    const repoSettingsRows = await this._repoSettingsRepo.findPoolConfiguredRepoSettings();
+    const settingsByRepo = new Map(
+      repoSettingsRows.map(row => [String(row.repository).toLowerCase(), row])
+    );
+    const repoNames = new Set(Object.keys(config.repos || {}));
+    for (const row of repoSettingsRows) {
+      repoNames.add(String(row.repository).toLowerCase());
+    }
     const adoptedInUse = [];
 
-    for (const repoName of Object.keys(repos)) {
-      const poolSize = getRepoPoolSize(this.config, repoName);
+    for (const repoName of repoNames) {
+      const repoSettings = settingsByRepo.get(String(repoName).toLowerCase()) || null;
+      const { poolSize } = resolvePoolConfig(config, repoName, repoSettings);
       if (!poolSize) continue;
 
       // Count existing pool entries for this repo

--- a/src/setup/pr-setup.js
+++ b/src/setup/pr-setup.js
@@ -17,7 +17,7 @@ const { WorktreePoolLifecycle } = require('../git/worktree-pool-lifecycle');
 const { GitHubClient } = require('../github/client');
 const { normalizeRepository } = require('../utils/paths');
 const { findMainGitRoot } = require('../local-review');
-const { getConfigDir, getRepoPath, resolveRepoOptions, getRepoPoolSize, getRepoResetScript, DEFAULT_CHECKOUT_TIMEOUT_MS } = require('../config');
+const { getConfigDir, getRepoPath, resolveRepoOptions, resolvePoolConfig, getRepoResetScript, DEFAULT_CHECKOUT_TIMEOUT_MS } = require('../config');
 const logger = require('../utils/logger');
 const { fireReviewStartedHook } = require('../hooks/payloads');
 const simpleGit = require('simple-git');
@@ -229,6 +229,7 @@ async function findRepositoryPath({ db, owner, repo, repository, prNumber, confi
   const worktreeManager = new GitWorktreeManager(db);
   const repoSettingsRepo = new RepoSettingsRepository(db);
   const worktreeRepo = new WorktreeRepository(db);
+  const repoSettings = await repoSettingsRepo.getRepoSettings(repository);
 
   let repositoryPath = null;
   let worktreeSourcePath = null;  // Path to use as cwd for `git worktree add` (may differ from repositoryPath)
@@ -288,7 +289,7 @@ async function findRepositoryPath({ db, owner, repo, repository, prNumber, confi
   // ------------------------------------------------------------------
   // Resolve monorepo worktree options (checkout_script, worktree_directory, worktree_name_template)
   // ------------------------------------------------------------------
-  const resolved = config ? resolveRepoOptions(config, repository) : { checkoutScript: null, checkoutTimeout: DEFAULT_CHECKOUT_TIMEOUT_MS, worktreeConfig: null };
+  const resolved = config ? resolveRepoOptions(config, repository, repoSettings) : { checkoutScript: null, checkoutTimeout: DEFAULT_CHECKOUT_TIMEOUT_MS, worktreeConfig: null };
   const { checkoutScript, checkoutTimeout, worktreeConfig } = resolved;
 
   // When a checkout script is configured, null out worktreeSourcePath —
@@ -301,7 +302,7 @@ async function findRepositoryPath({ db, owner, repo, repository, prNumber, confi
   // ------------------------------------------------------------------
   // Tier 0: Check known local path from repo_settings
   // ------------------------------------------------------------------
-  const knownPath = await repoSettingsRepo.getLocalPath(repository);
+  const knownPath = repoSettings?.local_path || null;
 
   if (!repositoryPath && knownPath && await worktreeManager.pathExists(knownPath)) {
     try {
@@ -464,7 +465,9 @@ async function setupPRReview({ db, owner, repo, prNumber, githubToken, config, o
   // Step: worktree - Create git worktree for the PR
   // ------------------------------------------------------------------
   const prInfo = { owner, repo, number: prNumber };
-  const poolSize = config ? getRepoPoolSize(config, repository) : 0;
+  const repoSettingsRepo = new RepoSettingsRepository(db);
+  const repoSettings = await repoSettingsRepo.getRepoSettings(repository);
+  const { poolSize } = resolvePoolConfig(config || {}, repository, repoSettings);
   const resetScript = config ? getRepoResetScript(config, repository) : null;
 
   let worktreePath;

--- a/tests/integration/database.test.js
+++ b/tests/integration/database.test.js
@@ -1526,6 +1526,24 @@ describe('RepoSettingsRepository', () => {
     });
   });
 
+  describe('findPoolConfiguredRepoSettings()', () => {
+    it('returns repo settings rows with pool config and excludes unrelated settings', async () => {
+      await repoSettingsRepo.saveRepoSettings('pool-size/repo', { pool_size: 10 });
+      await repoSettingsRepo.saveRepoSettings('fetch/repo', { pool_fetch_interval_minutes: 15 });
+      await repoSettingsRepo.saveRepoSettings('plain/repo', { default_instructions: 'No pool settings' });
+
+      const rows = await repoSettingsRepo.findPoolConfiguredRepoSettings();
+
+      expect(rows).toEqual(expect.arrayContaining([
+        expect.objectContaining({ repository: 'pool-size/repo', pool_size: 10 }),
+        expect.objectContaining({ repository: 'fetch/repo', pool_fetch_interval_minutes: 15 }),
+      ]));
+      expect(rows).not.toEqual(expect.arrayContaining([
+        expect.objectContaining({ repository: 'plain/repo' }),
+      ]));
+    });
+  });
+
   describe('deleteRepoSettings()', () => {
     it('should return false for non-existent repository', async () => {
       const result = await repoSettingsRepo.deleteRepoSettings('owner/repo');

--- a/tests/integration/pr-setup.test.js
+++ b/tests/integration/pr-setup.test.js
@@ -40,6 +40,7 @@ const hooksPayloads = require('../../src/hooks/payloads');
 vi.spyOn(configModule, 'getConfigDir');
 vi.spyOn(configModule, 'getRepoPath');
 vi.spyOn(configModule, 'resolveRepoOptions');
+vi.spyOn(configModule, 'resolvePoolConfig');
 vi.spyOn(configModule, 'getRepoPoolSize');
 vi.spyOn(configModule, 'getRepoResetScript');
 vi.spyOn(localReview, 'findMainGitRoot');
@@ -91,6 +92,7 @@ describe('findRepositoryPath with monorepo configuration', () => {
     configModule.getConfigDir.mockReturnValue('/tmp/.pair-review-test');
     configModule.getRepoPath.mockReturnValue(null);
     configModule.resolveRepoOptions.mockReturnValue({ checkoutScript: null, checkoutTimeout: 300000, worktreeConfig: null, resetScript: null, poolSize: 0, poolFetchIntervalMinutes: null });
+    configModule.resolvePoolConfig.mockReturnValue({ poolSize: 0, poolFetchIntervalMinutes: null });
     configModule.getRepoPoolSize.mockReturnValue(0);
     configModule.getRepoResetScript.mockReturnValue(null);
 
@@ -621,6 +623,7 @@ describe('pool-enabled PR setup', () => {
       poolSize: 3,
       poolFetchIntervalMinutes: null,
     });
+    configModule.resolvePoolConfig.mockReturnValue({ poolSize: 3, poolFetchIntervalMinutes: null });
     configModule.getRepoPoolSize.mockReturnValue(3);
     configModule.getRepoResetScript.mockReturnValue(null);
 
@@ -686,6 +689,24 @@ describe('pool-enabled PR setup', () => {
     // Correct review URL returned
     expect(result.reviewUrl).toBe('/pr/owner/repo/42');
     expect(result.title).toBe('Test PR');
+  });
+
+  it('should resolve pool size from repo settings before file config', async () => {
+    const repoSettingsRepo = new RepoSettingsRepository(db);
+    await repoSettingsRepo.saveRepoSettings(repository, { pool_size: 10 });
+    configModule.resolvePoolConfig.mockReturnValue({ poolSize: 10, poolFetchIntervalMinutes: null });
+
+    await setupPRReview({
+      db, owner, repo, prNumber, githubToken, config: testConfig,
+    });
+
+    expect(configModule.resolvePoolConfig).toHaveBeenCalledWith(
+      testConfig,
+      repository,
+      expect.objectContaining({ pool_size: 10 })
+    );
+    const optionsArg = worktreePoolLifecycleModule.WorktreePoolLifecycle.prototype.acquireForPR.mock.calls[0][3];
+    expect(optionsArg.poolSize).toBe(10);
   });
 
   it('should persist review ID to pool entry via setReviewOwner', async () => {
@@ -805,7 +826,7 @@ describe('pool-enabled PR setup', () => {
 
   it('should not use pool when poolSize is 0', async () => {
     // Override pool size to 0
-    configModule.getRepoPoolSize.mockReturnValue(0);
+    configModule.resolvePoolConfig.mockReturnValue({ poolSize: 0, poolFetchIntervalMinutes: null });
 
     // createWorktreeForPR must return the expected shape
     GitWorktreeManager.prototype.createWorktreeForPR.mockResolvedValue({
@@ -923,6 +944,7 @@ describe('restore mode (setupPRReview with restoreMetadata)', () => {
       poolSize: 3,
       poolFetchIntervalMinutes: null,
     });
+    configModule.resolvePoolConfig.mockReturnValue({ poolSize: 3, poolFetchIntervalMinutes: null });
     configModule.getRepoPoolSize.mockReturnValue(3);
     configModule.getRepoResetScript.mockReturnValue(null);
 

--- a/tests/unit/config.test.js
+++ b/tests/unit/config.test.js
@@ -1279,6 +1279,7 @@ describe('config.js', () => {
 
       expect(config.repos).toBeDefined();
       expect(config.repos['owner/repo']).toEqual({ path: '~/mono', pool_size: 3 });
+      expect(config.monorepos).toBeUndefined();
     });
 
     it('should let repos values take precedence over monorepos when both exist', async () => {
@@ -1300,6 +1301,31 @@ describe('config.js', () => {
       expect(config.repos['owner/repo'].path).toBe('~/repos-path');
       // monorepos pool_size should be merged in (deep merge: monorepos is base, repos overrides)
       expect(config.repos['owner/repo'].pool_size).toBe(2);
+      expect(config.monorepos).toBeUndefined();
+    });
+
+    it('should collapse case-differing monorepos and repos keys with repos taking precedence', async () => {
+      mockReadFile({
+        global: {
+          port: 7247,
+          monorepos: {
+            'MyOrg/Repo': { path: '~/mono-path', pool_size: 5, reset_script: './reset.sh' }
+          },
+          repos: {
+            'MyOrg/Repo': { path: '~/repos-path', pool_size: 0 }
+          }
+        },
+      });
+
+      const { config } = await loadConfig();
+
+      expect(config.monorepos).toBeUndefined();
+      expect(Object.keys(config.repos)).toEqual(['myorg/repo']);
+      expect(config.repos['myorg/repo']).toEqual({
+        path: '~/repos-path',
+        pool_size: 0,
+        reset_script: './reset.sh'
+      });
     });
   });
 
@@ -1422,6 +1448,14 @@ describe('config.js', () => {
         monorepos: { 'owner/repo': { path: '~/old-path' } }
       };
       expect(getRepoConfig(config, 'owner/repo')).toEqual({ path: '~/new-path' });
+    });
+
+    it('should prefer repos over monorepos with case-differing raw config keys', () => {
+      const config = {
+        repos: { 'owner/repo': { pool_size: 0 } },
+        monorepos: { 'Owner/Repo': { pool_size: 5 } }
+      };
+      expect(getRepoConfig(config, 'Owner/Repo')).toEqual({ pool_size: 0 });
     });
 
     it('should return null for unconfigured repository', () => {

--- a/tests/unit/worktree-pool-lifecycle.test.js
+++ b/tests/unit/worktree-pool-lifecycle.test.js
@@ -79,6 +79,9 @@ function createMockDeps() {
       updateLastAccessed: vi.fn().mockResolvedValue(true),
       delete: vi.fn().mockResolvedValue(true),
     },
+    repoSettingsRepo: {
+      findPoolConfiguredRepoSettings: vi.fn().mockResolvedValue([]),
+    },
     usageTracker: mockUsageTracker,
     simpleGit: vi.fn(() => mockGit),
     GitWorktreeManager: MockGitWorktreeManager,
@@ -869,6 +872,62 @@ describe('WorktreePoolLifecycle', () => {
 
       // Result should include the adopted in_use entry
       expect(result).toContainEqual({ id: 'wt-1', current_review_id: 100 });
+    });
+
+    it('uses DB pool size when adopting worktrees and DB size is higher than file config', async () => {
+      const config = {
+        repos: {
+          'test/repo': { pool_size: 2 },
+        },
+      };
+      deps.repoSettingsRepo.findPoolConfiguredRepoSettings.mockResolvedValue([
+        { repository: 'test/repo', pool_size: 10, pool_fetch_interval_minutes: null },
+      ]);
+      deps.poolRepo.countForRepo.mockResolvedValue(2);
+      deps.poolRepo.findOrphanWorktrees.mockResolvedValue(
+        Array.from({ length: 9 }, (_, index) => ({
+          id: `wt-${index + 1}`,
+          pr_number: index + 1,
+          path: `/tmp/wt-${index + 1}`,
+          repository: 'test/repo',
+          reviewId: null,
+        }))
+      );
+      const poolLifecycle = new WorktreePoolLifecycle({}, config, deps);
+
+      await poolLifecycle.resetAndRehydrate();
+
+      expect(deps.poolRepo.findOrphanWorktrees).toHaveBeenCalledWith('test/repo');
+      expect(deps.poolRepo.create).toHaveBeenCalledTimes(8);
+      expect(deps.poolRepo.create).toHaveBeenCalledWith({
+        id: 'wt-8', repository: 'test/repo', path: '/tmp/wt-8',
+      });
+      expect(deps.poolRepo.create).not.toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'wt-9' })
+      );
+    });
+
+    it('adopts worktrees for repositories configured only via DB repo_settings', async () => {
+      const config = { repos: {} };
+      deps.repoSettingsRepo.findPoolConfiguredRepoSettings.mockResolvedValue([
+        { repository: 'db-only/repo', pool_size: 2, pool_fetch_interval_minutes: null },
+      ]);
+      deps.poolRepo.countForRepo.mockResolvedValue(0);
+      deps.poolRepo.findOrphanWorktrees.mockResolvedValue([
+        { id: 'wt-a', pr_number: 1, path: '/tmp/wt-a', repository: 'db-only/repo', reviewId: null },
+        { id: 'wt-b', pr_number: 2, path: '/tmp/wt-b', repository: 'db-only/repo', reviewId: null },
+      ]);
+      const poolLifecycle = new WorktreePoolLifecycle({}, config, deps);
+
+      await poolLifecycle.resetAndRehydrate();
+
+      expect(deps.poolRepo.findOrphanWorktrees).toHaveBeenCalledWith('db-only/repo');
+      expect(deps.poolRepo.create).toHaveBeenCalledWith({
+        id: 'wt-a', repository: 'db-only/repo', path: '/tmp/wt-a',
+      });
+      expect(deps.poolRepo.create).toHaveBeenCalledWith({
+        id: 'wt-b', repository: 'db-only/repo', path: '/tmp/wt-b',
+      });
     });
 
     it('skips adoption when already at pool capacity', async () => {


### PR DESCRIPTION
## Summary
- honor UI repo_settings pool size before config-file pool size in web PR setup
- canonicalize legacy monorepos into lowercase repos at config load time
- adopt existing non-pool worktrees for UI-only pool configs up to effective capacity

## Tests
- pnpm exec vitest run tests/unit/config.test.js tests/unit/worktree-pool-lifecycle.test.js tests/integration/pr-setup.test.js tests/integration/database.test.js