### PR TITLE
Clean up empty nested worktree wrappers

### DIFF
--- a/.changeset/clean-empty-worktree-wrappers.md
+++ b/.changeset/clean-empty-worktree-wrappers.md
@@ -1,0 +1,7 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Clean up empty wrapper directories left behind after deleting nested `src` worktrees.
+
+When a worktree checkout is stored at `<worktreeBaseDir>/<id>/src`, deleting the git worktree removes `src` but can leave `<worktreeBaseDir>/<id>` behind as an empty ordinary directory. Pair Review now removes that wrapper only when it is inside the configured worktree base directory and empty.

--- a/src/git/worktree.js
+++ b/src/git/worktree.js
@@ -971,6 +971,7 @@ class GitWorktreeManager {
           }
           await owningRepo.raw(['worktree', 'remove', '--force', worktreePath]);
           console.log(`Removed worktree via git: ${worktreePath}`);
+          await this.cleanupEmptyWorktreeWrapper(worktreePath);
           return;
         } catch (gitError) {
           console.log('Git worktree remove failed, trying manual cleanup...');
@@ -979,11 +980,40 @@ class GitWorktreeManager {
         // git remove failed — remove directory manually
         await this.removeDirectory(worktreePath);
         console.log(`Removed worktree directory: ${worktreePath}`);
+        await this.cleanupEmptyWorktreeWrapper(worktreePath);
       }
 
     } catch (error) {
       console.warn(`Warning: Could not cleanup worktree at ${worktreePath}: ${error.message}`);
       // Don't throw - this is cleanup, continue with creation
+    }
+  }
+
+  /**
+   * Remove the empty wrapper directory left by nested checkout layouts.
+   * Pair Review can create worktrees at <base>/<id>/src so removing the git
+   * worktree leaves <base>/<id> behind as an ordinary empty directory.
+   * @param {string} worktreePath - Path to worktree that was just removed
+   * @returns {Promise<void>}
+   */
+  async cleanupEmptyWorktreeWrapper(worktreePath) {
+    if (path.basename(worktreePath) !== 'src') {
+      return;
+    }
+
+    const wrapperDir = path.dirname(worktreePath);
+    const relativeWrapper = path.relative(this.worktreeBaseDir, wrapperDir);
+    if (!relativeWrapper || relativeWrapper.startsWith('..') || path.isAbsolute(relativeWrapper)) {
+      return;
+    }
+
+    try {
+      await fs.rmdir(wrapperDir);
+      console.log(`Removed empty worktree wrapper: ${wrapperDir}`);
+    } catch (error) {
+      if (!['ENOENT', 'ENOTEMPTY', 'EEXIST'].includes(error.code)) {
+        console.warn(`Warning: Could not remove worktree wrapper ${wrapperDir}: ${error.message}`);
+      }
     }
   }
 
@@ -1309,12 +1339,14 @@ class GitWorktreeManager {
             }
             await owningRepo.raw(['worktree', 'remove', '--force', worktree.path]);
             console.log(`[pair-review] Removed worktree via git: ${worktree.path}`);
+            await this.cleanupEmptyWorktreeWrapper(worktree.path);
           } catch (gitError) {
             // If git worktree remove fails, try manual directory removal
             const exists = await this.pathExists(worktree.path);
             if (exists) {
               await this.removeDirectory(worktree.path);
               console.log(`[pair-review] Removed worktree directory manually: ${worktree.path}`);
+              await this.cleanupEmptyWorktreeWrapper(worktree.path);
             }
           }
 

--- a/tests/unit/worktree-cleanup.test.js
+++ b/tests/unit/worktree-cleanup.test.js
@@ -1,5 +1,8 @@
 // Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
 
 const { GitWorktreeManager } = require('../../src/git/worktree');
 
