### PR TITLE
Reject URLs for local review paths

### DIFF
--- a/.changeset/reject-local-review-urls.md
+++ b/.changeset/reject-local-review-urls.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Reject URL inputs immediately when starting a local review.

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -133,6 +133,20 @@
     return div.innerHTML;
   }
 
+  const LOCAL_REVIEW_PATH_URL_ERROR = 'Local reviews require a filesystem path, not a URL. Pass GitHub or Graphite URLs as PR review inputs instead.';
+
+  function isUrlLikeLocalReviewPath(value) {
+    if (!value || typeof value !== 'string') return false;
+    const trimmed = value.trim();
+    if (!trimmed) return false;
+    if (/^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed)) return true;
+    if (/^(?:github\.com|app\.graphite\.(?:dev|com))\//i.test(trimmed)) return true;
+    // Keep this aligned with src/utils/local-path-input.js: only a leading
+    // user@host:path token is treated as an SSH-style remote.
+    if (/^[^@/\\\s]+@[^:/\\\s]+:[^\s]+$/.test(trimmed)) return true;
+    return false;
+  }
+
   /**
    * Set loading state for a tab's form
    * @param {string} tab - 'pr' or 'local'
@@ -710,11 +724,32 @@
       return;
     }
 
+    if (isUrlLikeLocalReviewPath(pathValue)) {
+      showError('local', LOCAL_REVIEW_PATH_URL_ERROR);
+      input.focus();
+      return;
+    }
+
     // Navigate to the setup page which shows step-by-step progress
     // The /local?path= route serves setup.html which handles the full setup flow
     let href = '/local?path=' + encodeURIComponent(pathValue);
     if (analyze) href += '&analyze=true';
     window.location.href = href;
+  }
+
+  function handleLocalPathInput(event) {
+    const input = event && event.target ? event.target : document.getElementById('local-path-input');
+    const errorEl = document.getElementById('start-review-error-local');
+    if (!input || !errorEl) return;
+
+    if (isUrlLikeLocalReviewPath(input.value)) {
+      showError('local', LOCAL_REVIEW_PATH_URL_ERROR);
+      return;
+    }
+
+    if (errorEl.textContent === LOCAL_REVIEW_PATH_URL_ERROR) {
+      errorEl.classList.remove('visible', 'info');
+    }
   }
 
   // ─── Browse Directory ──────────────────────────────────────────────────────
@@ -746,6 +781,9 @@
 
       if (!data.cancelled && data.path) {
         input.value = data.path;
+        // Setting .value in JavaScript does not fire an input event, so run the
+        // same handler used for typing to clear any stale URL-specific error.
+        handleLocalPathInput({ target: input });
         input.focus();
       }
 
@@ -1871,6 +1909,11 @@
     const localForm = document.getElementById('start-local-form');
     if (localForm) {
       localForm.addEventListener('submit', handleStartLocal);
+    }
+
+    const localPathInput = document.getElementById('local-path-input');
+    if (localPathInput) {
+      localPathInput.addEventListener('input', handleLocalPathInput);
     }
 
     // Set up browse button handler

--- a/src/local-review.js
+++ b/src/local-review.js
@@ -6,6 +6,7 @@ const path = require('path');
 const fs = require('fs').promises;
 const { loadConfig, showWelcomeMessage, resolveDbName, getGitHubToken } = require('./config');
 const logger = require('./utils/logger');
+const { rejectUrlLikeLocalReviewPath } = require('./utils/local-path-input');
 const { fireHooks, hasHooks } = require('./hooks/hook-runner');
 const { buildReviewStartedPayload, buildReviewLoadedPayload, getCachedUser } = require('./hooks/payloads');
 
@@ -699,6 +700,8 @@ async function handleLocalReview(targetPath, flags = {}) {
   let db = null;
 
   try {
+    rejectUrlLikeLocalReviewPath(targetPath);
+
     // Resolve target path
     const resolvedPath = path.resolve(targetPath || process.cwd());
 

--- a/src/main.js
+++ b/src/main.js
@@ -13,6 +13,7 @@ const { handleLocalReview, findMainGitRoot } = require('./local-review');
 const { storePRData, registerRepositoryLocation, findRepositoryPath } = require('./setup/pr-setup');
 const { fireReviewStartedHook } = require('./hooks/payloads');
 const { normalizeRepository, resolveRenamedFile, resolveRenamedFileOld } = require('./utils/paths');
+const { rejectUrlLikeLocalReviewPath } = require('./utils/local-path-input');
 const logger = require('./utils/logger');
 const simpleGit = require('simple-git');
 const { getGeneratedFilePatterns } = require('./git/gitattributes');
@@ -288,6 +289,7 @@ function parseArgs(args) {
       flags.local = true;
       // Next argument is optional path (if not starting with -)
       if (i + 1 < args.length && !args[i + 1].startsWith('-')) {
+        rejectUrlLikeLocalReviewPath(args[i + 1]);
         flags.localPath = args[i + 1];
         i++; // Skip next argument since we consumed it
       }

--- a/src/routes/local.js
+++ b/src/routes/local.js
@@ -35,6 +35,7 @@ const { getProviderClass, createProvider } = require('../ai/provider');
 const { getDefaultBranch, tryGraphiteState } = require('../git/base-branch');
 const { CommentRepository } = require('../database');
 const { runExecutableAnalysis, getChangedFiles } = require('./executable-analysis');
+const { rejectUrlLikeLocalReviewPath } = require('../utils/local-path-input');
 const {
   activeAnalyses,
   localReviewDiffs,
@@ -378,6 +379,12 @@ router.post('/api/local/start', async (req, res) => {
       return res.status(400).json({
         error: 'Missing required field: path'
       });
+    }
+
+    try {
+      rejectUrlLikeLocalReviewPath(inputPath);
+    } catch (err) {
+      return res.status(400).json({ error: err.message });
     }
 
     // Required inline (not reusing top-level import) so that vi.spyOn()

--- a/src/routes/setup.js
+++ b/src/routes/setup.js
@@ -18,6 +18,7 @@ const { setupLocalReview } = require('../setup/local-setup');
 const { getGitHubToken, expandPath } = require('../config');
 const { queryOne, ReviewRepository } = require('../database');
 const { normalizeRepository } = require('../utils/paths');
+const { rejectUrlLikeLocalReviewPath } = require('../utils/local-path-input');
 const logger = require('../utils/logger');
 
 const router = express.Router();
@@ -184,6 +185,12 @@ router.post('/api/setup/local', async (req, res) => {
 
     if (!rawPath) {
       return res.status(400).json({ error: 'Missing required field: path' });
+    }
+
+    try {
+      rejectUrlLikeLocalReviewPath(rawPath);
+    } catch (err) {
+      return res.status(400).json({ error: err.message });
     }
 
     const targetPath = expandPath(rawPath);

--- a/src/setup/local-setup.js
+++ b/src/setup/local-setup.js
@@ -6,6 +6,7 @@ const { fireHooks, hasHooks } = require('../hooks/hook-runner');
 const { buildReviewStartedPayload, buildReviewLoadedPayload, getCachedUser } = require('../hooks/payloads');
 const { STOPS, DEFAULT_SCOPE, reviewScope } = require('../local-scope');
 const logger = require('../utils/logger');
+const { LOCAL_REVIEW_PATH_URL_ERROR, rejectUrlLikeLocalReviewPath } = require('../utils/local-path-input');
 const path = require('path');
 const fs = require('fs').promises;
 
@@ -31,11 +32,14 @@ async function setupLocalReview({ db, targetPath, onProgress, config }) {
   let resolvedPath;
   try {
     progress({ step: 'validate', status: 'running', message: 'Validating target path...' });
+    rejectUrlLikeLocalReviewPath(targetPath);
     resolvedPath = path.resolve(targetPath);
     await fs.access(resolvedPath);
     progress({ step: 'validate', status: 'completed', message: `Path resolved to ${resolvedPath}` });
   } catch (err) {
-    const message = `Path does not exist: ${path.resolve(targetPath)}`;
+    const message = err.message === LOCAL_REVIEW_PATH_URL_ERROR
+      ? err.message
+      : `Path does not exist: ${path.resolve(targetPath)}`;
     progress({ step: 'validate', status: 'error', message });
     throw new Error(message);
   }

--- a/src/single-port.js
+++ b/src/single-port.js
@@ -4,6 +4,7 @@ const path = require('path');
 const semver = require('semver');
 const { PRArgumentParser } = require('./github/parser');
 const logger = require('./utils/logger');
+const { rejectUrlLikeLocalReviewPath } = require('./utils/local-path-input');
 const { version: packageVersion } = require('../package.json');
 
 const HEALTH_TIMEOUT_MS = 2000;
@@ -158,6 +159,7 @@ async function attemptDelegation(config, flags, prArgs, _deps) {
   // Determine mode and build URL
   let url;
   if (flags.local) {
+    rejectUrlLikeLocalReviewPath(flags.localPath);
     const targetPath = path.resolve(flags.localPath || process.cwd());
     url = buildDelegationUrl(port, 'local', { localPath: targetPath, analyze: flags.ai });
   } else if (prArgs.length > 0) {

--- a/src/utils/local-path-input.js
+++ b/src/utils/local-path-input.js
@@ -1,0 +1,44 @@
+// Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+
+const LOCAL_REVIEW_PATH_URL_ERROR = 'Local reviews require a filesystem path, not a URL. Pass GitHub or Graphite URLs as PR review inputs instead.';
+
+/**
+ * Detect inputs that are URLs or remote-style Git URLs rather than filesystem paths.
+ * This intentionally checks only unambiguous URL forms so normal absolute,
+ * relative, tilde, and Windows paths continue to work.
+ *
+ * @param {unknown} input
+ * @returns {boolean}
+ */
+function isUrlLikeLocalReviewPath(input) {
+  if (typeof input !== 'string') return false;
+
+  const value = input.trim();
+  if (!value) return false;
+
+  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(value)) return true;
+  if (/^(?:github\.com|app\.graphite\.(?:dev|com))\//i.test(value)) return true;
+  // Treat only a leading user@host:path token as SSH remote syntax; if a
+  // directory prefix contains @ and : it should remain a filesystem path.
+  if (/^[^@/\\\s]+@[^:/\\\s]+:[^\s]+$/.test(value)) return true;
+
+  return false;
+}
+
+/**
+ * Throw a user-facing error when a local review path is actually a URL.
+ *
+ * @param {unknown} input
+ * @throws {Error}
+ */
+function rejectUrlLikeLocalReviewPath(input) {
+  if (isUrlLikeLocalReviewPath(input)) {
+    throw new Error(LOCAL_REVIEW_PATH_URL_ERROR);
+  }
+}
+
+module.exports = {
+  LOCAL_REVIEW_PATH_URL_ERROR,
+  isUrlLikeLocalReviewPath,
+  rejectUrlLikeLocalReviewPath
+};

