### PR TITLE
Avoid fetching tags for worktree setup

### DIFF
--- a/.changeset/avoid-worktree-tag-fetches.md
+++ b/.changeset/avoid-worktree-tag-fetches.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Avoid auto-following remote tags during pair-review git fetches for worktree setup and refresh.

--- a/src/git/fetch-helpers.js
+++ b/src/git/fetch-helpers.js
@@ -1,0 +1,29 @@
+// Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Fetch from a remote without auto-following tags reachable from the fetched
+ * commits. Large monorepos can have very large tag namespaces, and pair-review
+ * only needs commits/refs for review setup.
+ * @param {Object} git - simple-git instance
+ * @param {string[]} args - Arguments after `git fetch --no-tags`
+ * @returns {Promise<*>}
+ */
+async function fetchNoTags(git, args) {
+  return git.fetch(['--no-tags', ...args]);
+}
+
+/**
+ * Raw `git fetch --no-tags` wrapper for fetch forms not exposed cleanly by
+ * simple-git helpers.
+ * @param {Object} git - simple-git instance
+ * @param {string[]} args - Arguments after `git fetch --no-tags`
+ * @returns {Promise<*>}
+ */
+async function rawFetchNoTags(git, args) {
+  return git.raw(['fetch', '--no-tags', ...args]);
+}
+
+module.exports = {
+  fetchNoTags,
+  rawFetchNoTags,
+};

--- a/src/git/worktree.js
+++ b/src/git/worktree.js
@@ -8,6 +8,7 @@ const { WorktreeRepository, generateWorktreeId } = require('../database');
 const { getGeneratedFilePatterns } = require('./gitattributes');
 const { normalizeRepository, resolveRenamedFile, resolveRenamedFileOld } = require('../utils/paths');
 const { GIT_DIFF_FLAGS_ARRAY, GIT_DIFF_SUMMARY_FLAGS_ARRAY } = require('./diff-flags');
+const { fetchNoTags, rawFetchNoTags } = require('./fetch-helpers');
 const { spawn, execSync } = require('child_process');
 
 const MISSING_COMMIT_ERROR_CODE = 'PAIR_REVIEW_MISSING_COMMIT';