@@ -99,6 +102,51 @@ describe('GitWorktreeManager worktree cleanup', () => {
       manager.pruneWorktrees = vi.fn().mockRejectedValue(new Error('prune failed'));
 
       await expect(manager.cleanupWorktree('/tmp/worktrees/pr-42')).resolves.not.toThrow();
+    });
+
+    it('should remove an empty wrapper directory for nested src worktrees', async () => {
+      const baseDir = await fs.mkdtemp(path.join(os.tmpdir(), 'pair-review-worktrees-'));
+      const wrapperDir = path.join(baseDir, 'pair-review--abc');
+      const worktreePath = path.join(wrapperDir, 'src');
+      await fs.mkdir(worktreePath, { recursive: true });
+
+      manager = new GitWorktreeManager(null, { worktreeBaseDir: baseDir });
+      const mockOwningRepo = {
+        raw: vi.fn().mockImplementation(async () => {
+          await fs.rmdir(worktreePath);
+          return '';
+        }),
+      };
+      manager.resolveOwningRepo = vi.fn().mockResolvedValue(mockOwningRepo);
+      manager.pruneWorktrees = vi.fn().mockResolvedValue(undefined);
+
+      await manager.cleanupWorktree(worktreePath);
+
+      await expect(fs.access(wrapperDir)).rejects.toMatchObject({ code: 'ENOENT' });
+      await fs.rm(baseDir, { recursive: true, force: true });
+    });
+
+    it('should leave a non-empty wrapper directory in place', async () => {
+      const baseDir = await fs.mkdtemp(path.join(os.tmpdir(), 'pair-review-worktrees-'));
+      const wrapperDir = path.join(baseDir, 'pair-review--abc');
+      const worktreePath = path.join(wrapperDir, 'src');
+      await fs.mkdir(worktreePath, { recursive: true });
+      await fs.writeFile(path.join(wrapperDir, 'notes.txt'), 'keep me');
+
+      manager = new GitWorktreeManager(null, { worktreeBaseDir: baseDir });
+      const mockOwningRepo = {
+        raw: vi.fn().mockImplementation(async () => {
+          await fs.rmdir(worktreePath);
+          return '';
+        }),
+      };
+      manager.resolveOwningRepo = vi.fn().mockResolvedValue(mockOwningRepo);
+      manager.pruneWorktrees = vi.fn().mockResolvedValue(undefined);
+
+      await manager.cleanupWorktree(worktreePath);
+
+      await expect(fs.access(wrapperDir)).resolves.toBeUndefined();
+      await fs.rm(baseDir, { recursive: true, force: true });
     });
   });
 
@@ -242,6 +290,36 @@ describe('GitWorktreeManager worktree cleanup', () => {
       });
       expect(mockWorktreeRepo.delete).toHaveBeenCalledWith('wt-1');
       expect(mockWorktreeRepo.delete).not.toHaveBeenCalledWith('wt-2');
+    });
+
+    it('should remove empty wrappers for stale nested src worktrees', async () => {
+      const baseDir = await fs.mkdtemp(path.join(os.tmpdir(), 'pair-review-worktrees-'));
+      const wrapperDir = path.join(baseDir, 'pair-review--stale');
+      const worktreePath = path.join(wrapperDir, 'src');
+      await fs.mkdir(worktreePath, { recursive: true });
+
+      const mockOwningRepo = {
+        raw: vi.fn().mockImplementation(async (args) => {
+          if (args[0] === 'rev-parse' && args[1] === '--git-dir') {
+            return path.join(baseDir, 'repo.git');
+          }
+          await fs.rmdir(worktreePath);
+          return '';
+        }),
+      };
+      manager = new GitWorktreeManager(null, { worktreeBaseDir: baseDir });
+      manager.resolveOwningRepo = vi.fn().mockResolvedValue(mockOwningRepo);
+      manager.pruneWorktrees = vi.fn().mockResolvedValue(undefined);
+      manager.worktreeRepo = {
+        findStale: vi.fn().mockResolvedValue([{ id: 'wt-1', path: worktreePath }]),
+        delete: vi.fn().mockResolvedValue(undefined),
+      };
+
+      const result = await manager.cleanupStaleWorktrees(7);
+
+      expect(result.cleaned).toBe(1);
+      await expect(fs.access(wrapperDir)).rejects.toMatchObject({ code: 'ENOENT' });
+      await fs.rm(baseDir, { recursive: true, force: true });
     });
 
     it('should skip cleanup when no database connection', async () => {


### PR DESCRIPTION
If a Pair Review worktree is nested under `src`, deleting it from the UI can remove the git checkout but leave the parent wrapper directory behind.

For example, in my World setup the tracked git worktree path is:

```text
/Users/jamesmeng/world/trees/pair-review--ivm/src
```

When the UI deletes that review, Pair Review cleans up `src`, but the parent directory remains:

```text
/Users/jamesmeng/world/trees/pair-review--ivm
```

That leftover directory is harmless, but it is also now invisible to both Git and Pair Review:

- `git worktree prune` only knows about the git checkout metadata
- Pair Review deletes the DB row during UI deletion
- the parent wrapper is just an ordinary empty directory at that point

This builds on #353. That PR fixed resolving the owning repo for bare-repo worktree cleanup. This follow-up handles the extra wrapper directory that can remain after the nested checkout is removed.

## What changed

After removing a worktree, Pair Review now does a small best-effort cleanup for nested `src` layouts:

- only applies when the removed path basename is exactly `src`
- only targets the parent directory if it is under `worktreeBaseDir`
- only removes the parent if it is empty
- leaves non-empty wrappers alone

I wired this into both direct worktree deletion and stale worktree cleanup.

## Testing

```text
npx vitest run tests/unit/worktree-cleanup.test.js
npx vitest run tests/unit/worktree-settings.test.js tests/integration/worktree-settings.test.js
```

I have not done the final manual UI test yet; this is a draft so I can verify it against a real Pair Review-created World worktree later.