--- a/tests/e2e/local-start.spec.js
+++ b/tests/e2e/local-start.spec.js
@@ -1,0 +1,22 @@
+// Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+import { test, expect } from './fixtures.js';
+
+test.describe('Local Review Start', () => {
+  test('rejects URL input immediately without navigating', async ({ page }) => {
+    await page.goto('/');
+    await page.click('#unified-tab-bar [data-tab="local-tab"]');
+
+    const input = page.locator('#local-path-input');
+    const error = page.locator('#start-review-error-local');
+    await input.fill('https://github.com/test-owner/test-repo/pull/1');
+
+    await expect(error).toBeVisible();
+    await expect(error).toContainText('filesystem path');
+
+    const currentUrl = page.url();
+    await page.click('#start-local-btn');
+
+    await expect(page).toHaveURL(currentUrl);
+    await expect(error).toContainText('filesystem path');
+  });
+});

--- a/tests/integration/local-sessions.test.js
+++ b/tests/integration/local-sessions.test.js
@@ -259,6 +259,16 @@ describe('Local Sessions API', () => {
       expect(res.body.error).toMatch(/path/i);
     });
 
+    it('should return 400 immediately when path is a URL', async () => {
+      const res = await request(app)
+        .post('/api/local/start')
+        .send({ path: 'https://github.com/owner/repo/pull/123' });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toContain('filesystem path');
+      expect(localReviewModule.findGitRoot).not.toHaveBeenCalled();
+    });
+
     it('should start a local review for a valid directory', async () => {
       const res = await request(app)
         .post('/api/local/start')

--- a/tests/integration/setup-routes.test.js
+++ b/tests/integration/setup-routes.test.js
@@ -9,12 +9,15 @@ vi.spyOn(configModule, 'getGitHubToken');
 // Mock setupPRReview to prevent real git operations
 const prSetupModule = require('../../src/setup/pr-setup');
 vi.spyOn(prSetupModule, 'setupPRReview');
+const localSetupModule = require('../../src/setup/local-setup');
+vi.spyOn(localSetupModule, 'setupLocalReview');
 
 // Now load the route (after spies are in place)
 const express = require('express');
 const request = require('supertest');
 const setupRoutes = require('../../src/routes/setup');
 const { WorktreePoolRepository } = require('../../src/database');
+const { activeSetups } = require('../../src/routes/shared');
 
 function createApp(db, config = { github_token: 'test-token' }, { withPool = false } = {}) {
   const app = express();
@@ -57,13 +60,22 @@ describe('POST /api/setup/pr/:owner/:repo/:number', () => {
 
   beforeEach(() => {
     db = createTestDatabase();
+    activeSetups.clear();
     vi.clearAllMocks();
     configModule.getGitHubToken.mockReturnValue('test-token');
     // Default: setupPRReview resolves (should only be called when fast path is skipped)
     prSetupModule.setupPRReview.mockResolvedValue({ reviewUrl: '/pr/owner/repo/42', title: 'Test PR' });
+    localSetupModule.setupLocalReview.mockResolvedValue({
+      reviewUrl: '/local/1',
+      reviewId: 1,
+      existing: false,
+      branch: 'main',
+      repository: 'owner/repo'
+    });
   });
 
   afterEach(() => {
+    activeSetups.clear();
     closeTestDatabase(db);
   });
 
@@ -201,5 +213,40 @@ describe('POST /api/setup/pr/:owner/:repo/:number', () => {
     expect(prSetupModule.setupPRReview).toHaveBeenCalledOnce();
     const callArgs = prSetupModule.setupPRReview.mock.calls[0][0];
     expect(callArgs.restoreMetadata).toBeNull();
+  });
+});
+
+describe('POST /api/setup/local', () => {
+  let db;
+
+  beforeEach(() => {
+    db = createTestDatabase();
+    activeSetups.clear();
+    vi.clearAllMocks();
+    localSetupModule.setupLocalReview.mockResolvedValue({
+      reviewUrl: '/local/1',
+      reviewId: 1,
+      existing: false,
+      branch: 'main',
+      repository: 'owner/repo'
+    });
+  });
+
+  afterEach(() => {
+    activeSetups.clear();
+    closeTestDatabase(db);
+  });
+
+  it('returns 400 immediately when local path is a URL', async () => {
+    const app = createApp(db);
+    const res = await request(app)
+      .post('/api/setup/local')
+      .send({ path: 'https://github.com/owner/repo/pull/123' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain('filesystem path');
+    expect(res.body.setupId).toBeUndefined();
+    expect(activeSetups.size).toBe(0);
+    expect(localSetupModule.setupLocalReview).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/index-open-analyze-buttons.test.js
+++ b/tests/unit/index-open-analyze-buttons.test.js
@@ -325,6 +325,66 @@ describe('Index page Open/Analyze buttons', () => {
     expect(global.window.location.href).toBe('/local?path=%2Ftmp%2Fmyproject');
   });
 
+  it('Local Open button rejects URL input without navigating', async () => {
+    const form = elementsById['start-local-form'];
+    const input = elementsById['local-path-input'];
+    const errorEl = elementsById['start-review-error-local'];
+    input.value = 'https://github.com/testowner/testrepo/pull/42';
+
+    const submitHandler = form._listeners.submit[0];
+    await submitHandler({ preventDefault: vi.fn() });
+
+    expect(global.window.location.href).toBe('');
+    expect(errorEl.textContent).toContain('filesystem path');
+    expect(input.focus).toHaveBeenCalled();
+  });
+
+  it('Local Open button allows paths with SSH-like substrings', async () => {
+    const form = elementsById['start-local-form'];
+    const input = elementsById['local-path-input'];
+    input.value = '/tmp/git@github.com:owner/repo';
+
+    const submitHandler = form._listeners.submit[0];
+    await submitHandler({ preventDefault: vi.fn() });
+
+    expect(global.window.location.href).toBe('/local?path=%2Ftmp%2Fgit%40github.com%3Aowner%2Frepo');
+  });
+
+  it('Local path input shows URL error immediately on input', async () => {
+    const input = elementsById['local-path-input'];
+    const errorEl = elementsById['start-review-error-local'];
+    input.value = 'https://github.com/testowner/testrepo/pull/42';
+
+    const inputHandler = input._listeners.input[0];
+    inputHandler({ target: input });
+
+    expect(errorEl.textContent).toContain('filesystem path');
+  });
+
+  it('Browse clears stale URL validation after assigning selected path', async () => {
+    const browseBtn = elementsById['browse-local-btn'];
+    const input = elementsById['local-path-input'];
+    const errorEl = elementsById['start-review-error-local'];
+    errorEl.textContent = 'Local reviews require a filesystem path, not a URL. Pass GitHub or Graphite URLs as PR review inputs instead.';
+    errorEl.classList.remove.mockClear();
+
+    global.fetch = vi.fn((url) => {
+      if (url === '/api/local/browse') {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ cancelled: false, path: '/tmp/myproject' }),
+        });
+      }
+      return Promise.resolve({ ok: false });
+    });
+
+    const clickHandler = browseBtn._listeners.click[0];
+    await clickHandler({ preventDefault: vi.fn() });
+
+    expect(input.value).toBe('/tmp/myproject');
+    expect(errorEl.classList.remove).toHaveBeenCalledWith('visible', 'info');
+  });
+
   // ─── Test 4: Local Analyze button navigates with analyze param ───────────
 
   it('Local Analyze button navigates with analyze param', async () => {

--- a/tests/unit/local-path-input.test.js
+++ b/tests/unit/local-path-input.test.js
@@ -1,0 +1,40 @@
+// Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+import { describe, it, expect } from 'vitest';
+
+const {
+  LOCAL_REVIEW_PATH_URL_ERROR,
+  isUrlLikeLocalReviewPath,
+  rejectUrlLikeLocalReviewPath
+} = require('../../src/utils/local-path-input');
+
+describe('local path input validation', () => {
+  it('detects URL inputs', () => {
+    expect(isUrlLikeLocalReviewPath('https://github.com/owner/repo/pull/123')).toBe(true);
+    expect(isUrlLikeLocalReviewPath('github.com/owner/repo/pull/123')).toBe(true);
+    expect(isUrlLikeLocalReviewPath('app.graphite.com/github/pr/owner/repo/123')).toBe(true);
+    expect(isUrlLikeLocalReviewPath('app.graphite.dev/github/owner/repo/pull/123')).toBe(true);
+    expect(isUrlLikeLocalReviewPath('http://localhost:7247/local')).toBe(true);
+    expect(isUrlLikeLocalReviewPath('file:///Users/test/repo')).toBe(true);
+  });
+
+  it('detects SSH remote-style inputs', () => {
+    expect(isUrlLikeLocalReviewPath('git@github.com:owner/repo.git')).toBe(true);
+  });
+
+  it('allows filesystem path forms', () => {
+    expect(isUrlLikeLocalReviewPath('/Users/test/repo')).toBe(false);
+    expect(isUrlLikeLocalReviewPath('~/src/repo')).toBe(false);
+    expect(isUrlLikeLocalReviewPath('relative/path')).toBe(false);
+    expect(isUrlLikeLocalReviewPath('/tmp/git@github.com:owner/repo')).toBe(false);
+    expect(isUrlLikeLocalReviewPath('nested/git@github.com:owner/repo')).toBe(false);
+    expect(isUrlLikeLocalReviewPath('C:\\Users\\test\\repo')).toBe(false);
+    expect(isUrlLikeLocalReviewPath('C:\\Users\\git@github.com:owner\\repo')).toBe(false);
+    expect(isUrlLikeLocalReviewPath('')).toBe(false);
+    expect(isUrlLikeLocalReviewPath(null)).toBe(false);
+  });
+
+  it('throws a user-facing error for URL inputs', () => {
+    expect(() => rejectUrlLikeLocalReviewPath('https://github.com/owner/repo/pull/123'))
+      .toThrow(LOCAL_REVIEW_PATH_URL_ERROR);
+  });
+});

--- a/tests/unit/main.test.js
+++ b/tests/unit/main.test.js
@@ -46,6 +46,11 @@ describe('main.js parseArgs', () => {
       expect(result.flags.localPath).toBe('/path/to/repo');
     });
 
+    it('should reject --local flag with URL path', () => {
+      expect(() => parseArgs(['--local', 'https://github.com/owner/repo/pull/123']))
+        .toThrow('filesystem path');
+    });
+
     it('should parse -l short flag without path', () => {
       const result = parseArgs(['-l']);
       expect(result.flags.local).toBe(true);

--- a/tests/unit/single-port.test.js
+++ b/tests/unit/single-port.test.js
@@ -289,6 +289,17 @@ describe('attemptDelegation', () => {
     );
   });
 
+  it('rejects URL input for local mode before opening browser', async () => {
+    const deps = createMockDeps();
+    await expect(attemptDelegation(
+      baseConfig,
+      { local: true, localPath: 'https://github.com/owner/repo/pull/123' },
+      [],
+      deps
+    )).rejects.toThrow('filesystem path');
+    expect(deps.open).not.toHaveBeenCalled();
+  });
+
   it('delegates server-only mode and opens browser', async () => {
     const deps = createMockDeps();
     const result = await attemptDelegation(baseConfig, {}, [], deps);


### PR DESCRIPTION
Summary:
- Reject URL-like inputs before starting local reviews from the UI, CLI, setup routes, and single-port delegation.
- Keep browser and server validation aligned while allowing filesystem paths with SSH-like substrings.
- Clear stale local path URL validation after Browse fills a directory.

Tests:
- pnpm exec vitest run tests/unit/local-path-input.test.js tests/unit/index-open-analyze-buttons.test.js tests/unit/single-port.test.js tests/unit/main.test.js tests/integration/local-sessions.test.js tests/integration/setup-routes.test.js
- pnpm test:e2e -- tests/e2e/local-start.spec.js