@@ -250,7 +251,7 @@ class GitWorktreeManager {
 
     let fetchError = null;
     try {
-      await git.raw(['fetch', remote, sha]);
+      await rawFetchNoTags(git, [remote, sha]);
     } catch (error) {
       fetchError = error;
     }
@@ -370,7 +371,7 @@ class GitWorktreeManager {
     const prTrackingRef = `refs/remotes/${baseRemote}/pr-${prNumber}`;
 
     try {
-      await git.fetch([baseRemote, `+refs/pull/${prNumber}/head:${prTrackingRef}`]);
+      await fetchNoTags(git, [baseRemote, `+refs/pull/${prNumber}/head:${prTrackingRef}`]);
       return {
         remote: baseRemote,
         trackingRef: prTrackingRef,
@@ -387,7 +388,7 @@ class GitWorktreeManager {
         throw prRefError;
       }
 
-      await git.raw(['fetch', baseRemote, headSha]);
+      await rawFetchNoTags(git, [baseRemote, headSha]);
       return {
         remote: baseRemote,
         trackingRef: null,
@@ -591,13 +592,13 @@ class GitWorktreeManager {
       // Fetch only the specific base branch we need, with error handling for ref conflicts
       console.log(`Fetching base branch ${prData.base_branch} from ${remote}...`);
       try {
-        await git.fetch([remote, `+refs/heads/${prData.base_branch}:refs/remotes/${remote}/${prData.base_branch}`]);
+        await fetchNoTags(git, [remote, `+refs/heads/${prData.base_branch}:refs/remotes/${remote}/${prData.base_branch}`]);
       } catch (fetchError) {
         // If fetch fails due to ref conflicts, try alternative approaches
         console.log(`Standard fetch failed, trying alternative: ${fetchError.message}`);
         try {
           // Try fetching with force flag to overwrite conflicting refs
-          await git.raw(['fetch', remote, `+refs/heads/${prData.base_branch}:refs/remotes/${remote}/${prData.base_branch}`, '--force']);
+          await rawFetchNoTags(git, ['--force', remote, `+refs/heads/${prData.base_branch}:refs/remotes/${remote}/${prData.base_branch}`]);
         } catch (altFetchError) {
           console.warn(`Could not fetch base branch ${prData.base_branch}, will try to use existing ref`);
           // Continue anyway - the branch might already be available locally
@@ -658,7 +659,7 @@ class GitWorktreeManager {
         if (headBranch) {
           try {
             console.log(`Fetching head branch ${headBranch}...`);
-            await worktreeGit.fetch([remote, `+refs/heads/${headBranch}:refs/remotes/${remote}/${headBranch}`]);
+            await fetchNoTags(worktreeGit, [remote, `+refs/heads/${headBranch}:refs/remotes/${remote}/${headBranch}`]);
             // Create/update a local branch pointing to the fetched ref so tooling can reference it by name
             await worktreeGit.branch(['-f', headBranch, `${remote}/${headBranch}`]);
           } catch (branchFetchError) {
@@ -769,14 +770,14 @@ class GitWorktreeManager {
         // This mirrors the targeted fetch used in createWorktreeForPR.
         if (prData?.base_branch) {
           try {
-            await worktreeGit.fetch([remote, `+refs/heads/${prData.base_branch}:refs/remotes/${remote}/${prData.base_branch}`]);
+            await fetchNoTags(worktreeGit, [remote, `+refs/heads/${prData.base_branch}:refs/remotes/${remote}/${prData.base_branch}`]);
           } catch (fetchError) {
             console.warn(`Targeted base-branch fetch failed, will rely on existing refs: ${fetchError.message}`);
           }
         }
       } else {
         console.log(`Fetching latest changes from ${remote}...`);
-        await worktreeGit.fetch([remote, '--prune']);
+        await fetchNoTags(worktreeGit, ['--prune', remote]);
       }
 
       await this.ensureBaseShaAvailable(worktreeGit, prData, remote);

--- a/src/main.js
+++ b/src/main.js
@@ -5,6 +5,7 @@ const { initializeDatabase, run, queryOne, query, migrateExistingWorktrees, Work
 const { PRArgumentParser } = require('./github/parser');
 const { GitHubClient } = require('./github/client');
 const { GitWorktreeManager } = require('./git/worktree');
+const { fetchNoTags } = require('./git/fetch-helpers');
 const { WorktreePoolLifecycle } = require('./git/worktree-pool-lifecycle');
 const { startServer } = require('./server');
 const Analyzer = require('./ai/analyzer');
@@ -725,7 +726,7 @@ async function performHeadlessReview(args, config, db, flags, options, externalP
 
       // Ensure we have the base SHA available (fetch if needed)
       try {
-        await git.fetch(['origin', prData.base_sha]);
+        await fetchNoTags(git, ['origin', prData.base_sha]);
       } catch (fetchError) {
         // Fetch by SHA may fail (not all servers support it); verify SHA is available locally
         try {
@@ -1227,7 +1228,7 @@ function startPoolBackgroundFetches(db, config) {
               const git = simpleGit(entry.path, { timeout: { block: 300000 } });
               const remotes = await git.getRemotes();
               const remote = remotes.find(r => r.name === 'origin') || remotes[0];
-              if (remote) await git.fetch([remote.name, '--prune']);
+              if (remote) await fetchNoTags(git, ['--prune', remote.name]);
               await poolRepo.updateLastFetched(entry.id);
               // Refresh the lease so the stale guard only needs to outlive
               // a single stalled fetch, not the entire serial loop.

--- a/src/routes/stack-analysis.js
+++ b/src/routes/stack-analysis.js
@@ -220,7 +220,7 @@ async function executeStackAnalysis(params) {
     // 2. Bulk fetch all PR refs (runs against trigger worktree)
     const refspecs = prNumbers.map(n => `+refs/pull/${n}/head:refs/remotes/origin/pr-${n}`);
     try {
-      deps.execSync(`git fetch origin ${refspecs.join(' ')}`, {
+      deps.execSync(`git fetch --no-tags origin ${refspecs.join(' ')}`, {
         cwd: triggerWorktreePath, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'],
         timeout: 60000
       });

--- a/tests/unit/fetch-helpers.test.js
+++ b/tests/unit/fetch-helpers.test.js
@@ -1,0 +1,28 @@
+// Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it, vi } from 'vitest';
+
+const { fetchNoTags, rawFetchNoTags } = require('../../src/git/fetch-helpers');
+
+describe('git fetch helpers', () => {
+  it('prepends --no-tags to simple-git fetch arguments', async () => {
+    const git = {
+      fetch: vi.fn().mockResolvedValue('ok'),
+    };
+
+    const result = await fetchNoTags(git, ['--prune', 'origin']);
+
+    expect(result).toBe('ok');
+    expect(git.fetch).toHaveBeenCalledWith(['--no-tags', '--prune', 'origin']);
+  });
+
+  it('prepends fetch --no-tags to raw fetch arguments', async () => {
+    const git = {
+      raw: vi.fn().mockResolvedValue('ok'),
+    };
+
+    const result = await rawFetchNoTags(git, ['origin', 'abc123']);
+
+    expect(result).toBe('ok');
+    expect(git.raw).toHaveBeenCalledWith(['fetch', '--no-tags', 'origin', 'abc123']);
+  });
+});

--- a/tests/unit/stack-orchestrator.test.js
+++ b/tests/unit/stack-orchestrator.test.js
@@ -208,9 +208,10 @@ describe('executeStackAnalysis', () => {
     await executeStackAnalysis(params);
 
     const fetchCall = deps.execSync.mock.calls.find(
-      c => typeof c[0] === 'string' && c[0].includes('git fetch origin')
+      c => typeof c[0] === 'string' && c[0].includes('git fetch --no-tags origin')
     );
     expect(fetchCall).toBeTruthy();
+    expect(fetchCall[0]).toContain('git fetch --no-tags origin');
     expect(fetchCall[0]).toContain('+refs/pull/10/head:refs/remotes/origin/pr-10');
     expect(fetchCall[0]).toContain('+refs/pull/11/head:refs/remotes/origin/pr-11');
     expect(fetchCall[0]).toContain('+refs/pull/12/head:refs/remotes/origin/pr-12');

--- a/tests/unit/worktree-base-sha.test.js
+++ b/tests/unit/worktree-base-sha.test.js
@@ -46,7 +46,7 @@ describe('GitWorktreeManager base SHA availability', () => {
           }
           return 'commit\n';
         }
-        if (args[0] === 'fetch' && args[1] === 'fork-remote' && args[2] === 'base-sha') {
+        if (args[0] === 'fetch' && args[1] === '--no-tags' && args[2] === 'fork-remote' && args[3] === 'base-sha') {
           worktreeGit._seenBaseFetch = true;
           return '';
         }
@@ -64,7 +64,42 @@ describe('GitWorktreeManager base SHA availability', () => {
       repoPath
     );
 
-    expect(worktreeGit.raw).toHaveBeenCalledWith(['fetch', 'fork-remote', 'base-sha']);
+    expect(repoGit.fetch).toHaveBeenCalledWith([
+      '--no-tags',
+      'fork-remote',
+      '+refs/heads/main:refs/remotes/fork-remote/main',
+    ]);
+    expect(worktreeGit.raw).toHaveBeenCalledWith(['fetch', '--no-tags', 'fork-remote', 'base-sha']);
+  });
+
+  it('retries base branch fetch without tags when the standard fetch fails', async () => {
+    const repoPath = '/tmp/repo';
+    const repoGit = createMockGit({
+      fetch: vi.fn().mockRejectedValueOnce(new Error('ref hierarchy conflict')),
+    });
+    const worktreeGit = createMockGit({
+      raw: vi.fn(async (args) => {
+        if (args[0] === 'cat-file') return 'commit\n';
+        return '';
+      }),
+      revparse: vi.fn().mockResolvedValue('head-sha\n'),
+    });
+
+    manager._gitFor = vi.fn((dirPath) => (dirPath === repoPath ? repoGit : worktreeGit));
+
+    await manager.createWorktreeForPR(
+      { owner: 'owner', repo: 'repo', number: 42 },
+      { base_branch: 'main', base_sha: 'base-sha', head_sha: 'head-sha', head_branch: 'feature' },
+      repoPath
+    );
+
+    expect(repoGit.raw).toHaveBeenCalledWith([
+      'fetch',
+      '--no-tags',
+      '--force',
+      'fork-remote',
+      '+refs/heads/main:refs/remotes/fork-remote/main',
+    ]);
   });
 
   it('fetches the exact base SHA when updating an existing worktree', async () => {
@@ -76,7 +111,7 @@ describe('GitWorktreeManager base SHA availability', () => {
           }
           return 'commit\n';
         }
-        if (args[0] === 'fetch' && args[1] === 'fork-remote' && args[2] === 'base-sha') {
+        if (args[0] === 'fetch' && args[1] === '--no-tags' && args[2] === 'fork-remote' && args[3] === 'base-sha') {
           worktreeGit._seenBaseFetch = true;
           return '';
         }
@@ -93,8 +128,8 @@ describe('GitWorktreeManager base SHA availability', () => {
       head_sha: 'head-sha',
     });
 
-    expect(worktreeGit.fetch).toHaveBeenCalledWith(['fork-remote', '--prune']);
-    expect(worktreeGit.raw).toHaveBeenCalledWith(['fetch', 'fork-remote', 'base-sha']);
+    expect(worktreeGit.fetch).toHaveBeenCalledWith(['--no-tags', '--prune', 'fork-remote']);
+    expect(worktreeGit.raw).toHaveBeenCalledWith(['fetch', '--no-tags', 'fork-remote', 'base-sha']);
     expect(worktreeGit.checkout).toHaveBeenCalledWith(['refs/remotes/fork-remote/pr-42']);
   });
 
@@ -115,7 +150,7 @@ describe('GitWorktreeManager base SHA availability', () => {
       { skipBulkFetch: true }
     );
 
-    expect(worktreeGit.fetch).not.toHaveBeenCalledWith(['fork-remote', '--prune']);
+    expect(worktreeGit.fetch).not.toHaveBeenCalledWith(['--no-tags', '--prune', 'fork-remote']);
     expect(worktreeGit.fetch).not.toHaveBeenCalledWith(
       expect.arrayContaining([expect.stringContaining('+refs/heads/')])
     );
@@ -140,10 +175,11 @@ describe('GitWorktreeManager base SHA availability', () => {
     );
 
     expect(worktreeGit.fetch).toHaveBeenCalledWith([
+      '--no-tags',
       'fork-remote',
       '+refs/heads/main:refs/remotes/fork-remote/main',
     ]);
-    expect(worktreeGit.fetch).not.toHaveBeenCalledWith(['fork-remote', '--prune']);
+    expect(worktreeGit.fetch).not.toHaveBeenCalledWith(['--no-tags', '--prune', 'fork-remote']);
   });
 
   it('continues when targeted base-branch fetch fails under skipBulkFetch', async () => {
@@ -201,7 +237,7 @@ describe('GitWorktreeManager base SHA availability', () => {
           }
           return 'commit\n';
         }
-        if (args[0] === 'fetch' && args[1] === 'fork-remote' && args[2] === 'base-sha') {
+        if (args[0] === 'fetch' && args[1] === '--no-tags' && args[2] === 'fork-remote' && args[3] === 'base-sha') {
           worktreeGit._seenBaseFetch = true;
           return '';
         }
@@ -219,7 +255,7 @@ describe('GitWorktreeManager base SHA availability', () => {
       { owner: 'owner', repo: 'repo', number: 42 }
     );
 
-    expect(worktreeGit.raw).toHaveBeenCalledWith(['fetch', 'fork-remote', 'base-sha']);
+    expect(worktreeGit.raw).toHaveBeenCalledWith(['fetch', '--no-tags', 'fork-remote', 'base-sha']);
     expect(worktreeGit.raw).toHaveBeenCalledWith(['reset', '--hard', 'refs/remotes/fork-remote/pr-42']);
   });
 

--- a/tests/unit/worktree-checkout.test.js
+++ b/tests/unit/worktree-checkout.test.js
@@ -28,6 +28,7 @@ describe('GitWorktreeManager.checkoutBranch', () => {
 
     expect(manager.hasLocalChanges).toHaveBeenCalledWith('/tmp/worktree');
     expect(mockGit.fetch).toHaveBeenCalledWith([
+      '--no-tags',
       'origin',
       '+refs/pull/42/head:refs/remotes/origin/pr-42',
     ]);
@@ -56,6 +57,7 @@ describe('GitWorktreeManager.checkoutBranch', () => {
 
     expect(manager.resolveRemoteForPR).toHaveBeenCalledWith(mockGit, prData, null);
     expect(mockGit.fetch).toHaveBeenCalledWith([
+      '--no-tags',
       'fork-remote',
       '+refs/pull/99/head:refs/remotes/fork-remote/pr-99',
     ]);
@@ -70,6 +72,7 @@ describe('GitWorktreeManager.checkoutBranch', () => {
 
     expect(manager.resolveRemoteForPR).not.toHaveBeenCalled();
     expect(mockGit.fetch).toHaveBeenCalledWith([
+      '--no-tags',
       'origin',
       '+refs/pull/10/head:refs/remotes/origin/pr-10',
     ]);
@@ -87,7 +90,8 @@ describe('GitWorktreeManager.checkoutBranch', () => {
     await manager.checkoutBranch('/tmp/worktree', 77, { remote: 'upstream' });
 
     const fetchCall = mockGit.fetch.mock.calls[0][0];
-    expect(fetchCall[1]).toBe('+refs/pull/77/head:refs/remotes/upstream/pr-77');
+    expect(fetchCall[0]).toBe('--no-tags');
+    expect(fetchCall[2]).toBe('+refs/pull/77/head:refs/remotes/upstream/pr-77');
   });
 
   it('should fall back to fetching the head SHA when PR refs are unavailable', async () => {
@@ -100,11 +104,12 @@ describe('GitWorktreeManager.checkoutBranch', () => {
     });
 
     expect(mockGit.fetch).toHaveBeenNthCalledWith(1, [
+      '--no-tags',
       'upstream',
       '+refs/pull/42/head:refs/remotes/upstream/pr-42',
     ]);
     expect(mockGit.raw).toHaveBeenNthCalledWith(1, [
-      'fetch', 'upstream', 'abc123def456',
+      'fetch', '--no-tags', 'upstream', 'abc123def456',
     ]);
     expect(mockGit.raw).toHaveBeenNthCalledWith(2, [
       'reset', '--hard', 'abc123def456',


### PR DESCRIPTION
## Summary
- add shared git fetch helpers that always pass --no-tags
- route worktree setup, refresh, headless checkout, pool background fetches, and stack bulk fetches through no-tag fetches
- add regression tests and a patch changeset

## Tests
- pnpm exec vitest run tests/unit/fetch-helpers.test.js tests/unit/worktree-checkout.test.js tests/unit/worktree-base-sha.test.js tests/unit/worktree-pool-lifecycle.test.js tests/unit/stack-orchestrator.test.js
- node --check src/git/fetch-helpers.js
- node --check src/git/worktree.js
- node --check src/main.js
- node --check src/routes/stack-analysis.js
- git -c core.fsmonitor=false diff --check