### PR TITLE
Fetch and display GitHub PR review comments inline

### DIFF
--- a/.changeset/consolidate-refresh-external-comments-button.md
+++ b/.changeset/consolidate-refresh-external-comments-button.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Consolidate the "Refresh GitHub comments" button to a single location in the Review panel header, and resize its icon to match the adjacent navigation controls. The duplicate button next to **Analyze** has been removed; use the Review panel button or the top-level PR refresh button instead.

--- a/.changeset/external-comments-feature-toggle.md
+++ b/.changeset/external-comments-feature-toggle.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": minor
+---
+
+GitHub PR review-comment integration is now opt-in via a new `external_comments` flag in `~/.pair-review/config.json`. Defaults to `false`. When enabled, the **External** segment, the refresh button, the background sync, and the `/api/reviews/*/external-comments*` endpoints all light up. When disabled (the new default), they are completely absent — no UI, no requests, no routes mounted.

--- a/.changeset/fetch-github-review-comments.md
+++ b/.changeset/fetch-github-review-comments.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": minor
+---
+
+Display existing GitHub PR review comments inline in the diff alongside AI suggestions and user comments, with a distinct blue theme. Threads are preserved and each comment includes a chat-about button so you can discuss it with the AI.

--- a/.changeset/polish-external-comment-thread-layout.md
+++ b/.changeset/polish-external-comment-thread-layout.md
@@ -1,0 +1,7 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Polish the inline GitHub PR review comment display: bulleted lists, italics, and blockquotes inside comment bodies now render correctly, and root/reply cards share a clean right edge. The dedicated "Chat about thread" button is gone — the chat icon on the thread's root comment now opens a thread chat, while reply icons still chat about that single reply.
+</content>
+</invoke>

--- a/.changeset/review-panel-external-segment.md
+++ b/.changeset/review-panel-external-segment.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": minor
+---
+
+Add an **External** segment to the Review panel's navigation bar (AI | User | External | All), listing one entry per external GitHub PR review thread. Clicking an entry scrolls the inline thread into view and briefly highlights it. The External segment is hidden in Local mode. The segment bar now also supports horizontal scrolling via left/right chevrons when its buttons don't all fit in the panel width.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@
   - [Customization](#customization)
   - [Review Feedback Export](#review-feedback-export)
   - [Inline Comments](#inline-comments)
+  - [GitHub Review Comments](#github-review-comments)
   - [Comment Format](#comment-format)
   - [Local Mode](#local-mode)
 - [Claude Code Plugins](#claude-code-plugins)
@@ -514,6 +515,20 @@ The markdown includes file paths, line numbers, and your comments - everything t
 - See all comments in context with the diff
 - Edit or discard AI suggestions before finalizing
 - Comments include file and line number for precision
+
+### GitHub Review Comments
+
+When reviewing a PR, pair-review fetches existing inline review comments from GitHub and shows them in the diff alongside AI suggestions (orange) and your own draft comments (purple). External comments render as read-only blue-themed bubbles, with threads preserved (root plus replies). Each comment and each thread has a "Chat about this" button that opens the AI chat panel with the comment as context, so you can quickly ask the agent to investigate, explain, or draft a response.
+
+Sync runs automatically when the PR page loads (non-blocking) and on demand via a refresh button — there's no need to reload the page to pick up new comments.
+
+**Current scope:**
+
+- **Read-only.** No reply, resolve, or adopt actions in this iteration — pair-review surfaces the conversation but doesn't write back to GitHub from these bubbles. Use your usual GitHub workflow to reply or resolve.
+- **Inline (line-anchored) comments only.** The PR conversation tab (general issue comments) is not included.
+- **Outdated comments are kept.** If later commits removed the anchor line, the comment renders at its original location with an "outdated" badge so historical context isn't lost.
+- **No dedup of your own comments yet.** If you submitted a review from pair-review and later replied via the GitHub web UI, those replies may appear in the list under your GitHub username. Deduplication of pair-review-originated comments is on the roadmap.
+- **GitHub only, PR mode only.** The fetcher is built on an adapter pattern in `src/external/` so additional sources (GitLab, Linear, etc.) can be added later, but GitHub is the only supported source today. Local mode reviews don't fetch external comments.
 
 ### Comment Format
 

--- a/README.md
+++ b/README.md
@@ -237,6 +237,15 @@ On first run, pair-review creates `~/.pair-review/config.example.json` with comp
 
 For advanced configuration with custom providers and models, see [AI Provider Configuration](#ai-provider-configuration) below.
 
+#### Feature toggles
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `external_comments` | `false` | Opt-in: set to `true` to fetch and display GitHub PR review comments inline. Enables the **External** segment, the refresh button, and `/api/reviews/*/external-comments*` routes. |
+| `enable_chat` | `true` | Enables the chat panel feature (uses `chat_provider`). |
+| `enable_graphite` | `false` | Show Graphite links alongside GitHub links. |
+| `skip_update_notifier` | `false` | Suppress the "update available" notification on exit. |
+
 ### Configuration Files
 
 pair-review loads configuration from multiple files, merged in order of increasing precedence:

--- a/config.example.json
+++ b/config.example.json
@@ -13,6 +13,8 @@
   "debug_stream": false,
   "yolo": false,
   "skip_update_notifier": false,
+  "_external_comments_comment": "Opt-in feature toggle for fetching and displaying GitHub PR review comments inline. Default: false. Set to true to enable the External segment, refresh button, and /api/reviews/*/external-comments* routes.",
+  "external_comments": false,
   "chat": {
     "enable_shortcuts": true,
     "enter_to_send": true

--- a/plans/fetch-external-review-comments.md
+++ b/plans/fetch-external-review-comments.md
@@ -1,0 +1,359 @@
+# Fetch External Review Comments (Read-Only)
+
+## Goal
+
+Display review comments from external systems inline in pair-review's diff
+view, alongside existing AI suggestions (orange) and user comments (purple).
+External comments get a **blue** theme. Read-only — no reply, no resolve, no
+adopt. Threading preserved.
+
+First (and only) external source in this plan: **GitHub** PR inline review
+comments (`/pulls/{n}/comments`). The schema, API, and UI are designed so
+that adding GitLab, Linear, or other sources later is a per-source adapter,
+not a redesign.
+
+Primary value: the reviewer sees what other humans already said, and can use
+the existing **chat-about** flow to discuss any external thread or individual
+comment with the AI.
+
+Out of scope:
+- Replies, resolves, mark-as-outdated actions
+- Issue-level (PR conversation tab) comments — only line-anchored inline
+  review comments
+- Dedup of comments that originated from this pair-review session (deferred)
+- Local mode (no external source exists)
+- Non-GitHub adapters (designed-for, not built)
+
+---
+
+## Design Decisions
+
+### 1. Separate `external_comments` table
+
+External comments do **not** share the existing `comments` table. Three
+reasons:
+
+- **Lifecycle mismatch.** AI suggestions go `active → adopted/dismissed`.
+  User comments go `draft → submitted`. External comments are immutable
+  mirrors synced via upsert. Same `status` column, three different
+  meanings — junk drawer.
+- **Identity differs.** External authors are remote users; internal
+  comments are authored by the local reviewer. Different semantics.
+- **Upsert constraint.** External rows need `UNIQUE(review_id, source,
+  external_id)` for idempotent sync. That constraint doesn't belong on
+  internal comments.
+
+Tradeoff: two tables, two query paths. Frontend reconciles into one
+rendering pass. Worth it.
+
+### 2. `external_comments` schema
+
+New table, new migration in [src/database.js](src/database.js):
+
+| Column | Type | Notes |
+| --- | --- | --- |
+| `id` | INTEGER PK | Local id |
+| `review_id` | INTEGER FK | → `reviews(id)` |
+| `source` | TEXT | `'github'` for now; future `'gitlab'`, `'linear'` |
+| `external_id` | TEXT | The source system's comment id (TEXT — GitHub uses ints, others use strings) |
+| `in_reply_to_id` | TEXT | Raw external `in_reply_to_id` value; resolved to local `parent_id` during sync |
+| `parent_id` | INTEGER | FK → `external_comments(id)`; null for thread root |
+| `external_url` | TEXT | Permalink to the comment in the source system |
+| `author` | TEXT | Username on the source system |
+| `author_url` | TEXT | Profile link (optional) |
+| `file` | TEXT | Path |
+| `side` | TEXT | `'LEFT'` / `'RIGHT'` |
+| `line_start`, `line_end` | INTEGER | Current line anchor (null if outdated) |
+| `diff_position` | INTEGER | Source-system diff position (null if outdated) |
+| `commit_sha` | TEXT | Source `commit_id` (current) |
+| `is_outdated` | INTEGER (0/1) | True when `position` was null on fetch |
+| `original_line_start`, `original_line_end` | INTEGER | Anchor at the time the comment was created |
+| `original_commit_sha` | TEXT | `original_commit_id` |
+| `body` | TEXT | Comment markdown |
+| `external_created_at` | TEXT | ISO timestamp when created in source system |
+| `synced_at` | TEXT | ISO timestamp of last sync |
+
+**Indexes:**
+- `UNIQUE(review_id, source, external_id)` — primary upsert key
+- `INDEX(review_id, file, line_end)` — fast lookup for diff-row rendering
+- `INDEX(review_id, source, in_reply_to_id)` — parent resolution
+
+Per CLAUDE.md SQLite migration safety rules: idempotent (`CREATE TABLE
+IF NOT EXISTS`), wrapped in a transaction, with index names matching
+production exactly so the test schemas in
+[tests/e2e/global-setup.js](tests/e2e/global-setup.js) and
+[tests/integration/routes.test.js](tests/integration/routes.test.js) stay
+in lockstep.
+
+### 3. Outdated handling
+
+- GitHub returns `position: null` on outdated comments → set
+  `is_outdated = 1`, leave `line_*` / `diff_position` null, populate
+  `original_*` fields.
+- Renderer falls back to `original_line_*` when `line_*` is null.
+- Display: faded styling + "outdated" badge in the comment header,
+  expanded by default.
+- If both current and original positions are null (rare, force-push
+  edge case): skip and increment a `lostAnchors` count in the sync
+  response so the user knows some weren't shown.
+
+### 4. GitHubClient method
+
+Add `listReviewComments({ owner, repo, pull_number })` to
+[src/github/client.js](src/github/client.js). Wrap
+`octokit.pulls.listReviewComments` with `octokit.paginate()`. Reuse the
+existing error / rate-limit handling at lines 213-219. Return raw API
+objects — mapping to `external_comments` rows happens in the route layer
+(keeps the client thin and testable).
+
+### 5. Source adapter shape
+
+A thin mapper per source. For now, just GitHub:
+
+```
+src/external/
+  github-adapter.js     // maps GitHub API row → external_comments row
+  index.js              // dispatches by source name
+```
+
+`github-adapter.js` exports `mapComment(apiRow) → row` and
+`fetch({ client, owner, repo, pull_number }) → apiRow[]`. New sources
+land as sibling files implementing the same interface — no changes to
+routes or storage.
+
+### 6. Sync endpoint and trigger
+
+**Endpoint:** `POST /api/reviews/:reviewId/external-comments/sync?source=github`
+
+- Resolves the review's PR coords from DB.
+- Dispatches to the adapter for `source`.
+- Two-pass insert inside a transaction:
+  1. Upsert all rows with `parent_id = NULL`, keyed on
+     `(review_id, source, external_id)`.
+  2. Resolve `parent_id` for any row with `in_reply_to_id != NULL` by
+     looking up the local id of the parent (same review, same source,
+     matching `external_id`).
+- Returns `{ count, lostAnchors, syncedAt }`.
+
+**Trigger:**
+- Auto-fire on PR page load, non-blocking. Failure → small toast, page
+  still renders.
+- Manual "refresh external comments" button in the page header.
+
+### 7. Fetch and storage repo
+
+Add `ExternalCommentRepository` in [src/database.js](src/database.js):
+- `upsert(row)` — handles the UNIQUE constraint
+- `resolveParents(reviewId, source)` — second-pass parent resolution
+- `listByReview(reviewId, { source? })` — returns rows ordered for
+  rendering
+- `listThreadsByReview(reviewId, { source? })` — groups by root
+  (`parent_id IS NULL`) with replies attached
+
+**The existing `comments` table is untouched.** `getUserComments` stays
+as-is. No rename, no shared-function ripple.
+
+### 8. Frontend fetch and render
+
+**Endpoint:** `GET /api/reviews/:reviewId/external-comments?source=github`
+returns the thread-grouped shape:
+
+```
+[
+  { id, source: 'github', ...rootFields,
+    replies: [{ id, ...replyFields }, ...] },
+  ...
+]
+```
+
+**Module:** new `public/js/modules/external-comment-manager.js`. Mirrors
+the row-insertion logic in
+[public/js/modules/comment-manager.js](public/js/modules/comment-manager.js)
+but read-only — no draft/submit/edit/dismiss code paths.
+
+- Inserts `.external-comment-row` rows after the appropriate diff line.
+- Each row is a thread: root comment + indented replies in a single
+  card. One level of indent; no infinite nesting (GitHub itself treats
+  threads as flat-with-replies).
+- Per-comment chat-about button on every comment.
+- Per-thread chat-about button on the thread root.
+
+### 9. Theming
+
+Per-source CSS variables so future systems get their own colors without
+class renames. In [public/css/pr.css](public/css/pr.css):
+
+**Light:**
+```css
+--external-github-primary: #0969da;       /* GitHub brand blue */
+--external-github-subtle:  rgba(9, 105, 218, 0.08);
+--external-github-border:  rgba(9, 105, 218, 0.3);
+```
+
+**Dark:**
+```css
+--external-github-primary: #58a6ff;
+--external-github-subtle:  rgba(88, 166, 255, 0.1);
+--external-github-border:  rgba(88, 166, 255, 0.3);
+```
+
+Classes:
+- `.external-comment-row` / `.external-comment-cell` / `.external-comment`
+  — structural, source-agnostic
+- `.external-comment.source-github` — pulls the GitHub variables
+- `.external-comment.is-outdated` — muted variant
+- `.external-comment.is-reply` — indent + lighter background
+
+Future GitLab support = add `.source-gitlab` rule + three new variables.
+
+### 10. Chat-about wiring
+
+The chat panel currently accepts `suggestionContext`, `commentContext`,
+`fileContext` ([public/js/components/ChatPanel.js:527-602](public/js/components/ChatPanel.js)).
+Extend `commentContext` and add `threadContext`:
+
+```js
+// Per-comment
+window.chatPanel.open({
+  commentContext: {
+    commentId: localDbId,         // external_comments.id
+    body, file, line_start, line_end,
+    parentId,
+    source: 'external',            // distinguishes from internal user comments
+    externalSource: 'github',      // drives theming + label
+    author, externalUrl, isOutdated,
+  },
+});
+
+// Per-thread (root + replies)
+window.chatPanel.open({
+  threadContext: {
+    rootId, source: 'external', externalSource: 'github',
+    comments: [{ author, body, isOutdated, ... }, ...],
+    file, line_start, line_end,
+  },
+});
+```
+
+`ChatPanel._openInner` learns the `threadContext` branch and
+`_sendCommentContextMessage` / a new `_sendThreadContextMessage` render
+a blue-themed context card. Card style is driven by `externalSource` so
+new sources get the right color automatically.
+
+### 11. Local mode
+
+External comments are PR-mode only. [src/routes/local.js](src/routes/local.js)
+and [public/js/local.js](public/js/local.js) are untouched. Verify no
+`.external-comment-row` elements render on `/local/:reviewId` paths.
+
+---
+
+## Implementation Steps
+
+1. **DB migration** — create `external_comments` table + indexes,
+   idempotent and transactional. Update both test schemas.
+
+2. **GitHubClient method** — `listReviewComments` with pagination, unit
+   tests including rate-limit and 404 paths.
+
+3. **Adapter scaffolding** — `src/external/github-adapter.js` and
+   `src/external/index.js` (dispatch by source name).
+
+4. **Repository** — `ExternalCommentRepository` with upsert, parent
+   resolution, list-by-review, list-threads. Integration tests for
+   each.
+
+5. **Sync route** — `POST /api/reviews/:reviewId/external-comments/sync`.
+   Integration tests: fresh sync, re-sync idempotency, outdated handling,
+   threaded comments with out-of-order arrival, lost-anchor counting,
+   GitHub API error path, concurrent-sync guard.
+
+6. **Fetch route** — `GET /api/reviews/:reviewId/external-comments`
+   returning thread-grouped shape.
+
+7. **Frontend module** — `external-comment-manager.js`. Render rows,
+   thread grouping, per-source class application, chat-about handlers.
+
+8. **CSS** — per-source variables (light + dark), structural classes,
+   outdated + reply variants.
+
+9. **ChatPanel integration** — `commentContext` learns `source:
+   'external'` + `externalSource`; new `threadContext` branch; blue
+   context card styling.
+
+10. **PR page wiring** — auto-fire sync on load, refresh button, error
+    toast.
+
+11. **E2E test** — mock GitHub API, load PR, assert: blue-themed rows
+    render at the right lines, thread structure correct, outdated
+    badge appears where expected, chat-about opens with the right
+    payload, refresh button re-syncs.
+
+12. **Changeset** — `.changeset/*.md` with `minor` bump.
+
+13. **README** — feature blurb under Features describing external
+    review-comment display, current source list (GitHub), and the
+    read-only scope.
+
+---
+
+## Hazards
+
+- **Shared rendering surface.** Three independent renderers append rows
+  after the same diff lines:
+  `.ai-suggestion-row`, `.user-comment-row`, `.external-comment-row`.
+  Decide ordering up front (suggest: AI → user → external, then by
+  `created_at` within group) and ensure each renderer only touches its
+  own row class on re-render. Cross-check
+  [public/js/modules/comment-manager.js:535-633](public/js/modules/comment-manager.js)
+  and the suggestion-manager append logic before wiring the new module.
+
+- **Parent resolution requires two passes.** GitHub returns comments in
+  API order, not parent-before-child. Sync inserts all rows with
+  `parent_id = NULL` then resolves in a second pass. Wrap both in one
+  transaction — partial state would orphan replies. Pre-flight check:
+  `DROP TABLE IF EXISTS` on any temp tables used in the migration to
+  stay idempotent per CLAUDE.md SQLite rules.
+
+- **Concurrent sync.** Page-load sync + manual refresh can race. Row-
+  level upsert via `UNIQUE(review_id, source, external_id)` is safe,
+  but two interleaving parent-resolution passes could briefly leave a
+  reply unparented. Guard with a per-`(review_id, source)` in-flight
+  flag in the route; second caller waits or returns "already syncing".
+
+- **Lost anchors.** When both `position` and `original_position` are
+  null (force-push edge case), the comment has no place to render.
+  Count and surface in the sync response. Do NOT silently drop —
+  reviewer should know.
+
+- **Author identity collision.** A user who replied to a GitHub thread
+  via the web UI will appear in the external feed under their GitHub
+  username, even if it's "them". Dedup of pair-review-originated
+  comments is deferred — when that lands, this is where it'll hook in.
+  Document the dedup gap in the README.
+
+- **Test schemas must mirror production.** Per CLAUDE.md, update
+  [tests/e2e/global-setup.js](tests/e2e/global-setup.js) and
+  [tests/integration/routes.test.js](tests/integration/routes.test.js)
+  with the new table AND its indexes. Index names must match exactly.
+
+- **Browser-tab discipline.** Per CLAUDE.md, no new code path may call
+  the `open` npm package outside the existing
+  `PAIR_REVIEW_NO_OPEN`-gated paths. External-comment permalinks are
+  plain `<a target="_blank">` — browser-handled, no Node involvement.
+  E2E test runs must include `PAIR_REVIEW_NO_OPEN=1`.
+
+- **No hot-reload.** Per CLAUDE.md, config is loaded once at startup —
+  do not add cleanup logic for config reapply scenarios.
+
+- **Three analyzer code paths.** This plan does not touch the analyzer,
+  so the `analyzeAllLevels` / `runReviewerCentricCouncil` /
+  `runCouncilAnalysis` parity rule is N/A. Worth noting in case a
+  follow-up wants to feed external comments into AI analysis as
+  context — that change would have to land in all three paths.
+
+- **ESM-only dependencies.** No new deps proposed. If one becomes
+  necessary (e.g., a richer markdown renderer for external bodies),
+  check for `"type": "module"` in its package.json per the CLAUDE.md
+  ESM rule and use the lazy-`import()` pattern from
+  [src/chat/acp-bridge.js](src/chat/acp-bridge.js).

--- a/plans/review-panel-external-segment.md
+++ b/plans/review-panel-external-segment.md
@@ -1,0 +1,225 @@
+# Review Panel: External Segment + Overflow Scroll
+
+## Goal
+
+Add a fourth segment, **External**, to the Review panel segment switcher so
+the bar reads **AI | User | External | All**. The External segment lists one
+entry per external (GitHub PR) comment thread; clicking an entry scrolls to
+that thread inline, mirroring the existing AI/User behavior. Inline rows are
+unaffected by which segment is selected — segments only switch the navigation
+list.
+
+Also: when the segment buttons don't all fit in the panel width, show `<` /
+`>` chevrons on the left/right to scroll the segment row horizontally.
+
+The External segment is **hidden in Local mode** (no external source exists
+there, and the segment would always be empty).
+
+## Decisions (confirmed with user)
+
+- **One entry per thread**, anchored on the root. Reply count shown as a
+  badge. Inline view already has per-comment granularity.
+- **Segment selection does not hide inline rows.** Today AI/User segments
+  don't hide anything in the diff — only the panel's nav list changes. New
+  segment follows the same rule.
+- **Blue theming.** External list items pick up the same `--ec-*` CSS
+  variables used by inline external comments, with `.source-github` driving
+  per-source colors.
+- **Local mode**: hide the External segment button entirely.
+
+---
+
+## File Map (from exploration)
+
+| Concern | File | Anchor |
+|---|---|---|
+| Panel component | `public/js/components/AIPanel.js` | `selectedSegment` 38, `getFilteredItems` 611, `renderFindings` 666, `onFindingClick` 932, `scrollToComment` 1061 |
+| Segment HTML | `public/pr.html` | 1283-1288 |
+| External manager (data source) | `public/js/modules/external-comment-manager.js` | `threadsBySource` 33, `loadAndRender` 85, `_buildThreadRow` 425 |
+| Theming variables | `public/css/pr.css` | `:root --external-github-*` 709-724, dark overrides 815-824, `.external-comment.source-github` 4740 |
+| Segment E2E patterns | `tests/e2e/ai-analysis.spec.js` | 304-416 |
+| External E2E | `tests/e2e/external-comments.spec.js` | n/a (extend) |
+
+---
+
+## Implementation
+
+### 1. HTML — segment button + scroll chevrons
+
+[public/pr.html:1283-1288](public/pr.html:1283)
+
+- Wrap the existing segment row in a container that allows horizontal overflow
+  scrolling (`overflow-x: auto; scroll-behavior: smooth;`).
+- Insert chevrons (`<button class="segment-scroll segment-scroll--left">`
+  and `--right`) flanking the scrollable area. Default to hidden; reveal via
+  JS when `scrollWidth > clientWidth`.
+- Insert new `<button class="segment-btn" data-segment="external"
+  data-target-type="external">External <span class="segment-count">0</span></button>`
+  between `comments` and `all`.
+- In Local mode the button is rendered with `[hidden]` (or omitted) via a
+  body-class gate — see step 7.
+
+### 2. AIPanel state + filtering
+
+[public/js/components/AIPanel.js](public/js/components/AIPanel.js)
+
+- Add `this.externalThreads = []` to the constructor (alongside `findings`,
+  `comments`).
+- New `setExternalThreads(threads)` method mirrors `setComments()`:
+  - Replace state.
+  - Recompute filtered list.
+  - Re-render the visible list (`renderFindings()` is the entry point —
+    rename internal helpers if needed, but keep public method name stable to
+    avoid breaking callers).
+  - Update the `External` count badge.
+- Extend `getFilteredItems()`:
+  - `'external'` branch returns `this.externalThreads.map(thread => ({
+    ...thread, _itemType: 'external' }))`.
+  - `'all'` branch concatenates external threads alongside findings + comments.
+- Sort: `sortItemsByFileOrder()` currently keys on `file` / `line` /
+  `line_start`. Verify external threads carry these on the root (they do —
+  see `_buildThreadRow` line resolution). Add a defensive `?? 0` fallback in
+  the comparator to keep it safe for any item missing keys.
+
+### 3. List item rendering
+
+- New `renderExternalThreadItem(thread)` modeled on `renderCommentItem()`.
+- DOM:
+  - `.ai-panel__list-item .ai-panel__list-item--external.source-${thread.source}`
+  - Author (root.author), short body snippet (first 80 chars of root.body,
+    plain text — strip markdown), `file:line` tag, reply count badge if
+    `thread.replies.length > 0`, `is-outdated` class when root is outdated.
+- `data-item-type="external"`, `data-thread-id=root.id`,
+  `data-source=root.source`, `data-file`, `data-line` for the scroll handler.
+
+### 4. Click → scroll-to-inline
+
+[onFindingClick](public/js/components/AIPanel.js:932)
+
+- Add `'external'` branch calling `scrollToExternalThread(threadId, source,
+  file, line)`.
+- New `scrollToExternalThread()` mirrors `scrollToComment()`:
+  1. Expand the file's collapse state if needed.
+  2. Find `.external-comment-row[data-thread-id="..."][data-source="..."]`.
+     **Hazard:** confirm `_buildThreadRow` writes those data attributes — if
+     not, add them (low-touch).
+  3. `scrollIntoView({ behavior: 'smooth', block: 'center' })`.
+  4. Add a transient `.external-comment-row--focused` class (2s timeout) for
+     the visual flash. Style with `--ec-primary` outline.
+
+### 5. External manager → panel handoff
+
+[external-comment-manager.js](public/js/modules/external-comment-manager.js)
+
+- After `loadAndRender()` finishes (success path) and after a manual refresh,
+  call `window.aiPanel?.setExternalThreads(allThreadsFlattened)`.
+  Flatten `threadsBySource` into a single array — the panel doesn't care
+  about source grouping in the list.
+- On manager init, if `window.aiPanel` is ready, push current threads
+  immediately so a late-instantiated panel still receives them.
+
+### 6. CSS — theming for the list items
+
+[public/css/pr.css](public/css/pr.css)
+
+- New section near the existing list-item rules:
+  - `.ai-panel__list-item--external` — uses `--ec-*` for border-left, hover
+    background, and reply-count badge tint.
+  - `.ai-panel__list-item--external.source-github` — maps `--ec-primary` etc.
+    to `--external-github-*`, matching the inline indirection pattern at line
+    4740.
+  - `.ai-panel__list-item--external.is-outdated` — faded + dashed border,
+    matching inline `.external-comment.is-outdated`.
+- Dark-mode overrides under `[data-theme="dark"]` mirroring the existing
+  inline pattern at lines 815-824 / 4920-4934.
+
+### 7. Local-mode gating
+
+- `pr.js` (PR mode) renders normally; `local.js` runs in Local mode.
+- Add a body-level marker the CSS / panel JS can key off:
+  - In Local mode, when AIPanel initializes, hide the External segment
+    button: `this.elements.segmentExternal?.setAttribute('hidden', '')`.
+  - Drop the external segment from the `all` filter when running in Local
+    mode (it'll be empty anyway, but keep it tidy).
+- The simplest signal is `typeof window.localManager !== 'undefined'` (or
+  whatever the existing Local-mode init module exposes — verify on read pass).
+
+### 8. Segment overflow scroll buttons
+
+- New module or section inside AIPanel: `setupSegmentOverflow()`.
+- On panel init and on `ResizeObserver` (observe the segment-row container):
+  - If `scrollWidth > clientWidth + 1`, show both chevrons (`.hidden` toggled
+    based on `scrollLeft` to suppress the relevant one at each end).
+  - Otherwise hide both.
+- Click handlers on chevrons scroll the container by `~150px` (one segment
+  width).
+- On `scroll` event update chevron visibility (`scrollLeft === 0` hides
+  left; `scrollLeft + clientWidth >= scrollWidth` hides right).
+- CSS: chevrons sit `position: absolute` over the row edges with a small
+  gradient mask so segments fading under them read cleanly.
+
+### 9. Tests
+
+- **Unit** (`tests/unit/`):
+  - Extend or add a sibling to `ai-panel-collapse.test.js`:
+    - `setExternalThreads()` stores state, updates filtered list when
+      `selectedSegment === 'external'`.
+    - `getFilteredItems()` returns external threads when segment is `'external'`,
+      and includes them in `'all'`.
+  - New: a small unit test for `sortItemsByFileOrder()` with mixed item types.
+- **E2E** (`tests/e2e/external-comments.spec.js`):
+  - Add a `describe('External segment in Review panel')` block:
+    - With external threads mocked, panel shows an `External` segment with
+      correct count.
+    - Clicking the segment switches active state to External.
+    - List shows one item per thread; each item has the blue source-github
+      accent.
+    - Clicking an item scrolls to and highlights the inline external row.
+- **E2E** (Local mode):
+  - In a Local-mode test (use the existing local mode harness if present),
+    assert the External segment button is not visible.
+- **E2E** (overflow scroll):
+  - Resize viewport to a narrow width and assert chevrons appear; click
+    right chevron and assert `scrollLeft` increases.
+
+---
+
+## Hazards
+
+- **`getFilteredItems()` has multiple consumers**: count badges, "no items"
+  empty-state copy, keyboard-navigation helpers (if any), All-segment
+  aggregator. Trace every call and confirm each handles `external` items
+  before declaring done.
+- **Async external arrival**: panel may render before external sync finishes.
+  `setExternalThreads()` must re-render without disturbing the currently
+  focused segment or scroll position of the list.
+- **`sortItemsByFileOrder()`**: assumes file/line keys; external thread roots
+  carry these on the root comment. For outdated threads the live coordinates
+  may be null — fall back to `original_line` to keep ordering stable. Add a
+  `?? 0` guard so a missing key never crashes the comparator.
+- **`comment-minimizer.js`**: it toggles inline rows. Confirm it ignores
+  `.external-comment-row` so the External panel filter has no inline side
+  effect (user explicitly does not want segment selection to hide rows).
+- **localStorage `reviewPanelSegment_${PRKey}`**: legacy values like `'all'`
+  must still be honored; an unknown stored value should fall back to `'ai'`.
+- **Two render entry points**: external rows are created in
+  `_buildThreadRow`; if a refresh happens, the row DOM is rebuilt and
+  `.external-comment-row--focused` classes are lost. Acceptable — flash is
+  transient. But confirm `data-thread-id` survives a rebuild.
+- **PR mode vs Local mode parity (CLAUDE.md rule)**: changes must work in
+  both. External segment is intentionally hidden in Local mode; verify the
+  rest of the panel (and overflow scroll) still work there.
+- **Re-anchoring on diff rebuild**: when `refreshPR` rebuilds the diff DOM,
+  external rows are torn down and re-rendered. The panel item's
+  `data-thread-id` lookup must keep working. Confirm
+  `external-comment-manager._loadExternalComments()` re-fires after rebuild
+  (it does — see PR comment in `pr.js:1088`).
+
+---
+
+## Out of Scope
+
+- Per-source filtering inside External (only GitHub today; future).
+- Inline filter for outdated external threads (separate concern).
+- Bulk actions on external threads.
+- Search/filter within the External list.

--- a/public/css/pr.css
+++ b/public/css/pr.css
@@ -4969,6 +4969,15 @@ tr.line-range-start .d2h-code-line-ctn {
   color: var(--color-danger, #d1242f);
 }
 
+/* Feature toggle: when `external_comments` is false in config, the
+   /runtime-config.js script adds `external-comments-disabled` to
+   documentElement before AIPanel/pr.js construct. Any element marked
+   `.external-comments-only` is hidden synchronously so the user never sees
+   external-related controls flicker into view. */
+:root.external-comments-disabled .external-comments-only {
+  display: none !important;
+}
+
 /* ========================================
    Dismissed User Comment Styling
    Visual state for soft-deleted comments when "show dismissed" is enabled

--- a/public/css/pr.css
+++ b/public/css/pr.css
@@ -710,6 +710,15 @@
   --comment-subtle: rgba(130, 80, 223, 0.08);
   --comment-border: rgba(130, 80, 223, 0.3);
 
+  /* External review-comment accent colors - blue, themed per source.
+     One block per source so future sources (GitLab, Linear, etc.) get
+     their own palette without renaming classes. The .source-<name> rule
+     on .external-comment maps these into --ec-* locals. */
+  --external-github-primary: #0969da;
+  --external-github-secondary: #0860c5;
+  --external-github-subtle: rgba(9, 105, 218, 0.08);
+  --external-github-border: rgba(9, 105, 218, 0.3);
+
   /* Reasoning toggle hover - deep purple for light backgrounds */
   --color-reasoning-hover: #7c3aed;
   --color-reasoning-hover-bg: rgba(124, 58, 237, 0.1);
@@ -806,6 +815,13 @@
   --comment-primary: #a371f7;
   --comment-subtle: rgba(163, 113, 247, 0.1);
   --comment-border: rgba(163, 113, 247, 0.3);
+
+  /* External review-comment accent colors - blue, themed per source (dark theme).
+     Mirrors the light-theme block above. */
+  --external-github-primary: #58a6ff;
+  --external-github-secondary: #79b8ff;
+  --external-github-subtle: rgba(88, 166, 255, 0.1);
+  --external-github-border: rgba(88, 166, 255, 0.3);
 
   /* Reasoning toggle hover - rich purple for dark backgrounds */
   --color-reasoning-hover: #9333ea;
@@ -4677,6 +4693,237 @@ tr.line-range-start .d2h-code-line-ctn {
 }
 
 /* ========================================
+   External Review Comments Display
+   Read-only mirror of comments from external systems (GitHub PR review
+   comments first; GitLab/Linear/etc. land as per-source rules below).
+   Structural rules are source-agnostic; color comes via the --ec-*
+   indirection set by .source-<name>.
+   ======================================== */
+.external-comment-row {
+  border: none;
+}
+
+.external-comment-cell {
+  padding: 4px 0;
+  background: transparent;
+}
+
+/* Source-agnostic defaults. .source-<name> rules below override these
+   indirection variables, and every internal rule references --ec-* so
+   adding a new source is just a new variable block + .source-<name>. */
+.external-comment {
+  --ec-primary: var(--comment-primary);
+  --ec-secondary: var(--comment-primary);
+  --ec-subtle: var(--comment-subtle);
+  --ec-border: var(--comment-border);
+
+  background: linear-gradient(to right, var(--ec-subtle) 0%, var(--color-bg-primary, #ffffff) 100%);
+  border: 1px solid var(--ec-border);
+  border-left: 4px solid var(--ec-primary);
+  border-radius: 6px;
+  padding: 8px 10px;
+  margin: 6px auto;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+  position: relative;
+  overflow: hidden;
+  word-break: break-word;
+  /* Match the viewport-based max-width used by .user-comment so external
+     bubbles sit at the same visual width. */
+  max-width: calc(100vw - var(--sidebar-width) - var(--right-panel-group-width, 0px) - 64px);
+  box-sizing: border-box;
+}
+
+.external-comment:hover {
+  border-color: var(--ec-border);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
+}
+
+/* Per-source color binding. Each rule maps the source's primary/border/
+   subtle variables into the agnostic --ec-* locals. */
+.external-comment.source-github {
+  --ec-primary: var(--external-github-primary);
+  --ec-secondary: var(--external-github-secondary);
+  --ec-subtle: var(--external-github-subtle);
+  --ec-border: var(--external-github-border);
+}
+
+.external-comment-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 4px;
+  padding-bottom: 4px;
+  border-bottom: 1px solid var(--ec-border);
+  min-width: 0;
+  gap: 8px;
+}
+
+.external-comment-header-left {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.external-comment-author {
+  color: var(--ec-primary);
+  font-weight: 600;
+  font-size: 13px;
+  text-decoration: none;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.external-comment-author:hover {
+  text-decoration: underline;
+}
+
+.external-comment-permalink {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-text-secondary, #57606a);
+  text-decoration: none;
+  padding: 2px;
+  border-radius: 4px;
+  transition: color 0.2s, background 0.2s;
+}
+
+.external-comment-permalink:hover {
+  color: var(--ec-primary);
+  background: var(--ec-subtle);
+}
+
+.external-comment-permalink svg {
+  width: 14px;
+  height: 14px;
+  fill: currentColor;
+}
+
+.external-comment-body {
+  color: var(--color-text-primary, #1f2328);
+  line-height: 1.4;
+  font-size: 14px;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans", Helvetica, Arial, sans-serif;
+  padding: 0;
+  margin: 0;
+  word-break: break-word;
+}
+
+.external-comment-body p {
+  margin: 0 0 6px 0;
+}
+
+.external-comment-body p:last-child {
+  margin-bottom: 0;
+}
+
+.external-comment-body code {
+  background: var(--ec-subtle);
+  color: var(--ec-secondary);
+  padding: 1px 4px;
+  border-radius: 3px;
+  font-size: 85%;
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, monospace;
+}
+
+.external-comment-body pre {
+  background: var(--color-bg-secondary, #f6f8fa);
+  border: 1px solid var(--ec-border);
+  border-radius: 6px;
+  padding: 8px;
+  overflow-x: auto;
+  margin: 6px 0;
+}
+
+.external-comment-body pre code {
+  background: transparent;
+  color: inherit;
+  padding: 0;
+}
+
+.external-comment-actions {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin-left: auto;
+  flex-shrink: 0;
+}
+
+/* Thread = root comment + replies, grouped in one card stack. */
+.external-comment-thread {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+/* One level of indent for replies. GitHub treats threads as
+   flat-with-replies; no deeper nesting needed. */
+.external-comment.is-reply {
+  margin-left: 24px;
+  background: linear-gradient(to right, var(--ec-subtle) 0%, var(--color-bg-secondary, #f6f8fa) 100%);
+}
+
+/* Outdated: comment's anchor no longer maps to current diff. Faded with
+   a dashed accent border so it reads as "still here but stale". */
+.external-comment.is-outdated {
+  opacity: 0.7;
+  border-left-style: dashed;
+}
+
+.external-comment-outdated-badge {
+  display: inline-block;
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-size: 10px;
+  font-weight: 600;
+  background: var(--color-bg-secondary, #f6f8fa);
+  color: var(--color-text-secondary, #57606a);
+  border: 1px solid var(--color-border-primary, #d0d7de);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+[data-theme="dark"] .external-comment {
+  background: linear-gradient(to right, var(--ec-subtle) 0%, var(--color-bg-primary, #0d1117) 100%);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+}
+
+[data-theme="dark"] .external-comment.is-reply {
+  background: linear-gradient(to right, var(--ec-subtle) 0%, var(--color-bg-secondary, #161b22) 100%);
+}
+
+[data-theme="dark"] .external-comment-body {
+  color: var(--color-text-primary, #e6edf3);
+}
+
+[data-theme="dark"] .external-comment-body pre {
+  background: var(--color-bg-primary, #0d1117);
+}
+
+[data-theme="dark"] .external-comment-outdated-badge {
+  background: var(--color-bg-tertiary, #1c2128);
+  color: var(--color-text-secondary, #8b949e);
+  border-color: var(--color-border-primary, #30363d);
+}
+
+/* Refresh button spinner: reuse the project-wide `spin` keyframes (defined
+   above for #refresh-pr and elsewhere). Triggered by JS toggling
+   `.is-refreshing` on the button while a sync is in flight. */
+.btn-refresh-external-comments.is-refreshing svg {
+  animation: spin 1s linear infinite;
+}
+
+/* Brief error state on the refresh button — JS sets data-state='error' for a
+   couple seconds when sync fails so the reviewer notices even if the toast
+   was dismissed. */
+.btn-refresh-external-comments[data-state="error"] {
+  color: var(--color-danger, #d1242f);
+}
+
+/* ========================================
    Dismissed User Comment Styling
    Visual state for soft-deleted comments when "show dismissed" is enabled
    ======================================== */
@@ -7499,15 +7746,18 @@ body.resizing * {
    Comment Minimize Mode
    -------------------------------------------------------------------------- */
 
-/* When minimize mode is active, hide all inline comment and suggestion rows */
+/* When minimize mode is active, hide all inline comment, suggestion, and
+   external-comment rows */
 .comments-minimized .user-comment-row,
-.comments-minimized .ai-suggestion-row {
+.comments-minimized .ai-suggestion-row,
+.comments-minimized .external-comment-row {
   display: none;
 }
 
 /* Per-line expansion override — clicking an indicator reveals that line's rows */
 .comments-minimized .user-comment-row.comment-expanded,
-.comments-minimized .ai-suggestion-row.comment-expanded {
+.comments-minimized .ai-suggestion-row.comment-expanded,
+.comments-minimized .external-comment-row.comment-expanded {
   display: table-row;
 }
 
@@ -7670,6 +7920,24 @@ body.resizing * {
   box-shadow: 0 1px 3px rgba(217, 119, 6, 0.15);
 }
 
+/* External review-comment indicator (blue). Currently sourced from GitHub
+   inline review comments; future GitLab/Linear adapters will reuse the
+   same `.indicator-external` class with their own color tokens defined in
+   .external-comment.source-<name>. */
+.comment-indicator .indicator-external {
+  color: var(--external-github-primary, #0969da);
+}
+
+.comment-indicator:has(.indicator-external) {
+  border-color: var(--external-github-border, rgba(9, 105, 218, 0.3));
+  background: var(--external-github-subtle, rgba(9, 105, 218, 0.08));
+}
+
+.comment-indicator:has(.indicator-external):hover {
+  background: rgba(9, 105, 218, 0.16);
+  box-shadow: 0 1px 3px rgba(9, 105, 218, 0.18);
+}
+
 .comment-indicator .indicator-count {
   font-weight: 600;
   font-size: 10px;
@@ -7716,6 +7984,20 @@ body.resizing * {
 [data-theme="dark"] .comment-indicator:has(.indicator-ai):hover {
   background: rgba(251, 191, 36, 0.18);
   box-shadow: 0 1px 3px rgba(251, 191, 36, 0.25);
+}
+
+[data-theme="dark"] .comment-indicator:has(.indicator-external) {
+  border-color: var(--external-github-border, rgba(88, 166, 255, 0.3));
+  background: var(--external-github-subtle, rgba(88, 166, 255, 0.1));
+}
+
+[data-theme="dark"] .comment-indicator .indicator-external {
+  color: var(--external-github-primary, #58a6ff);
+}
+
+[data-theme="dark"] .comment-indicator:has(.indicator-external):hover {
+  background: rgba(88, 166, 255, 0.18);
+  box-shadow: 0 1px 3px rgba(88, 166, 255, 0.25);
 }
 
 [data-theme="dark"] .comment-indicator.expanded {
@@ -12665,6 +12947,82 @@ body.resizing * {
   display: flex;
 }
 
+/* Thread modifier: a thread card contains a header plus a stack of
+   comments. The single-line flex layout used by `.chat-panel__context-card`
+   (and `overflow: hidden`) would clip the body to one row — switch to a
+   column layout that lets contents grow vertically. */
+.chat-panel__context-card.chat-panel__context-card--thread {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 6px;
+  overflow: visible;
+  padding: 8px 12px;
+}
+
+.chat-panel__context-card--thread .chat-panel__context-thread-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.chat-panel__context-card--thread .chat-panel__context-thread-body {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.chat-panel__context-card--thread .chat-panel__context-thread-comment {
+  border-left: 2px solid var(--color-border-primary, #d0d7de);
+  padding-left: 8px;
+  font-size: 12px;
+}
+
+.chat-panel__context-card--thread .chat-panel__context-thread-comment.is-outdated {
+  opacity: 0.7;
+}
+
+.chat-panel__context-card--thread .chat-panel__context-thread-comment-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 4px;
+  font-weight: 500;
+}
+
+.chat-panel__context-card--thread .chat-panel__context-thread-comment-body {
+  color: var(--color-text-primary, #1f2328);
+  font-size: 12px;
+  line-height: 1.4;
+  word-break: break-word;
+}
+
+.chat-panel__context-card--thread .chat-panel__context-thread-comment-body p {
+  margin: 0 0 4px 0;
+}
+
+.chat-panel__context-card--thread .chat-panel__context-thread-comment-body p:last-child {
+  margin-bottom: 0;
+}
+
+.chat-panel__context-card--thread .chat-panel__context-count {
+  margin-left: auto;
+  font-size: 10px;
+  color: var(--color-text-tertiary);
+}
+
+.chat-panel__context-card--thread .chat-panel__context-badge--outdated {
+  font-size: 9px;
+  padding: 1px 4px;
+  border-radius: 3px;
+  background: var(--color-bg-secondary, #f6f8fa);
+  color: var(--color-text-secondary, #57606a);
+  border: 1px solid var(--color-border-primary, #d0d7de);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
 .chat-panel__context-remove:hover {
   background: var(--color-danger, #d1242f);
   color: #ffffff;
@@ -13226,6 +13584,9 @@ body.resizing * {
 [data-chat="disabled"] .btn-collapsed-chat,
 [data-chat="disabled"] .finding-chat-action,
 [data-chat="disabled"] .btn-chat-comment,
+[data-chat="disabled"] .btn-chat-thread,
+[data-chat="disabled"] .external-comment-chat-btn,
+[data-chat="disabled"] .external-comment-chat-thread-btn,
 [data-chat="disabled"] .analysis-history-chat-btn,
 [data-chat="disabled"] .chat-line-btn,
 [data-chat="disabled"] .btn-chat-from-comment {
@@ -13240,6 +13601,9 @@ body.resizing * {
 [data-chat="unavailable"] .btn-collapsed-chat,
 [data-chat="unavailable"] .finding-chat-action,
 [data-chat="unavailable"] .btn-chat-comment,
+[data-chat="unavailable"] .btn-chat-thread,
+[data-chat="unavailable"] .external-comment-chat-btn,
+[data-chat="unavailable"] .external-comment-chat-thread-btn,
 [data-chat="unavailable"] .analysis-history-chat-btn,
 [data-chat="unavailable"] .chat-line-btn,
 [data-chat="unavailable"] .btn-chat-from-comment {

--- a/public/css/pr.css
+++ b/public/css/pr.css
@@ -8838,6 +8838,7 @@ body.resizing * {
 
 /* Segment Control */
 .segment-control {
+  position: relative;
   display: flex;
   align-items: center;
   gap: 8px;
@@ -8847,6 +8848,23 @@ body.resizing * {
   flex-shrink: 0;
 }
 
+/* Scroll container: clips the segment row at the panel edge so chevrons
+   can drive horizontal scroll when the buttons don't fit. Wrapped around
+   .segment-control-inner so the inner row keeps its existing pill styling. */
+.segment-control-scroll {
+  flex: 1;
+  min-width: 0; /* allow shrink below intrinsic content width */
+  overflow-x: auto;
+  overflow-y: hidden;
+  scroll-behavior: smooth;
+  scrollbar-width: none; /* Firefox */
+  -ms-overflow-style: none; /* IE/Edge */
+}
+
+.segment-control-scroll::-webkit-scrollbar {
+  display: none; /* Chrome/Safari */
+}
+
 .segment-control-inner {
   display: flex;
   gap: 2px;
@@ -8854,12 +8872,48 @@ body.resizing * {
   background: var(--color-bg-tertiary);
   border: 1px solid var(--color-border-primary);
   border-radius: var(--radius-md);
-  flex: 1;
+  /* No flex:1 here — let the inner row take its natural width so we can
+     scroll horizontally when it overflows the scroll container. */
+  width: max-content;
+  min-width: 100%;
+}
+
+/* Chevron buttons that scroll the segment row left/right. Hidden by
+   default; JS toggles [hidden] based on scrollWidth / scrollLeft. */
+.segment-scroll {
+  flex-shrink: 0;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--color-bg-tertiary);
+  border: 1px solid var(--color-border-primary);
+  border-radius: var(--radius-sm);
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  transition: background var(--transition-fast), color var(--transition-fast), border-color var(--transition-fast);
+}
+
+.segment-scroll:hover {
+  background: var(--color-bg-primary);
+  color: var(--color-text-primary);
+  border-color: var(--color-border-secondary);
+}
+
+.segment-scroll[hidden] {
+  display: none;
 }
 
 .segment-btn {
-  flex: 1;
-  padding: 5px 4px;
+  /* flex: 1 0 auto = grow to share extra space, never shrink below natural
+     width, use intrinsic content width as the basis. When the sum of
+     natural widths exceeds the scroll container, the inner row overflows
+     and the chevrons take over. When there is extra room, the buttons
+     distribute it evenly. */
+  flex: 1 0 auto;
+  padding: 5px 8px;
   font-family: inherit;
   font-size: 0.6875rem;
   font-weight: 500;
@@ -8870,6 +8924,11 @@ body.resizing * {
   cursor: pointer;
   transition: all var(--transition-fast);
   white-space: nowrap;
+  text-align: center;
+}
+
+.segment-btn[hidden] {
+  display: none;
 }
 
 .segment-btn:hover {
@@ -8891,6 +8950,15 @@ body.resizing * {
 .segment-btn[data-segment="comments"].active {
   color: var(--comment-primary);
   background: var(--comment-subtle);
+}
+
+/* External segment uses the GitHub external-comment blue. When future
+   sources (GitLab, Linear) land, this rule can switch on a body-level
+   class or rely on JS to toggle a modifier — for now GitHub is the only
+   external source and the blue accent is shared. */
+.segment-btn[data-segment="external"].active {
+  color: var(--external-github-primary);
+  background: var(--external-github-subtle);
 }
 
 .segment-btn[data-segment="all"].active {
@@ -9022,6 +9090,16 @@ body.resizing * {
   display: flex;
   align-items: center;
   gap: 4px;
+}
+
+/* Right-aligned actions slot in the findings header (PR mode: refresh
+   external comments). Kept as a static sibling of .findings-nav so the
+   bound click handler survives header re-renders. Empty in Local mode. */
+.findings-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin-left: auto;
 }
 
 .findings-nav-btn {
@@ -9432,6 +9510,121 @@ body.resizing * {
 /* Restore comment button - now wrapped in .finding-quick-actions for consistent hover behavior.
    The parent wrapper handles opacity transitions, so no special styles needed here.
    This selector remains for specificity in case of future customization needs. */
+
+/* ========================================
+   Review panel: External thread list items
+   Mirrors the .external-comment indirection pattern: source-agnostic
+   structural rules use --ec-*, then .source-<name> binds those to the
+   per-source palette. Today only .source-github exists; future sources
+   (GitLab, Linear) drop in a single block below.
+   ======================================== */
+.finding-item.ai-panel__list-item--external {
+  /* Default --ec-* fallback if a thread renders without source-<name>.
+     Real threads always carry .source-github (set by the renderer). */
+  --ec-primary: var(--comment-primary);
+  --ec-subtle: var(--comment-subtle);
+  --ec-border: var(--comment-border);
+  --ec-secondary: var(--comment-primary);
+
+  /* Set the generic border color first, then restore the left accent so the
+     shorthand-vs-longhand cascade doesn't wipe out the primary-source stripe. */
+  border-color: var(--ec-border);
+  border-left: 3px solid var(--ec-primary);
+  padding-left: 9px;
+  background: var(--ec-subtle);
+  position: relative;
+}
+
+.finding-item.ai-panel__list-item--external:hover {
+  background: var(--ec-subtle);
+  border-color: var(--ec-border);
+  border-left-color: var(--ec-primary);
+  /* Slight contrast bump on hover via box-shadow rather than color shift,
+     so the blue accent doesn't fight the surrounding panel. */
+  box-shadow: inset 0 0 0 1px var(--ec-border);
+}
+
+.finding-item.ai-panel__list-item--external.active {
+  background: var(--ec-subtle);
+  border-color: var(--ec-primary);
+  box-shadow: inset 0 0 0 1px var(--ec-primary);
+}
+
+.finding-item.ai-panel__list-item--external.source-github {
+  --ec-primary: var(--external-github-primary);
+  --ec-secondary: var(--external-github-secondary);
+  --ec-subtle: var(--external-github-subtle);
+  --ec-border: var(--external-github-border);
+}
+
+/* Outdated thread: faded + dashed accent, matching the inline
+   .external-comment.is-outdated treatment. */
+.finding-item.ai-panel__list-item--external.is-outdated {
+  opacity: 0.7;
+  border-left-style: dashed;
+}
+
+.finding-item.ai-panel__list-item--external .external-list-author {
+  font-weight: 600;
+  color: var(--ec-primary);
+}
+
+.finding-item.ai-panel__list-item--external .external-list-snippet {
+  color: var(--color-text-secondary);
+  font-weight: 400;
+}
+
+/* Total-comment count for an external thread (root + replies). Replaces
+   the prior left-side dot + right-side reply badge with a single always-
+   present pill that reads "1" for a lone comment and ticks up with the
+   thread size. */
+.finding-item.ai-panel__list-item--external .external-list-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 5px;
+  border-radius: 9px;
+  font-size: 10px;
+  font-weight: 600;
+  background: var(--ec-primary);
+  color: var(--color-bg-primary, #ffffff);
+  line-height: 1;
+  flex-shrink: 0;
+}
+
+.finding-item.ai-panel__list-item--external .external-list-outdated-badge {
+  display: inline-block;
+  padding: 1px 5px;
+  border-radius: 4px;
+  font-size: 9px;
+  font-weight: 600;
+  background: var(--color-bg-secondary, #f6f8fa);
+  color: var(--color-text-secondary, #57606a);
+  border: 1px solid var(--color-border-primary, #d0d7de);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+/* Transient focus flash for the matching inline external-comment-row after
+   the user clicks an External list item. Removed automatically by JS after
+   2 seconds, mirroring the .current-suggestion / .highlight-flash pattern. */
+.external-comment-row--focused .external-comment {
+  outline: 2px solid var(--ec-primary);
+  outline-offset: 2px;
+  transition: outline-color 200ms ease;
+}
+
+[data-theme="dark"] .finding-item.ai-panel__list-item--external .external-list-count {
+  color: var(--color-bg-primary, #0d1117);
+}
+
+[data-theme="dark"] .finding-item.ai-panel__list-item--external .external-list-outdated-badge {
+  background: var(--color-bg-tertiary, #1c2128);
+  color: var(--color-text-secondary, #8b949e);
+  border-color: var(--color-border-primary, #30363d);
+}
 
 /* Adopted findings - brighter green success state with solid left border */
 .finding-item.finding-adopted {
@@ -12993,80 +13186,15 @@ body.resizing * {
   display: flex;
 }
 
-/* Thread modifier: a thread card contains a header plus a stack of
-   comments. The single-line flex layout used by `.chat-panel__context-card`
-   (and `overflow: hidden`) would clip the body to one row — switch to a
-   column layout that lets contents grow vertically. */
-.chat-panel__context-card.chat-panel__context-card--thread {
-  display: flex;
-  flex-direction: column;
-  align-items: stretch;
-  gap: 6px;
-  overflow: visible;
-  padding: 8px 12px;
-}
-
-.chat-panel__context-card--thread .chat-panel__context-thread-header {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  flex-wrap: wrap;
-}
-
-.chat-panel__context-card--thread .chat-panel__context-thread-body {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
-
-.chat-panel__context-card--thread .chat-panel__context-thread-comment {
-  border-left: 2px solid var(--color-border-primary, #d0d7de);
-  padding-left: 8px;
-  font-size: 12px;
-}
-
-.chat-panel__context-card--thread .chat-panel__context-thread-comment.is-outdated {
-  opacity: 0.7;
-}
-
-.chat-panel__context-card--thread .chat-panel__context-thread-comment-header {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  margin-bottom: 4px;
-  font-weight: 500;
-}
-
-.chat-panel__context-card--thread .chat-panel__context-thread-comment-body {
-  color: var(--color-text-primary, #1f2328);
-  font-size: 12px;
-  line-height: 1.4;
-  word-break: break-word;
-}
-
-.chat-panel__context-card--thread .chat-panel__context-thread-comment-body p {
-  margin: 0 0 4px 0;
-}
-
-.chat-panel__context-card--thread .chat-panel__context-thread-comment-body p:last-child {
-  margin-bottom: 0;
-}
-
-.chat-panel__context-card--thread .chat-panel__context-count {
+/* Thread context card: compact single-line layout. The visible row mirrors
+   .chat-panel__context-card (icon + label + title + file). The card's
+   `title` attribute carries the full thread (one comment per block) for
+   the native hover tooltip — so the chat stays scannable. */
+.chat-panel__context-card .chat-panel__context-count {
   margin-left: auto;
   font-size: 10px;
   color: var(--color-text-tertiary);
-}
-
-.chat-panel__context-card--thread .chat-panel__context-badge--outdated {
-  font-size: 9px;
-  padding: 1px 4px;
-  border-radius: 3px;
-  background: var(--color-bg-secondary, #f6f8fa);
-  color: var(--color-text-secondary, #57606a);
-  border: 1px solid var(--color-border-primary, #d0d7de);
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
+  flex-shrink: 0;
 }
 
 .chat-panel__context-remove:hover {

--- a/public/css/pr.css
+++ b/public/css/pr.css
@@ -4722,14 +4722,11 @@ tr.line-range-start .d2h-code-line-ctn {
   border-left: 4px solid var(--ec-primary);
   border-radius: 6px;
   padding: 8px 10px;
-  margin: 6px auto;
+  margin: 0;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
   position: relative;
   overflow: hidden;
   word-break: break-word;
-  /* Match the viewport-based max-width used by .user-comment so external
-     bubbles sit at the same visual width. */
-  max-width: calc(100vw - var(--sidebar-width) - var(--right-panel-group-width, 0px) - 64px);
   box-sizing: border-box;
 }
 
@@ -4844,19 +4841,68 @@ tr.line-range-start .d2h-code-line-ctn {
   padding: 0;
 }
 
-.external-comment-actions {
+.external-comment-body ul,
+.external-comment-body ol {
+  margin: 8px 0;
+  padding-left: 24px;
+}
+
+.external-comment-body li {
+  margin: 4px 0;
+}
+
+.external-comment-body strong {
+  font-weight: 600;
+}
+
+.external-comment-body em {
+  font-style: italic;
+}
+
+.external-comment-body blockquote {
+  border-left: 4px solid var(--color-border-primary);
+  padding-left: 16px;
+  margin: 8px 0;
+  color: var(--color-text-secondary);
+}
+
+.external-comment-header-right {
   display: flex;
   align-items: center;
   gap: 4px;
-  margin-left: auto;
   flex-shrink: 0;
 }
 
-/* Thread = root comment + replies, grouped in one card stack. */
+.external-comment .btn-chat-comment {
+  color: var(--ec-primary);
+}
+
+.external-comment .btn-chat-comment:hover {
+  background: var(--ec-subtle);
+  border-color: var(--ec-border);
+  color: var(--ec-primary);
+}
+
+[data-theme="dark"] .external-comment .btn-chat-comment {
+  color: var(--ec-primary);
+}
+
+[data-theme="dark"] .external-comment .btn-chat-comment:hover {
+  background: var(--ec-subtle);
+  border-color: var(--ec-border);
+  color: var(--ec-primary);
+}
+
+/* Thread = root comment + replies, grouped in one card stack.
+   The thread owns the width constraint so the root, replies, and the
+   thread-actions row all share the same right edge. */
 .external-comment-thread {
   display: flex;
   flex-direction: column;
   gap: 4px;
+  max-width: calc(100vw - var(--sidebar-width) - var(--right-panel-group-width, 0px) - 64px);
+  margin: 6px auto;
+  box-sizing: border-box;
 }
 
 /* One level of indent for replies. GitHub treats threads as
@@ -13584,9 +13630,7 @@ body.resizing * {
 [data-chat="disabled"] .btn-collapsed-chat,
 [data-chat="disabled"] .finding-chat-action,
 [data-chat="disabled"] .btn-chat-comment,
-[data-chat="disabled"] .btn-chat-thread,
 [data-chat="disabled"] .external-comment-chat-btn,
-[data-chat="disabled"] .external-comment-chat-thread-btn,
 [data-chat="disabled"] .analysis-history-chat-btn,
 [data-chat="disabled"] .chat-line-btn,
 [data-chat="disabled"] .btn-chat-from-comment {
@@ -13601,9 +13645,7 @@ body.resizing * {
 [data-chat="unavailable"] .btn-collapsed-chat,
 [data-chat="unavailable"] .finding-chat-action,
 [data-chat="unavailable"] .btn-chat-comment,
-[data-chat="unavailable"] .btn-chat-thread,
 [data-chat="unavailable"] .external-comment-chat-btn,
-[data-chat="unavailable"] .external-comment-chat-thread-btn,
 [data-chat="unavailable"] .analysis-history-chat-btn,
 [data-chat="unavailable"] .chat-line-btn,
 [data-chat="unavailable"] .btn-chat-from-comment {

--- a/public/js/components/AIPanel.js
+++ b/public/js/components/AIPanel.js
@@ -34,6 +34,7 @@ class AIPanel {
         this.isCollapsed = this.panel?.classList.contains('collapsed') ?? false;
         this.findings = [];
         this.comments = [];
+        this.externalThreads = [];
         this.selectedLevel = 'final';
         this.selectedSegment = 'ai'; // Default to AI segment until PR loads
         this.currentIndex = -1; // Current navigation index
@@ -41,7 +42,7 @@ class AIPanel {
         this.analysisState = 'unknown'; // 'unknown' | 'loading' | 'complete' | 'none'
 
         // Track selected item by stable identifier for restoration
-        this.selectedItemKey = null; // Format: "file:lineNumber:itemType"
+        this.selectedItemKey = null; // Format: "file:lineNumber:itemType:identity"
 
         // Canonical file order for consistent sorting across components
         this.fileOrder = new Map(); // Map of file path -> index
@@ -52,6 +53,11 @@ class AIPanel {
         this.initElements();
         this.bindEvents();
         this.setupKeyboardNavigation();
+        this.setupSegmentOverflow();
+        // Hide the External segment in Local mode — no external source exists there.
+        if (typeof window !== 'undefined' && window.PAIR_REVIEW_LOCAL_MODE) {
+            this.segmentExternalBtn?.setAttribute('hidden', '');
+        }
         // Don't restore segment on init - wait for setPR() call
 
         // Set CSS variable immediately based on collapsed state to prevent flicker
@@ -80,7 +86,11 @@ class AIPanel {
 
         // Segment control
         this.segmentControl = document.getElementById('segment-control');
+        this.segmentControlScroll = document.getElementById('segment-control-scroll');
         this.segmentBtns = this.segmentControl?.querySelectorAll('.segment-btn');
+        this.segmentScrollLeft = document.getElementById('segment-scroll-left');
+        this.segmentScrollRight = document.getElementById('segment-scroll-right');
+        this.segmentExternalBtn = this.segmentControl?.querySelector('.segment-btn[data-segment="external"]');
 
         // Create filter toggle button (will be inserted after segment control)
         this.filterToggleBtn = null; // Created dynamically in createFilterToggle()
@@ -122,13 +132,14 @@ class AIPanel {
         }
         this.filterToggleBtn.setAttribute('aria-label', this.filterToggleBtn.title);
 
-        // Insert inside segment-control container, after segment-control-inner
-        // This positions it on the same row as the segment buttons
-        const innerControl = this.segmentControl.querySelector('.segment-control-inner');
-        if (innerControl) {
-            this.segmentControl.insertBefore(this.filterToggleBtn, innerControl.nextSibling);
-        } else {
-            // Fallback: append to the segment control container
+        // Insert as the LAST child of segment-control so it sits at the
+        // right edge of the row, after the segment buttons and the right
+        // overflow chevron. Previous versions used insertBefore relative
+        // to .segment-control-inner — that breaks now that the inner row
+        // is nested inside a scroll wrapper. Append-to-end is correct for
+        // both old and new structures and avoids the cross-parent
+        // insertBefore footgun.
+        if (this.segmentControl) {
             this.segmentControl.appendChild(this.filterToggleBtn);
         }
 
@@ -167,6 +178,14 @@ class AIPanel {
         // Filter toggle button
         if (this.filterToggleBtn) {
             this.filterToggleBtn.addEventListener('click', () => this.onFilterToggle());
+        }
+
+        // Segment overflow scroll chevrons
+        if (this.segmentScrollLeft) {
+            this.segmentScrollLeft.addEventListener('click', () => this.scrollSegmentRow(-1));
+        }
+        if (this.segmentScrollRight) {
+            this.segmentScrollRight.addEventListener('click', () => this.scrollSegmentRow(1));
         }
     }
 
@@ -340,6 +359,23 @@ class AIPanel {
         this._restoreOrCollapsePanel();
         this.restoreSegmentSelection();
         this.restoreFilterState();
+
+        // If the external-comment manager finished its initial fetch BEFORE
+        // the panel was wired up (race on slow loads), pull the threads it
+        // already has so the External segment count is correct on first
+        // paint. Guarded behind a function check so tests that stub the
+        // manager don't blow up.
+        if (typeof window !== 'undefined'
+            && window.externalCommentManager
+            && typeof window.externalCommentManager.getAllThreads === 'function') {
+            try {
+                this.setExternalThreads(window.externalCommentManager.getAllThreads());
+            } catch (err) {
+                if (typeof console !== 'undefined') {
+                    console.warn('[AIPanel] initial external thread sync failed', err);
+                }
+            }
+        }
     }
 
     /**
@@ -358,7 +394,7 @@ class AIPanel {
     setFileOrder(orderMap) {
         this.fileOrder = orderMap || new Map();
         // Re-render to apply new ordering
-        if (this.findings.length > 0 || this.comments.length > 0) {
+        if (this.findings.length > 0 || this.comments.length > 0 || (this.externalThreads?.length ?? 0) > 0) {
             this.renderFindings();
         }
     }
@@ -385,13 +421,23 @@ class AIPanel {
     restoreSegmentSelection() {
         if (!this.segmentBtns) return;
 
+        // Set of segment values currently available in the DOM. In Local mode
+        // the External button is hidden — never restore to it. Any stored
+        // value not present in the bar (legacy or hidden) falls back to 'ai'.
+        const availableSegments = new Set();
+        this.segmentBtns.forEach(btn => {
+            if (!btn.hasAttribute('hidden')) {
+                availableSegments.add(btn.dataset.segment);
+            }
+        });
+
         // Only restore if we have a PR key
         if (this.currentPRKey) {
             const stored = localStorage.getItem(`reviewPanelSegment_${this.currentPRKey}`);
-            if (stored) {
+            if (stored && availableSegments.has(stored)) {
                 this.selectedSegment = stored;
             } else {
-                // Default to 'ai' for new PRs
+                // Default to 'ai' for new PRs or unknown/hidden stored values
                 this.selectedSegment = 'ai';
             }
         }
@@ -526,7 +572,14 @@ class AIPanel {
         const file = item.file || '';
         const line = item.line_start || 0;
         const type = item._itemType || 'finding';
-        return `${file}:${line}:${type}`;
+        // External threads can share a (file, line) anchor — multiple GitHub
+        // review threads on the same line collide otherwise. Disambiguate
+        // with source + external_id (falling back to id) so selection survives
+        // re-render to the thread the reviewer actually picked.
+        const identity = item._itemType === 'external'
+            ? `${item.source || ''}:${item.external_id ?? item.id ?? ''}`
+            : (item.id ?? '');
+        return `${file}:${line}:${type}:${identity}`;
     }
 
     /**
@@ -579,7 +632,15 @@ class AIPanel {
     updateSegmentCounts() {
         const aiCount = this.findings.length;
         const commentsCount = this.comments.length;
-        const allCount = aiCount + commentsCount;
+        // External threads are PR-only; hidden in Local mode. The button is
+        // [hidden], but the count is harmless to compute either way.
+        // Defensive: legacy test fixtures construct panels via Object.create
+        // without externalThreads — fall back to an empty array length.
+        const externalCount = this.externalThreads?.length ?? 0;
+        // 'All' = every visible category. In Local mode the External button
+        // is hidden and externalThreads stays at length 0 anyway, so the sum
+        // collapses naturally.
+        const allCount = aiCount + commentsCount + externalCount;
 
         if (this.segmentBtns) {
             this.segmentBtns.forEach(btn => {
@@ -596,12 +657,18 @@ class AIPanel {
                     } else if (segment === 'comments') {
                         count = commentsCount;
                         countSpan.textContent = `(${commentsCount})`;
+                    } else if (segment === 'external') {
+                        count = externalCount;
+                        countSpan.textContent = `(${externalCount})`;
                     }
                     // Dim the count when zero
                     countSpan.classList.toggle('segment-count--zero', count === 0);
                 }
             });
         }
+        // Count text changes (e.g. "(0)" → "(12)") can alter scrollWidth
+        // without triggering resize/scroll listeners, so re-check chevrons.
+        this.updateSegmentScrollChevrons?.();
     }
 
     /**
@@ -617,18 +684,51 @@ class AIPanel {
             case 'comments':
                 items = this.comments.map(c => ({ ...c, _itemType: 'comment' }));
                 break;
+            case 'external':
+                items = (this.externalThreads || []).map(t => this._normalizeExternalThread(t));
+                break;
             case 'all':
             default:
-                // Combine findings and comments
+                // Combine findings, comments, and external threads.
+                // In Local mode externalThreads is always empty so this
+                // collapses to findings + comments, matching prior behavior.
                 items = [
                     ...this.findings.map(f => ({ ...f, _itemType: 'finding' })),
-                    ...this.comments.map(c => ({ ...c, _itemType: 'comment' }))
+                    ...this.comments.map(c => ({ ...c, _itemType: 'comment' })),
+                    ...(this.externalThreads || []).map(t => this._normalizeExternalThread(t))
                 ];
                 break;
         }
 
         // Sort by canonical file order, then file-level first, then line number
         return this.sortItemsByFileOrder(items);
+    }
+
+    /**
+     * Project an external thread root onto the same shape sortItemsByFileOrder
+     * uses (file + line_start), preferring live coordinates and falling back
+     * to original_* when the thread is outdated. Returns an object that
+     * preserves the source thread fields for downstream renderers.
+     * @private
+     */
+    _normalizeExternalThread(thread) {
+        if (!thread) return { _itemType: 'external' };
+        const outdated = thread.is_outdated === 1 || thread.is_outdated === true;
+        const liveStart = Number.isFinite(thread.line_start) ? thread.line_start : null;
+        const origStart = Number.isFinite(thread.original_line_start) ? thread.original_line_start : null;
+        const liveEnd = Number.isFinite(thread.line_end) ? thread.line_end : null;
+        const origEnd = Number.isFinite(thread.original_line_end) ? thread.original_line_end : null;
+        const lineStart = outdated ? (origStart ?? liveStart) : (liveStart ?? origStart);
+        const lineEnd = outdated ? (origEnd ?? liveEnd) : (liveEnd ?? origEnd);
+        return {
+            ...thread,
+            _itemType: 'external',
+            // Surface line_start at the top level so sort + display helpers
+            // do not have to know about the outdated fallback rule.
+            line_start: lineStart,
+            line_end: lineEnd,
+            is_outdated: outdated
+        };
     }
 
     /**
@@ -701,6 +801,15 @@ class AIPanel {
                         <div class="empty-state-description">Click <strong>Analyze</strong> to get AI suggestions</div>
                     `;
                 }
+            } else if (this.selectedSegment === 'external') {
+                // External threads come from GitHub PR review activity. There
+                // is no in-app action that creates them — surface that
+                // expectation rather than the generic "no items yet" copy.
+                emptyContent = `
+                    <div class="empty-state-icon">${this.getEmptyStateIcon('comment')}</div>
+                    <div class="empty-state-title">No external review comments</div>
+                    <div class="empty-state-description">Comments from GitHub PR reviews appear here once reviewers leave them.</div>
+                `;
             } else {
                 // 'all' segment - check analysis state to determine empty message
                 if (this.analysisState === 'complete') {
@@ -732,9 +841,11 @@ class AIPanel {
         this.updateFindingsHeader(items.length);
 
         this.findingsList.innerHTML = items.map((item, index) => {
-            // Check if this is a comment or a finding
+            // Dispatch on _itemType so each renderer owns its DOM contract.
             if (item._itemType === 'comment') {
                 return this.renderCommentItem(item, index);
+            } else if (item._itemType === 'external') {
+                return this.renderExternalThreadItem(item, index);
             } else {
                 return this.renderFindingItem(item, index);
             }
@@ -889,6 +1000,51 @@ class AIPanel {
             return;
         }
 
+        // External thread chat — mirrors ExternalCommentManager._openThreadChat.
+        // The button carries data-thread-id + data-source; the full thread is
+        // looked up from this.externalThreads so replies are included.
+        if (btn.dataset.itemType === 'external') {
+            const threadId = btn.dataset.threadId;
+            const numericId = threadId != null && threadId !== '' ? Number(threadId) : null;
+            const thread = (this.externalThreads || []).find(t =>
+                String(t.id) === String(threadId) ||
+                (numericId != null && t.id === numericId)
+            );
+            if (thread) {
+                const outdated = thread.is_outdated === 1 || thread.is_outdated === true;
+                const replies = Array.isArray(thread.replies) ? thread.replies : [];
+                window.chatPanel.open({
+                    reviewId,
+                    threadContext: {
+                        rootId: thread.id,
+                        source: 'external',
+                        externalSource: thread.source,
+                        file: thread.file,
+                        side: thread.side || 'RIGHT',
+                        line_start: outdated ? thread.original_line_start : thread.line_start,
+                        line_end: outdated ? thread.original_line_end : thread.line_end,
+                        comments: [
+                            {
+                                author: thread.author,
+                                body: thread.body,
+                                isOutdated: !!outdated,
+                                externalUrl: thread.external_url,
+                                externalCreatedAt: thread.external_created_at,
+                            },
+                            ...replies.map((r) => ({
+                                author: r.author,
+                                body: r.body,
+                                isOutdated: !!(r.is_outdated === 1 || r.is_outdated === true),
+                                externalUrl: r.external_url,
+                                externalCreatedAt: r.external_created_at,
+                            })),
+                        ],
+                    },
+                });
+            }
+            return;
+        }
+
         const file = btn.dataset.findingFile || '';
         const title = btn.dataset.findingTitle || '';
         let suggestionContext = { title, file };
@@ -950,6 +1106,14 @@ class AIPanel {
         // Handle comments - scroll to user comment row
         if (itemType === 'comment') {
             this.scrollToComment(itemId, file, line);
+            return;
+        }
+
+        // Handle external threads - scroll to inline external-comment-row
+        if (itemType === 'external') {
+            const source = item.dataset.source || '';
+            const threadId = item.dataset.threadId || itemId;
+            this.scrollToExternalThread(threadId, source, file, line);
             return;
         }
 
@@ -1124,6 +1288,167 @@ class AIPanel {
             setTimeout(doScroll, 50);
         } else {
             doScroll();
+        }
+    }
+
+    /**
+     * Scroll to an external review-comment thread in the diff view.
+     *
+     * Mirrors `scrollToComment`: expand the file if collapsed, find the
+     * `.external-comment-row` for the (threadId, source) pair, scroll it into
+     * view, and add a transient focus class for the visual flash.
+     *
+     * @param {string|number} threadId - Root comment id of the thread
+     * @param {string} source - External source key (e.g. 'github')
+     * @param {string} file - File path for collapse-expand fallback
+     * @param {string|number} line - Anchor line; used for file/line fallback
+     */
+    scrollToExternalThread(threadId, source, file, line) {
+        // Expand the file first if it's collapsed
+        const wasExpanded = this.expandFileIfCollapsed(file);
+
+        const doScroll = () => {
+            let target = null;
+
+            // Most reliable: match on (threadId, source). `data-thread-id`
+            // and `data-source` are written by ExternalCommentManager._buildThreadRow.
+            if (threadId) {
+                const idAttr = (typeof globalThis !== 'undefined' && globalThis.CSS?.escape)
+                    ? globalThis.CSS.escape(String(threadId))
+                    : String(threadId);
+                if (source) {
+                    const srcAttr = (typeof globalThis !== 'undefined' && globalThis.CSS?.escape)
+                        ? globalThis.CSS.escape(String(source))
+                        : String(source);
+                    target = document.querySelector(
+                        `.external-comment-row[data-thread-id="${idAttr}"][data-source="${srcAttr}"]`
+                    );
+                }
+                if (!target) {
+                    target = document.querySelector(
+                        `.external-comment-row[data-thread-id="${idAttr}"]`
+                    );
+                }
+            }
+
+            // Fallback: scan within the matching file by anchor line. Useful
+            // when the row was rebuilt and IDs are momentarily missing.
+            if (!target && file) {
+                const rows = document.querySelectorAll('.external-comment-row');
+                for (const row of rows) {
+                    const rowFile = row.closest('[data-file-name]')?.dataset?.fileName;
+                    if (rowFile && rowFile === file) {
+                        target = row;
+                        break;
+                    }
+                }
+            }
+
+            if (target) {
+                const minimizer = window.prManager?.commentMinimizer;
+                if (minimizer?.active) {
+                    minimizer.expandForElement(target);
+                    const diffRow = minimizer.findDiffRowFor(target);
+                    (diffRow || target).scrollIntoView({ behavior: 'smooth', block: 'center' });
+                } else {
+                    target.scrollIntoView({ behavior: 'smooth', block: 'center' });
+                }
+
+                // Transient focus flash. The class is removed after 2s — if
+                // the row is rebuilt before then, the class is lost with it,
+                // which is fine: the flash is purely cosmetic.
+                target.classList.add('external-comment-row--focused');
+                setTimeout(() => target.classList.remove('external-comment-row--focused'), 2000);
+            }
+        };
+
+        if (wasExpanded) {
+            setTimeout(doScroll, 50);
+        } else {
+            doScroll();
+        }
+    }
+
+    // ========================================
+    // Segment overflow scroll
+    // ========================================
+
+    /**
+     * Set up horizontal overflow scroll for the segment row.
+     *
+     * When the segment buttons don't all fit in the panel width, show
+     * chevron buttons on either side that scroll the row horizontally.
+     * Watches via ResizeObserver (panel width can change with the resizer
+     * handle) and the scroll container's own scroll event (to update
+     * chevron visibility at each end of travel).
+     */
+    setupSegmentOverflow() {
+        if (!this.segmentControlScroll) return;
+
+        const update = () => this.updateSegmentScrollChevrons();
+
+        // Wire the scroll container's scroll event for visibility updates.
+        this.segmentControlScroll.addEventListener('scroll', update, { passive: true });
+
+        // Observe size changes on the scroll container itself. Triggered by
+        // panel resize, segment hidden/shown (e.g. local-mode gate), and
+        // window resize.
+        if (typeof ResizeObserver !== 'undefined') {
+            this._segmentResizeObserver = new ResizeObserver(update);
+            this._segmentResizeObserver.observe(this.segmentControlScroll);
+        } else if (typeof window !== 'undefined') {
+            // Fallback for very old browsers — react to window resize at least.
+            window.addEventListener('resize', update);
+        }
+
+        // Initial measurement after layout settles.
+        update();
+    }
+
+    /**
+     * Show or hide the segment overflow chevrons based on current scroll
+     * geometry. Idempotent — safe to call from resize, scroll, or after a
+     * segment button is hidden/shown.
+     */
+    updateSegmentScrollChevrons() {
+        const container = this.segmentControlScroll;
+        if (!container) return;
+
+        const overflow = container.scrollWidth > container.clientWidth + 1;
+        const scrollLeft = container.scrollLeft;
+        const maxScroll = container.scrollWidth - container.clientWidth;
+        const atStart = scrollLeft <= 0;
+        const atEnd = scrollLeft >= maxScroll - 1;
+
+        if (this.segmentScrollLeft) {
+            // Hide left chevron when not overflowing or already at start.
+            if (!overflow || atStart) {
+                this.segmentScrollLeft.setAttribute('hidden', '');
+            } else {
+                this.segmentScrollLeft.removeAttribute('hidden');
+            }
+        }
+        if (this.segmentScrollRight) {
+            if (!overflow || atEnd) {
+                this.segmentScrollRight.setAttribute('hidden', '');
+            } else {
+                this.segmentScrollRight.removeAttribute('hidden');
+            }
+        }
+    }
+
+    /**
+     * Scroll the segment row horizontally by approximately one segment width.
+     * @param {number} direction - -1 for left, 1 for right
+     */
+    scrollSegmentRow(direction) {
+        const container = this.segmentControlScroll;
+        if (!container) return;
+        const amount = 150 * (direction < 0 ? -1 : 1);
+        if (typeof container.scrollBy === 'function') {
+            container.scrollBy({ left: amount, behavior: 'smooth' });
+        } else {
+            container.scrollLeft += amount;
         }
     }
 
@@ -1338,6 +1663,87 @@ class AIPanel {
     }
 
     /**
+     * Render a single external review-comment thread item.
+     *
+     * Modeled on `renderCommentItem` so the panel list stays visually
+     * consistent. Differs from comments in:
+     *   - no quick-action (adopt/dismiss) buttons — external threads are
+     *     read-only mirrors from GitHub.
+     *   - a reply-count badge when the thread has replies.
+     *   - `data-thread-id` + `data-source` so `scrollToExternalThread` can
+     *     find the inline `.external-comment-row` element.
+     *   - `.source-<name>` modifier so the blue --ec-* color block applies.
+     *
+     * @param {Object} thread - Normalized external thread (root + replies)
+     * @param {number} index - Item index in the rendered list
+     * @returns {string} HTML string
+     */
+    renderExternalThreadItem(thread, index) {
+        const source = thread.source || 'github';
+        const author = thread.author || 'reviewer';
+        // Plain-text snippet of the root body for the title slot. Markdown
+        // formatting is stripped so the line stays compact.
+        const rawBody = this.stripMarkdown(thread.body || '');
+        const snippet = this.truncateText(rawBody, 80);
+
+        const fileName = thread.file ? thread.file.split('/').pop() : null;
+        const lineNum = thread.line_start;
+        const fullLocation = fileName ? `${fileName}${lineNum ? ':' + lineNum : ''}` : '';
+
+        const replies = Array.isArray(thread.replies) ? thread.replies : [];
+        // Strict count of comments in the thread (root + replies). Always
+        // shown — replaces the static author dot to give a left-side anchor
+        // that conveys thread size at a glance.
+        const totalComments = 1 + replies.length;
+        const commentNoun = totalComments === 1 ? 'comment' : 'comments';
+
+        const outdatedClass = thread.is_outdated ? ' is-outdated' : '';
+
+        // Compose the tooltip: author + body snippet for quick context.
+        const tooltipBits = [];
+        if (author) tooltipBits.push(author);
+        if (fullLocation) tooltipBits.push(fullLocation);
+        if (rawBody) tooltipBits.push(rawBody.length > 200 ? rawBody.substring(0, 200) + '…' : rawBody);
+        const tooltip = tooltipBits.join(' — ');
+
+        const threadId = thread.id != null ? String(thread.id) : '';
+
+        // Chat button — mirrors the finding/comment quick-action pattern.
+        // Dispatches threadContext (not commentContext) so the chat receives
+        // the full thread + replies, matching the inline header button.
+        // External threads carry GitHub-sourced strings (author, body, file,
+        // source, id). Anything that lands inside a quoted HTML attribute must
+        // be escaped with the attribute-safe helper (escapes ", ', <, >, &) —
+        // the local escapeHtml is text-node-only and leaves quotes intact,
+        // which would let a crafted body break out of the attribute.
+        const attr = window.escapeHtmlAttribute;
+        let chatAction = '';
+        if (document.documentElement.getAttribute('data-chat') === 'available') {
+            chatAction = `
+            <div class="finding-chat-action">
+                <button class="quick-action-btn quick-action-chat" data-thread-id="${attr(threadId)}" data-source="${attr(source)}" data-item-type="external" title="Chat about thread" aria-label="Chat about thread">
+                    <svg viewBox="0 0 16 16" fill="currentColor" width="12" height="12"><path d="M1.75 1h8.5c.966 0 1.75.784 1.75 1.75v5.5A1.75 1.75 0 0 1 10.25 10H7.061l-2.574 2.573A1.458 1.458 0 0 1 2 11.543V10h-.25A1.75 1.75 0 0 1 0 8.25v-5.5C0 1.784.784 1 1.75 1ZM1.5 2.75v5.5c0 .138.112.25.25.25h1a.75.75 0 0 1 .75.75v2.19l2.72-2.72a.749.749 0 0 1 .53-.22h3.5a.25.25 0 0 0 .25-.25v-5.5a.25.25 0 0 0-.25-.25h-8.5a.25.25 0 0 0-.25.25Zm13 2a.25.25 0 0 0-.25-.25h-.5a.75.75 0 0 1 0-1.5h.5c.966 0 1.75.784 1.75 1.75v5.5A1.75 1.75 0 0 1 14.25 12H14v1.543a1.458 1.458 0 0 1-2.487 1.03L9.22 12.28a.749.749 0 0 1 .326-1.275.749.749 0 0 1 .734.215l2.22 2.22v-2.19a.75.75 0 0 1 .75-.75h1a.25.25 0 0 0 .25-.25Z"/></svg>
+                </button>
+            </div>
+        `;
+        }
+
+        return `
+            <div class="finding-item-wrapper">
+                <button class="finding-item ai-panel__list-item ai-panel__list-item--external source-${attr(source)}${outdatedClass}" data-index="${index}" data-id="${attr(threadId)}" data-thread-id="${attr(threadId)}" data-source="${attr(source)}" data-file="${attr(thread.file || '')}" data-line="${lineNum != null ? lineNum : ''}" data-item-type="external" title="${attr(tooltip)}">
+                    <span class="external-list-count" title="${totalComments} ${commentNoun}" aria-label="${totalComments} ${commentNoun} in thread">${totalComments}</span>
+                    <div class="finding-content">
+                        <span class="finding-title"><span class="external-list-author">${this.escapeHtml(author)}</span><span class="external-list-snippet">${snippet ? ' — ' + this.escapeHtml(snippet) : ''}</span></span>
+                        ${thread.is_outdated ? '<span class="finding-meta"><span class="external-list-outdated-badge">outdated</span></span>' : ''}
+                        ${fileName ? `<span class="finding-location">${this.escapeHtml(fileName)}${lineNum ? ':' + lineNum : ''}</span>` : ''}
+                    </div>
+                </button>
+                ${chatAction}
+            </div>
+        `;
+    }
+
+    /**
      * Get the comment-ai Octicon SVG for AI-adopted comments
      * @returns {string} SVG HTML string
      */
@@ -1480,7 +1886,8 @@ class AIPanel {
      */
     clearAllFindings() {
         this.findings = [];
-        // NOTE: Do NOT clear this.comments here. User comments are independent
+        // NOTE: Do NOT clear this.comments or this.externalThreads here.
+        // User comments and external review-comment threads are independent
         // of AI analysis and must persist across analysis runs.
         this.currentIndex = -1; // Reset navigation
         this.updateSegmentCounts();
@@ -1524,6 +1931,33 @@ class AIPanel {
         this.saveCurrentSelection();
 
         this.comments = comments || [];
+        this.updateSegmentCounts();
+        this.renderFindings();
+
+        // Try to restore previous selection, or auto-select first
+        if (!this.restoreSelection()) {
+            this.autoSelectFirst();
+        }
+    }
+
+    /**
+     * Replace the set of external comment threads displayed in the External
+     * segment. Mirrors {@link setComments}: replaces state, recomputes the
+     * count badge, re-renders the visible list (if the user is on External
+     * or All), and preserves any restorable selection.
+     *
+     * The panel never owns inline external rows — they live in
+     * `.external-comment-row` elements rendered by ExternalCommentManager.
+     * Pass the flattened union of `threadsBySource.values()`.
+     *
+     * @param {Array<Object>} threads - Flattened external threads (roots).
+     */
+    setExternalThreads(threads) {
+        // Save current selection before updating so the active item survives
+        // a re-render when its identity is still in the new list.
+        this.saveCurrentSelection();
+
+        this.externalThreads = Array.isArray(threads) ? threads : [];
         this.updateSegmentCounts();
         this.renderFindings();
 
@@ -1645,40 +2079,40 @@ class AIPanel {
         const itemCount = items.length;
         const currentDisplay = this.currentIndex >= 0 ? (this.currentIndex + 1) : '\u2014';
 
-        // Always get the .findings-header element directly to avoid parent reference issues
-        const headerContainer = document.querySelector('.findings-header');
-        if (!headerContainer) return;
+        // Target the .findings-nav slot only; the sibling .findings-header-actions
+        // (refresh button in PR mode) must persist across re-renders so its
+        // statically-bound click handler stays valid.
+        const navContainer = document.getElementById('findings-nav')
+            || document.querySelector('.findings-nav');
+        if (!navContainer) return;
 
-        // Hide navigation section entirely when there are no items
+        // Empty state: blank the nav slot so it collapses, but leave the
+        // sibling actions container alone. The refresh button stays available
+        // even when there are zero items (the reviewer may want to fetch).
         if (itemCount === 0) {
-            headerContainer.innerHTML = '';
+            navContainer.innerHTML = '';
             this.findingsCount = null;
             return;
         }
 
-        // Update or create the header content (no label - segments already indicate content type)
-        headerContainer.innerHTML = `
-            <div class="findings-nav">
-                <button class="findings-nav-btn nav-prev" title="Previous item (k)">
-                    <svg viewBox="0 0 16 16" width="12" height="12" fill="currentColor">
-                        <path d="M3.22 9.78a.75.75 0 010-1.06l4.25-4.25a.75.75 0 011.06 0l4.25 4.25a.75.75 0 01-1.06 1.06L8 6.06 4.28 9.78a.75.75 0 01-1.06 0z"/>
-                    </svg>
-                </button>
-                <span class="findings-counter" id="findings-count">${currentDisplay} of ${itemCount}</span>
-                <button class="findings-nav-btn nav-next" title="Next item (j)">
-                    <svg viewBox="0 0 16 16" width="12" height="12" fill="currentColor">
-                        <path d="M12.78 6.22a.75.75 0 010 1.06l-4.25 4.25a.75.75 0 01-1.06 0L3.22 7.28a.75.75 0 011.06-1.06L8 9.94l3.72-3.72a.75.75 0 011.06 0z"/>
-                    </svg>
-                </button>
-            </div>
+        navContainer.innerHTML = `
+            <button class="findings-nav-btn nav-prev" title="Previous item (k)">
+                <svg viewBox="0 0 16 16" width="12" height="12" fill="currentColor">
+                    <path d="M3.22 9.78a.75.75 0 010-1.06l4.25-4.25a.75.75 0 011.06 0l4.25 4.25a.75.75 0 01-1.06 1.06L8 6.06 4.28 9.78a.75.75 0 01-1.06 0z"/>
+                </svg>
+            </button>
+            <span class="findings-counter" id="findings-count">${currentDisplay} of ${itemCount}</span>
+            <button class="findings-nav-btn nav-next" title="Next item (j)">
+                <svg viewBox="0 0 16 16" width="12" height="12" fill="currentColor">
+                    <path d="M12.78 6.22a.75.75 0 010 1.06l-4.25 4.25a.75.75 0 01-1.06 0L3.22 7.28a.75.75 0 011.06-1.06L8 9.94l3.72-3.72a.75.75 0 011.06 0z"/>
+                </svg>
+            </button>
         `;
 
-        // Re-bind reference to findings count
-        this.findingsCount = headerContainer.querySelector('#findings-count');
+        this.findingsCount = navContainer.querySelector('#findings-count');
 
-        // Bind nav button events
-        const prevBtn = headerContainer.querySelector('.nav-prev');
-        const nextBtn = headerContainer.querySelector('.nav-next');
+        const prevBtn = navContainer.querySelector('.nav-prev');
+        const nextBtn = navContainer.querySelector('.nav-next');
         if (prevBtn) {
             prevBtn.addEventListener('click', () => this.goToPrevious());
         }
@@ -1768,6 +2202,8 @@ class AIPanel {
 
         if (item._itemType === 'comment') {
             this.scrollToComment(itemId, file, line);
+        } else if (item._itemType === 'external') {
+            this.scrollToExternalThread(itemId, item.source, file, line);
         } else {
             this.scrollToFinding(itemId, file, line);
         }

--- a/public/js/components/AIPanel.js
+++ b/public/js/components/AIPanel.js
@@ -54,9 +54,17 @@ class AIPanel {
         this.bindEvents();
         this.setupKeyboardNavigation();
         this.setupSegmentOverflow();
-        // Hide the External segment in Local mode — no external source exists there.
-        if (typeof window !== 'undefined' && window.PAIR_REVIEW_LOCAL_MODE) {
-            this.segmentExternalBtn?.setAttribute('hidden', '');
+        // Hide the External segment when:
+        //   1. Local mode — no external source exists for local reviews.
+        //   2. The `external_comments` feature toggle is off in config.
+        // Both are synchronous flags (set before this constructor runs) so
+        // the segment never flashes into view when it shouldn't.
+        if (typeof window !== 'undefined') {
+            const localMode = window.PAIR_REVIEW_LOCAL_MODE;
+            const externalDisabled = window.PAIR_REVIEW_RUNTIME_CONFIG?.external_comments_enabled === false;
+            if (localMode || externalDisabled) {
+                this.segmentExternalBtn?.setAttribute('hidden', '');
+            }
         }
         // Don't restore segment on init - wait for setPR() call
 

--- a/public/js/components/ChatPanel.js
+++ b/public/js/components/ChatPanel.js
@@ -3125,9 +3125,9 @@ class ChatPanel {
       : '';
 
     // Author rendering — linked to externalUrl only when the URL passes
-    // the scheme allowlist. Mirrors `_renderThreadCommentHTML` and the
-    // external-comment-manager so `javascript:` / `data:` URLs from a
-    // malicious upstream can't smuggle a live `<a href>` into the DOM.
+    // the scheme allowlist. Mirrors the external-comment-manager so
+    // `javascript:` / `data:` URLs from a malicious upstream can't smuggle
+    // a live `<a href>` into the DOM.
     let authorHTML = '';
     if (isExternal && ctx.author) {
       const escapedAuthor = this._escapeHtml(ctx.author);
@@ -3177,17 +3177,16 @@ class ChatPanel {
   _addThreadContextCard(ctx, { removable = false } = {}) {
     const card = document.createElement('div');
     const externalSource = ctx.externalSource || null;
-    const classes = ['chat-panel__context-card', 'chat-panel__context-card--thread', 'external-comment-context'];
+    // No --thread modifier: thread cards now use the same compact single-line
+    // layout as line/file cards. The full thread content is exposed via the
+    // card's title attribute (hover tooltip).
+    const classes = ['chat-panel__context-card', 'external-comment-context'];
     if (externalSource) classes.push(`source-${externalSource}`);
     card.className = classes.join(' ');
 
     const sourceLabel = this._formatExternalSourceLabel(externalSource);
     const fileLabel = ctx.file || 'unknown file';
     let anchor = fileLabel;
-    // Mirror the prompt builder: start with line_start, then append
-    // "-line_end" only when end is set and differs from start. Showing
-    // line_end alone (the previous behavior) silently dropped the start
-    // of multi-line ranges.
     if (ctx.line_start) {
       anchor += `:${ctx.line_start}`;
       if (ctx.line_end && ctx.line_end !== ctx.line_start) {
@@ -3196,23 +3195,35 @@ class ChatPanel {
     }
     const comments = Array.isArray(ctx.comments) ? ctx.comments : [];
 
-    const headerHTML = `
-      <div class="chat-panel__context-thread-header">
-        <svg viewBox="0 0 16 16" fill="currentColor" width="12" height="12">
-          <path d="M1 2.75C1 1.784 1.784 1 2.75 1h10.5c.966 0 1.75.784 1.75 1.75v7.5A1.75 1.75 0 0 1 13.25 12H9.06l-2.573 2.573A1.458 1.458 0 0 1 4 13.543V12H2.75A1.75 1.75 0 0 1 1 10.25Z"/>
-        </svg>
-        <span class="chat-panel__context-label">${this._escapeHtml(sourceLabel)} thread on ${this._escapeHtml(anchor)}</span>
-        <span class="chat-panel__context-count">${comments.length} comment${comments.length === 1 ? '' : 's'}</span>
-      </div>
-    `;
+    // Snippet from the first comment for the visible title slot. Stripped of
+    // markdown syntax so the line reads cleanly when truncated by ellipsis.
+    const firstBody = comments[0]?.body || '';
+    const stripped = this._stripMarkdownForSnippet(firstBody);
+    const snippet = stripped.length > 80 ? stripped.substring(0, 80) + '…' : stripped;
 
-    const commentsHTML = comments.map((c) => this._renderThreadCommentHTML(c)).join('');
+    // Full thread content for the hover tooltip — plain text, one comment per
+    // block so the native title attribute (which respects newlines on most
+    // platforms) gives the reviewer the full conversation on hover.
+    const tooltip = comments.map((c, i) => {
+      const author = c.author || 'unknown';
+      const ts = c.externalCreatedAt ? ` · ${c.externalCreatedAt}` : '';
+      const out = c.isOutdated ? ' (outdated)' : '';
+      const body = (c.body || '(no body)').trim();
+      return `${i + 1}. ${author}${ts}${out}\n${body}`;
+    }).join('\n\n');
+
+    card.setAttribute('title', tooltip);
+
+    const countText = `${comments.length} comment${comments.length === 1 ? '' : 's'}`;
 
     card.innerHTML = `
-      ${headerHTML}
-      <div class="chat-panel__context-thread-body">
-        ${commentsHTML}
-      </div>
+      <svg viewBox="0 0 16 16" fill="currentColor" width="12" height="12">
+        <path d="M1 2.75C1 1.784 1.784 1 2.75 1h10.5c.966 0 1.75.784 1.75 1.75v7.5A1.75 1.75 0 0 1 13.25 12H9.06l-2.573 2.573A1.458 1.458 0 0 1 4 13.543V12H2.75A1.75 1.75 0 0 1 1 10.25Z"/>
+      </svg>
+      <span class="chat-panel__context-label"><strong>${this._escapeHtml(sourceLabel.toUpperCase())} THREAD</strong></span>
+      <span class="chat-panel__context-title">${snippet ? this._escapeHtml(snippet) : '<em>(empty)</em>'}</span>
+      <span class="chat-panel__context-file">${this._escapeHtml(anchor)}</span>
+      <span class="chat-panel__context-count">${countText}</span>
     `;
 
     if (removable) this._makeCardRemovable(card);
@@ -3222,49 +3233,24 @@ class ChatPanel {
   }
 
   /**
-   * Render a single comment in a thread context card.
-   * @param {Object} c - Comment entry {author, body, isOutdated, externalUrl, externalCreatedAt}
-   * @returns {string} HTML string
+   * Strip a small set of common markdown syntax so a snippet reads cleanly
+   * when truncated. Not a full parser — just enough to drop heading/list
+   * markers, inline code backticks, and bold/italic emphasis.
+   * @private
    */
-  _renderThreadCommentHTML(c) {
-    const author = c.author || 'unknown';
-    const escapedAuthor = this._escapeHtml(author);
-    let authorHTML;
-    // Only emit a link when the URL is safe (http/https/mailto). Otherwise
-    // a malicious upstream could smuggle a `javascript:` URL into our DOM.
-    if (c.externalUrl && this._isSafeUrl(c.externalUrl)) {
-      const escapedUrl = window.escapeHtmlAttribute
-        ? window.escapeHtmlAttribute(c.externalUrl)
-        : this._escapeHtml(c.externalUrl);
-      authorHTML = `<a class="chat-panel__context-author" href="${escapedUrl}" target="_blank" rel="noopener noreferrer">${escapedAuthor}</a>`;
-    } else {
-      authorHTML = `<span class="chat-panel__context-author">${escapedAuthor}</span>`;
-    }
-
-    const timestampHTML = c.externalCreatedAt
-      ? `<span class="chat-panel__context-timestamp">${this._escapeHtml(c.externalCreatedAt)}</span>`
-      : '';
-    const outdatedHTML = c.isOutdated
-      ? '<span class="chat-panel__context-badge chat-panel__context-badge--outdated">outdated</span>'
-      : '';
-
-    const bodyHTML = c.body
-      ? this.renderMarkdown(c.body)
-      : '<em>(no body)</em>';
-
-    const entryClasses = ['chat-panel__context-thread-comment'];
-    if (c.isOutdated) entryClasses.push('is-outdated');
-
-    return `
-      <div class="${entryClasses.join(' ')}">
-        <div class="chat-panel__context-thread-comment-header">
-          ${authorHTML}
-          ${timestampHTML}
-          ${outdatedHTML}
-        </div>
-        <div class="chat-panel__context-thread-comment-body">${bodyHTML}</div>
-      </div>
-    `;
+  _stripMarkdownForSnippet(text) {
+    if (!text) return '';
+    return String(text)
+      .replace(/```[\s\S]*?```/g, ' ')
+      .replace(/`([^`]+)`/g, '$1')
+      .replace(/^\s{0,3}#{1,6}\s+/gm, '')
+      .replace(/^\s*[-*+]\s+/gm, '')
+      .replace(/\*\*([^*]+)\*\*/g, '$1')
+      .replace(/\*([^*]+)\*/g, '$1')
+      .replace(/__([^_]+)__/g, '$1')
+      .replace(/_([^_]+)_/g, '$1')
+      .replace(/\s+/g, ' ')
+      .trim();
   }
 
   /**

--- a/public/js/components/ChatPanel.js
+++ b/public/js/components/ChatPanel.js
@@ -1195,14 +1195,31 @@ class ChatPanel {
    * @param {number} options.reviewId - Review ID
    * @param {number} options.suggestionId - Suggestion ID to ask about
    * @param {Object} options.suggestionContext - AI suggestion details for context
-   * @param {Object} options.commentContext - User comment details for context
+   * @param {Object} options.commentContext - Comment details for context
    * @param {string} options.commentContext.commentId - Comment ID
    * @param {string} options.commentContext.body - Comment body text
    * @param {string} options.commentContext.file - File path
    * @param {number} options.commentContext.line_start - Start line number
    * @param {number} options.commentContext.line_end - End line number
-   * @param {string} options.commentContext.source - 'user' for user comments
+   * @param {string} options.commentContext.source - 'user' for user comments, 'external' for external systems (e.g. GitHub)
+   * @param {string} [options.commentContext.externalSource] - When source === 'external', the external system id (e.g. 'github'). Drives theming.
+   * @param {string} [options.commentContext.externalUrl] - Permalink to the comment in the external system.
+   * @param {boolean} [options.commentContext.isOutdated] - Whether the external comment is anchored to an outdated diff position.
+   * @param {string} [options.commentContext.author] - External author/username.
    * @param {boolean} options.commentContext.isFileLevel - True if file-level comment
+   * @param {Object} options.threadContext - Multi-comment thread context (external systems only)
+   * @param {number|string} options.threadContext.rootId - Local id of the thread root
+   * @param {string} options.threadContext.source - Always 'external' for now
+   * @param {string} options.threadContext.externalSource - e.g. 'github'; drives theming + label
+   * @param {string} options.threadContext.file - File path
+   * @param {number|null} options.threadContext.line_start - Start line (null if outdated)
+   * @param {number|null} options.threadContext.line_end - End line (null if outdated)
+   * @param {Array<Object>} options.threadContext.comments - Ordered comments in the thread
+   * @param {string|null} options.threadContext.comments[].author - Author name
+   * @param {string} options.threadContext.comments[].body - Comment markdown
+   * @param {boolean} options.threadContext.comments[].isOutdated - Whether this comment is outdated
+   * @param {string|null} options.threadContext.comments[].externalUrl - Permalink in the source system
+   * @param {string|null} options.threadContext.comments[].externalCreatedAt - ISO timestamp of creation
    */
   async open(options = {}) {
     // Concurrency guard: if a previous open() is still loading MRU / messages,
@@ -1258,7 +1275,14 @@ class ChatPanel {
     // attached as tabs are created/restored.
     this._ensureSubscriptions();
 
-    const hasExplicitContext = !!(options.suggestionContext || options.commentContext || options.fileContext);
+    // Recognise thread context (external systems) alongside suggestion / user
+    // comment / file when deciding whether to open with explicit context.
+    const hasExplicitContext = !!(
+      options.suggestionContext ||
+      options.commentContext ||
+      options.threadContext ||
+      options.fileContext
+    );
 
     // First-time open behaviour:
     //   1. If localStorage has a tab list for this review, restore those tabs.
@@ -1313,10 +1337,19 @@ class ChatPanel {
           line_start: options.commentContext.line_start,
           line_end: options.commentContext.line_end,
         };
+      } else if (options.commentContext.source === 'external') {
+        // External comments are read-only — no adopt/update/dismiss actions
+        this._contextSource = 'external-comment';
+        this._contextItemId = options.commentContext.commentId || null;
       } else {
         this._contextSource = 'user';
         this._contextItemId = options.commentContext.commentId || null;
       }
+    } else if (options.threadContext) {
+      // If opening with thread context (external systems only), inject as a card
+      this._sendThreadContextMessage(options.threadContext);
+      this._contextSource = 'external-thread';
+      this._contextItemId = options.threadContext.rootId || null;
     } else if (options.fileContext) {
       // If opening with file context, inject it as a context card
       this._sendFileContextMessage(options.fileContext);
@@ -1388,6 +1421,11 @@ class ChatPanel {
   async _startNewConversation() {
     this._hideProviderDropdown();
     this._hideSessionDropdown();
+    // Multi-chat replaces the legacy in-place reset with a fresh tab; the
+    // per-tab restore path inside _appendTab handles context cards
+    // (including thread cards introduced by external-comments) so the
+    // savedContext / ctxData.type === 'thread' branch is no longer needed
+    // at this entry point.
     await this._openNewTab();
   }
 
@@ -1586,6 +1624,8 @@ class ChatPanel {
               this._addLineContextCard(ctxData);
             } else if (ctxData.type === 'comment') {
               this._addCommentContextCard(ctxData);
+            } else if (ctxData.type === 'thread') {
+              this._addThreadContextCard(ctxData);
             } else {
               this._addContextCard(ctxData);
             }
@@ -2477,12 +2517,13 @@ class ChatPanel {
   }
 
   /**
-   * Store pending context and render a compact context card for a user comment or line reference.
-   * Called when the user clicks "Ask about this" on a user comment, or clicks
-   * the gutter chat button (line reference with no comment body).
+   * Store pending context and render a compact context card for a user/external comment or line reference.
+   * Called when the user clicks "Ask about this" on a user comment, an external (e.g. GitHub) comment,
+   * or clicks the gutter chat button (line reference with no comment body).
    * The context is NOT sent to the agent immediately -- it is prepended
    * to the next user message so the agent receives question + context together.
-   * @param {Object} ctx - Comment context {commentId, type, body, file, line_start, line_end, source, isFileLevel}
+   * @param {Object} ctx - Comment context. When `source === 'external'`, additional fields are honored:
+   *   `externalSource` (string, e.g. 'github'), `externalUrl` (permalink), `isOutdated` (boolean), `author` (string).
    */
   _sendCommentContextMessage(ctx) {
     const tab = this._getActiveTab();
@@ -2492,6 +2533,7 @@ class ChatPanel {
     if (emptyState) emptyState.remove();
 
     const isLine = ctx.type === 'line';
+    const isExternal = ctx.source === 'external';
 
     // Store structured context data for DB persistence
     const lineLabel = !ctx.line_start
@@ -2503,19 +2545,33 @@ class ChatPanel {
         ? lineLabel
         : (ctx.isFileLevel ? 'File comment' : `Comment on line ${ctx.line_start || '?'}`),
       file: ctx.file || null,
+      side: ctx.side || null,
       line_start: ctx.line_start || null,
       line_end: ctx.line_end || null,
       body: ctx.body || null,
-      source: 'user'
+      source: isExternal ? 'external' : 'user'
     };
+    if (isExternal) {
+      contextData.externalSource = ctx.externalSource || null;
+      contextData.externalUrl = ctx.externalUrl || null;
+      contextData.isOutdated = !!ctx.isOutdated;
+      contextData.author = ctx.author || null;
+    }
     tab.pendingContextData.push(contextData);
 
     // Build the plain text context for the agent
+    const sourceLabel = isExternal
+      ? (ctx.externalSource ? this._formatExternalSourceLabel(ctx.externalSource) : 'an external system')
+      : null;
     const lines = isLine
       ? [ctx.line_start
         ? `The user wants to discuss code at ${lineLabel} in ${contextData.file || 'unknown file'}:`
         : `The user wants to discuss the file ${contextData.file || 'unknown file'}:`]
-      : ['The user wants to discuss a review comment:'];
+      : isExternal
+        ? [ctx.author
+          ? `The user wants to discuss a review comment posted on ${sourceLabel} by ${ctx.author}:`
+          : `The user wants to discuss a review comment posted on ${sourceLabel}:`]
+        : ['The user wants to discuss a review comment:'];
     if (contextData.file) {
       let fileLine = `- File: ${contextData.file}`;
       if (contextData.line_start) {
@@ -2526,8 +2582,19 @@ class ChatPanel {
     if (ctx.isFileLevel) {
       lines.push('- Scope: File-level comment');
     }
-    if (ctx.parentId) {
+    if (ctx.parentId && !isExternal) {
       lines.push('- Origin: adopted from AI suggestion');
+    }
+    if (isExternal) {
+      if (ctx.author) {
+        lines.push(`- Author: ${ctx.author}`);
+      }
+      if (ctx.isOutdated) {
+        lines.push('- Status: outdated (the diff position no longer exists in the current PR head)');
+      }
+      if (ctx.externalUrl) {
+        lines.push(`- Link: ${ctx.externalUrl}`);
+      }
     }
     if (contextData.body) {
       lines.push(`- Comment: ${contextData.body}`);
@@ -2538,7 +2605,7 @@ class ChatPanel {
     if (patch && window.DiffContext) {
       if (contextData.line_start && !ctx.isFileLevel) {
         const hunk = window.DiffContext.extractHunkForLines(
-          patch, contextData.line_start, contextData.line_end || contextData.line_start
+          patch, contextData.line_start, contextData.line_end || contextData.line_start, contextData.side
         );
         if (hunk) {
           lines.push(`- Diff hunk:\n\`\`\`\n${hunk}\n\`\`\``);
@@ -2559,6 +2626,120 @@ class ChatPanel {
     } else {
       this._addCommentContextCard(ctx, { removable: true });
     }
+  }
+
+  /**
+   * Format an externalSource identifier into a human-readable label.
+   * @param {string} externalSource - e.g. 'github', 'gitlab'
+   * @returns {string}
+   */
+  _formatExternalSourceLabel(externalSource) {
+    if (!externalSource) return 'an external system';
+    switch (externalSource) {
+      case 'github': return 'GitHub';
+      case 'gitlab': return 'GitLab';
+      case 'linear': return 'Linear';
+      default:
+        return externalSource.charAt(0).toUpperCase() + externalSource.slice(1);
+    }
+  }
+
+  /**
+   * Store pending context and render a compact context card for a comment thread.
+   * Called when the user clicks "chat about this thread" on an external thread (e.g. GitHub).
+   * Threads are external systems only -- internal user comments don't have a thread shape.
+   * @param {Object} threadContext - See JSDoc on open() for full shape.
+   */
+  _sendThreadContextMessage(threadContext) {
+    const tab = this._getActiveTab();
+    if (!tab) return;
+    // Remove empty state if present
+    const emptyState = tab.messagesEl?.querySelector('.chat-panel__empty');
+    if (emptyState) emptyState.remove();
+
+    const comments = Array.isArray(threadContext.comments) ? threadContext.comments : [];
+    const externalSource = threadContext.externalSource || null;
+    const sourceLabel = this._formatExternalSourceLabel(externalSource);
+
+    // Store structured context data for DB persistence
+    const contextData = {
+      type: 'thread',
+      title: `${sourceLabel} thread`,
+      file: threadContext.file || null,
+      side: threadContext.side || null,
+      line_start: threadContext.line_start || null,
+      line_end: threadContext.line_end || null,
+      body: null,
+      source: 'external',
+      externalSource,
+      rootId: threadContext.rootId || null,
+      comments: comments.map((c) => ({
+        author: c.author || null,
+        body: c.body || '',
+        isOutdated: !!c.isOutdated,
+        externalUrl: c.externalUrl || null,
+        externalCreatedAt: c.externalCreatedAt || null,
+      })),
+    };
+    tab.pendingContextData.push(contextData);
+
+    // Build the plain text context for the agent
+    const fileLabel = contextData.file || 'unknown file';
+    let anchor = fileLabel;
+    if (contextData.line_start) {
+      anchor += `:${contextData.line_start}`;
+      if (contextData.line_end && contextData.line_end !== contextData.line_start) {
+        anchor += `-${contextData.line_end}`;
+      }
+    }
+    const lines = [
+      `The user wants to discuss a thread of ${comments.length} comment${comments.length === 1 ? '' : 's'} from ${sourceLabel} on ${anchor}:`,
+    ];
+    if (contextData.file) {
+      let fileLine = `- File: ${contextData.file}`;
+      if (contextData.line_start) {
+        fileLine += ` (line ${contextData.line_start}${contextData.line_end && contextData.line_end !== contextData.line_start ? '-' + contextData.line_end : ''})`;
+      }
+      lines.push(fileLine);
+    }
+    lines.push(`- Source: ${sourceLabel}`);
+    lines.push(`- Comment count: ${comments.length}`);
+
+    comments.forEach((c, idx) => {
+      const author = c.author || 'unknown';
+      const parts = [`Comment ${idx + 1} by ${author}`];
+      if (c.externalCreatedAt) parts.push(`at ${c.externalCreatedAt}`);
+      if (c.isOutdated) parts.push('(outdated)');
+      if (c.externalUrl) parts.push(`(${c.externalUrl})`);
+      lines.push(`- ${parts.join(' ')}:`);
+      const body = (c.body || '').trim() || '(no body)';
+      // Indent body so it renders as a quote block
+      const indented = body.split('\n').map((ln) => `  > ${ln}`).join('\n');
+      lines.push(indented);
+    });
+
+    // Enrich with diff hunk if available
+    const patch = window.prManager?.filePatches?.get(contextData.file);
+    if (patch && window.DiffContext) {
+      if (contextData.line_start) {
+        const hunk = window.DiffContext.extractHunkForLines(
+          patch, contextData.line_start, contextData.line_end || contextData.line_start, contextData.side
+        );
+        if (hunk) {
+          lines.push(`- Diff hunk:\n\`\`\`\n${hunk}\n\`\`\``);
+        }
+      } else {
+        const ranges = window.DiffContext.extractHunkRangesForFile(patch);
+        if (ranges.length) {
+          lines.push(`- Diff hunk ranges: ${JSON.stringify(ranges)}`);
+        }
+      }
+    }
+
+    tab.pendingContext.push(lines.join('\n'));
+
+    // Render the compact context card in the UI
+    this._addThreadContextCard(contextData, { removable: true });
   }
 
   /**
@@ -2914,17 +3095,54 @@ class ChatPanel {
   }
 
   /**
-   * Add a compact context card for a user comment to the messages area.
-   * @param {Object} ctx - Comment context {commentId, body, file, line_start, line_end, isFileLevel}
+   * Add a compact context card for a user or external comment to the messages area.
+   * When `ctx.source === 'external'`, adds external-comment-context classes
+   * (and `source-<externalSource>`) so per-source theming variables apply,
+   * renders the author label (linked to externalUrl when present), and shows
+   * an "outdated" badge when `ctx.isOutdated`.
+   * @param {Object} ctx - Comment context {commentId, body, file, line_start, line_end, isFileLevel, source, externalSource, externalUrl, isOutdated, author}
    */
   _addCommentContextCard(ctx, { removable = false } = {}) {
     const card = document.createElement('div');
-    card.className = 'chat-panel__context-card';
+    const isExternal = ctx.source === 'external';
+    const classes = ['chat-panel__context-card'];
+    if (isExternal) {
+      classes.push('external-comment-context');
+      if (ctx.externalSource) classes.push(`source-${ctx.externalSource}`);
+      if (ctx.isOutdated) classes.push('is-outdated');
+    }
+    card.className = classes.join(' ');
 
-    const label = ctx.isFileLevel ? 'file comment' : 'comment';
+    const sourceLabel = isExternal
+      ? this._formatExternalSourceLabel(ctx.externalSource)
+      : null;
+    const label = isExternal
+      ? (ctx.isFileLevel ? `${sourceLabel} file comment` : `${sourceLabel} comment`)
+      : (ctx.isFileLevel ? 'file comment' : 'comment');
     const bodyPreview = ctx.body ? (ctx.body.length > 60 ? ctx.body.substring(0, 60) + '...' : ctx.body) : 'Comment';
     const fileInfo = ctx.file
       ? `${ctx.file}${ctx.line_start ? ':' + ctx.line_start : ''}`
+      : '';
+
+    // Author rendering — linked to externalUrl only when the URL passes
+    // the scheme allowlist. Mirrors `_renderThreadCommentHTML` and the
+    // external-comment-manager so `javascript:` / `data:` URLs from a
+    // malicious upstream can't smuggle a live `<a href>` into the DOM.
+    let authorHTML = '';
+    if (isExternal && ctx.author) {
+      const escapedAuthor = this._escapeHtml(ctx.author);
+      if (ctx.externalUrl && this._isSafeUrl(ctx.externalUrl)) {
+        const escapedUrl = window.escapeHtmlAttribute
+          ? window.escapeHtmlAttribute(ctx.externalUrl)
+          : this._escapeHtml(ctx.externalUrl);
+        authorHTML = `<a class="chat-panel__context-author" href="${escapedUrl}" target="_blank" rel="noopener noreferrer">${escapedAuthor}</a>`;
+      } else {
+        authorHTML = `<span class="chat-panel__context-author">${escapedAuthor}</span>`;
+      }
+    }
+
+    const outdatedHTML = isExternal && ctx.isOutdated
+      ? '<span class="chat-panel__context-badge chat-panel__context-badge--outdated">outdated</span>'
       : '';
 
     card.innerHTML = `
@@ -2932,6 +3150,8 @@ class ChatPanel {
         <path d="M10.561 8.073a6.005 6.005 0 0 1 3.432 5.142.75.75 0 1 1-1.498.07 4.5 4.5 0 0 0-8.99 0 .75.75 0 0 1-1.498-.07 6.004 6.004 0 0 1 3.431-5.142 3.999 3.999 0 1 1 5.123 0ZM10.5 5a2.5 2.5 0 1 0-5 0 2.5 2.5 0 0 0 5 0Z"/>
       </svg>
       <span class="chat-panel__context-label">${this._escapeHtml(label)}</span>
+      ${authorHTML}
+      ${outdatedHTML}
       <span class="chat-panel__context-title">${this._renderInlineMarkdown(bodyPreview)}</span>
       ${fileInfo ? `<span class="chat-panel__context-file">${this._escapeHtml(fileInfo)}</span>` : ''}
     `;
@@ -2943,6 +3163,108 @@ class ChatPanel {
 
     this.messagesEl.appendChild(card);
     requestAnimationFrame(() => this.scrollToBottom({ force: true }));
+  }
+
+  /**
+   * Add a compact context card for an external comment thread to the messages area.
+   * Renders the thread header (source + file:line) and a list of comments,
+   * each with author (linked to externalUrl when present), timestamp, body
+   * (rendered as markdown), and an "outdated" badge when applicable.
+   * @param {Object} ctx - Thread context data persisted by _sendThreadContextMessage.
+   * @param {Object} [options] - Options
+   * @param {boolean} [options.removable=false] - Whether the card should have a remove button
+   */
+  _addThreadContextCard(ctx, { removable = false } = {}) {
+    const card = document.createElement('div');
+    const externalSource = ctx.externalSource || null;
+    const classes = ['chat-panel__context-card', 'chat-panel__context-card--thread', 'external-comment-context'];
+    if (externalSource) classes.push(`source-${externalSource}`);
+    card.className = classes.join(' ');
+
+    const sourceLabel = this._formatExternalSourceLabel(externalSource);
+    const fileLabel = ctx.file || 'unknown file';
+    let anchor = fileLabel;
+    // Mirror the prompt builder: start with line_start, then append
+    // "-line_end" only when end is set and differs from start. Showing
+    // line_end alone (the previous behavior) silently dropped the start
+    // of multi-line ranges.
+    if (ctx.line_start) {
+      anchor += `:${ctx.line_start}`;
+      if (ctx.line_end && ctx.line_end !== ctx.line_start) {
+        anchor += `-${ctx.line_end}`;
+      }
+    }
+    const comments = Array.isArray(ctx.comments) ? ctx.comments : [];
+
+    const headerHTML = `
+      <div class="chat-panel__context-thread-header">
+        <svg viewBox="0 0 16 16" fill="currentColor" width="12" height="12">
+          <path d="M1 2.75C1 1.784 1.784 1 2.75 1h10.5c.966 0 1.75.784 1.75 1.75v7.5A1.75 1.75 0 0 1 13.25 12H9.06l-2.573 2.573A1.458 1.458 0 0 1 4 13.543V12H2.75A1.75 1.75 0 0 1 1 10.25Z"/>
+        </svg>
+        <span class="chat-panel__context-label">${this._escapeHtml(sourceLabel)} thread on ${this._escapeHtml(anchor)}</span>
+        <span class="chat-panel__context-count">${comments.length} comment${comments.length === 1 ? '' : 's'}</span>
+      </div>
+    `;
+
+    const commentsHTML = comments.map((c) => this._renderThreadCommentHTML(c)).join('');
+
+    card.innerHTML = `
+      ${headerHTML}
+      <div class="chat-panel__context-thread-body">
+        ${commentsHTML}
+      </div>
+    `;
+
+    if (removable) this._makeCardRemovable(card);
+
+    this.messagesEl.appendChild(card);
+    requestAnimationFrame(() => this.scrollToBottom({ force: true }));
+  }
+
+  /**
+   * Render a single comment in a thread context card.
+   * @param {Object} c - Comment entry {author, body, isOutdated, externalUrl, externalCreatedAt}
+   * @returns {string} HTML string
+   */
+  _renderThreadCommentHTML(c) {
+    const author = c.author || 'unknown';
+    const escapedAuthor = this._escapeHtml(author);
+    let authorHTML;
+    // Only emit a link when the URL is safe (http/https/mailto). Otherwise
+    // a malicious upstream could smuggle a `javascript:` URL into our DOM.
+    if (c.externalUrl && this._isSafeUrl(c.externalUrl)) {
+      const escapedUrl = window.escapeHtmlAttribute
+        ? window.escapeHtmlAttribute(c.externalUrl)
+        : this._escapeHtml(c.externalUrl);
+      authorHTML = `<a class="chat-panel__context-author" href="${escapedUrl}" target="_blank" rel="noopener noreferrer">${escapedAuthor}</a>`;
+    } else {
+      authorHTML = `<span class="chat-panel__context-author">${escapedAuthor}</span>`;
+    }
+
+    const timestampHTML = c.externalCreatedAt
+      ? `<span class="chat-panel__context-timestamp">${this._escapeHtml(c.externalCreatedAt)}</span>`
+      : '';
+    const outdatedHTML = c.isOutdated
+      ? '<span class="chat-panel__context-badge chat-panel__context-badge--outdated">outdated</span>'
+      : '';
+
+    const bodyHTML = c.body
+      ? this.renderMarkdown(c.body)
+      : '<em>(no body)</em>';
+
+    const entryClasses = ['chat-panel__context-thread-comment'];
+    if (c.isOutdated) entryClasses.push('is-outdated');
+
+    return `
+      <div class="${entryClasses.join(' ')}">
+        <div class="chat-panel__context-thread-comment-header">
+          ${authorHTML}
+          ${timestampHTML}
+          ${outdatedHTML}
+        </div>
+        <div class="chat-panel__context-thread-comment-body">${bodyHTML}</div>
+      </div>
+    `;
   }
 
   /**
@@ -4218,6 +4540,28 @@ class ChatPanel {
     const div = document.createElement('div');
     div.textContent = text;
     return div.innerHTML;
+  }
+
+  /**
+   * Allow only http/https/mailto URLs in href attributes. Used to gate
+   * server-supplied URLs (external comment permalinks, profile URLs) so a
+   * malicious upstream cannot smuggle `javascript:` or `data:` schemes
+   * into our DOM.
+   * @param {string} url
+   * @returns {boolean}
+   */
+  _isSafeUrl(url) {
+    if (typeof url !== 'string' || !url) return false;
+    const trimmed = url.trim();
+    if (!trimmed) return false;
+    if (trimmed.startsWith('/') || trimmed.startsWith('#') || trimmed.startsWith('?')) return true;
+    try {
+      const base = (typeof window !== 'undefined' && window.location) ? window.location.href : 'http://localhost/';
+      const u = new URL(trimmed, base);
+      return u.protocol === 'http:' || u.protocol === 'https:' || u.protocol === 'mailto:';
+    } catch {
+      return false;
+    }
   }
 
   /**

--- a/public/js/modules/comment-minimizer.js
+++ b/public/js/modules/comment-minimizer.js
@@ -2,10 +2,11 @@
 /**
  * CommentMinimizer - Manages "minimize comments" mode for the diff view.
  *
- * When active, all inline comment rows (.user-comment-row) and AI suggestion
- * rows (.ai-suggestion-row) are hidden via CSS class.  Small indicator buttons
- * are injected on the right edge of each diff line that has comments, showing
- * a person icon (user comments) or sparkles icon (AI suggestions).
+ * When active, all inline comment rows (.user-comment-row, .ai-suggestion-row,
+ * and .external-comment-row) are hidden via CSS class. Small indicator
+ * buttons are injected on the right edge of each diff line that has
+ * comments, showing a person icon (user comments), sparkles icon (AI
+ * suggestions), or chat-bubble icon (external review comments).
  *
  * File-level comments (.file-comment-card inside .file-comments-zone) are also
  * hidden, with an indicator button injected into the file header bar.
@@ -22,6 +23,9 @@ class CommentMinimizer {
 
   /** AI comment icon SVG — speech bubble with sparkles (matches CommentManager.AI_ICON_SVG, different size) */
   static AI_COMMENT_ICON = `<svg viewBox="0 0 16 16" width="14" height="14" fill="currentColor"><path d="M7.75 1a.75.75 0 0 1 0 1.5h-5a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h2c.199 0 .39.079.53.22.141.14.22.331.22.53v2.19l2.72-2.72a.747.747 0 0 1 .53-.22h4.5a.25.25 0 0 0 .25-.25v-2a.75.75 0 0 1 1.5 0v2c0 .464-.184.909-.513 1.237A1.746 1.746 0 0 1 13.25 12H9.06l-2.573 2.573A1.457 1.457 0 0 1 4 13.543V12H2.75A1.75 1.75 0 0 1 1 10.25v-7.5C1 1.784 1.784 1 2.75 1h5Zm4.519-.837a.248.248 0 0 1 .466 0l.238.648a3.726 3.726 0 0 0 2.218 2.219l.649.238a.249.249 0 0 1 0 .467l-.649.238a3.725 3.725 0 0 0-2.218 2.218l-.238.649a.248.248 0 0 1-.466 0l-.239-.649a3.725 3.725 0 0 0-2.218-2.218l-.649-.238a.249.249 0 0 1 0-.467l.649-.238A3.726 3.726 0 0 0 12.03.811l.239-.648Z"/></svg>`;
+
+  /** External comment icon SVG — plain chat bubble (octicon-comment). Matches the chat-comment glyph used elsewhere for external rows. */
+  static EXTERNAL_ICON = `<svg viewBox="0 0 16 16" width="14" height="14" fill="currentColor"><path d="M1.75 1h8.5c.966 0 1.75.784 1.75 1.75v5.5A1.75 1.75 0 0 1 10.25 10H7.061l-2.574 2.573A1.458 1.458 0 0 1 2 11.543V10h-.25A1.75 1.75 0 0 1 0 8.25v-5.5C0 1.784.784 1 1.75 1ZM1.5 2.75v5.5c0 .138.112.25.25.25h1a.75.75 0 0 1 .75.75v2.19l2.72-2.72a.749.749 0 0 1 .53-.22h3.5a.25.25 0 0 0 .25-.25v-5.5a.25.25 0 0 0-.25-.25h-8.5a.25.25 0 0 0-.25.25Z"/></svg>`;
 
   constructor() {
     this._active = false;
@@ -70,17 +74,22 @@ class CommentMinimizer {
 
     this._removeAllIndicators();
 
-    // Find all comment and suggestion rows currently in the DOM
+    // Find all comment, suggestion, and external-comment rows currently in the DOM
     const commentRows = document.querySelectorAll('.user-comment-row');
     const suggestionRows = document.querySelectorAll('.ai-suggestion-row');
+    const externalRows = document.querySelectorAll('.external-comment-row');
 
-    // Build a map: diff row element → { hasUser, hasAI, hasAdopted, userCount, aiCount, adoptedCount }
+    // Build a map: diff row element → indicator info entry
     const lineMap = new Map();
+    const newEntry = () => ({
+      hasUser: false, hasAI: false, hasAdopted: false, hasExternal: false,
+      userCount: 0, aiCount: 0, adoptedCount: 0, externalCount: 0
+    });
 
     for (const row of commentRows) {
       const diffRow = this._findDiffRowFor(row);
       if (!diffRow) continue;
-      const entry = lineMap.get(diffRow) || { hasUser: false, hasAI: false, hasAdopted: false, userCount: 0, aiCount: 0, adoptedCount: 0 };
+      const entry = lineMap.get(diffRow) || newEntry();
       if (row.querySelector('.adopted-comment')) {
         entry.hasAdopted = true;
         entry.adoptedCount++;
@@ -94,7 +103,7 @@ class CommentMinimizer {
     for (const row of suggestionRows) {
       const diffRow = this._findDiffRowFor(row);
       if (!diffRow) continue;
-      const entry = lineMap.get(diffRow) || { hasUser: false, hasAI: false, hasAdopted: false, userCount: 0, aiCount: 0, adoptedCount: 0 };
+      const entry = lineMap.get(diffRow) || newEntry();
       // Count non-adopted suggestion divs only — adopted ones are already
       // represented by the adopted comment row (avoid double-counting)
       const allSuggestions = row.querySelectorAll('.ai-suggestion');
@@ -111,6 +120,20 @@ class CommentMinimizer {
       lineMap.set(diffRow, entry);
     }
 
+    for (const row of externalRows) {
+      const diffRow = this._findDiffRowFor(row);
+      if (!diffRow) continue;
+      const entry = lineMap.get(diffRow) || newEntry();
+      // Count root + replies — each .external-comment is one bubble in the
+      // thread card and the reviewer should see the same total here that
+      // the thread itself shows.
+      const bubbles = row.querySelectorAll('.external-comment');
+      const bubbleCount = bubbles.length || 1;
+      entry.hasExternal = true;
+      entry.externalCount += bubbleCount;
+      lineMap.set(diffRow, entry);
+    }
+
     // Inject line-level indicators
     for (const [diffRow, info] of lineMap) {
       this._injectIndicator(diffRow, info);
@@ -121,8 +144,9 @@ class CommentMinimizer {
   }
 
   /**
-   * Walk backward from a comment/suggestion row to find its parent diff line.
-   * Skips other comment rows, suggestion rows, and context-expand rows.
+   * Walk backward from a comment/suggestion/external row to find its parent
+   * diff line. Skips other comment/suggestion/external rows and
+   * context-expand rows.
    * @param {HTMLElement} row
    * @returns {HTMLElement|null}
    */
@@ -132,6 +156,7 @@ class CommentMinimizer {
       if (
         !prev.classList.contains('user-comment-row') &&
         !prev.classList.contains('ai-suggestion-row') &&
+        !prev.classList.contains('external-comment-row') &&
         !prev.classList.contains('comment-form-row') &&
         !prev.classList.contains('context-expand-row')
       ) {
@@ -158,10 +183,11 @@ class CommentMinimizer {
     btn.className = 'comment-indicator';
     btn.type = 'button';
 
-    // Build icon content — three types:
-    //   person (purple)   = user-originated comments
+    // Build icon content — four types:
+    //   person (purple)     = user-originated comments
     //   ai-comment (purple) = adopted AI suggestions
-    //   sparkles (amber)  = AI suggestions
+    //   sparkles (amber)    = AI suggestions
+    //   chat bubble (blue)  = external review comments (e.g. GitHub)
     const icons = [];
     if (info.hasUser) {
       icons.push(`<span class="indicator-icon indicator-user" title="${info.userCount} comment${info.userCount !== 1 ? 's' : ''}">${CommentMinimizer.PERSON_ICON}</span>`);
@@ -172,8 +198,11 @@ class CommentMinimizer {
     if (info.hasAI) {
       icons.push(`<span class="indicator-icon indicator-ai" title="${info.aiCount} suggestion${info.aiCount !== 1 ? 's' : ''}">${CommentMinimizer.SPARKLES_ICON}</span>`);
     }
+    if (info.hasExternal) {
+      icons.push(`<span class="indicator-icon indicator-external" title="${info.externalCount} external comment${info.externalCount !== 1 ? 's' : ''}">${CommentMinimizer.EXTERNAL_ICON}</span>`);
+    }
 
-    const total = info.userCount + info.adoptedCount + info.aiCount;
+    const total = info.userCount + info.adoptedCount + info.aiCount + info.externalCount;
     const countBadge = total > 1 ? `<span class="indicator-count">${total}</span>` : '';
 
     btn.innerHTML = icons.join('') + countBadge;
@@ -182,11 +211,19 @@ class CommentMinimizer {
     if (info.userCount) totalLabel.push(`${info.userCount} comment${info.userCount !== 1 ? 's' : ''}`);
     if (info.adoptedCount) totalLabel.push(`${info.adoptedCount} adopted comment${info.adoptedCount !== 1 ? 's' : ''}`);
     if (info.aiCount) totalLabel.push(`${info.aiCount} suggestion${info.aiCount !== 1 ? 's' : ''}`);
+    if (info.externalCount) totalLabel.push(`${info.externalCount} external comment${info.externalCount !== 1 ? 's' : ''}`);
     btn.title = totalLabel.join(', ');
 
-    // Check if this line was previously expanded
+    // Check if this line was previously expanded. Re-applying
+    // `.comment-expanded` to the (possibly rebuilt) comment rows is
+    // important: when an external-comment refresh tears down and rebuilds
+    // `.external-comment-row` elements, the new rows have no expanded
+    // class even though the indicator button is still marked expanded.
+    // Without this step the indicator says "open" but the rows stay
+    // hidden via the `.comments-minimized` display: none rule.
     if (this._expandedLines.has(diffRow)) {
       btn.classList.add('expanded');
+      this._getCommentRowsFor(diffRow).forEach(row => row.classList.add('comment-expanded'));
     }
 
     // Click handler: toggle this line's comments
@@ -234,7 +271,8 @@ class CommentMinimizer {
     while (next) {
       if (
         next.classList.contains('user-comment-row') ||
-        next.classList.contains('ai-suggestion-row')
+        next.classList.contains('ai-suggestion-row') ||
+        next.classList.contains('external-comment-row')
       ) {
         rows.push(next);
       } else if (
@@ -261,8 +299,12 @@ class CommentMinimizer {
    * @returns {HTMLElement|null} The parent diff row, or null
    */
   findDiffRowFor(element) {
-    const commentRow = element.closest('.user-comment-row, .ai-suggestion-row') || element;
-    if (!commentRow.classList.contains('user-comment-row') && !commentRow.classList.contains('ai-suggestion-row')) {
+    const commentRow = element.closest('.user-comment-row, .ai-suggestion-row, .external-comment-row') || element;
+    if (
+      !commentRow.classList.contains('user-comment-row') &&
+      !commentRow.classList.contains('ai-suggestion-row') &&
+      !commentRow.classList.contains('external-comment-row')
+    ) {
       return null;
     }
     return this._findDiffRowFor(commentRow);
@@ -293,8 +335,12 @@ class CommentMinimizer {
     }
 
     // Line-level: find the containing comment/suggestion row
-    const commentRow = element.closest('.user-comment-row, .ai-suggestion-row') || element;
-    if (!commentRow.classList.contains('user-comment-row') && !commentRow.classList.contains('ai-suggestion-row')) {
+    const commentRow = element.closest('.user-comment-row, .ai-suggestion-row, .external-comment-row') || element;
+    if (
+      !commentRow.classList.contains('user-comment-row') &&
+      !commentRow.classList.contains('ai-suggestion-row') &&
+      !commentRow.classList.contains('external-comment-row')
+    ) {
       return;
     }
 

--- a/public/js/modules/external-comment-manager.js
+++ b/public/js/modules/external-comment-manager.js
@@ -154,7 +154,46 @@ class ExternalCommentManager {
       }
     }
     await this.render();
+    // Hand off the flattened thread list to the Review panel so its
+    // External segment stays in sync with the inline rows.
+    this._notifyPanel();
     return { errors };
+  }
+
+  /**
+   * Flatten threadsBySource into a single array. The Review panel does
+   * not care about source grouping in its list — sort + display keys are
+   * file + line — so a flat union is the right shape to hand off.
+   *
+   * @returns {Array<Object>} The flattened thread roots.
+   */
+  getAllThreads() {
+    const out = [];
+    for (const threads of this.threadsBySource.values()) {
+      if (Array.isArray(threads)) {
+        for (const thread of threads) out.push(thread);
+      }
+    }
+    return out;
+  }
+
+  /**
+   * Push the current flattened thread list onto the Review panel's
+   * External segment. No-op when the panel isn't ready (e.g. before
+   * DOMContentLoaded or in tests that don't initialize it).
+   * @private
+   */
+  _notifyPanel() {
+    if (typeof window === 'undefined') return;
+    const panel = window.aiPanel;
+    if (!panel || typeof panel.setExternalThreads !== 'function') return;
+    try {
+      panel.setExternalThreads(this.getAllThreads());
+    } catch (err) {
+      if (typeof console !== 'undefined') {
+        console.warn('[ExternalCommentManager] setExternalThreads threw', err);
+      }
+    }
   }
 
   // ------------------------------------------------------------------

--- a/public/js/modules/external-comment-manager.js
+++ b/public/js/modules/external-comment-manager.js
@@ -1,0 +1,852 @@
+// Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+/**
+ * ExternalCommentManager - Read-only renderer for external review comments.
+ *
+ * Consumes `GET /api/reviews/:reviewId/external-comments?source=<source>` and
+ * renders thread-grouped comments as `.external-comment-row` rows inserted
+ * after the appropriate diff line.
+ *
+ * Read-only: no draft / submit / edit / dismiss flows. Only chat-about
+ * actions, which delegate to the global chat panel.
+ *
+ * Ordering rule (shared diff-row surface — see plans/fetch-external-review-comments.md
+ * "Hazards"): three independent renderers append rows after the same diff
+ * line: `.ai-suggestion-row`, `.user-comment-row`, `.external-comment-row`.
+ * External rows sit BELOW AI suggestion + user comment rows for the same
+ * diff line. This module ONLY touches `.external-comment-row` elements when
+ * clearing — it never strips rows owned by other renderers.
+ */
+
+class ExternalCommentManager {
+  /**
+   * @param {Object} opts
+   * @param {string|number} opts.reviewId - Review id used to build the API URL
+   * @param {string[]} [opts.sources=['github']] - External sources to load
+   * @param {Object} [opts.chatPanel=window.chatPanel] - Chat panel reference
+   */
+  constructor({ reviewId, sources = ['github'], chatPanel } = {}) {
+    this.reviewId = reviewId;
+    this.sources = sources;
+    // Bind lazily so tests / late-loaded chat panel both work
+    this.chatPanel = chatPanel || (typeof window !== 'undefined' ? window.chatPanel : null);
+    // source -> threads[]
+    this.threadsBySource = new Map();
+    // Track whether we've already warned about a missing anchor for a given thread
+    this._anchorWarnings = new Set();
+    // Per-manager in-flight promise. Coalesces concurrent loadAndRender calls
+    // (page-load + manual refresh + post-AI re-render) into one round-trip.
+    this._inflight = null;
+  }
+
+  // ------------------------------------------------------------------
+  // Data fetch
+  // ------------------------------------------------------------------
+
+  /**
+   * Fetch threads for a single source and cache them in `threadsBySource`.
+   * @param {string} source - Source identifier (e.g. 'github')
+   * @returns {Promise<Array>} The fetched threads
+   */
+  async fetch(source) {
+    if (!this.reviewId) {
+      throw new Error('ExternalCommentManager: reviewId is required to fetch');
+    }
+    const url = `/api/reviews/${encodeURIComponent(this.reviewId)}/external-comments?source=${encodeURIComponent(source)}`;
+    let res;
+    try {
+      res = await fetch(url);
+    } catch (err) {
+      this._toast(`Failed to load ${source} review comments`, 'error');
+      throw err;
+    }
+    if (!res.ok) {
+      this._toast(`Failed to load ${source} review comments`, 'error');
+      throw new Error(`Failed to fetch external comments: ${res.status}`);
+    }
+    const data = await res.json();
+    const threads = Array.isArray(data) ? data : (data.threads || []);
+    this.threadsBySource.set(source, threads);
+    return threads;
+  }
+
+  /**
+   * Fetch + render for all configured sources. Failure in one source does
+   * not abort the rest.
+   *
+   * Canonical refresh entry point for GET-only callers (analysis rebuilds,
+   * whitespace toggles, post-AI rerender). For full sync+load — POST to
+   * /external-comments/sync followed by GET + render — use `syncAndRender`
+   * instead. Both methods share `this._inflight`, so a GET-only caller
+   * that races an in-flight `syncAndRender` joins the full sync+load
+   * promise rather than racing the POST with a stale GET. This is NOT
+   * declared `async` on purpose; an async wrapper would create a fresh
+   * Promise on each call and break the shared-Promise contract.
+   */
+  loadAndRender() {
+    if (this._inflight) return this._inflight;
+    const inflight = (async () => {
+      const result = await this._fetchAllAndRender();
+      return result;
+    })().finally(() => {
+      this._inflight = null;
+    });
+    this._inflight = inflight;
+    return this._inflight;
+  }
+
+  /**
+   * Sync upstream → load → render. The orchestration sequence for the
+   * "refresh external comments" button and PR-page load.
+   *
+   * Shares `this._inflight` with `loadAndRender`: while a sync+load is in
+   * flight, any GET-only caller (analysis rebuild, whitespace toggle) that
+   * calls `loadAndRender` joins this promise instead of racing the POST
+   * with a stale GET. The POST happens BEFORE the GET so the GET sees the
+   * latest mirror.
+   *
+   * @param {Object} options
+   * @param {() => Promise<{count: number, lostAnchors: number, deleted: number, syncedAt: string}>} options.syncFn -
+   *   Async function that performs the POST /external-comments/sync. Injected so the manager
+   *   doesn't have to know about pr.js — keeps it testable and source-agnostic.
+   * @returns {Promise<{errors: Array, syncResult: Object|null, syncError: Error|null}>}
+   */
+  syncAndRender({ syncFn } = {}) {
+    if (this._inflight) return this._inflight;
+    const inflight = (async () => {
+      let syncResult = null;
+      let syncError = null;
+      if (typeof syncFn === 'function') {
+        try {
+          syncResult = await syncFn();
+        } catch (err) {
+          // Sync failure shouldn't block render — we may have cached rows
+          // from a previous run. The caller is responsible for surfacing
+          // the failure (toast, etc.); we just keep going.
+          syncError = err;
+        }
+      }
+      const renderResult = await this._fetchAllAndRender();
+      return { ...renderResult, syncResult, syncError };
+    })().finally(() => {
+      this._inflight = null;
+    });
+    this._inflight = inflight;
+    return this._inflight;
+  }
+
+  /**
+   * Internal helper shared by loadAndRender and syncAndRender. Pulls
+   * threads for each configured source and re-renders. Failures in one
+   * source don't abort the rest.
+   * @private
+   */
+  async _fetchAllAndRender() {
+    const errors = [];
+    for (const source of this.sources) {
+      try {
+        await this.fetch(source);
+      } catch (err) {
+        errors.push({ source, err });
+        // Toast already shown in fetch()
+        if (typeof console !== 'undefined') {
+          console.warn(`[ExternalCommentManager] Failed to fetch ${source}:`, err);
+        }
+      }
+    }
+    await this.render();
+    return { errors };
+  }
+
+  // ------------------------------------------------------------------
+  // Render
+  // ------------------------------------------------------------------
+
+  /**
+   * Render all cached threads into the diff. Idempotent: clears any
+   * previously rendered external-comment rows first.
+   *
+   * Async because `_renderThread` may await `prManager.ensureLinesVisible`
+   * when an outdated comment's anchor row is collapsed.
+   */
+  async render() {
+    this.clear();
+    for (const [, threads] of this.threadsBySource) {
+      if (!Array.isArray(threads)) continue;
+      for (const thread of threads) {
+        try {
+          await this._renderThread(thread);
+        } catch (err) {
+          if (typeof console !== 'undefined') {
+            console.warn('[ExternalCommentManager] Failed to render thread', thread?.id, err);
+          }
+        }
+      }
+    }
+
+    // Rebuild minimize-mode indicators so external rows are reflected in
+    // the per-line count badges. Mirrors what comment-manager and
+    // suggestion-manager do on render. No-op when the minimizer isn't
+    // active (refreshIndicators short-circuits on `!this._active`).
+    try {
+      if (typeof window !== 'undefined' && window.prManager && window.prManager.commentMinimizer) {
+        window.prManager.commentMinimizer.refreshIndicators();
+      }
+    } catch (err) {
+      if (typeof console !== 'undefined') {
+        console.warn('[ExternalCommentManager] minimizer.refreshIndicators threw', err);
+      }
+    }
+  }
+
+  /**
+   * Remove all `.external-comment-row` rows we own from the DOM.
+   * Leaves `.user-comment-row` and `.ai-suggestion-row` rows untouched.
+   */
+  clear() {
+    if (typeof document === 'undefined') return;
+    const rows = document.querySelectorAll('.external-comment-row');
+    rows.forEach((row) => row.remove());
+  }
+
+  // ------------------------------------------------------------------
+  // Internals
+  // ------------------------------------------------------------------
+
+  /**
+   * Resolve the diff row that an external comment / thread root anchors to.
+   * Uses the project-wide DiffRenderer file lookup when available, and the
+   * LineTracker side-aware coordinate lookup when present — both already
+   * power the suggestion-manager and comment-manager renderers, so behavior
+   * stays consistent across the three.
+   *
+   * @param {string} file
+   * @param {number} line
+   * @param {string} side - 'LEFT' or 'RIGHT'
+   * @returns {Element|null}
+   */
+  _findDiffLineRow(file, line, side) {
+    if (typeof document === 'undefined') return null;
+    if (!file || !Number.isFinite(line)) return null;
+
+    let fileElement = null;
+    if (typeof window !== 'undefined' && window.DiffRenderer && typeof window.DiffRenderer.findFileElement === 'function') {
+      fileElement = window.DiffRenderer.findFileElement(file);
+    }
+    if (!fileElement) {
+      try {
+        const escaped = (typeof globalThis !== 'undefined' && globalThis.CSS?.escape)
+          ? globalThis.CSS.escape(file)
+          : file;
+        fileElement = document.querySelector(`[data-file-name="${escaped}"]`);
+      } catch {
+        fileElement = null;
+      }
+    }
+    if (!fileElement) return null;
+
+    const wantedSide = side || 'RIGHT';
+    const rows = fileElement.querySelectorAll('tr');
+    const lineTracker = (typeof window !== 'undefined' && window.LineTracker)
+      ? new window.LineTracker()
+      : null;
+
+    for (const row of rows) {
+      let lineNum = null;
+      if (lineTracker && typeof lineTracker.getLineNumber === 'function') {
+        lineNum = lineTracker.getLineNumber(row, wantedSide);
+      } else {
+        // Minimal fallback: dataset.lineNumber + dataset.side check
+        const ds = row.dataset || {};
+        if (wantedSide === 'LEFT' && ds.oldLineNumber) {
+          lineNum = parseInt(ds.oldLineNumber, 10);
+        } else if (wantedSide === 'RIGHT' && ds.newLineNumber) {
+          lineNum = parseInt(ds.newLineNumber, 10);
+        } else if (ds.lineNumber && (!ds.side || ds.side === wantedSide)) {
+          lineNum = parseInt(ds.lineNumber, 10);
+        }
+      }
+      if (lineNum === line) return row;
+    }
+    return null;
+  }
+
+  /**
+   * Compute the (file, line, side) anchor for a comment, accounting for
+   * outdated rows that fall back to the original anchor.
+   * Returns null if the comment cannot be anchored.
+   */
+  _resolveAnchor(comment) {
+    if (!comment || !comment.file) return null;
+    const side = comment.side || 'RIGHT';
+    const outdated = comment.is_outdated === 1 || comment.is_outdated === true;
+
+    // Treat `is_outdated` as a hint about which anchor to PREFER, not a
+    // strict switch. The GitHub adapter couples is_outdated with line_end
+    // being null, but future adapters (GitLab, Linear) won't necessarily
+    // observe that invariant. Falling back to the other anchor when our
+    // preferred one is missing keeps cells like "outdated row that still
+    // has a live line_end" or "non-outdated row missing line_end"
+    // renderable instead of silently dropped.
+    const live = Number.isFinite(comment.line_end) ? comment.line_end : null;
+    const orig = Number.isFinite(comment.original_line_end) ? comment.original_line_end : null;
+    const line = outdated ? (orig ?? live) : (live ?? orig);
+    if (line == null) return null;
+    return { file: comment.file, line, side };
+  }
+
+  /**
+   * Render a single thread (root + replies) into the diff.
+   *
+   * When the anchor line isn't initially in the DOM (collapsed context for
+   * outdated comments is the common case) we ask the PR manager to expand
+   * any hidden lines that cover the anchor and re-look-up before giving up.
+   * If still missing we drop to a file-level fallback so the discussion
+   * stays visible rather than disappearing silently.
+   *
+   * Async because `PRManager.ensureLinesVisible` returns a Promise — we
+   * MUST await it before re-looking-up, otherwise the freshly-materialized
+   * row is not yet in the DOM when we ask for it.
+   * @private
+   */
+  async _renderThread(thread) {
+    if (!thread) return;
+    const anchor = this._resolveAnchor(thread);
+    if (!anchor) {
+      const key = `${thread.source}:${thread.id}`;
+      if (!this._anchorWarnings.has(key)) {
+        this._anchorWarnings.add(key);
+        if (typeof console !== 'undefined') {
+          console.warn('[ExternalCommentManager] Skipping thread with no anchor', thread.id);
+        }
+      }
+      return;
+    }
+
+    let targetRow = this._findDiffLineRow(anchor.file, anchor.line, anchor.side);
+
+    // Outdated discussions often land on lines that the diff renderer
+    // collapsed behind an "expand context" gap. Ask the PR manager (when
+    // present) to expand the gap, then await before retrying the lookup.
+    // PRManager.ensureLinesVisible takes an array of items and returns a
+    // Promise — must await or the row isn't in the DOM yet.
+    if (!targetRow && this._canEnsureLinesVisible()) {
+      try {
+        await window.prManager.ensureLinesVisible([
+          {
+            file: anchor.file,
+            line_start: anchor.line,
+            line_end: anchor.line,
+            side: anchor.side
+          }
+        ]);
+      } catch (err) {
+        if (typeof console !== 'undefined') {
+          console.warn('[ExternalCommentManager] ensureLinesVisible threw, falling back', err);
+        }
+      }
+      targetRow = this._findDiffLineRow(anchor.file, anchor.line, anchor.side);
+    }
+
+    if (!targetRow) {
+      // File-level fallback: outdated discussions that we can't anchor
+      // precisely still need to be discoverable. Render them at the top of
+      // the file wrapper so the reviewer can find them via the file panel.
+      const fallbackTarget = this._resolveFileFallbackTarget(anchor.file);
+      if (fallbackTarget) {
+        const externalRow = this._buildThreadRow(thread, fallbackTarget);
+        if (externalRow) {
+          externalRow.classList.add('external-comment-row--file-fallback');
+          this._insertAtOrderedPosition(fallbackTarget, externalRow);
+          return;
+        }
+      }
+
+      if (typeof console !== 'undefined') {
+        console.warn(`[ExternalCommentManager] Could not find diff row for ${anchor.file}:${anchor.line} (${anchor.side})`);
+      }
+      return;
+    }
+
+    const externalRow = this._buildThreadRow(thread, targetRow);
+    if (!externalRow) return;
+    this._insertAtOrderedPosition(targetRow, externalRow);
+  }
+
+  /**
+   * @returns {boolean} true when `window.prManager.ensureLinesVisible` is callable.
+   * @private
+   */
+  _canEnsureLinesVisible() {
+    return (
+      typeof window !== 'undefined' &&
+      window.prManager &&
+      typeof window.prManager.ensureLinesVisible === 'function'
+    );
+  }
+
+  /**
+   * Find a fallback insertion target for a file when no diff row matches
+   * the comment's anchor (e.g. outdated comment whose original line is no
+   * longer in the diff at all). Returns the first <tr> in the file
+   * wrapper's table so the thread renders at file-level. Returns null when
+   * the file wrapper itself isn't in the DOM.
+   * @private
+   */
+  _resolveFileFallbackTarget(file) {
+    if (typeof document === 'undefined' || !file) return null;
+    let fileElement = null;
+    if (typeof window !== 'undefined' && window.DiffRenderer && typeof window.DiffRenderer.findFileElement === 'function') {
+      fileElement = window.DiffRenderer.findFileElement(file);
+    }
+    if (!fileElement) {
+      try {
+        const escaped = (typeof globalThis !== 'undefined' && globalThis.CSS?.escape)
+          ? globalThis.CSS.escape(file)
+          : file;
+        fileElement = document.querySelector(`[data-file-name="${escaped}"]`);
+      } catch {
+        fileElement = null;
+      }
+    }
+    if (!fileElement) return null;
+    return fileElement.querySelector('tr');
+  }
+
+  /**
+   * Build the `<tr class="external-comment-row">` wrapper containing the
+   * root comment, replies, and per-thread actions.
+   * @private
+   */
+  _buildThreadRow(thread, targetRow) {
+    if (typeof document === 'undefined') return null;
+    const tr = document.createElement('tr');
+    tr.className = 'external-comment-row';
+    tr.dataset.threadId = thread.id != null ? String(thread.id) : '';
+    tr.dataset.source = thread.source || '';
+
+    const td = document.createElement('td');
+    // Match user-comment-row colspan of 4 used elsewhere in the diff table
+    td.colSpan = this._resolveColSpan(targetRow);
+    td.className = 'external-comment-cell';
+
+    const threadEl = document.createElement('div');
+    threadEl.className = 'external-comment-thread';
+
+    // Root comment
+    const rootEl = this._buildCommentElement(thread, { isReply: false });
+    threadEl.appendChild(rootEl);
+
+    // Replies
+    const replies = Array.isArray(thread.replies) ? thread.replies : [];
+    for (const reply of replies) {
+      const replyEl = this._buildCommentElement(reply, { isReply: true });
+      threadEl.appendChild(replyEl);
+    }
+
+    // Thread-level action: chat about whole thread
+    const threadActions = document.createElement('div');
+    threadActions.className = 'external-comment-actions external-comment-thread-actions';
+    const chatThreadBtn = this._buildChatThreadButton(thread);
+    threadActions.appendChild(chatThreadBtn);
+    threadEl.appendChild(threadActions);
+
+    td.appendChild(threadEl);
+    tr.appendChild(td);
+    return tr;
+  }
+
+  /**
+   * Best-effort colSpan resolution. The diff renderer uses a 4-column
+   * layout (matches `.user-comment-cell` colSpan=4). Fall back to that
+   * if we can't introspect the target row's column count.
+   * @private
+   */
+  _resolveColSpan(targetRow) {
+    try {
+      const cells = targetRow?.cells || targetRow?.children;
+      if (cells && cells.length) return cells.length;
+    } catch {
+      // ignore
+    }
+    return 4;
+  }
+
+  /**
+   * Build a single `.external-comment` element (root or reply).
+   * @private
+   */
+  _buildCommentElement(comment, { isReply }) {
+    const escapeHtml = this._escapeHtml;
+    const source = comment.source || 'github';
+
+    const el = document.createElement('div');
+    const classes = ['external-comment', `source-${source}`];
+    if (isReply) classes.push('is-reply');
+    if (comment.is_outdated === 1 || comment.is_outdated === true) classes.push('is-outdated');
+    el.className = classes.join(' ');
+    el.dataset.commentId = comment.id != null ? String(comment.id) : '';
+    el.dataset.source = source;
+    if (comment.external_id != null) el.dataset.externalId = String(comment.external_id);
+
+    // ---- Header ----
+    const header = document.createElement('div');
+    header.className = 'external-comment-header';
+
+    const headerLeft = document.createElement('div');
+    headerLeft.className = 'external-comment-header-left';
+
+    // Author (link only when the URL is safe — falls back to plain text
+    // for `javascript:`, `data:`, or other non-navigational schemes).
+    if (comment.author_url && this._isSafeUrl(comment.author_url)) {
+      const a = document.createElement('a');
+      a.className = 'external-comment-author';
+      a.href = comment.author_url;
+      a.target = '_blank';
+      a.rel = 'noopener noreferrer';
+      a.textContent = comment.author || '';
+      headerLeft.appendChild(a);
+    } else {
+      const span = document.createElement('span');
+      span.className = 'external-comment-author';
+      span.textContent = comment.author || '';
+      headerLeft.appendChild(span);
+    }
+
+    // Outdated badge
+    if (comment.is_outdated === 1 || comment.is_outdated === true) {
+      const badge = document.createElement('span');
+      badge.className = 'external-comment-outdated-badge';
+      badge.title = 'This comment was made against an earlier version of the file';
+      badge.textContent = 'outdated';
+      headerLeft.appendChild(badge);
+    }
+
+    // Timestamp
+    const tsText = this._formatTimestamp(comment.external_created_at);
+    if (tsText) {
+      const ts = document.createElement('span');
+      ts.className = 'external-comment-timestamp';
+      ts.textContent = tsText;
+      if (comment.external_created_at) ts.title = comment.external_created_at;
+      headerLeft.appendChild(ts);
+    }
+
+    header.appendChild(headerLeft);
+
+    // Permalink (right side of header) — drop when URL fails the safety check.
+    if (comment.external_url && this._isSafeUrl(comment.external_url)) {
+      const link = document.createElement('a');
+      link.className = 'external-comment-permalink';
+      link.href = comment.external_url;
+      link.target = '_blank';
+      link.rel = 'noopener noreferrer';
+      link.title = 'Open in source system';
+      link.innerHTML = '<svg viewBox="0 0 16 16" width="14" height="14" fill="currentColor" aria-hidden="true"><path d="M7.75 2.5a.75.75 0 0 0 0 1.5h2.69L5.22 9.22a.75.75 0 1 0 1.06 1.06L11.5 5.06v2.69a.75.75 0 0 0 1.5 0v-4.5a.75.75 0 0 0-.75-.75ZM3.75 3A1.75 1.75 0 0 0 2 4.75v7.5C2 13.216 2.784 14 3.75 14h7.5A1.75 1.75 0 0 0 13 12.25v-3.5a.75.75 0 0 0-1.5 0v3.5a.25.25 0 0 1-.25.25h-7.5a.25.25 0 0 1-.25-.25v-7.5a.25.25 0 0 1 .25-.25h3.5a.75.75 0 0 0 0-1.5Z"/></svg>';
+      header.appendChild(link);
+    }
+
+    el.appendChild(header);
+
+    // ---- Body ----
+    const body = document.createElement('div');
+    body.className = 'external-comment-body';
+    const bodyText = comment.body || '';
+    if (typeof window !== 'undefined' && typeof window.renderMarkdown === 'function') {
+      body.innerHTML = window.renderMarkdown(bodyText);
+    } else {
+      body.textContent = bodyText;
+    }
+    el.appendChild(body);
+
+    // ---- Actions ----
+    const actions = document.createElement('div');
+    actions.className = 'external-comment-actions';
+    const chatBtn = this._buildChatCommentButton(comment);
+    actions.appendChild(chatBtn);
+    el.appendChild(actions);
+
+    return el;
+  }
+
+  /**
+   * Build the per-comment "Chat about this comment" button.
+   * @private
+   */
+  _buildChatCommentButton(comment) {
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'btn-chat-comment external-comment-chat-btn';
+    btn.title = 'Chat about this comment';
+    btn.innerHTML = '<svg viewBox="0 0 16 16" width="14" height="14" fill="currentColor" aria-hidden="true"><path d="M1.75 1h8.5c.966 0 1.75.784 1.75 1.75v5.5A1.75 1.75 0 0 1 10.25 10H7.061l-2.574 2.573A1.458 1.458 0 0 1 2 11.543V10h-.25A1.75 1.75 0 0 1 0 8.25v-5.5C0 1.784.784 1 1.75 1ZM1.5 2.75v5.5c0 .138.112.25.25.25h1a.75.75 0 0 1 .75.75v2.19l2.72-2.72a.749.749 0 0 1 .53-.22h3.5a.25.25 0 0 0 .25-.25v-5.5a.25.25 0 0 0-.25-.25h-8.5a.25.25 0 0 0-.25.25Zm13 2a.25.25 0 0 0-.25-.25h-.5a.75.75 0 0 1 0-1.5h.5c.966 0 1.75.784 1.75 1.75v5.5A1.75 1.75 0 0 1 14.25 12H14v1.543a1.458 1.458 0 0 1-2.487 1.03L9.22 12.28a.749.749 0 0 1 .326-1.275.749.749 0 0 1 .734.215l2.22 2.22v-2.19a.75.75 0 0 1 .75-.75h1a.25.25 0 0 0 .25-.25Z"/></svg>';
+
+    btn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      this._openCommentChat(comment);
+    });
+    return btn;
+  }
+
+  /**
+   * Build the per-thread "Chat about this thread" button.
+   * @private
+   */
+  _buildChatThreadButton(thread) {
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'btn-chat-thread external-comment-chat-thread-btn';
+    btn.title = 'Chat about this thread';
+    // Stacked-bubbles glyph: two overlapping chat bubbles. Visually distinct
+    // from the single-bubble chat-comment button so the reviewer can tell
+    // "chat about THIS comment" apart from "chat about WHOLE thread".
+    btn.innerHTML = '<svg viewBox="0 0 16 16" width="14" height="14" fill="currentColor" aria-hidden="true"><path d="M1.75 1h8.5c.966 0 1.75.784 1.75 1.75v5.5A1.75 1.75 0 0 1 10.25 10H7.061l-2.574 2.573A1.458 1.458 0 0 1 2 11.543V10h-.25A1.75 1.75 0 0 1 0 8.25v-5.5C0 1.784.784 1 1.75 1ZM1.5 2.75v5.5c0 .138.112.25.25.25h1a.75.75 0 0 1 .75.75v2.19l2.72-2.72a.749.749 0 0 1 .53-.22h3.5a.25.25 0 0 0 .25-.25v-5.5a.25.25 0 0 0-.25-.25h-8.5a.25.25 0 0 0-.25.25Zm13 2a.25.25 0 0 0-.25-.25h-.5a.75.75 0 0 1 0-1.5h.5c.966 0 1.75.784 1.75 1.75v5.5A1.75 1.75 0 0 1 14.25 12H14v1.543a1.458 1.458 0 0 1-2.487 1.03L9.22 12.28a.749.749 0 0 1 .326-1.275.749.749 0 0 1 .734.215l2.22 2.22v-2.19a.75.75 0 0 1 .75-.75h1a.25.25 0 0 0 .25-.25Z"/></svg> Chat about thread';
+
+    btn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      this._openThreadChat(thread);
+    });
+    return btn;
+  }
+
+  /**
+   * Dispatch chat-about-comment to the chat panel using the canonical
+   * `commentContext` shape (see plans/fetch-external-review-comments.md
+   * § 10 and Phase 4 task spec).
+   * @private
+   */
+  _openCommentChat(comment) {
+    const panel = this._resolveChatPanel();
+    if (!panel || typeof panel.open !== 'function') {
+      // The panel is gone — surface that to the reviewer instead of
+      // silently dropping the click. Buttons should also be CSS-hidden via
+      // [data-chat='disabled'], this is the backstop for racing state.
+      this._toast('Chat is unavailable', 'warn');
+      return;
+    }
+    const outdated = comment.is_outdated === 1 || comment.is_outdated === true;
+    panel.open({
+      commentContext: {
+        commentId: comment.id,
+        body: comment.body,
+        file: comment.file,
+        side: comment.side || 'RIGHT',
+        line_start: outdated ? comment.original_line_start : comment.line_start,
+        line_end: outdated ? comment.original_line_end : comment.line_end,
+        source: 'external',
+        externalSource: comment.source,
+        author: comment.author,
+        externalUrl: comment.external_url,
+        isOutdated: !!outdated,
+      },
+    });
+  }
+
+  /**
+   * Dispatch chat-about-thread to the chat panel using the canonical
+   * `threadContext` shape.
+   * @private
+   */
+  _openThreadChat(root) {
+    const panel = this._resolveChatPanel();
+    if (!panel || typeof panel.open !== 'function') {
+      this._toast('Chat is unavailable', 'warn');
+      return;
+    }
+    const outdated = root.is_outdated === 1 || root.is_outdated === true;
+    const replies = Array.isArray(root.replies) ? root.replies : [];
+    panel.open({
+      threadContext: {
+        rootId: root.id,
+        source: 'external',
+        externalSource: root.source,
+        file: root.file,
+        side: root.side || 'RIGHT',
+        line_start: outdated ? root.original_line_start : root.line_start,
+        line_end: outdated ? root.original_line_end : root.line_end,
+        comments: [
+          {
+            author: root.author,
+            body: root.body,
+            isOutdated: !!outdated,
+            externalUrl: root.external_url,
+            externalCreatedAt: root.external_created_at,
+          },
+          ...replies.map((r) => ({
+            author: r.author,
+            body: r.body,
+            isOutdated: !!(r.is_outdated === 1 || r.is_outdated === true),
+            externalUrl: r.external_url,
+            externalCreatedAt: r.external_created_at,
+          })),
+        ],
+      },
+    });
+  }
+
+  /**
+   * Resolve the chat panel reference late so callers that attach
+   * `window.chatPanel` after this manager is constructed still work.
+   * @private
+   */
+  _resolveChatPanel() {
+    if (this.chatPanel) return this.chatPanel;
+    if (typeof window !== 'undefined' && window.chatPanel) {
+      this.chatPanel = window.chatPanel;
+      return this.chatPanel;
+    }
+    return null;
+  }
+
+  /**
+   * Insert the external comment row at the correct position after the diff
+   * line, preserving the ordering rule:
+   *   AI suggestions  →  user comments  →  external comments
+   *
+   * Walk forward from `targetRow.nextSibling` while we see rows that should
+   * come BEFORE us (AI suggestion rows, user comment rows, or already-
+   * existing external comment rows for the same diff line). Insert before
+   * the first non-comment row we encounter, or at the end of the table.
+   * @private
+   */
+  _insertAtOrderedPosition(targetRow, externalRow) {
+    const parent = targetRow.parentNode;
+    if (!parent) return;
+    let insertBefore = targetRow.nextSibling;
+    while (insertBefore && this._isOwnedCommentRow(insertBefore)) {
+      insertBefore = insertBefore.nextSibling;
+    }
+    if (insertBefore) {
+      parent.insertBefore(externalRow, insertBefore);
+    } else {
+      parent.appendChild(externalRow);
+    }
+  }
+
+  /**
+   * Returns true if the given node is a comment-like row that belongs
+   * to one of the three diff renderers and should remain ABOVE this
+   * new external-comment row.
+   * @private
+   */
+  _isOwnedCommentRow(node) {
+    if (!node || node.nodeType !== 1 /* ELEMENT_NODE */) return false;
+    const cls = node.classList;
+    if (!cls) return false;
+    return (
+      cls.contains('ai-suggestion-row') ||
+      cls.contains('user-comment-row') ||
+      cls.contains('external-comment-row')
+    );
+  }
+
+  // ------------------------------------------------------------------
+  // Small helpers
+  // ------------------------------------------------------------------
+
+  /**
+   * Show a toast via the project-wide toast helper. Falls back to console
+   * when the helper isn't available (e.g. unit tests).
+   * @private
+   */
+  _toast(message, level = 'error') {
+    if (typeof window === 'undefined') return;
+    const t = window.toast;
+    if (t) {
+      if (level === 'error' && typeof t.showError === 'function') return t.showError(message);
+      if (level === 'warn' && typeof t.showWarning === 'function') return t.showWarning(message);
+      if (level === 'info' && typeof t.showInfo === 'function') return t.showInfo(message);
+      if (level === 'success' && typeof t.showSuccess === 'function') return t.showSuccess(message);
+    }
+    if (typeof window.showToast === 'function') {
+      return window.showToast(message, level);
+    }
+    // Last-resort log only — never throw from a toast helper.
+    if (typeof console !== 'undefined') {
+      console.warn(`[ExternalCommentManager] toast(${level}): ${message}`);
+    }
+  }
+
+  /**
+   * Format an ISO timestamp into a short relative description.
+   * Falls back to the raw string on parse failure.
+   * @private
+   */
+  _formatTimestamp(iso) {
+    if (!iso) return '';
+    const date = new Date(iso);
+    if (isNaN(date.getTime())) return iso;
+    const now = Date.now();
+    const diffMs = now - date.getTime();
+    const seconds = Math.round(diffMs / 1000);
+    if (seconds < 60) return 'just now';
+    const minutes = Math.round(seconds / 60);
+    if (minutes < 60) return `${minutes}m ago`;
+    const hours = Math.round(minutes / 60);
+    if (hours < 24) return `${hours}h ago`;
+    const days = Math.round(hours / 24);
+    if (days < 30) return `${days}d ago`;
+    const months = Math.round(days / 30);
+    if (months < 12) return `${months}mo ago`;
+    const years = Math.round(months / 12);
+    return `${years}y ago`;
+  }
+
+  /**
+   * Allow only http/https/mailto URLs. Used to gate `<a href>` attributes
+   * built from server-supplied data so a malicious upstream cannot smuggle
+   * `javascript:` or `data:` URLs into our DOM.
+   * @private
+   */
+  _isSafeUrl(url) {
+    if (typeof url !== 'string' || !url) return false;
+    const trimmed = url.trim();
+    if (!trimmed) return false;
+    // Relative URLs are safe — they resolve under our origin.
+    if (trimmed.startsWith('/') || trimmed.startsWith('#') || trimmed.startsWith('?')) return true;
+    try {
+      const u = new URL(trimmed, (typeof window !== 'undefined' && window.location) ? window.location.href : 'http://localhost/');
+      return u.protocol === 'http:' || u.protocol === 'https:' || u.protocol === 'mailto:';
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Minimal HTML escape used as a fallback when window helpers aren't loaded.
+   * @private
+   */
+  _escapeHtml(s) {
+    if (s == null) return '';
+    return String(s)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+}
+
+// Browser singleton — instantiated on DOMContentLoaded so the PR page
+// can immediately `await window.externalCommentManager.loadAndRender()`
+// once the review id is known. Callers should set `reviewId` and
+// `sources` before invoking `loadAndRender` (see PR page wiring).
+if (typeof window !== 'undefined') {
+  window.ExternalCommentManager = ExternalCommentManager;
+
+  if (typeof document !== 'undefined' && !window.externalCommentManager) {
+    const initSingleton = () => {
+      if (!window.externalCommentManager) {
+        window.externalCommentManager = new ExternalCommentManager({});
+      }
+    };
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', initSingleton);
+    } else {
+      initSingleton();
+    }
+  }
+}
+
+// Export for Node.js testing
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { ExternalCommentManager };
+}

--- a/public/js/modules/external-comment-manager.js
+++ b/public/js/modules/external-comment-manager.js
@@ -443,13 +443,6 @@ class ExternalCommentManager {
       threadEl.appendChild(replyEl);
     }
 
-    // Thread-level action: chat about whole thread
-    const threadActions = document.createElement('div');
-    threadActions.className = 'external-comment-actions external-comment-thread-actions';
-    const chatThreadBtn = this._buildChatThreadButton(thread);
-    threadActions.appendChild(chatThreadBtn);
-    threadEl.appendChild(threadActions);
-
     td.appendChild(threadEl);
     tr.appendChild(td);
     return tr;
@@ -533,7 +526,14 @@ class ExternalCommentManager {
 
     header.appendChild(headerLeft);
 
-    // Permalink (right side of header) — drop when URL fails the safety check.
+    // Right side of header: chat-about + permalink, mirroring the
+    // header-right layout used by user comments and AI suggestions.
+    const headerRight = document.createElement('div');
+    headerRight.className = 'external-comment-header-right';
+
+    const chatBtn = this._buildChatCommentButton(comment, { isReply });
+    headerRight.appendChild(chatBtn);
+
     if (comment.external_url && this._isSafeUrl(comment.external_url)) {
       const link = document.createElement('a');
       link.className = 'external-comment-permalink';
@@ -542,9 +542,10 @@ class ExternalCommentManager {
       link.rel = 'noopener noreferrer';
       link.title = 'Open in source system';
       link.innerHTML = '<svg viewBox="0 0 16 16" width="14" height="14" fill="currentColor" aria-hidden="true"><path d="M7.75 2.5a.75.75 0 0 0 0 1.5h2.69L5.22 9.22a.75.75 0 1 0 1.06 1.06L11.5 5.06v2.69a.75.75 0 0 0 1.5 0v-4.5a.75.75 0 0 0-.75-.75ZM3.75 3A1.75 1.75 0 0 0 2 4.75v7.5C2 13.216 2.784 14 3.75 14h7.5A1.75 1.75 0 0 0 13 12.25v-3.5a.75.75 0 0 0-1.5 0v3.5a.25.25 0 0 1-.25.25h-7.5a.25.25 0 0 1-.25-.25v-7.5a.25.25 0 0 1 .25-.25h3.5a.75.75 0 0 0 0-1.5Z"/></svg>';
-      header.appendChild(link);
+      headerRight.appendChild(link);
     }
 
+    header.appendChild(headerRight);
     el.appendChild(header);
 
     // ---- Body ----
@@ -558,51 +559,29 @@ class ExternalCommentManager {
     }
     el.appendChild(body);
 
-    // ---- Actions ----
-    const actions = document.createElement('div');
-    actions.className = 'external-comment-actions';
-    const chatBtn = this._buildChatCommentButton(comment);
-    actions.appendChild(chatBtn);
-    el.appendChild(actions);
-
     return el;
   }
 
   /**
-   * Build the per-comment "Chat about this comment" button.
+   * Build the per-comment chat button.
+   * - On the thread root (`isReply: false`), chats about the whole thread.
+   * - On a reply, chats about just that reply.
    * @private
    */
-  _buildChatCommentButton(comment) {
+  _buildChatCommentButton(comment, { isReply } = {}) {
     const btn = document.createElement('button');
     btn.type = 'button';
     btn.className = 'btn-chat-comment external-comment-chat-btn';
-    btn.title = 'Chat about this comment';
+    btn.title = isReply ? 'Chat about this comment' : 'Chat about thread';
     btn.innerHTML = '<svg viewBox="0 0 16 16" width="14" height="14" fill="currentColor" aria-hidden="true"><path d="M1.75 1h8.5c.966 0 1.75.784 1.75 1.75v5.5A1.75 1.75 0 0 1 10.25 10H7.061l-2.574 2.573A1.458 1.458 0 0 1 2 11.543V10h-.25A1.75 1.75 0 0 1 0 8.25v-5.5C0 1.784.784 1 1.75 1ZM1.5 2.75v5.5c0 .138.112.25.25.25h1a.75.75 0 0 1 .75.75v2.19l2.72-2.72a.749.749 0 0 1 .53-.22h3.5a.25.25 0 0 0 .25-.25v-5.5a.25.25 0 0 0-.25-.25h-8.5a.25.25 0 0 0-.25.25Zm13 2a.25.25 0 0 0-.25-.25h-.5a.75.75 0 0 1 0-1.5h.5c.966 0 1.75.784 1.75 1.75v5.5A1.75 1.75 0 0 1 14.25 12H14v1.543a1.458 1.458 0 0 1-2.487 1.03L9.22 12.28a.749.749 0 0 1 .326-1.275.749.749 0 0 1 .734.215l2.22 2.22v-2.19a.75.75 0 0 1 .75-.75h1a.25.25 0 0 0 .25-.25Z"/></svg>';
 
     btn.addEventListener('click', (e) => {
       e.stopPropagation();
-      this._openCommentChat(comment);
-    });
-    return btn;
-  }
-
-  /**
-   * Build the per-thread "Chat about this thread" button.
-   * @private
-   */
-  _buildChatThreadButton(thread) {
-    const btn = document.createElement('button');
-    btn.type = 'button';
-    btn.className = 'btn-chat-thread external-comment-chat-thread-btn';
-    btn.title = 'Chat about this thread';
-    // Stacked-bubbles glyph: two overlapping chat bubbles. Visually distinct
-    // from the single-bubble chat-comment button so the reviewer can tell
-    // "chat about THIS comment" apart from "chat about WHOLE thread".
-    btn.innerHTML = '<svg viewBox="0 0 16 16" width="14" height="14" fill="currentColor" aria-hidden="true"><path d="M1.75 1h8.5c.966 0 1.75.784 1.75 1.75v5.5A1.75 1.75 0 0 1 10.25 10H7.061l-2.574 2.573A1.458 1.458 0 0 1 2 11.543V10h-.25A1.75 1.75 0 0 1 0 8.25v-5.5C0 1.784.784 1 1.75 1ZM1.5 2.75v5.5c0 .138.112.25.25.25h1a.75.75 0 0 1 .75.75v2.19l2.72-2.72a.749.749 0 0 1 .53-.22h3.5a.25.25 0 0 0 .25-.25v-5.5a.25.25 0 0 0-.25-.25h-8.5a.25.25 0 0 0-.25.25Zm13 2a.25.25 0 0 0-.25-.25h-.5a.75.75 0 0 1 0-1.5h.5c.966 0 1.75.784 1.75 1.75v5.5A1.75 1.75 0 0 1 14.25 12H14v1.543a1.458 1.458 0 0 1-2.487 1.03L9.22 12.28a.749.749 0 0 1 .326-1.275.749.749 0 0 1 .734.215l2.22 2.22v-2.19a.75.75 0 0 1 .75-.75h1a.25.25 0 0 0 .25-.25Z"/></svg> Chat about thread';
-
-    btn.addEventListener('click', (e) => {
-      e.stopPropagation();
-      this._openThreadChat(thread);
+      if (isReply) {
+        this._openCommentChat(comment);
+      } else {
+        this._openThreadChat(comment);
+      }
     });
     return btn;
   }

--- a/public/js/pr.js
+++ b/public/js/pr.js
@@ -305,6 +305,16 @@ class PRManager {
       refreshBtn.addEventListener('click', () => this.refreshPR());
     }
 
+    // Refresh external (GitHub) review comments. Handler lives on the
+    // instance so unit tests can call it directly (avoids duplicating the
+    // production click logic in tests, per CLAUDE.md).
+    const refreshExternalBtn = document.getElementById('refresh-external-comments-btn');
+    if (refreshExternalBtn) {
+      refreshExternalBtn.addEventListener('click', () => {
+        void this._handleExternalCommentsRefreshClick({ button: refreshExternalBtn });
+      });
+    }
+
     // PR description popover
     this.setupPRDescriptionPopover();
 
@@ -612,6 +622,15 @@ class PRManager {
       // Fire-and-forget staleness check — shows badge or auto-refreshes
       this._stalenessPromise = this._checkStalenessOnLoad(owner, repo, number);
 
+      // Fire-and-forget external review-comment sync + render.
+      // Runs after the diff and user comments have been rendered so the
+      // external-comment manager has DOM anchors to attach blue rows to.
+      // Failures are swallowed inside _loadExternalComments and surface via
+      // console.warn; they must never block the main PR-load path.
+      void this._loadExternalComments().catch((err) => {
+        console.warn('[external-comments] _loadExternalComments threw', err);
+      });
+
     } catch (error) {
       console.error('Error loading PR:', error);
       this.showError(error.message);
@@ -623,16 +642,238 @@ class PRManager {
   }
 
   /**
-   * Reload AI suggestions and user comments after an analysis completes.
-   * Shared by the foreground `analysis_completed` handler and the deferred
-   * `_dirtyAnalysis` branch in the visibilitychange listener.
+   * Sync external review comments against the source system and render the
+   * results. Non-blocking from the user's perspective: a sync failure does
+   * not prevent rendering of any cached rows from a previous run.
+   *
+   * No-op in local mode (external sources require a real GitHub PR).
+   */
+  /**
+   * Re-render every overlay (AI suggestions, user comments, external comments)
+   * after the underlying diff DOM has been rebuilt.
+   *
+   * Used by anything that destroys and re-mounts the diff (refreshPR, the
+   * whitespace toggle, pre-analysis refresh). Centralizing keeps the three
+   * renderers from drifting: each one has its own clear()/append cycle and
+   * forgetting any of them produces hard-to-spot bugs like "comments
+   * disappeared after refresh".
+   *
+   * @param {Object} [options]
+   * @param {string} [options.analysisRunId] - Optional run id to pin AI suggestions to.
+   * @param {boolean} [options.syncExternal=false] - When true, fire the
+   *   external-comments sync POST before re-rendering. Used by `refreshPR`
+   *   where the diff was just fetched fresh from GitHub and cached anchors
+   *   may not match the new commit. GET-only callers (whitespace toggle,
+   *   analysis rebuilds, post-analysis reload) pass the default and reuse
+   *   the existing mirror.
+   */
+  async _rerenderAllOverlays({ analysisRunId, syncExternal = false } = {}) {
+    const includeDismissed = window.aiPanel?.showDismissedComments || false;
+    await this.loadUserComments(includeDismissed);
+    await this.loadAISuggestions(null, analysisRunId);
+    try {
+      if (typeof window !== 'undefined' && window.externalCommentManager) {
+        if (this.currentPR && this.currentPR.id) {
+          window.externalCommentManager.reviewId = this.currentPR.id;
+        }
+        if (syncExternal) {
+          // refreshPR path: full sync+load through the canonical entry
+          // point. `_loadExternalComments` already owns the toast + error
+          // wiring for the sync result.
+          await this._loadExternalComments();
+        } else {
+          // GET-only path: the local mirror is current; just re-anchor
+          // rows on the freshly-rebuilt diff DOM.
+          await window.externalCommentManager.loadAndRender();
+        }
+      }
+    } catch (err) {
+      console.warn('[external-comments] re-render after diff rebuild failed', err);
+    }
+  }
+
+  /**
+   * Click handler for the "refresh external comments" header button.
+   *
+   * Extracted from `setupEventListeners` so unit tests can exercise the
+   * production handler directly without re-implementing it (CLAUDE.md
+   * forbids duplicating production code in tests). The DOM button id is
+   * the canonical attach point — pass it in for tests that build their
+   * own button.
+   *
+   * @param {Object} [options]
+   * @param {HTMLElement} [options.button] - The button element to toggle. Defaults to `#refresh-external-comments-btn`.
+   * @returns {Promise<void>}
+   */
+  async _handleExternalCommentsRefreshClick({ button } = {}) {
+    const btn = button
+      || (typeof document !== 'undefined' ? document.getElementById('refresh-external-comments-btn') : null);
+    if (!btn || btn.disabled) return;
+    btn.disabled = true;
+    btn.classList.add('is-refreshing');
+    btn.setAttribute('aria-busy', 'true');
+    btn.removeAttribute('data-state');
+    try {
+      await this._loadExternalComments();
+    } finally {
+      btn.disabled = false;
+      btn.classList.remove('is-refreshing');
+      btn.removeAttribute('aria-busy');
+    }
+  }
+
+  async _loadExternalComments() {
+    if (typeof window !== 'undefined' && window.PAIR_REVIEW_LOCAL_MODE) return;
+    if (!this.currentPR || !this.currentPR.id) return;
+    if (typeof window === 'undefined' || !window.externalCommentManager) return;
+
+    window.externalCommentManager.reviewId = this.currentPR.id;
+
+    // Route through the manager's `syncAndRender`. That method owns the
+    // in-flight guard for the FULL sync+load sequence, so a GET-only
+    // caller (analysis rebuild, whitespace toggle) that hits
+    // `loadAndRender` during this window joins the same promise instead
+    // of racing the POST with a stale GET. The manager surfaces sync
+    // result and sync error separately so this method can fire the
+    // status-aware toasts without intercepting render.
+    let result;
+    try {
+      result = await window.externalCommentManager.syncAndRender({
+        syncFn: () => this._syncExternalComments(),
+      });
+    } catch (err) {
+      console.warn('[external-comments] syncAndRender failed', err);
+      return;
+    }
+
+    if (result && result.syncError) {
+      // Sync failed but render proceeded against the previously-cached
+      // mirror. Toast + button-error cue so the reviewer knows the
+      // counts may lag upstream.
+      this._showExternalSyncErrorToast(result.syncError);
+      this._markExternalRefreshErrorState();
+      console.warn('[external-comments] sync failed; rendering cached data only', result.syncError);
+    } else if (result && result.syncResult && typeof result.syncResult.lostAnchors === 'number' && result.syncResult.lostAnchors > 0) {
+      // Surface lost-anchor counts so the reviewer knows why visible
+      // external-comment counts may lag what GitHub shows — these are
+      // comments whose anchors were destroyed upstream (force-push, file
+      // delete, etc.) and have no place to render in the current diff.
+      this._showExternalLostAnchorsToast(result.syncResult.lostAnchors);
+    }
+  }
+
+  /**
+   * Pick a toast message by HTTP status for a failed external-comment sync.
+   * Falls back to a generic message when status is missing or unknown.
+   * @private
+   */
+  _showExternalSyncErrorToast(err) {
+    const status = err && typeof err.status === 'number' ? err.status : 0;
+    let message;
+    if (status === 401) {
+      message = 'GitHub token missing or invalid — external comments not refreshed.';
+    } else if (status === 403) {
+      message = 'GitHub denied the request (403) — external comments not refreshed.';
+    } else if (status === 429) {
+      message = 'GitHub rate limited — external comments not refreshed.';
+    } else {
+      message = 'Could not refresh GitHub review comments.';
+    }
+    try {
+      if (typeof window !== 'undefined') {
+        if (window.toast && typeof window.toast.showError === 'function') {
+          window.toast.showError(message);
+          return;
+        }
+        if (typeof window.showToast === 'function') {
+          window.showToast(message, 'error');
+          return;
+        }
+      }
+    } catch {
+      // toast helpers must never break the page; swallow.
+    }
+  }
+
+  /**
+   * Show a warning toast describing how many external comments couldn't be
+   * anchored to the current diff (lost-anchor count from the sync result).
+   * Mirrors `_showExternalSyncErrorToast` so failures and partial successes
+   * have symmetrical UI treatment.
+   * @param {number} count - Number of lost-anchor comments
+   * @private
+   */
+  _showExternalLostAnchorsToast(count) {
+    if (typeof window === 'undefined') return;
+    const noun = count === 1 ? 'comment' : 'comments';
+    const message = `${count} ${noun} lost their anchor due to upstream changes`;
+    try {
+      if (window.toast && typeof window.toast.showWarning === 'function') {
+        window.toast.showWarning(message);
+        return;
+      }
+      if (window.toast && typeof window.toast.showInfo === 'function') {
+        window.toast.showInfo(message);
+        return;
+      }
+      if (typeof window.showToast === 'function') {
+        window.showToast(message, 'warn');
+        return;
+      }
+    } catch {
+      // toast helpers must never break the page; swallow.
+    }
+  }
+
+  /**
+   * Briefly mark the refresh button so the user notices the failure even if
+   * they dismissed the toast. Cleared after 4s; no state machine — best
+   * effort cue. No-op when the button isn't present.
+   * @private
+   */
+  _markExternalRefreshErrorState() {
+    if (typeof document === 'undefined') return;
+    const btn = document.getElementById('refresh-external-comments-btn');
+    if (!btn) return;
+    btn.setAttribute('data-state', 'error');
+    setTimeout(() => {
+      if (btn.getAttribute('data-state') === 'error') {
+        btn.removeAttribute('data-state');
+      }
+    }, 4000);
+  }
+
+  /**
+   * POST to the sync endpoint for the GitHub source. Coalesced server-side
+   * for concurrent (review, source) calls; safe to invoke from page-load and
+   * the manual refresh button in parallel.
+   * @returns {Promise<{ count: number, lostAnchors: number, syncedAt: string }>}
+   */
+  async _syncExternalComments() {
+    const source = 'github';
+    const res = await fetch(
+      `/api/reviews/${this.currentPR.id}/external-comments/sync?source=${source}`,
+      { method: 'POST' }
+    );
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      const err = new Error(body.error || `Sync failed with status ${res.status}`);
+      err.status = res.status;
+      throw err;
+    }
+    return res.json();
+  }
+
+  /**
+   * Reload AI suggestions, user comments, and external comments after an
+   * analysis completes. Shared by the foreground `analysis_completed`
+   * handler and the deferred `_dirtyAnalysis` branch in the
+   * visibilitychange listener. Routing through `_rerenderAllOverlays`
+   * keeps external-comment rows in sync with the other two overlays
+   * whenever post-analysis refresh fires.
    */
   _reloadAfterAnalysis() {
-    const includeDismissed = window.aiPanel?.showDismissedComments ?? false;
-    return Promise.all([
-      this.loadAISuggestions(),
-      this.loadUserComments(includeDismissed)
-    ]);
+    return this._rerenderAllOverlays();
   }
 
   /**
@@ -842,10 +1083,11 @@ class PRManager {
     // Re-fetch and re-render the diff
     await this.loadAndDisplayFiles(owner, repo, number);
 
-    // Re-anchor comments and suggestions on the fresh DOM
-    const includeDismissed = window.aiPanel?.showDismissedComments || false;
-    await this.loadUserComments(includeDismissed);
-    await this.loadAISuggestions(null, this.selectedRunId);
+    // Re-anchor every overlay (user comments, AI suggestions, external
+    // comments) via the shared helper so the three renderers can't drift.
+    // The diff DOM was just rebuilt, so external-comment rows are gone
+    // until loadAndRender re-inserts them.
+    await this._rerenderAllOverlays({ analysisRunId: this.selectedRunId });
 
     // Restore scroll position after the DOM settles
     requestAnimationFrame(() => {
@@ -5221,14 +5463,22 @@ class PRManager {
         // Reload the files/diff with fresh data
         await this.loadAndDisplayFiles(owner, repo, number);
 
-        // Re-render comments and AI suggestions on the fresh DOM
-        // (renderDiff clears the diff container, so we must re-populate)
-        const includeDismissed = window.aiPanel?.showDismissedComments || false;
-        await this.loadUserComments(includeDismissed);
-        // Note: Unlike loadPR() which skips this when analysisHistoryManager exists
-        // (because the manager triggers loadAISuggestions via onSelectionChange on init),
-        // refresh must call unconditionally since the manager won't re-fire its callback.
-        await this.loadAISuggestions(null, this.selectedRunId);
+        // Re-render the three independent overlay layers on the fresh DOM
+        // (renderDiff clears the diff container). Going through the shared
+        // helper guarantees the three renderers can't drift again — adding
+        // a fourth overlay only requires updating this one place.
+        // `syncExternal: true` because refreshPR fetched a brand-new diff
+        // (commit SHA may have changed). Cached external-comment anchors
+        // need a sync POST to re-evaluate which ones are outdated against
+        // the new HEAD — otherwise we'd render stale `is_outdated` flags.
+        // Note: Unlike loadPR() which skips loadAISuggestions when
+        // analysisHistoryManager exists (because the manager triggers it via
+        // onSelectionChange on init), refresh must call unconditionally
+        // since the manager won't re-fire its callback.
+        await this._rerenderAllOverlays({
+          analysisRunId: this.selectedRunId,
+          syncExternal: true,
+        });
 
         // Restore expanded folders
         this.expandedFolders = expandedFolders;

--- a/public/js/pr.js
+++ b/public/js/pr.js
@@ -308,10 +308,20 @@ class PRManager {
     // Refresh external (GitHub) review comments. Handler lives on the
     // instance so unit tests can call it directly (avoids duplicating the
     // production click logic in tests, per CLAUDE.md).
+    // Two physical buttons share the handler: the always-visible toolbar
+    // button (#refresh-external-comments-btn) and the mirror inside the AI
+    // panel header (#refresh-external-comments-btn-panel). Either click
+    // triggers the same sync; the handler toggles whichever button fired it.
     const refreshExternalBtn = document.getElementById('refresh-external-comments-btn');
     if (refreshExternalBtn) {
       refreshExternalBtn.addEventListener('click', () => {
         void this._handleExternalCommentsRefreshClick({ button: refreshExternalBtn });
+      });
+    }
+    const refreshExternalBtnPanel = document.getElementById('refresh-external-comments-btn-panel');
+    if (refreshExternalBtnPanel) {
+      refreshExternalBtnPanel.addEventListener('click', () => {
+        void this._handleExternalCommentsRefreshClick({ button: refreshExternalBtnPanel });
       });
     }
 
@@ -833,12 +843,19 @@ class PRManager {
    */
   _markExternalRefreshErrorState() {
     if (typeof document === 'undefined') return;
-    const btn = document.getElementById('refresh-external-comments-btn');
-    if (!btn) return;
-    btn.setAttribute('data-state', 'error');
+    const btns = [
+      document.getElementById('refresh-external-comments-btn'),
+      document.getElementById('refresh-external-comments-btn-panel'),
+    ].filter(Boolean);
+    if (btns.length === 0) return;
+    for (const btn of btns) {
+      btn.setAttribute('data-state', 'error');
+    }
     setTimeout(() => {
-      if (btn.getAttribute('data-state') === 'error') {
-        btn.removeAttribute('data-state');
+      for (const btn of btns) {
+        if (btn.getAttribute('data-state') === 'error') {
+          btn.removeAttribute('data-state');
+        }
       }
     }, 4000);
   }

--- a/public/js/pr.js
+++ b/public/js/pr.js
@@ -308,16 +308,6 @@ class PRManager {
     // Refresh external (GitHub) review comments. Handler lives on the
     // instance so unit tests can call it directly (avoids duplicating the
     // production click logic in tests, per CLAUDE.md).
-    // Two physical buttons share the handler: the always-visible toolbar
-    // button (#refresh-external-comments-btn) and the mirror inside the AI
-    // panel header (#refresh-external-comments-btn-panel). Either click
-    // triggers the same sync; the handler toggles whichever button fired it.
-    const refreshExternalBtn = document.getElementById('refresh-external-comments-btn');
-    if (refreshExternalBtn) {
-      refreshExternalBtn.addEventListener('click', () => {
-        void this._handleExternalCommentsRefreshClick({ button: refreshExternalBtn });
-      });
-    }
     const refreshExternalBtnPanel = document.getElementById('refresh-external-comments-btn-panel');
     if (refreshExternalBtnPanel) {
       refreshExternalBtnPanel.addEventListener('click', () => {
@@ -712,12 +702,12 @@ class PRManager {
    * own button.
    *
    * @param {Object} [options]
-   * @param {HTMLElement} [options.button] - The button element to toggle. Defaults to `#refresh-external-comments-btn`.
+   * @param {HTMLElement} [options.button] - The button element to toggle. Defaults to `#refresh-external-comments-btn-panel`.
    * @returns {Promise<void>}
    */
   async _handleExternalCommentsRefreshClick({ button } = {}) {
     const btn = button
-      || (typeof document !== 'undefined' ? document.getElementById('refresh-external-comments-btn') : null);
+      || (typeof document !== 'undefined' ? document.getElementById('refresh-external-comments-btn-panel') : null);
     if (!btn || btn.disabled) return;
     btn.disabled = true;
     btn.classList.add('is-refreshing');
@@ -843,19 +833,12 @@ class PRManager {
    */
   _markExternalRefreshErrorState() {
     if (typeof document === 'undefined') return;
-    const btns = [
-      document.getElementById('refresh-external-comments-btn'),
-      document.getElementById('refresh-external-comments-btn-panel'),
-    ].filter(Boolean);
-    if (btns.length === 0) return;
-    for (const btn of btns) {
-      btn.setAttribute('data-state', 'error');
-    }
+    const btn = document.getElementById('refresh-external-comments-btn-panel');
+    if (!btn) return;
+    btn.setAttribute('data-state', 'error');
     setTimeout(() => {
-      for (const btn of btns) {
-        if (btn.getAttribute('data-state') === 'error') {
-          btn.removeAttribute('data-state');
-        }
+      if (btn.getAttribute('data-state') === 'error') {
+        btn.removeAttribute('data-state');
       }
     }, 4000);
   }

--- a/public/js/pr.js
+++ b/public/js/pr.js
@@ -308,11 +308,16 @@ class PRManager {
     // Refresh external (GitHub) review comments. Handler lives on the
     // instance so unit tests can call it directly (avoids duplicating the
     // production click logic in tests, per CLAUDE.md).
-    const refreshExternalBtnPanel = document.getElementById('refresh-external-comments-btn-panel');
-    if (refreshExternalBtnPanel) {
-      refreshExternalBtnPanel.addEventListener('click', () => {
-        void this._handleExternalCommentsRefreshClick({ button: refreshExternalBtnPanel });
-      });
+    // Skip wiring entirely when the external_comments feature toggle is
+    // off — the button is also CSS-hidden via .external-comments-only, so
+    // this is belt-and-suspenders.
+    if (this._externalCommentsEnabled()) {
+      const refreshExternalBtnPanel = document.getElementById('refresh-external-comments-btn-panel');
+      if (refreshExternalBtnPanel) {
+        refreshExternalBtnPanel.addEventListener('click', () => {
+          void this._handleExternalCommentsRefreshClick({ button: refreshExternalBtnPanel });
+        });
+      }
     }
 
     // PR description popover
@@ -671,6 +676,10 @@ class PRManager {
     const includeDismissed = window.aiPanel?.showDismissedComments || false;
     await this.loadUserComments(includeDismissed);
     await this.loadAISuggestions(null, analysisRunId);
+    // Skip external-comment re-rendering entirely when the feature is off.
+    // The manager is never populated with rows in that case, so there's
+    // nothing to re-anchor.
+    if (!this._externalCommentsEnabled()) return;
     try {
       if (typeof window !== 'undefined' && window.externalCommentManager) {
         if (this.currentPR && this.currentPR.id) {
@@ -706,6 +715,9 @@ class PRManager {
    * @returns {Promise<void>}
    */
   async _handleExternalCommentsRefreshClick({ button } = {}) {
+    // Defensive guard: even if a stale caller invokes this with the
+    // feature disabled, swallow it. UI wiring already skips this path.
+    if (!this._externalCommentsEnabled()) return;
     const btn = button
       || (typeof document !== 'undefined' ? document.getElementById('refresh-external-comments-btn-panel') : null);
     if (!btn || btn.disabled) return;
@@ -722,8 +734,23 @@ class PRManager {
     }
   }
 
+  /**
+   * Feature toggle for the external-comments (GitHub PR review-comment)
+   * subsystem. Reads `window.PAIR_REVIEW_RUNTIME_CONFIG` which is set
+   * synchronously by `/runtime-config.js` BEFORE this file loads, so the
+   * check is safe at any call site. Defaults to enabled when the flag is
+   * missing — preserves behavior for any environment that omits the
+   * runtime-config script (e.g., older test fixtures).
+   * @returns {boolean}
+   */
+  _externalCommentsEnabled() {
+    if (typeof window === 'undefined') return true;
+    return window.PAIR_REVIEW_RUNTIME_CONFIG?.external_comments_enabled !== false;
+  }
+
   async _loadExternalComments() {
     if (typeof window !== 'undefined' && window.PAIR_REVIEW_LOCAL_MODE) return;
+    if (!this._externalCommentsEnabled()) return;
     if (!this.currentPR || !this.currentPR.id) return;
     if (typeof window === 'undefined' || !window.externalCommentManager) return;
 

--- a/public/local.html
+++ b/public/local.html
@@ -525,11 +525,20 @@
 
                     <!-- Segment Control -->
                     <div class="segment-control" id="segment-control">
-                        <div class="segment-control-inner">
-                            <button class="segment-btn active" data-segment="ai">AI <span class="segment-count">(0)</span></button>
-                            <button class="segment-btn" data-segment="comments">User <span class="segment-count">(0)</span></button>
-                            <button class="segment-btn" data-segment="all">All <span class="segment-count">(0)</span></button>
+                        <button type="button" class="segment-scroll segment-scroll--left" id="segment-scroll-left" hidden aria-label="Scroll segments left" tabindex="-1">
+                            <svg viewBox="0 0 16 16" width="12" height="12" fill="currentColor" aria-hidden="true"><path d="M9.78 12.78a.75.75 0 0 1-1.06 0L4.47 8.53a.75.75 0 0 1 0-1.06l4.25-4.25a.751.751 0 0 1 1.042.018.751.751 0 0 1 .018 1.042L6.06 8l3.72 3.72a.75.75 0 0 1 0 1.06Z"/></svg>
+                        </button>
+                        <div class="segment-control-scroll" id="segment-control-scroll">
+                            <div class="segment-control-inner">
+                                <button class="segment-btn active" data-segment="ai">AI <span class="segment-count">(0)</span></button>
+                                <button class="segment-btn" data-segment="comments">User <span class="segment-count">(0)</span></button>
+                                <button class="segment-btn" data-segment="external" hidden>External <span class="segment-count">(0)</span></button>
+                                <button class="segment-btn" data-segment="all">All <span class="segment-count">(0)</span></button>
+                            </div>
                         </div>
+                        <button type="button" class="segment-scroll segment-scroll--right" id="segment-scroll-right" hidden aria-label="Scroll segments right" tabindex="-1">
+                            <svg viewBox="0 0 16 16" width="12" height="12" fill="currentColor" aria-hidden="true"><path d="M6.22 3.22a.75.75 0 0 1 1.06 0l4.25 4.25a.75.75 0 0 1 0 1.06l-4.25 4.25a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L9.94 8 6.22 4.28a.75.75 0 0 1 0-1.06Z"/></svg>
+                        </button>
                     </div>
 
                     <!-- Level Filter -->
@@ -543,7 +552,9 @@
                     <!-- Findings Summary -->
                     <div class="findings-summary" id="findings-summary">
                         <div class="findings-header">
-                            <span class="findings-count" id="findings-count">0 items</span>
+                            <!-- Nav controls (prev | n of N | next) are injected by AIPanel.updateFindingsHeader.
+                                 Local mode has no external comments, so the actions slot stays empty. -->
+                            <div class="findings-nav" id="findings-nav"></div>
                         </div>
                         <div class="findings-list" id="findings-list">
                             <div class="findings-empty">

--- a/public/local.html
+++ b/public/local.html
@@ -652,6 +652,11 @@
         window.PAIR_REVIEW_LOCAL_MODE = true;
     </script>
 
+    <!-- Runtime configuration: sets window.PAIR_REVIEW_RUNTIME_CONFIG and
+         the `external-comments-disabled` class on documentElement before
+         pr.js / AIPanel initialise. Must load BEFORE pr.js. -->
+    <script src="/runtime-config.js"></script>
+
     <!-- PR JavaScript (shared with local mode) -->
     <script src="/js/pr.js"></script>
 

--- a/public/pr.html
+++ b/public/pr.html
@@ -326,11 +326,20 @@
 
                     <!-- Segment Control -->
                     <div class="segment-control" id="segment-control">
-                        <div class="segment-control-inner">
-                            <button class="segment-btn active" data-segment="ai">AI <span class="segment-count">(0)</span></button>
-                            <button class="segment-btn" data-segment="comments">User <span class="segment-count">(0)</span></button>
-                            <button class="segment-btn" data-segment="all">All <span class="segment-count">(0)</span></button>
+                        <button type="button" class="segment-scroll segment-scroll--left" id="segment-scroll-left" hidden aria-label="Scroll segments left" tabindex="-1">
+                            <svg viewBox="0 0 16 16" width="12" height="12" fill="currentColor" aria-hidden="true"><path d="M9.78 12.78a.75.75 0 0 1-1.06 0L4.47 8.53a.75.75 0 0 1 0-1.06l4.25-4.25a.751.751 0 0 1 1.042.018.751.751 0 0 1 .018 1.042L6.06 8l3.72 3.72a.75.75 0 0 1 0 1.06Z"/></svg>
+                        </button>
+                        <div class="segment-control-scroll" id="segment-control-scroll">
+                            <div class="segment-control-inner">
+                                <button class="segment-btn active" data-segment="ai">AI <span class="segment-count">(0)</span></button>
+                                <button class="segment-btn" data-segment="comments">User <span class="segment-count">(0)</span></button>
+                                <button class="segment-btn" data-segment="external">External <span class="segment-count">(0)</span></button>
+                                <button class="segment-btn" data-segment="all">All <span class="segment-count">(0)</span></button>
+                            </div>
                         </div>
+                        <button type="button" class="segment-scroll segment-scroll--right" id="segment-scroll-right" hidden aria-label="Scroll segments right" tabindex="-1">
+                            <svg viewBox="0 0 16 16" width="12" height="12" fill="currentColor" aria-hidden="true"><path d="M6.22 3.22a.75.75 0 0 1 1.06 0l4.25 4.25a.75.75 0 0 1 0 1.06l-4.25 4.25a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L9.94 8 6.22 4.28a.75.75 0 0 1 0-1.06Z"/></svg>
+                        </button>
                     </div>
 
                     <!-- Level Filter -->
@@ -344,7 +353,16 @@
                     <!-- Findings Summary -->
                     <div class="findings-summary" id="findings-summary">
                         <div class="findings-header">
-                            <span class="findings-count" id="findings-count">0 items</span>
+                            <!-- Nav controls (prev | n of N | next) are injected by AIPanel.updateFindingsHeader.
+                                 Kept as a static slot so the sibling actions container survives re-render. -->
+                            <div class="findings-nav" id="findings-nav"></div>
+                            <div class="findings-header-actions">
+                                <button class="btn btn-sm btn-icon btn-refresh-external-comments" id="refresh-external-comments-btn-panel" title="Refresh GitHub comments" aria-label="Refresh GitHub comments">
+                                    <svg viewBox="0 0 16 16" fill="currentColor" width="14" height="14" aria-hidden="true">
+                                        <path d="M1.705 8.005a.75.75 0 0 1 .834.656 5.5 5.5 0 0 0 9.592 2.97l-1.204-1.204a.25.25 0 0 1 .177-.427h3.646a.25.25 0 0 1 .25.25v3.646a.25.25 0 0 1-.427.177l-1.38-1.38A7.002 7.002 0 0 1 1.05 8.84a.75.75 0 0 1 .656-.834ZM8 2.5a5.487 5.487 0 0 0-4.131 1.869l1.204 1.204A.25.25 0 0 1 4.896 6H1.25A.25.25 0 0 1 1 5.75V2.104a.25.25 0 0 1 .427-.177l1.38 1.38A7.002 7.002 0 0 1 14.95 7.16a.75.75 0 0 1-1.49.178A5.5 5.5 0 0 0 8 2.5Z"/>
+                                    </svg>
+                                </button>
+                            </div>
                         </div>
                         <div class="findings-list" id="findings-list">
                             <div class="findings-empty">

--- a/public/pr.html
+++ b/public/pr.html
@@ -244,6 +244,11 @@
                             </svg>
                             <span class="btn-text">Analyze</span>
                         </button>
+                        <button class="btn btn-sm btn-icon btn-refresh-external-comments" id="refresh-external-comments-btn" title="Refresh GitHub comments" aria-label="Refresh GitHub comments">
+                            <svg viewBox="0 0 16 16" fill="currentColor" width="14" height="14" aria-hidden="true">
+                                <path d="M1.705 8.005a.75.75 0 0 1 .834.656 5.5 5.5 0 0 0 9.592 2.97l-1.204-1.204a.25.25 0 0 1 .177-.427h3.646a.25.25 0 0 1 .25.25v3.646a.25.25 0 0 1-.427.177l-1.38-1.38A7.002 7.002 0 0 1 1.05 8.84a.75.75 0 0 1 .656-.834ZM8 2.5a5.487 5.487 0 0 0-4.131 1.869l1.204 1.204A.25.25 0 0 1 4.896 6H1.25A.25.25 0 0 1 1 5.75V2.104a.25.25 0 0 1 .427-.177l1.38 1.38A7.002 7.002 0 0 1 14.95 7.16a.75.75 0 0 1-1.49.178A5.5 5.5 0 0 0 8 2.5Z"/>
+                            </svg>
+                        </button>
                         <button class="btn btn-sm btn-icon" id="chat-toggle-btn" title="Toggle Chat panel">
                             <svg class="chat-icon" viewBox="0 0 16 16" fill="currentColor" width="14" height="14">
                                 <path d="M1.75 1h8.5c.966 0 1.75.784 1.75 1.75v5.5A1.75 1.75 0 0 1 10.25 10H7.061l-2.574 2.573A1.458 1.458 0 0 1 2 11.543V10h-.25A1.75 1.75 0 0 1 0 8.25v-5.5C0 1.784.784 1 1.75 1ZM1.5 2.75v5.5c0 .138.112.25.25.25h1a.75.75 0 0 1 .75.75v2.19l2.72-2.72a.749.749 0 0 1 .53-.22h3.5a.25.25 0 0 0 .25-.25v-5.5a.25.25 0 0 0-.25-.25h-8.5a.25.25 0 0 0-.25.25Zm13 2a.25.25 0 0 0-.25-.25h-.5a.75.75 0 0 1 0-1.5h.5c.966 0 1.75.784 1.75 1.75v5.5A1.75 1.75 0 0 1 14.25 12H14v1.543a1.458 1.458 0 0 1-2.487 1.03L9.22 12.28a.749.749 0 0 1 .326-1.275.749.749 0 0 1 .734.215l2.22 2.22v-2.19a.75.75 0 0 1 .75-.75h1a.25.25 0 0 0 .25-.25Z"/>
@@ -428,6 +433,9 @@
 
     <!-- Chat Panel Component -->
     <script src="/js/components/ChatPanel.js"></script>
+
+    <!-- External review-comment renderer (must load after chat-panel + comment-manager) -->
+    <script src="/js/modules/external-comment-manager.js"></script>
 
     <!-- Panel Group Component -->
     <script src="/js/components/PanelGroup.js"></script>

--- a/public/pr.html
+++ b/public/pr.html
@@ -352,7 +352,7 @@
                                  Kept as a static slot so the sibling actions container survives re-render. -->
                             <div class="findings-nav" id="findings-nav"></div>
                             <div class="findings-header-actions">
-                                <button class="findings-nav-btn btn-refresh-external-comments" id="refresh-external-comments-btn-panel" title="Refresh GitHub comments" aria-label="Refresh GitHub comments">
+                                <button class="findings-nav-btn btn-refresh-external-comments external-comments-only" id="refresh-external-comments-btn-panel" title="Refresh GitHub comments" aria-label="Refresh GitHub comments">
                                     <svg viewBox="0 0 16 16" fill="currentColor" width="12" height="12" aria-hidden="true">
                                         <path d="M1.705 8.005a.75.75 0 0 1 .834.656 5.5 5.5 0 0 0 9.592 2.97l-1.204-1.204a.25.25 0 0 1 .177-.427h3.646a.25.25 0 0 1 .25.25v3.646a.25.25 0 0 1-.427.177l-1.38-1.38A7.002 7.002 0 0 1 1.05 8.84a.75.75 0 0 1 .656-.834ZM8 2.5a5.487 5.487 0 0 0-4.131 1.869l1.204 1.204A.25.25 0 0 1 4.896 6H1.25A.25.25 0 0 1 1 5.75V2.104a.25.25 0 0 1 .427-.177l1.38 1.38A7.002 7.002 0 0 1 14.95 7.16a.75.75 0 0 1-1.49.178A5.5 5.5 0 0 0 8 2.5Z"/>
                                     </svg>
@@ -452,6 +452,11 @@
 
     <!-- Panel Group Component -->
     <script src="/js/components/PanelGroup.js"></script>
+
+    <!-- Runtime configuration: sets window.PAIR_REVIEW_RUNTIME_CONFIG and
+         the `external-comments-disabled` class on documentElement before
+         pr.js / AIPanel initialise. Must load BEFORE pr.js. -->
+    <script src="/runtime-config.js"></script>
 
     <!-- PR JavaScript -->
     <script src="/js/pr.js"></script>

--- a/public/pr.html
+++ b/public/pr.html
@@ -244,11 +244,6 @@
                             </svg>
                             <span class="btn-text">Analyze</span>
                         </button>
-                        <button class="btn btn-sm btn-icon btn-refresh-external-comments" id="refresh-external-comments-btn" title="Refresh GitHub comments" aria-label="Refresh GitHub comments">
-                            <svg viewBox="0 0 16 16" fill="currentColor" width="14" height="14" aria-hidden="true">
-                                <path d="M1.705 8.005a.75.75 0 0 1 .834.656 5.5 5.5 0 0 0 9.592 2.97l-1.204-1.204a.25.25 0 0 1 .177-.427h3.646a.25.25 0 0 1 .25.25v3.646a.25.25 0 0 1-.427.177l-1.38-1.38A7.002 7.002 0 0 1 1.05 8.84a.75.75 0 0 1 .656-.834ZM8 2.5a5.487 5.487 0 0 0-4.131 1.869l1.204 1.204A.25.25 0 0 1 4.896 6H1.25A.25.25 0 0 1 1 5.75V2.104a.25.25 0 0 1 .427-.177l1.38 1.38A7.002 7.002 0 0 1 14.95 7.16a.75.75 0 0 1-1.49.178A5.5 5.5 0 0 0 8 2.5Z"/>
-                            </svg>
-                        </button>
                         <button class="btn btn-sm btn-icon" id="chat-toggle-btn" title="Toggle Chat panel">
                             <svg class="chat-icon" viewBox="0 0 16 16" fill="currentColor" width="14" height="14">
                                 <path d="M1.75 1h8.5c.966 0 1.75.784 1.75 1.75v5.5A1.75 1.75 0 0 1 10.25 10H7.061l-2.574 2.573A1.458 1.458 0 0 1 2 11.543V10h-.25A1.75 1.75 0 0 1 0 8.25v-5.5C0 1.784.784 1 1.75 1ZM1.5 2.75v5.5c0 .138.112.25.25.25h1a.75.75 0 0 1 .75.75v2.19l2.72-2.72a.749.749 0 0 1 .53-.22h3.5a.25.25 0 0 0 .25-.25v-5.5a.25.25 0 0 0-.25-.25h-8.5a.25.25 0 0 0-.25.25Zm13 2a.25.25 0 0 0-.25-.25h-.5a.75.75 0 0 1 0-1.5h.5c.966 0 1.75.784 1.75 1.75v5.5A1.75 1.75 0 0 1 14.25 12H14v1.543a1.458 1.458 0 0 1-2.487 1.03L9.22 12.28a.749.749 0 0 1 .326-1.275.749.749 0 0 1 .734.215l2.22 2.22v-2.19a.75.75 0 0 1 .75-.75h1a.25.25 0 0 0 .25-.25Z"/>
@@ -357,8 +352,8 @@
                                  Kept as a static slot so the sibling actions container survives re-render. -->
                             <div class="findings-nav" id="findings-nav"></div>
                             <div class="findings-header-actions">
-                                <button class="btn btn-sm btn-icon btn-refresh-external-comments" id="refresh-external-comments-btn-panel" title="Refresh GitHub comments" aria-label="Refresh GitHub comments">
-                                    <svg viewBox="0 0 16 16" fill="currentColor" width="14" height="14" aria-hidden="true">
+                                <button class="findings-nav-btn btn-refresh-external-comments" id="refresh-external-comments-btn-panel" title="Refresh GitHub comments" aria-label="Refresh GitHub comments">
+                                    <svg viewBox="0 0 16 16" fill="currentColor" width="12" height="12" aria-hidden="true">
                                         <path d="M1.705 8.005a.75.75 0 0 1 .834.656 5.5 5.5 0 0 0 9.592 2.97l-1.204-1.204a.25.25 0 0 1 .177-.427h3.646a.25.25 0 0 1 .25.25v3.646a.25.25 0 0 1-.427.177l-1.38-1.38A7.002 7.002 0 0 1 1.05 8.84a.75.75 0 0 1 .656-.834ZM8 2.5a5.487 5.487 0 0 0-4.131 1.869l1.204 1.204A.25.25 0 0 1 4.896 6H1.25A.25.25 0 0 1 1 5.75V2.104a.25.25 0 0 1 .427-.177l1.38 1.38A7.002 7.002 0 0 1 14.95 7.16a.75.75 0 0 1-1.49.178A5.5 5.5 0 0 0 8 2.5Z"/>
                                     </svg>
                                 </button>

--- a/src/config.js
+++ b/src/config.js
@@ -39,7 +39,8 @@ const DEFAULT_CONFIG = {
   assisted_by_url: "https://github.com/in-the-loop-labs/pair-review",  // URL for "Review assisted by" footer link
   hooks: {},  // Hook commands per event: { "review.started": { "my_hook": { "command": "..." } } }
   enable_graphite: false,  // When true, shows Graphite links alongside GitHub links
-  skip_update_notifier: false  // When true, suppresses the "update available" notification on exit
+  skip_update_notifier: false,  // When true, suppresses the "update available" notification on exit
+  external_comments: false  // Opt-in: set to true to enable GitHub PR review-comment sync (External segment, refresh button, /api/reviews/*/external-comments routes)
 };
 
 /**

--- a/src/database.js
+++ b/src/database.js
@@ -21,7 +21,7 @@ function getDbPath() {
 /**
  * Current schema version - increment this when adding new migrations
  */
-const CURRENT_SCHEMA_VERSION = 44;
+const CURRENT_SCHEMA_VERSION = 46;
 
 /**
  * Database schema SQL statements
@@ -299,6 +299,35 @@ const SCHEMA_SQL = {
       last_fetched_at TEXT,
       created_at TEXT NOT NULL
     )
+  `,
+
+  external_comments: `
+    CREATE TABLE IF NOT EXISTS external_comments (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      review_id INTEGER NOT NULL,
+      source TEXT NOT NULL,
+      external_id TEXT NOT NULL,
+      in_reply_to_id TEXT,
+      parent_id INTEGER,
+      external_url TEXT,
+      author TEXT,
+      author_url TEXT,
+      file TEXT NOT NULL,
+      side TEXT,
+      line_start INTEGER,
+      line_end INTEGER,
+      diff_position INTEGER,
+      commit_sha TEXT,
+      is_outdated INTEGER NOT NULL DEFAULT 0,
+      original_line_start INTEGER,
+      original_line_end INTEGER,
+      original_commit_sha TEXT,
+      body TEXT,
+      external_created_at TEXT,
+      synced_at TEXT,
+      FOREIGN KEY (review_id) REFERENCES reviews(id) ON DELETE CASCADE,
+      FOREIGN KEY (parent_id) REFERENCES external_comments(id) ON DELETE SET NULL
+    )
   `
 };
 
@@ -341,7 +370,11 @@ const INDEX_SQL = [
   // Worktree pool indexes
   'CREATE INDEX IF NOT EXISTS idx_worktree_pool_repo ON worktree_pool(repository)',
   'CREATE INDEX IF NOT EXISTS idx_worktree_pool_status ON worktree_pool(repository, status)',
-  'CREATE INDEX IF NOT EXISTS idx_worktree_pool_lru ON worktree_pool(repository, status, last_switched_at)'
+  'CREATE INDEX IF NOT EXISTS idx_worktree_pool_lru ON worktree_pool(repository, status, last_switched_at)',
+  // External comments indexes (read-only mirror of GitHub/etc. PR review comments)
+  'CREATE UNIQUE INDEX IF NOT EXISTS idx_external_comments_unique ON external_comments(review_id, source, external_id)',
+  'CREATE INDEX IF NOT EXISTS idx_external_comments_anchor ON external_comments(review_id, file, line_end)',
+  'CREATE INDEX IF NOT EXISTS idx_external_comments_parent_lookup ON external_comments(review_id, source, in_reply_to_id)'
 ];
 
 /**
@@ -1886,6 +1919,165 @@ const MIGRATIONS = {
       console.log('  Column level_outcomes already exists');
     }
     console.log('Migration to schema version 44 complete');
+  },
+
+  // Migration to version 45: Create external_comments table for read-only mirroring
+  // of GitHub (and future GitLab/Linear/etc.) PR review comments.
+  // Idempotent: CREATE TABLE / CREATE INDEX use IF NOT EXISTS. Wrapped in a
+  // transaction so a crash mid-rebuild won't leave the schema half-built.
+  // No foreign_keys pragma toggle needed — this is a brand-new table with no
+  // existing data to migrate.
+  // NOTE: Migration 46 rebuilds this table to change the parent_id FK from
+  // ON DELETE CASCADE to ON DELETE SET NULL. The constraint here matches
+  // what 46 enforces so fresh installs land at the correct state before 46
+  // runs, and so a databases re-running this migration (idempotent path)
+  // doesn't fight 46's rebuild.
+  45: (db) => {
+    console.log('Running migration to schema version 45: Create external_comments table...');
+
+    const createSchema = db.transaction(() => {
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS external_comments (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          review_id INTEGER NOT NULL,
+          source TEXT NOT NULL,
+          external_id TEXT NOT NULL,
+          in_reply_to_id TEXT,
+          parent_id INTEGER,
+          external_url TEXT,
+          author TEXT,
+          author_url TEXT,
+          file TEXT NOT NULL,
+          side TEXT,
+          line_start INTEGER,
+          line_end INTEGER,
+          diff_position INTEGER,
+          commit_sha TEXT,
+          is_outdated INTEGER NOT NULL DEFAULT 0,
+          original_line_start INTEGER,
+          original_line_end INTEGER,
+          original_commit_sha TEXT,
+          body TEXT,
+          external_created_at TEXT,
+          synced_at TEXT,
+          FOREIGN KEY (review_id) REFERENCES reviews(id) ON DELETE CASCADE,
+          FOREIGN KEY (parent_id) REFERENCES external_comments(id) ON DELETE SET NULL
+        )
+      `);
+      db.exec('CREATE UNIQUE INDEX IF NOT EXISTS idx_external_comments_unique ON external_comments(review_id, source, external_id)');
+      db.exec('CREATE INDEX IF NOT EXISTS idx_external_comments_anchor ON external_comments(review_id, file, line_end)');
+      db.exec('CREATE INDEX IF NOT EXISTS idx_external_comments_parent_lookup ON external_comments(review_id, source, in_reply_to_id)');
+    });
+    createSchema();
+
+    console.log('  Created external_comments table with indexes');
+    console.log('Migration to schema version 45 complete');
+  },
+
+  // Migration to version 46: Rebuild external_comments so parent_id uses
+  // ON DELETE SET NULL instead of ON DELETE CASCADE.
+  //
+  // Why: the sync route prunes parent rows that disappear from the upstream
+  // snapshot while keeping replies whose external IDs are still present.
+  // Under CASCADE the kept replies were silently destroyed when their
+  // parent was deleted, defeating `listThreadsByReview`'s orphan-promotion
+  // logic and causing silent data loss.
+  //
+  // Follows the SQLite migration safety rules in CLAUDE.md:
+  //   - DROP TABLE IF EXISTS for the temp/rebuild table (idempotent restart)
+  //   - PRAGMA foreign_keys OFF in try/finally so the toggle is restored
+  //     even if the rebuild throws
+  //   - Transaction-wrapped DDL so partial failures don't leave a broken schema
+  //   - Indexes recreated by name to match production exactly
+  46: (db) => {
+    console.log('Running migration to schema version 46: Rebuild external_comments with ON DELETE SET NULL on parent_id...');
+
+    // Quick exit when the table doesn't exist yet — migration 45 hasn't run
+    // (older instance with version<45 will run 45 first; if someone reset
+    // user_version backwards this avoids crashing).
+    const tableInfo = db.prepare(
+      "SELECT name FROM sqlite_master WHERE type='table' AND name='external_comments'"
+    ).get();
+    if (!tableInfo) {
+      console.log('  external_comments table not present; nothing to rebuild');
+      console.log('Migration to schema version 46 complete');
+      return;
+    }
+
+    // Disable foreign-key enforcement for the duration of the rebuild so
+    // existing rows can be copied without spurious cascade checks. ALWAYS
+    // restore in a finally — partial restores corrupt later writes.
+    const originalForeignKeys = db.prepare('PRAGMA foreign_keys').get().foreign_keys;
+    db.exec('PRAGMA foreign_keys = OFF');
+    try {
+      const rebuild = db.transaction(() => {
+        // Drop any leftover rebuild table from a previous crashed run.
+        // Without this the next CREATE would either UNIQUE-conflict on its
+        // index name or silently keep stale rows around.
+        db.exec('DROP TABLE IF EXISTS external_comments_new');
+
+        db.exec(`
+          CREATE TABLE external_comments_new (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            review_id INTEGER NOT NULL,
+            source TEXT NOT NULL,
+            external_id TEXT NOT NULL,
+            in_reply_to_id TEXT,
+            parent_id INTEGER,
+            external_url TEXT,
+            author TEXT,
+            author_url TEXT,
+            file TEXT NOT NULL,
+            side TEXT,
+            line_start INTEGER,
+            line_end INTEGER,
+            diff_position INTEGER,
+            commit_sha TEXT,
+            is_outdated INTEGER NOT NULL DEFAULT 0,
+            original_line_start INTEGER,
+            original_line_end INTEGER,
+            original_commit_sha TEXT,
+            body TEXT,
+            external_created_at TEXT,
+            synced_at TEXT,
+            FOREIGN KEY (review_id) REFERENCES reviews(id) ON DELETE CASCADE,
+            FOREIGN KEY (parent_id) REFERENCES external_comments(id) ON DELETE SET NULL
+          )
+        `);
+
+        db.exec(`
+          INSERT INTO external_comments_new (
+            id, review_id, source, external_id, in_reply_to_id, parent_id,
+            external_url, author, author_url, file, side,
+            line_start, line_end, diff_position, commit_sha,
+            is_outdated, original_line_start, original_line_end, original_commit_sha,
+            body, external_created_at, synced_at
+          )
+          SELECT
+            id, review_id, source, external_id, in_reply_to_id, parent_id,
+            external_url, author, author_url, file, side,
+            line_start, line_end, diff_position, commit_sha,
+            is_outdated, original_line_start, original_line_end, original_commit_sha,
+            body, external_created_at, synced_at
+          FROM external_comments
+        `);
+
+        db.exec('DROP TABLE external_comments');
+        db.exec('ALTER TABLE external_comments_new RENAME TO external_comments');
+
+        // Recreate indexes by their canonical names — must match the
+        // INDEX_SQL block and the test schemas exactly.
+        db.exec('CREATE UNIQUE INDEX IF NOT EXISTS idx_external_comments_unique ON external_comments(review_id, source, external_id)');
+        db.exec('CREATE INDEX IF NOT EXISTS idx_external_comments_anchor ON external_comments(review_id, file, line_end)');
+        db.exec('CREATE INDEX IF NOT EXISTS idx_external_comments_parent_lookup ON external_comments(review_id, source, in_reply_to_id)');
+      });
+      rebuild();
+    } finally {
+      db.exec(`PRAGMA foreign_keys = ${originalForeignKeys ? 'ON' : 'OFF'}`);
+    }
+
+    console.log('  Rebuilt external_comments with ON DELETE SET NULL on parent_id');
+    console.log('Migration to schema version 46 complete');
   }
 };
 
@@ -3492,6 +3684,377 @@ class CommentRepository {
 }
 
 /**
+ * ExternalCommentRepository class for managing external review comments
+ *
+ * External comments are a read-only mirror of review comments from external
+ * systems (GitHub, GitLab, etc.). The repository is the ONLY layer that talks
+ * to the external_comments table — routes and sync logic go through it.
+ *
+ * Upsert is keyed on UNIQUE(review_id, source, external_id). Parent resolution
+ * is a separate second pass because external APIs return rows in arrival order,
+ * not parent-before-child.
+ */
+class ExternalCommentRepository {
+  /**
+   * Create a new ExternalCommentRepository instance
+   * @param {Database} db - Database instance
+   */
+  constructor(db) {
+    this.db = db;
+  }
+
+  /**
+   * Insert or update a single external comment row.
+   *
+   * Keyed on (review_id, source, external_id). On conflict, updates all
+   * columns except `id` and `parent_id` (parent_id is set later by
+   * `resolveParents`). `synced_at` is set automatically to the current
+   * ISO timestamp.
+   *
+   * @param {number} reviewId - Local review id (FK → reviews.id)
+   * @param {string} source - Source system identifier (e.g. 'github')
+   * @param {Object} mappedRow - Mapped comment row (output of an adapter)
+   * @param {string} mappedRow.external_id - Source-system comment id
+   * @param {string} [mappedRow.in_reply_to_id] - Source-system parent comment id
+   * @param {string} [mappedRow.external_url] - Permalink
+   * @param {string} [mappedRow.author]
+   * @param {string} [mappedRow.author_url]
+   * @param {string} mappedRow.file
+   * @param {string} [mappedRow.side] - 'LEFT' or 'RIGHT'
+   * @param {number} [mappedRow.line_start]
+   * @param {number} [mappedRow.line_end]
+   * @param {number} [mappedRow.diff_position]
+   * @param {string} [mappedRow.commit_sha]
+   * @param {boolean|number} [mappedRow.is_outdated]
+   * @param {number} [mappedRow.original_line_start]
+   * @param {number} [mappedRow.original_line_end]
+   * @param {string} [mappedRow.original_commit_sha]
+   * @param {string} [mappedRow.body]
+   * @param {string} [mappedRow.external_created_at]
+   * @returns {Promise<number>} Local id of the inserted/updated row
+   */
+  async upsert(reviewId, source, mappedRow) {
+    if (!reviewId) {
+      throw new Error('upsert: reviewId is required');
+    }
+    if (!source) {
+      throw new Error('upsert: source is required');
+    }
+    if (!mappedRow || mappedRow.external_id === undefined || mappedRow.external_id === null) {
+      throw new Error('upsert: mappedRow.external_id is required');
+    }
+    if (!mappedRow.file) {
+      throw new Error('upsert: mappedRow.file is required');
+    }
+
+    const syncedAt = new Date().toISOString();
+    const externalId = String(mappedRow.external_id);
+    const inReplyToId = mappedRow.in_reply_to_id !== undefined && mappedRow.in_reply_to_id !== null
+      ? String(mappedRow.in_reply_to_id)
+      : null;
+    const isOutdated = mappedRow.is_outdated ? 1 : 0;
+    const side = mappedRow.side === 'LEFT' ? 'LEFT' : (mappedRow.side === 'RIGHT' ? 'RIGHT' : null);
+
+    // SQLite UPSERT. Update every column except id and parent_id; parent_id is
+    // resolved by the second pass (resolveParents). RETURNING id gives the
+    // local row id whether it was inserted or updated.
+    const row = await queryOne(this.db, `
+      INSERT INTO external_comments (
+        review_id, source, external_id, in_reply_to_id,
+        external_url, author, author_url,
+        file, side, line_start, line_end, diff_position, commit_sha,
+        is_outdated, original_line_start, original_line_end, original_commit_sha,
+        body, external_created_at, synced_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ON CONFLICT(review_id, source, external_id) DO UPDATE SET
+        in_reply_to_id = excluded.in_reply_to_id,
+        external_url = excluded.external_url,
+        author = excluded.author,
+        author_url = excluded.author_url,
+        file = excluded.file,
+        side = excluded.side,
+        line_start = excluded.line_start,
+        line_end = excluded.line_end,
+        diff_position = excluded.diff_position,
+        commit_sha = excluded.commit_sha,
+        is_outdated = excluded.is_outdated,
+        original_line_start = excluded.original_line_start,
+        original_line_end = excluded.original_line_end,
+        original_commit_sha = excluded.original_commit_sha,
+        body = excluded.body,
+        external_created_at = excluded.external_created_at,
+        synced_at = excluded.synced_at
+      RETURNING id
+    `, [
+      reviewId,
+      source,
+      externalId,
+      inReplyToId,
+      mappedRow.external_url ?? null,
+      mappedRow.author ?? null,
+      mappedRow.author_url ?? null,
+      mappedRow.file,
+      side,
+      mappedRow.line_start ?? null,
+      mappedRow.line_end ?? null,
+      mappedRow.diff_position ?? null,
+      mappedRow.commit_sha ?? null,
+      isOutdated,
+      mappedRow.original_line_start ?? null,
+      mappedRow.original_line_end ?? null,
+      mappedRow.original_commit_sha ?? null,
+      mappedRow.body ?? null,
+      mappedRow.external_created_at ?? null,
+      syncedAt
+    ]);
+
+    return row.id;
+  }
+
+  /**
+   * Resolve `parent_id` for every row that has an `in_reply_to_id`.
+   *
+   * Looks up the parent row by (review_id, source, external_id =
+   * in_reply_to_id) and sets parent_id to its local id. Rows whose
+   * in_reply_to_id doesn't match any sibling stay with parent_id = NULL
+   * (orphan / out-of-batch parent).
+   *
+   * Returns the count of rows that had a non-null parent_id after the
+   * update — i.e. rows that successfully resolved. Idempotent: re-running
+   * produces the same count without further changes.
+   *
+   * @param {number} reviewId
+   * @param {string} source
+   * @returns {Promise<number>} Number of rows whose parent_id is now non-null
+   */
+  async resolveParents(reviewId, source) {
+    if (!reviewId) {
+      throw new Error('resolveParents: reviewId is required');
+    }
+    if (!source) {
+      throw new Error('resolveParents: source is required');
+    }
+
+    // EXISTS guard: SQLite's correlated subquery returns NULL when no
+    // sibling matches, which would silently NULL-overwrite a
+    // previously-resolved parent_id. Restrict the UPDATE to rows where the
+    // parent actually exists in the current snapshot — replies whose
+    // parent has been pruned (deleteMissing) keep their previously-resolved
+    // parent_id, and orphan-promotion in listThreadsByReview takes over.
+    await run(this.db, `
+      UPDATE external_comments
+      SET parent_id = (
+        SELECT p.id
+        FROM external_comments AS p
+        WHERE p.review_id = external_comments.review_id
+          AND p.source = external_comments.source
+          AND p.external_id = external_comments.in_reply_to_id
+      )
+      WHERE review_id = ?
+        AND source = ?
+        AND in_reply_to_id IS NOT NULL
+        AND EXISTS (
+          SELECT 1
+          FROM external_comments AS p
+          WHERE p.review_id = external_comments.review_id
+            AND p.source = external_comments.source
+            AND p.external_id = external_comments.in_reply_to_id
+        )
+    `, [reviewId, source]);
+
+    // Return the count of resolved (non-null parent_id) rows for this batch.
+    const row = await queryOne(this.db, `
+      SELECT COUNT(*) AS count
+      FROM external_comments
+      WHERE review_id = ?
+        AND source = ?
+        AND in_reply_to_id IS NOT NULL
+        AND parent_id IS NOT NULL
+    `, [reviewId, source]);
+
+    return row ? row.count : 0;
+  }
+
+  /**
+   * List all external comments for a review, flat (roots + replies).
+   *
+   * Ordered by file, then line_end with NULLs last (outdated rows sink to
+   * the bottom of their file group), then external_created_at.
+   *
+   * @param {number} reviewId
+   * @param {Object} [options]
+   * @param {string} [options.source] - Filter by source if provided
+   * @returns {Promise<Array<Object>>} All matching rows
+   */
+  async listByReview(reviewId, options = {}) {
+    if (!reviewId) {
+      throw new Error('listByReview: reviewId is required');
+    }
+
+    const params = [reviewId];
+    let sql = `
+      SELECT *
+      FROM external_comments
+      WHERE review_id = ?
+    `;
+    if (options.source) {
+      sql += ' AND source = ?';
+      params.push(options.source);
+    }
+    // Sort by COALESCE(line_end, original_line_end) so outdated rows (line_end
+    // null because the comment's current anchor was lost upstream) still sort
+    // near their renderable position via original_line_end. Without COALESCE,
+    // every outdated row sinks to the bottom of its file regardless of which
+    // original line it was anchored to — confusing when the original anchor
+    // is in the middle of the file.
+    sql += `
+      ORDER BY
+        file ASC,
+        CASE WHEN COALESCE(line_end, original_line_end) IS NULL THEN 1 ELSE 0 END,
+        COALESCE(line_end, original_line_end) ASC,
+        external_created_at ASC,
+        id ASC
+    `;
+
+    return query(this.db, sql, params);
+  }
+
+  /**
+   * List external comments grouped into threads.
+   *
+   * Returns one object per thread root (rows where parent_id IS NULL).
+   * Each root has a `replies` array containing reply rows ordered by
+   * `external_created_at`. Roots themselves are ordered the same way as
+   * `listByReview`.
+   *
+   * A reply whose `parent_id` does not resolve to a root in this result
+   * set (shouldn't happen if `resolveParents` ran, but defensive) is
+   * promoted to a root with `replies: []`.
+   *
+   * @param {number} reviewId
+   * @param {Object} [options]
+   * @param {string} [options.source] - Filter by source if provided
+   * @returns {Promise<Array<Object>>}
+   */
+  async listThreadsByReview(reviewId, options = {}) {
+    const rows = await this.listByReview(reviewId, options);
+
+    // Split rows into roots and replies in a single pass.
+    const roots = [];
+    const rootById = new Map();
+    const replies = [];
+
+    for (const row of rows) {
+      if (row.parent_id === null || row.parent_id === undefined) {
+        const thread = { ...row, replies: [] };
+        roots.push(thread);
+        rootById.set(row.id, thread);
+      } else {
+        replies.push(row);
+      }
+    }
+
+    // Attach replies to their root. Orphans (parent_id refers to a row not
+    // in this result — possible if filtered by source, or a defensive guard
+    // against data inconsistency) are promoted to standalone roots.
+    for (const reply of replies) {
+      const root = rootById.get(reply.parent_id);
+      if (root) {
+        root.replies.push(reply);
+      } else {
+        const thread = { ...reply, replies: [] };
+        roots.push(thread);
+        rootById.set(reply.id, thread);
+      }
+    }
+
+    // listByReview already ordered replies by external_created_at, so reply
+    // arrays are pre-sorted. Re-sort defensively for promoted orphans that
+    // were appended after roots in their file group.
+    for (const thread of roots) {
+      if (thread.replies.length > 1) {
+        thread.replies.sort((a, b) => {
+          const ta = a.external_created_at || '';
+          const tb = b.external_created_at || '';
+          if (ta < tb) return -1;
+          if (ta > tb) return 1;
+          return a.id - b.id;
+        });
+      }
+    }
+
+    return roots;
+  }
+
+  /**
+   * Delete external comment rows whose external_id is NOT in the provided
+   * set, scoped to (review_id, source). Used by the sync route to reconcile
+   * the local mirror after upserting the latest snapshot — rows that
+   * upstream removed (or that the snapshot no longer contains because they
+   * lost anchors) get pruned.
+   *
+   * When `keepExternalIds` is empty, this deletes every row for that
+   * (review_id, source). Callers must wrap this in the same transaction as
+   * the upserts to avoid a window where rows are missing.
+   *
+   * @param {number} reviewId
+   * @param {string} source
+   * @param {Iterable<string>} keepExternalIds - Set/Array of external_ids to keep
+   * @returns {Promise<number>} Count of rows deleted
+   */
+  async deleteMissing(reviewId, source, keepExternalIds) {
+    if (!reviewId) {
+      throw new Error('deleteMissing: reviewId is required');
+    }
+    if (!source) {
+      throw new Error('deleteMissing: source is required');
+    }
+
+    const keepList = Array.from(keepExternalIds || []).map((v) => String(v));
+
+    if (keepList.length === 0) {
+      const result = await run(this.db,
+        'DELETE FROM external_comments WHERE review_id = ? AND source = ?',
+        [reviewId, source]
+      );
+      return result.changes || 0;
+    }
+
+    const placeholders = keepList.map(() => '?').join(',');
+    const result = await run(this.db, `
+      DELETE FROM external_comments
+      WHERE review_id = ?
+        AND source = ?
+        AND external_id NOT IN (${placeholders})
+    `, [reviewId, source, ...keepList]);
+    return result.changes || 0;
+  }
+
+  /**
+   * Count of external comments for a review, optionally filtered by source.
+   *
+   * @param {number} reviewId
+   * @param {string} [source]
+   * @returns {Promise<number>}
+   */
+  async countByReview(reviewId, source) {
+    if (!reviewId) {
+      throw new Error('countByReview: reviewId is required');
+    }
+
+    let sql = 'SELECT COUNT(*) AS count FROM external_comments WHERE review_id = ?';
+    const params = [reviewId];
+    if (source) {
+      sql += ' AND source = ?';
+      params.push(source);
+    }
+
+    const row = await queryOne(this.db, sql, params);
+    return row ? row.count : 0;
+  }
+}
+
+/**
  * ReviewRepository class for managing review database records
  */
 class ReviewRepository {
@@ -5002,6 +5565,7 @@ module.exports = {
   RepoSettingsRepository,
   ReviewRepository,
   CommentRepository,
+  ExternalCommentRepository,
   PRMetadataRepository,
   AnalysisRunRepository,
   GitHubReviewRepository,

--- a/src/external/github-adapter.js
+++ b/src/external/github-adapter.js
@@ -1,0 +1,152 @@
+// Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+
+/**
+ * GitHub source adapter for external review comments.
+ *
+ * Two responsibilities:
+ *   1. `fetchComments` — delegate to the GitHubClient method that paginates
+ *      `pulls.listReviewComments`. Adapter does NOT construct its own client;
+ *      the caller injects it (dependency injection per CLAUDE.md).
+ *   2. `mapComment` — translate a raw GitHub REST API row into the column
+ *      shape of the `external_comments` table (see `src/database.js`).
+ *
+ * The dispatcher in `src/external/index.js` stamps `source = 'github'` at
+ * write time, so `mapComment` does not include a `source` field — keeps
+ * adapters from needing to know their own name.
+ *
+ * `synced_at` and the resolved local `parent_id` are also set by the
+ * route/repository layer, not here.
+ */
+
+const { GitHubClient, GitHubApiError } = require('../github/client');
+const { getGitHubToken } = require('../config');
+
+const name = 'github';
+
+/**
+ * Adapter-owned env var name. Surfaced in credential-missing errors so the
+ * user is told which env var/config key to set for THIS source. Future
+ * adapters (GitLab, Linear) name their own variable here and the route
+ * needs no per-source branching.
+ */
+const credentialEnvVar = 'GITHUB_TOKEN';
+
+/**
+ * Resolve the credentials this adapter needs to call its source system.
+ * Returns an opaque `{ client }` shape; the route hands `client` straight
+ * back to `fetchComments` without knowing it's a `GitHubClient`. Throwing
+ * `GitHubApiError(status: 401)` keeps the existing 401 mapping at the
+ * route layer.
+ *
+ * @param {Object} config - Server config (see `loadConfig()`)
+ * @param {Object} [_deps] - Test overrides for { GitHubClient, getGitHubToken }
+ * @returns {{ client: Object }}
+ * @throws {GitHubApiError} with status 401 when no token is configured
+ */
+function resolveCredentials(config, _deps) {
+  const deps = {
+    GitHubClient,
+    getGitHubToken,
+    ..._deps
+  };
+  const token = deps.getGitHubToken(config || {});
+  if (!token) {
+    throw new GitHubApiError(
+      `GitHub token not configured. Set ${credentialEnvVar} or add github_token to ~/.pair-review/config.json`,
+      401
+    );
+  }
+  return { client: new deps.GitHubClient(token) };
+}
+
+/**
+ * Fetch all inline review comments for a pull request from GitHub.
+ *
+ * @param {Object} params
+ * @param {Object} params.client - GitHubClient instance (injected)
+ * @param {string} params.owner
+ * @param {string} params.repo
+ * @param {number} params.pull_number
+ * @returns {Promise<Array<Object>>} Raw Octokit review-comment objects
+ */
+async function fetchComments({ client, owner, repo, pull_number }) {
+  return client.listReviewComments({ owner, repo, pull_number });
+}
+
+/**
+ * Map a raw GitHub review-comment API row to an `external_comments` row.
+ *
+ * Edge cases handled here (per the phase spec):
+ *   - `apiRow.user` is null (deleted account): `author` and `author_url`
+ *     both become null. No throw.
+ *   - `apiRow.position` is null (outdated): `is_outdated = 1`, current
+ *     line/position fields null. `original_*` may still be populated.
+ *   - `apiRow.position` AND `apiRow.original_position` both null
+ *     (force-push lost anchor): still produces a row — the sync route
+ *     decides whether to count or skip. We do NOT throw here.
+ *   - `apiRow.path` missing: throws — `file` is NOT NULL in the schema
+ *     and a missing path means upstream gave us something malformed.
+ *     Failing early in the mapper is far easier to debug than a SQL
+ *     constraint violation deep in an upsert loop.
+ *
+ * @param {Object} apiRow
+ * @returns {Object} A row matching the `external_comments` column names
+ */
+function mapComment(apiRow) {
+  if (!apiRow || apiRow.path == null) {
+    throw new Error('GitHub adapter: comment missing required field "path"');
+  }
+  // Validate id presence — `String(undefined)` returns the literal
+  // 'undefined' which would upsert as a valid external_id and even
+  // satisfy UNIQUE(review_id, source, external_id) by colliding on that
+  // string. Fail early so the route's row-level catch logs the bad row
+  // and moves on instead of corrupting the mirror.
+  if (apiRow.id == null) {
+    throw new Error('GitHub adapter: comment missing required field "id"');
+  }
+
+  const user = apiRow.user || null;
+  const positionIsNull = apiRow.position == null;
+
+  // When position is null the comment is outdated. GitHub still populates
+  // `line` in many of these responses, but the line number does NOT
+  // correspond to a position in the current diff — using it would create
+  // two conflicting truths (line_end set AND is_outdated=1) and would
+  // make the lost-anchor filter under-count. Force the current-anchor
+  // fields to null so `original_*` is the only authoritative anchor.
+  const line_start = positionIsNull
+    ? null
+    : apiRow.start_line ?? apiRow.line ?? null;
+  const line_end = positionIsNull ? null : apiRow.line ?? null;
+  const diff_position = positionIsNull ? null : apiRow.position ?? null;
+
+  return {
+    external_id: String(apiRow.id),
+    in_reply_to_id:
+      apiRow.in_reply_to_id != null ? String(apiRow.in_reply_to_id) : null,
+    external_url: apiRow.html_url || null,
+    author: user ? user.login ?? null : null,
+    author_url: user ? user.html_url ?? null : null,
+    file: apiRow.path,
+    side: apiRow.side ?? null,
+    line_start,
+    line_end,
+    diff_position,
+    commit_sha: apiRow.commit_id ?? null,
+    is_outdated: positionIsNull ? 1 : 0,
+    original_line_start:
+      apiRow.original_start_line ?? apiRow.original_line ?? null,
+    original_line_end: apiRow.original_line ?? null,
+    original_commit_sha: apiRow.original_commit_id ?? null,
+    body: apiRow.body ?? '',
+    external_created_at: apiRow.created_at ?? null,
+  };
+}
+
+module.exports = {
+  name,
+  credentialEnvVar,
+  resolveCredentials,
+  fetchComments,
+  mapComment,
+};

--- a/src/external/index.js
+++ b/src/external/index.js
@@ -1,0 +1,37 @@
+// Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+
+/**
+ * External comment source dispatcher.
+ *
+ * Each external source (currently GitHub; GitLab/Linear planned) ships a
+ * sibling adapter module that exports `{ name, fetchComments, mapComment }`.
+ * This file maintains the keyed registry and resolves a `source` string to
+ * the matching adapter. Adding a new source is a one-file change here plus
+ * the new adapter module — no routes or repositories need to know.
+ */
+
+const githubAdapter = require('./github-adapter');
+
+const adapters = {
+  [githubAdapter.name]: githubAdapter,
+};
+
+/**
+ * Look up an adapter by its `source` string.
+ *
+ * @param {string} source - e.g. 'github'
+ * @returns {{ name: string, fetchComments: Function, mapComment: Function }}
+ * @throws {Error} when no adapter is registered for the source name
+ */
+function getAdapter(source) {
+  // Own-property guard: `adapters` is a plain object, so `adapters['toString']`
+  // would resolve to Object.prototype.toString (a function) and the route's
+  // unknown-source check (which depends on this function throwing) would
+  // silently pass. Use hasOwnProperty so only registered adapters resolve.
+  if (typeof source !== 'string' || !Object.prototype.hasOwnProperty.call(adapters, source)) {
+    throw new Error(`Unknown external comment source: ${source}`);
+  }
+  return adapters[source];
+}
+
+module.exports = { getAdapter, adapters };

--- a/src/github/client.js
+++ b/src/github/client.js
@@ -159,6 +159,48 @@ class GitHubClient {
   }
 
   /**
+   * Fetch all inline (line-anchored) review comments on a pull request.
+   *
+   * Uses the GitHub REST API `pulls.listReviewComments` endpoint and paginates
+   * automatically via `octokit.paginate` to handle PRs with more than 100
+   * comments. Returns the raw API objects unchanged — mapping to local rows
+   * happens in the adapter / route layer (keeps this client thin and testable).
+   *
+   * Note: this endpoint returns inline review comments only. Issue-level (PR
+   * conversation tab) comments come from a different endpoint and are not
+   * included here.
+   *
+   * @param {Object} params
+   * @param {string} params.owner - Repository owner
+   * @param {string} params.repo - Repository name
+   * @param {number} params.pull_number - Pull request number
+   * @returns {Promise<Array<Object>>} Raw review-comment objects with fields
+   *   such as `id`, `pull_request_review_id`, `in_reply_to_id`, `body`,
+   *   `user`, `path`, `commit_id`, `original_commit_id`, `position`,
+   *   `original_position`, `line`, `start_line`, `original_line`,
+   *   `original_start_line`, `side`, `start_side`, `html_url`, `created_at`,
+   *   `updated_at`.
+   * @throws {GitHubApiError} 404 when the PR is not found, 429 on rate limit,
+   *   503 on network failure, or a wrapped error for other API failures.
+   */
+  async listReviewComments({ owner, repo, pull_number }) {
+    try {
+      const comments = await this.octokit.paginate(
+        this.octokit.rest.pulls.listReviewComments,
+        {
+          owner,
+          repo,
+          pull_number,
+          per_page: 100
+        }
+      );
+      return comments;
+    } catch (error) {
+      await this.handleApiError(error, owner, repo, pull_number);
+    }
+  }
+
+  /**
    * Validate GitHub token by making a test API call
    * @returns {Promise<boolean>} Whether the token is valid
    */
@@ -209,7 +251,8 @@ class GitHubClient {
       console.error('GitHub API error:', error);
     }
 
-    // Handle rate limiting with exponential backoff
+    // Handle rate limiting with exponential backoff (primary rate limit:
+    // `x-ratelimit-remaining: 0`).
     if (error.status === 403 && error.response?.headers?.['x-ratelimit-remaining'] === '0') {
       const resetTime = parseInt(error.response.headers['x-ratelimit-reset']) * 1000;
       const waitTime = Math.max(resetTime - Date.now(), 1000);
@@ -217,6 +260,39 @@ class GitHubClient {
       console.log(`Rate limit exceeded. Retrying in ${Math.ceil(waitTime / 1000)} seconds...`);
 
       throw new GitHubApiError(`GitHub API rate limit exceeded. Retrying in ${Math.ceil(waitTime / 1000)} seconds...`, 429);
+    }
+
+    // Secondary rate limits ("abuse detection") return 403 WITHOUT the
+    // standard rate-limit headers. They're signaled either by a `retry-after`
+    // header or by message text mentioning "secondary rate limit", "abuse",
+    // or "rate limit". Without this branch they'd fall through to the
+    // permission-failure path and the user would be told their token is
+    // missing scopes — misleading.
+    if (error.status === 403) {
+      const retryAfterHeader = error.response?.headers?.['retry-after'];
+      const messageText = String(error.message || '');
+      const looksLikeRateLimit =
+        retryAfterHeader != null ||
+        /secondary rate limit/i.test(messageText) ||
+        /abuse/i.test(messageText) ||
+        /rate limit/i.test(messageText);
+
+      if (looksLikeRateLimit) {
+        const retryAfterSec = retryAfterHeader != null ? parseInt(retryAfterHeader, 10) : null;
+        const suffix = Number.isFinite(retryAfterSec) && retryAfterSec > 0
+          ? ` Retry after ${retryAfterSec} seconds.`
+          : '';
+        throw new GitHubApiError(`GitHub API rate limit exceeded (secondary rate limit).${suffix}`, 429);
+      }
+
+      // Genuine permission / scope failure. Without this branch the error
+      // would fall through to the generic plain-`Error` path and route
+      // handlers would map it to a 500 instead of a 403, hiding the real
+      // cause from the reviewer.
+      throw new GitHubApiError(
+        `Insufficient permissions for ${owner}/${repo}. Your GitHub token may be missing required scopes.`,
+        403
+      );
     }
 
     // Handle authentication errors

--- a/src/routes/config.js
+++ b/src/routes/config.js
@@ -36,6 +36,32 @@ const router = express.Router();
 let pendingUpdateVersion = null;
 
 /**
+ * Runtime configuration script
+ *
+ * Returns a tiny JS file that sets `window.PAIR_REVIEW_RUNTIME_CONFIG`
+ * synchronously, plus an `external-comments-disabled` class on
+ * `documentElement` when the feature is off. Loaded via a `<script>` tag
+ * BEFORE the main app JS so components like AIPanel can check the flag
+ * at construction time (avoids FOUC of UI elements that should be hidden).
+ *
+ * No-store so each page load reflects current config without restart.
+ */
+router.get('/runtime-config.js', (req, res) => {
+  const config = req.app.get('config') || {};
+  const externalCommentsEnabled = config.external_comments !== false;
+  const runtimeConfig = { external_comments_enabled: externalCommentsEnabled };
+  const body = [
+    `window.PAIR_REVIEW_RUNTIME_CONFIG = ${JSON.stringify(runtimeConfig)};`,
+    `if (!window.PAIR_REVIEW_RUNTIME_CONFIG.external_comments_enabled) {`,
+    `  document.documentElement.classList.add('external-comments-disabled');`,
+    `}`,
+  ].join('\n');
+  res.setHeader('Content-Type', 'application/javascript; charset=utf-8');
+  res.setHeader('Cache-Control', 'no-store, no-cache, must-revalidate');
+  res.send(body);
+});
+
+/**
  * Get user configuration (for frontend use)
  * Returns safe-to-expose configuration values
  */
@@ -65,6 +91,7 @@ router.get('/api/config', (req, res) => {
     pi_available: getCachedAvailability('pi')?.available || false,
     assisted_by_url: config.assisted_by_url || 'https://github.com/in-the-loop-labs/pair-review',
     enable_graphite: config.enable_graphite === true,
+    external_comments: config.external_comments !== false,
     chat_spinner: config.chat_spinner || 'dots',
     // Share configuration for external review viewers.
     // - url: The base URL of the external share site

--- a/src/routes/external-comments.js
+++ b/src/routes/external-comments.js
@@ -1,0 +1,394 @@
+// Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+/**
+ * External Comment Routes
+ *
+ * Endpoints for syncing and reading review comments from external systems
+ * (currently GitHub PR review comments; designed for GitLab/Linear/etc.).
+ * External comments are stored as a read-only mirror in the
+ * `external_comments` table — see ExternalCommentRepository.
+ *
+ * This file is shared between two implementation agents:
+ *   --- SYNC ROUTES --- : POST /api/reviews/:reviewId/external-comments/sync
+ *   --- FETCH ROUTES --- : GET /api/reviews/:reviewId/external-comments
+ *
+ * Canonical PR-mode predicate: `isPRMode(review)`. Use it from EVERY route
+ * in this file — sync and fetch must agree on what counts as a PR review,
+ * otherwise the two endpoints diverge on local-mode handling.
+ */
+
+const express = require('express');
+const {
+  ExternalCommentRepository,
+  ReviewRepository,
+  withTransaction
+} = require('../database');
+const { getAdapter } = require('../external');
+const { GitHubApiError } = require('../github/client');
+const logger = require('../utils/logger');
+
+const router = express.Router();
+
+// --- SYNC ROUTES ---
+
+/**
+ * Default dependencies for the sync flow. Tests override these via the
+ * `externalCommentsDeps` Express app setting (or by passing `_deps` to
+ * `executeSync` directly). Credential resolution is delegated to the
+ * adapter via `adapter.resolveCredentials(config)` — keeps the route
+ * source-agnostic and lets each adapter name its own env var in errors.
+ */
+const defaults = {
+  getAdapter
+};
+
+/**
+ * In-flight sync registry keyed by `${reviewId}:${source}`.
+ *
+ * Page-load auto-sync and the manual "refresh external comments" button
+ * can race. When a sync is already running for a (reviewId, source) pair,
+ * a second caller awaits the same promise instead of making a duplicate
+ * GitHub round-trip. This also avoids two parent-resolution passes briefly
+ * interleaving (the hazard called out in the plan).
+ *
+ * Entries are removed in a `finally` so failures do not permanently block
+ * retries.
+ *
+ * @type {Map<string, Promise<{count: number, lostAnchors: number, syncedAt: string}>>}
+ */
+const inFlight = new Map();
+
+/**
+ * Global write-phase serializer. The per-key `inFlight` map only dedupes
+ * matching (reviewId, source) pairs — two syncs for DIFFERENT reviews can
+ * still race their write phases on the same better-sqlite3 connection,
+ * which cannot nest BEGIN…COMMIT (throws "cannot start a transaction
+ * within a transaction"). We do all network I/O and mapping outside the
+ * transaction (cheap to interleave), then chain transactional writes
+ * through this single promise so only one BEGIN…COMMIT runs at a time.
+ *
+ * Per-db serialization would be cleaner if the route handled multiple DBs,
+ * but pair-review uses one SQLite file per process; a module-level chain
+ * is sufficient and avoids a per-db WeakMap dance.
+ */
+let writeChain = Promise.resolve();
+
+/**
+ * Typed 400 error. Mirrors the GitHubApiError shape (name/message/status)
+ * so the route's catch ladder can fan-out by `instanceof` rather than
+ * string-sniff. Used for client-correctable problems (malformed inputs)
+ * that previously bubbled out as plain Error → 500.
+ */
+class BadRequestError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'BadRequestError';
+    this.status = 400;
+  }
+}
+
+/**
+ * Canonical PR-mode predicate. Both routes in this file (sync + fetch) must
+ * use this same check so the two endpoints agree on what a "PR review" is.
+ *
+ * A row is PR-mode iff:
+ *   - it has a numeric `pr_number`
+ *   - it has a non-empty `repository`
+ *   - its `review_type` is not 'local' (default is 'pr')
+ *   - it has no `local_path` (which would identify a local-mode review)
+ */
+function isPRMode(review) {
+  if (!review) return false;
+  if (review.review_type && review.review_type !== 'pr') return false;
+  if (review.local_path) return false;
+  if (!Number.isInteger(review.pr_number)) return false;
+  if (!review.repository) return false;
+  return true;
+}
+
+/**
+ * Run a full sync for one (reviewId, source) pair. Idempotent. Throws
+ * domain errors (Error / GitHubApiError) — the route handler catches them
+ * and maps them to HTTP responses.
+ *
+ * @param {Object} params
+ * @param {Object} params.db - Database handle
+ * @param {Object} params.config - Server config (for token lookup)
+ * @param {Object} params.review - Validated review row
+ * @param {string} params.source - Adapter source name (e.g. 'github')
+ * @param {Object} [params._deps] - Test overrides for { GitHubClient, getGitHubToken, getAdapter }
+ * @returns {Promise<{count: number, lostAnchors: number, syncedAt: string}>}
+ */
+async function executeSync({ db, config, review, source, _deps }) {
+  const deps = { ...defaults, ..._deps };
+
+  // Look up adapter — throws on unknown sources, caught by the route.
+  const adapter = deps.getAdapter(source);
+
+  // Delegate credential resolution to the adapter so the route stays
+  // source-agnostic and each adapter can name its own env var in errors.
+  // The adapter throws (e.g. GitHubApiError 401) when credentials are
+  // missing — the route's catch maps it to a 401 response.
+  const { client } = adapter.resolveCredentials(config || {}, _deps);
+
+  const [owner, repo] = String(review.repository).split('/');
+  if (!owner || !repo) {
+    throw new BadRequestError(
+      `Invalid review.repository "${review.repository}"; expected "owner/repo"`
+    );
+  }
+
+  const apiRows = await adapter.fetchComments({
+    client,
+    owner,
+    repo,
+    pull_number: review.pr_number
+  });
+
+  // Map raw API rows and filter out "lost anchors" (BOTH current AND original
+  // position fields null — unrenderable). Counting them lets the UI tell the
+  // user why their visible count differs from GitHub's reported total.
+  // Track external_ids seen this sync so we can prune rows that upstream
+  // has removed (or that we no longer render because they lost anchors)
+  // inside the same transaction as the upserts.
+  let lostAnchors = 0;
+  const mappedRows = [];
+  const seenExternalIds = new Set();
+  for (const apiRow of apiRows || []) {
+    let mapped;
+    try {
+      mapped = adapter.mapComment(apiRow);
+    } catch (mapError) {
+      // A malformed row from the source shouldn't kill the whole sync — log
+      // it and keep going. The adapter only throws for genuinely malformed
+      // rows (e.g. missing required `path`).
+      logger.warn(`External comment adapter ${source} could not map row: ${mapError.message}`);
+      continue;
+    }
+
+    if (mapped.line_end == null && mapped.original_line_end == null) {
+      lostAnchors++;
+      continue;
+    }
+    mappedRows.push(mapped);
+    seenExternalIds.add(String(mapped.external_id));
+  }
+
+  const repository = new ExternalCommentRepository(db);
+  const syncedAt = new Date().toISOString();
+
+  // Write phase: upsert all rows, conditionally prune rows missing from
+  // this snapshot, then resolve parents. Wrapped in a single transaction
+  // so concurrent readers never see a partial mirror.
+  //
+  // Empty-snapshot prune is intentionally skipped (`seenExternalIds.size`
+  // gate below). A transient empty response from upstream (e.g. GitHub
+  // briefly returning [] while a PR is being reorganized) used to wipe the
+  // entire local mirror for (review_id, source). Skipping the prune turns
+  // that transient into a no-op; the non-empty case still prunes rows that
+  // upstream removed.
+  //
+  // We serialize the transactional write phase through a module-level
+  // promise chain because better-sqlite3 cannot nest BEGIN…COMMIT — two
+  // concurrent syncs for DIFFERENT reviews would otherwise collide here.
+  let deletedCount = 0;
+  const performWrites = async () => {
+    await withTransaction(db, async () => {
+      for (const mapped of mappedRows) {
+        await repository.upsert(review.id, source, mapped);
+      }
+      if (seenExternalIds.size > 0) {
+        deletedCount = await repository.deleteMissing(review.id, source, seenExternalIds);
+      }
+      await repository.resolveParents(review.id, source);
+    });
+  };
+
+  // Chain the current write phase onto whatever's already pending. The
+  // chain swallows errors at the join point so a failed sync doesn't
+  // permanently break the next caller's link in the chain — the *current*
+  // caller still observes its own failure via the `await` below.
+  const previous = writeChain;
+  const myWrite = previous.then(performWrites, performWrites);
+  writeChain = myWrite.catch(() => {});
+  await myWrite;
+
+  return {
+    count: mappedRows.length,
+    lostAnchors,
+    deleted: deletedCount,
+    syncedAt
+  };
+}
+
+/**
+ * Middleware: validate `:reviewId`, attach `req.review`.
+ *
+ * Mirrors the pattern in `routes/reviews.js` but lives here to keep the
+ * sync route self-contained. The fetch route below intentionally uses a
+ * different (older) shape because it predates this middleware.
+ */
+async function validateReviewId(req, res, next) {
+  try {
+    const reviewId = parseInt(req.params.reviewId, 10);
+    if (isNaN(reviewId) || reviewId <= 0) {
+      return res.status(400).json({ error: 'Invalid review ID' });
+    }
+
+    const db = req.app.get('db');
+    const reviewRepo = new ReviewRepository(db);
+    const review = await reviewRepo.getReview(reviewId);
+
+    if (!review) {
+      return res.status(404).json({ error: 'Review not found' });
+    }
+
+    req.review = review;
+    req.reviewId = reviewId;
+    next();
+  } catch (error) {
+    next(error);
+  }
+}
+
+/**
+ * POST /api/reviews/:reviewId/external-comments/sync?source=github
+ *
+ * Fetches inline review comments from the external source and upserts them
+ * into the local mirror. Idempotent. Returns
+ * `{ count, lostAnchors, syncedAt }`. See module header for the
+ * concurrent-sync guard contract.
+ */
+router.post('/api/reviews/:reviewId/external-comments/sync', validateReviewId, async (req, res) => {
+  const source = (req.query.source || 'github').toString();
+  const review = req.review;
+
+  if (!isPRMode(review)) {
+    return res.status(400).json({ error: 'External comment sync requires a PR mode review' });
+  }
+
+  const db = req.app.get('db');
+  const config = req.app.get('config') || {};
+  const key = `${review.id}:${source}`;
+
+  // Tests inject dependency overrides via the app setting
+  // `externalCommentsDeps`. In production this is undefined and the module
+  // defaults win.
+  const _deps = req.app.get('externalCommentsDeps') || undefined;
+
+  try {
+    let promise = inFlight.get(key);
+    if (!promise) {
+      promise = executeSync({ db, config, review, source, _deps })
+        .finally(() => {
+          // Remove the slot only after the promise settles — concurrent
+          // callers awaiting this entry must see the same outcome.
+          inFlight.delete(key);
+        });
+      inFlight.set(key, promise);
+    }
+
+    const result = await promise;
+    res.json(result);
+  } catch (error) {
+    // Unknown source — the adapter dispatcher throws a plain Error.
+    if (error && typeof error.message === 'string' && error.message.startsWith('Unknown external comment source:')) {
+      logger.warn(`External comments sync rejected: ${error.message}`);
+      return res.status(400).json({ error: error.message });
+    }
+
+    // Client-correctable problem (e.g. malformed review.repository).
+    // BadRequestError carries status=400 explicitly so we don't fall
+    // through to the catch-all 500.
+    if (error instanceof BadRequestError) {
+      logger.warn(`External comments sync rejected: ${error.message}`);
+      return res.status(error.status).json({ error: error.message });
+    }
+
+    if (error instanceof GitHubApiError) {
+      logger.error(`External comments sync GitHub error (${error.status}): ${error.message}`);
+
+      // Single mapping path: trust GitHubApiError.message, which
+      // `handleApiError` already populates with the retry-after seconds on
+      // 429s and the auth/rate context on other failures. The previously
+      // separate 429 branch read `error.retryAfter`, which GitHubApiError
+      // doesn't carry — dead code that masked the real message.
+      if (error.status >= 400 && error.status < 600) {
+        return res.status(error.status).json({ error: error.message });
+      }
+
+      return res.status(500).json({ error: error.message });
+    }
+
+    logger.error('External comments sync failed:', error);
+    res.status(500).json({ error: error.message || 'Failed to sync external comments' });
+  }
+});
+
+// --- FETCH ROUTES ---
+
+/**
+ * GET /api/reviews/:reviewId/external-comments?source=github
+ *
+ * Returns external comments persisted for a review, grouped into threads.
+ * Each thread is a root comment object with all original row fields plus a
+ * `replies` array of the same shape.
+ *
+ * Query params:
+ *   - source: (optional) filter to one external source (e.g. 'github').
+ *             If omitted, returns rows from all known sources.
+ *             If provided but unknown, responds 400.
+ *
+ * Responses:
+ *   - 200: { threads: Array<Thread> }
+ *   - 400: unknown source
+ *   - 404: review not found
+ *   - 500: unexpected
+ *
+ * Local-mode reviews always return { threads: [] } — external comments
+ * are a PR-mode concept, but the endpoint is safe to call from local pages.
+ */
+router.get('/api/reviews/:reviewId/external-comments', validateReviewId, async (req, res) => {
+  try {
+    const reviewId = req.reviewId;
+    const review = req.review;
+
+    const source = req.query.source;
+
+    // If a source filter is provided, validate it against the adapter registry
+    // before touching the DB. Catches typos early with a meaningful message.
+    if (source !== undefined && source !== null && source !== '') {
+      try {
+        getAdapter(source);
+      } catch (err) {
+        return res.status(400).json({ error: `Unknown external comment source: ${source}` });
+      }
+    }
+
+    // Non-PR reviews (local-mode, malformed rows) never have external
+    // comments. Return an empty thread list so the frontend can call this
+    // endpoint unconditionally. We use the canonical `isPRMode` predicate
+    // here so sync and fetch stay in lockstep on what counts as PR mode.
+    if (!isPRMode(review)) {
+      return res.json({ threads: [] });
+    }
+
+    const db = req.app.get('db');
+    const repo = new ExternalCommentRepository(db);
+    const listOptions = {};
+    if (source) {
+      listOptions.source = source;
+    }
+
+    const threads = await repo.listThreadsByReview(reviewId, listOptions);
+
+    res.json({ threads });
+  } catch (error) {
+    logger.error('Error fetching external comments:', error);
+    res.status(500).json({ error: 'Failed to fetch external comments' });
+  }
+});
+
+module.exports = router;
+module.exports.executeSync = executeSync;
+// Exported for tests only — production code should not reach into this map.
+module.exports._inFlight = inFlight;

--- a/src/server.js
+++ b/src/server.js
@@ -349,6 +349,7 @@ async function startServer(sharedDb = null, sharedPoolLifecycle = null) {
     const contextFilesRoutes = require('./routes/context-files');
     const githubCollectionsRoutes = require('./routes/github-collections');
     const stackAnalysisRoutes = require('./routes/stack-analysis');
+    const externalCommentsRoutes = require('./routes/external-comments');
     const { createSoundRouter } = require('./routes/sound');
 
     // Initialize chat session manager
@@ -369,6 +370,7 @@ async function startServer(sharedDb = null, sharedPoolLifecycle = null) {
     app.use('/', mcpRoutes);
     app.use('/', githubCollectionsRoutes);
     app.use('/', stackAnalysisRoutes);
+    app.use('/', externalCommentsRoutes);
     app.use('/', createSoundRouter());
     app.use('/', prRoutes);
     

--- a/src/server.js
+++ b/src/server.js
@@ -370,7 +370,14 @@ async function startServer(sharedDb = null, sharedPoolLifecycle = null) {
     app.use('/', mcpRoutes);
     app.use('/', githubCollectionsRoutes);
     app.use('/', stackAnalysisRoutes);
-    app.use('/', externalCommentsRoutes);
+    // External-comments routes (GitHub PR review-comment sync + fetch) are
+    // gated by the `external_comments` config flag. When disabled, the
+    // router is not mounted so any GET/POST against `/api/reviews/*/
+    // external-comments*` returns 404 — matching the frontend's intent that
+    // the feature simply doesn't exist for that user.
+    if (config.external_comments !== false) {
+      app.use('/', externalCommentsRoutes);
+    }
     app.use('/', createSoundRouter());
     app.use('/', prRoutes);
     

--- a/tests/e2e/external-comments.spec.js
+++ b/tests/e2e/external-comments.spec.js
@@ -348,17 +348,22 @@ test.describe('External comments: chat about thread', () => {
     const chatPanel = page.locator('.chat-panel');
     await expect(chatPanel).toBeVisible({ timeout: 5000 });
 
-    // Thread context card has the thread modifier class
+    // Compact thread context card carries the source-specific theming class.
     const threadCard = page.locator(
-      '.chat-panel__context-card.chat-panel__context-card--thread.external-comment-context'
+      '.chat-panel__context-card.external-comment-context.source-github'
     );
     await expect(threadCard).toBeVisible();
 
-    // Both authors and both body fragments should be visible inside
-    await expect(threadCard).toContainText('reviewer-alice');
-    await expect(threadCard).toContainText('reviewer-bob');
-    await expect(threadCard).toContainText('Should this be');
-    await expect(threadCard).toContainText('Good catch');
+    // The visible row shows the "GITHUB THREAD" label and the comment count.
+    await expect(threadCard).toContainText('GITHUB THREAD');
+    await expect(threadCard).toContainText(/\d+ comment/);
+
+    // Full content lives in the title tooltip (single line + hover, per UX).
+    const tooltip = await threadCard.getAttribute('title');
+    expect(tooltip).toContain('reviewer-alice');
+    expect(tooltip).toContain('reviewer-bob');
+    expect(tooltip).toContain('Should this be');
+    expect(tooltip).toContain('Good catch');
   });
 });
 
@@ -532,3 +537,280 @@ test.describe('External comments: coexistence with user + AI rows', () => {
 // init() entirely, so waitForDiffToRender timed out and the guard still
 // wasn't reached). The unit-level coverage is strictly stronger; no E2E
 // equivalent here.
+
+// ---------------------------------------------------------------------
+// 7. External segment in the Review (AI) panel
+//
+// Asserts the fourth segment exists, populates with one row per thread,
+// shows the correct count, and routes clicks back to the inline external
+// row in the diff. Mocking is the same as the rest of this spec.
+// ---------------------------------------------------------------------
+
+test.describe('External segment in Review panel', () => {
+  test('renders the External segment button with a per-thread count', async ({ page }) => {
+    await installExternalCommentMocks(page, { threads: [HAPPY_THREAD] });
+
+    await page.goto('/pr/test-owner/test-repo/1');
+    await waitForDiffToRender(page);
+    await waitForExternalRowsRendered(page);
+
+    // Expand the panel so segment buttons are interactable; the default
+    // for a new review is collapsed.
+    await page.evaluate(() => window.aiPanel?.expand());
+
+    const externalBtn = page.locator('.segment-btn[data-segment="external"]');
+    await expect(externalBtn).toBeVisible();
+
+    // Count badge should be (1) — one thread, regardless of reply count.
+    const count = externalBtn.locator('.segment-count');
+    await expect(count).toHaveText('(1)');
+  });
+
+  test('clicking the External segment activates it and shows one list item per thread', async ({ page }) => {
+    // Two threads on different lines so we can verify "one item per thread"
+    const secondThread = {
+      ...HAPPY_THREAD,
+      id: 102,
+      external_id: '900003',
+      external_url: 'https://github.com/test-owner/test-repo/pull/1#discussion_r900003',
+      file: 'src/main.js',
+      line_start: 12,
+      line_end: 12,
+      original_line_start: 12,
+      original_line_end: 12,
+      body: 'A second thread on main.js',
+      replies: [],
+    };
+    await installExternalCommentMocks(page, { threads: [HAPPY_THREAD, secondThread] });
+
+    await page.goto('/pr/test-owner/test-repo/1');
+    await waitForDiffToRender(page);
+    await waitForExternalRowsRendered(page);
+
+    await page.evaluate(() => window.aiPanel?.expand());
+
+    const externalBtn = page.locator('.segment-btn[data-segment="external"]');
+    await externalBtn.click();
+    await expect(externalBtn).toHaveClass(/active/);
+
+    const items = page.locator('.ai-panel__list-item--external');
+    await expect(items).toHaveCount(2);
+
+    // Each item has the source-github class (blue accent contract)
+    for (let i = 0; i < 2; i++) {
+      await expect(items.nth(i)).toHaveClass(/source-github/);
+    }
+
+    // Locate items by thread id rather than position — the panel sorts by
+    // file order which depends on the diff fixture and is not the spec's
+    // contract here.
+    const happyItem = items.locator('[data-thread-id="101"]').or(
+      page.locator('.ai-panel__list-item--external[data-thread-id="101"]')
+    ).first();
+    // Total comments badge: root + replies. The happy thread has 1 root +
+    // 1 reply = 2. Always present (replaces the prior author dot).
+    const totalBadge = happyItem.locator('.external-list-count');
+    await expect(totalBadge).toBeVisible();
+    await expect(totalBadge).toHaveText('2');
+
+    // The second thread (no replies) shows "1" — the root comment itself.
+    const secondItem = page.locator('.ai-panel__list-item--external[data-thread-id="102"]');
+    await expect(secondItem.locator('.external-list-count')).toHaveText('1');
+  });
+
+  test('clicking a list item scrolls the inline external-comment-row into view and flashes it', async ({ page }) => {
+    await installExternalCommentMocks(page, { threads: [HAPPY_THREAD] });
+
+    await page.goto('/pr/test-owner/test-repo/1');
+    await waitForDiffToRender(page);
+    await waitForExternalRowsRendered(page);
+
+    await page.evaluate(() => window.aiPanel?.expand());
+
+    // Activate the External segment first
+    const externalBtn = page.locator('.segment-btn[data-segment="external"]');
+    await externalBtn.click();
+
+    const listItem = page.locator('.ai-panel__list-item--external').first();
+    await expect(listItem).toBeVisible();
+    await listItem.click();
+
+    // The matching inline row picks up the .external-comment-row--focused
+    // class. The class is removed after ~2 seconds, so assert quickly.
+    const focusedRow = page.locator('.external-comment-row--focused');
+    await expect(focusedRow).toHaveCount(1, { timeout: 1500 });
+  });
+
+  test('refreshing external comments updates the External segment count', async ({ page }) => {
+    // First load: one thread. After clicking refresh we'll swap in a fixture
+    // with two threads to verify the count updates.
+    let threads = [HAPPY_THREAD];
+    await page.route('**/api/reviews/*/external-comments?**', async (route) => {
+      if (route.request().method() !== 'GET') {
+        return route.continue();
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ threads }),
+      });
+    });
+    await page.route('**/api/reviews/*/external-comments/sync**', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ count: threads.length, lostAnchors: 0, syncedAt: new Date().toISOString() }),
+      });
+    });
+
+    await page.goto('/pr/test-owner/test-repo/1');
+    await waitForDiffToRender(page);
+    await waitForExternalRowsRendered(page);
+
+    await page.evaluate(() => window.aiPanel?.expand());
+
+    const externalCount = page.locator('.segment-btn[data-segment="external"] .segment-count');
+    await expect(externalCount).toHaveText('(1)');
+
+    // Swap fixture and trigger a refresh
+    threads = [
+      HAPPY_THREAD,
+      {
+        ...HAPPY_THREAD,
+        id: 999,
+        external_id: '900099',
+        file: 'src/main.js',
+        line_start: 12,
+        line_end: 12,
+        original_line_start: 12,
+        original_line_end: 12,
+        body: 'New thread after refresh',
+        replies: [],
+      },
+    ];
+    await page.locator('#refresh-external-comments-btn').click();
+
+    // Wait for the panel to reflect the new count
+    await expect(externalCount).toHaveText('(2)', { timeout: 5000 });
+  });
+});
+
+// ---------------------------------------------------------------------
+// 8. Local-mode: External segment button is hidden
+//
+// Local reviews never have an external source — the button should be
+// absent from the visible UI. Asserted at the visibility layer (not just
+// the `[hidden]` attribute) so the assertion stays accurate if a future
+// rule swaps the gate to display:none.
+// ---------------------------------------------------------------------
+
+test.describe('Local mode: External segment hidden', () => {
+  test('External segment button is not visible on /local pages', async ({ page }) => {
+    await page.goto('/local/2');
+    await waitForDiffToRender(page);
+    await page.evaluate(() => window.aiPanel?.expand());
+
+    const externalBtn = page.locator('.segment-btn[data-segment="external"]');
+    // Either absent from the DOM or hidden via [hidden]/display:none.
+    await expect(externalBtn).toBeHidden();
+
+    // The other three segments must still be visible — no collateral
+    // damage from the gating logic.
+    await expect(page.locator('.segment-btn[data-segment="ai"]')).toBeVisible();
+    await expect(page.locator('.segment-btn[data-segment="comments"]')).toBeVisible();
+    await expect(page.locator('.segment-btn[data-segment="all"]')).toBeVisible();
+  });
+});
+
+// ---------------------------------------------------------------------
+// 9. Segment overflow scroll chevrons
+//
+// When the AI panel is narrow enough that the four segment buttons
+// can't fit, chevrons appear on the left/right and scroll the row
+// horizontally. We narrow the panel via JS rather than the viewport so
+// the test is robust against future layout changes outside the panel.
+// ---------------------------------------------------------------------
+
+test.describe('Review panel segment overflow scroll', () => {
+  // Helper: shrink the AI panel container so the four segment buttons
+  // overflow their scroll container, forcing the chevrons to appear.
+  async function shrinkPanel(page) {
+    await page.evaluate(() => {
+      // Drop the CSS variable that drives panel width; also force inline
+      // width on the panel root in case the variable is consumed elsewhere.
+      document.documentElement.style.setProperty('--ai-panel-width', '120px');
+      const panel = document.getElementById('ai-panel');
+      if (panel) panel.style.width = '120px';
+      window.aiPanel?.updateSegmentScrollChevrons?.();
+    });
+  }
+
+  test('shows a right chevron when segment buttons overflow the panel width', async ({ page }) => {
+    await installExternalCommentMocks(page, { threads: [HAPPY_THREAD] });
+    await page.goto('/pr/test-owner/test-repo/1');
+    await waitForDiffToRender(page);
+    await waitForExternalRowsRendered(page);
+    await page.evaluate(() => window.aiPanel?.expand());
+
+    // Narrow the panel so the inner segment row has to overflow its
+    // scroll container. The chevrons sit outside the scroll container
+    // so they still consume some space — 120px guarantees overflow.
+    await shrinkPanel(page);
+
+    const rightChevron = page.locator('#segment-scroll-right');
+    await expect(rightChevron).toBeVisible({ timeout: 2000 });
+
+    // Left chevron starts hidden because we're at scrollLeft = 0
+    const leftChevron = page.locator('#segment-scroll-left');
+    await expect(leftChevron).toBeHidden();
+  });
+
+  test('clicking the right chevron increases scrollLeft of the segment row', async ({ page }) => {
+    await installExternalCommentMocks(page, { threads: [HAPPY_THREAD] });
+    await page.goto('/pr/test-owner/test-repo/1');
+    await waitForDiffToRender(page);
+    await waitForExternalRowsRendered(page);
+    await page.evaluate(() => window.aiPanel?.expand());
+
+    await shrinkPanel(page);
+
+    const initialScroll = await page.evaluate(() =>
+      document.getElementById('segment-control-scroll').scrollLeft
+    );
+    expect(initialScroll).toBe(0);
+
+    await page.locator('#segment-scroll-right').click();
+
+    // Smooth scroll completes asynchronously — poll briefly.
+    await page.waitForFunction(
+      () => document.getElementById('segment-control-scroll').scrollLeft > 0,
+      { timeout: 2000 }
+    );
+
+    const newScroll = await page.evaluate(() =>
+      document.getElementById('segment-control-scroll').scrollLeft
+    );
+    expect(newScroll).toBeGreaterThan(0);
+  });
+
+  test('chevrons are hidden when segment buttons fit', async ({ page }) => {
+    await installExternalCommentMocks(page, { threads: [HAPPY_THREAD] });
+    await page.goto('/pr/test-owner/test-repo/1');
+    await waitForDiffToRender(page);
+    await waitForExternalRowsRendered(page);
+    await page.evaluate(() => window.aiPanel?.expand());
+
+    // Widen the panel container generously so the four short labels are
+    // guaranteed to fit. The default panel width depends on the saved
+    // resizer preference, which is not the contract being tested here.
+    await page.evaluate(() => {
+      document.documentElement.style.setProperty('--ai-panel-width', '600px');
+      const panel = document.getElementById('ai-panel');
+      if (panel) panel.style.width = '600px';
+      window.aiPanel?.updateSegmentScrollChevrons?.();
+    });
+
+    await expect(page.locator('#segment-scroll-left')).toBeHidden();
+    await expect(page.locator('#segment-scroll-right')).toBeHidden();
+  });
+});

--- a/tests/e2e/external-comments.spec.js
+++ b/tests/e2e/external-comments.spec.js
@@ -296,10 +296,10 @@ test.describe('External comments: chat about a single comment', () => {
     await enableChat(page);
     await waitForExternalRowsRendered(page);
 
-    // Click the per-comment chat-about button on the root.
-    // (The reply also has one; we click the first which is the root.)
+    // Click the per-comment chat-about button on a reply. (The root's
+    // button opens a thread chat; only replies open a single-comment chat.)
     const chatBtn = page.locator(
-      '.external-comment-row .external-comment .btn-chat-comment.external-comment-chat-btn'
+      '.external-comment-row .external-comment.is-reply .btn-chat-comment.external-comment-chat-btn'
     ).first();
     await expect(chatBtn).toBeVisible();
     await chatBtn.click();
@@ -316,9 +316,9 @@ test.describe('External comments: chat about a single comment', () => {
     );
     await expect(contextCard).toBeVisible();
 
-    // Author and a fragment of the body should be visible in the card
-    await expect(contextCard).toContainText('reviewer-alice');
-    await expect(contextCard).toContainText('Should this be');
+    // Author and a fragment of the reply body should be visible in the card
+    await expect(contextCard).toContainText('reviewer-bob');
+    await expect(contextCard).toContainText('Good catch');
 
     // Do NOT send a message — that would require running an AI provider.
   });
@@ -337,10 +337,11 @@ test.describe('External comments: chat about thread', () => {
     await enableChat(page);
     await waitForExternalRowsRendered(page);
 
-    // Click the thread-level chat-about button
+    // The thread root's chat button opens a chat about the whole thread.
+    // (`.first()` skips reply buttons.)
     const threadBtn = page.locator(
-      '.external-comment-row .external-comment-thread-actions .btn-chat-thread'
-    );
+      '.external-comment-row .external-comment:not(.is-reply) .btn-chat-comment.external-comment-chat-btn'
+    ).first();
     await expect(threadBtn).toBeVisible();
     await threadBtn.click();
 

--- a/tests/e2e/external-comments.spec.js
+++ b/tests/e2e/external-comments.spec.js
@@ -1,0 +1,533 @@
+// Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+/**
+ * E2E Tests: External (GitHub) PR Review Comments
+ *
+ * Exercises the end-to-end behavior of fetching, displaying, and chatting
+ * about GitHub PR review comments rendered as blue `.external-comment-row`
+ * cards in the diff view.
+ *
+ * Plan: plans/fetch-external-review-comments.md
+ *
+ * --- MOCKING STRATEGY ---------------------------------------------------
+ * The shared test server (tests/e2e/test-server.js) does NOT wire the
+ * external-comments routes. Rather than modifying that shared file, every
+ * test in this spec intercepts the two endpoints at the network layer via
+ * `page.route()`:
+ *
+ *   1. POST /api/reviews/:reviewId/external-comments/sync?source=github
+ *      -> responds with a canned { count, lostAnchors, syncedAt } body and
+ *         optionally bumps a per-test counter so we can assert sync fires.
+ *
+ *   2. GET  /api/reviews/:reviewId/external-comments?source=github
+ *      -> responds with a thread-grouped payload that matches the shape
+ *         the ExternalCommentRepository.listThreadsByReview() would emit
+ *         in production.
+ *
+ * The shape (root comment + replies, with all column fields exposed) is
+ * documented in plans/fetch-external-review-comments.md § 8 and
+ * src/database.js (ExternalCommentRepository).
+ *
+ * This network-level approach lets the test pin every field that drives
+ * the frontend (file, line_end, side, is_outdated, original_line_*,
+ * source, author, body, external_url) without coupling to GitHub's
+ * Octokit, the github-adapter mapping layer, or DB migrations.
+ *
+ * NOTE on PAIR_REVIEW_NO_OPEN: the worker server is spawned by Playwright
+ * fixtures (tests/e2e/fixtures.js) which already runs headless and does
+ * not call the `open` package. No env var setup is needed in this spec.
+ */
+
+import { test, expect } from './fixtures.js';
+import { waitForDiffToRender } from './helpers.js';
+
+// ---------------------------------------------------------------------
+// Fixture data
+// ---------------------------------------------------------------------
+
+/**
+ * Thread fixture: a root comment + one reply on src/utils.js line 3.
+ * Mirrors the shape produced by ExternalCommentRepository.listThreadsByReview
+ * for a GitHub PR review thread that has a single follow-up reply.
+ */
+const HAPPY_THREAD = {
+  id: 101,
+  source: 'github',
+  external_id: '900001',
+  in_reply_to_id: null,
+  parent_id: null,
+  external_url: 'https://github.com/test-owner/test-repo/pull/1#discussion_r900001',
+  author: 'reviewer-alice',
+  author_url: 'https://github.com/reviewer-alice',
+  file: 'src/utils.js',
+  side: 'RIGHT',
+  line_start: 3,
+  line_end: 3,
+  diff_position: 4,
+  commit_sha: 'def456head',
+  is_outdated: 0,
+  original_line_start: 3,
+  original_line_end: 3,
+  original_commit_sha: 'def456head',
+  body: 'Should this be a `const`? Reassignment seems unlikely here.',
+  external_created_at: '2025-10-01T12:00:00Z',
+  synced_at: '2025-10-01T12:05:00Z',
+  replies: [
+    {
+      id: 102,
+      source: 'github',
+      external_id: '900002',
+      in_reply_to_id: '900001',
+      parent_id: 101,
+      external_url: 'https://github.com/test-owner/test-repo/pull/1#discussion_r900002',
+      author: 'reviewer-bob',
+      author_url: 'https://github.com/reviewer-bob',
+      file: 'src/utils.js',
+      side: 'RIGHT',
+      line_start: 3,
+      line_end: 3,
+      diff_position: 4,
+      commit_sha: 'def456head',
+      is_outdated: 0,
+      original_line_start: 3,
+      original_line_end: 3,
+      original_commit_sha: 'def456head',
+      body: 'Good catch — let me make that change.',
+      external_created_at: '2025-10-01T13:00:00Z',
+      synced_at: '2025-10-01T13:05:00Z',
+    },
+  ],
+};
+
+/**
+ * Outdated thread fixture: GitHub returned `position: null`, so the mapper
+ * stored line_end = null and the renderer must fall back to original_line_end.
+ * Anchored to src/main.js line 12 (original) — that line is in the new diff.
+ */
+const OUTDATED_THREAD = {
+  id: 201,
+  source: 'github',
+  external_id: '900101',
+  in_reply_to_id: null,
+  parent_id: null,
+  external_url: 'https://github.com/test-owner/test-repo/pull/1#discussion_r900101',
+  author: 'reviewer-stale',
+  author_url: null,
+  file: 'src/main.js',
+  side: 'RIGHT',
+  line_start: null,
+  line_end: null,
+  diff_position: null,
+  commit_sha: null,
+  is_outdated: 1,
+  original_line_start: 12,
+  original_line_end: 12,
+  original_commit_sha: 'olderbasesha',
+  body: 'This block used to do something different.',
+  external_created_at: '2025-09-01T08:00:00Z',
+  synced_at: '2025-10-01T13:05:00Z',
+  replies: [],
+};
+
+// ---------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------
+
+/**
+ * Install network-level mocks for the two external-comment endpoints.
+ *
+ * @param {import('@playwright/test').Page} page
+ * @param {Object} opts
+ * @param {Array<Object>} opts.threads - Threads returned by GET
+ * @param {Function} [opts.onSync] - Optional callback fired on each POST sync.
+ *                                   Receives the route's request object.
+ */
+async function installExternalCommentMocks(page, { threads, onSync } = {}) {
+  const threadsList = Array.isArray(threads) ? threads : [];
+
+  // NB: route handlers are processed last-registered-first in Playwright, so
+  // we install the broader GET catcher FIRST and the narrower sync catcher
+  // LAST. That way the sync handler "wins" for POSTs to /sync while the
+  // catcher serves the GET threads list.
+  await page.route('**/api/reviews/*/external-comments**', async (route) => {
+    const req = route.request();
+    // Defensive: pass through anything that isn't a GET for the threads list.
+    // The sync handler installed below will normally intercept POSTs first.
+    if (req.method() !== 'GET') {
+      return route.continue();
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ threads: threadsList }),
+    });
+  });
+
+  await page.route('**/api/reviews/*/external-comments/sync**', async (route) => {
+    if (typeof onSync === 'function') {
+      try { onSync(route.request()); } catch { /* keep mock alive */ }
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        count: threadsList.reduce((n, t) => n + 1 + (Array.isArray(t.replies) ? t.replies.length : 0), 0),
+        lostAnchors: 0,
+        syncedAt: new Date().toISOString(),
+      }),
+    });
+  });
+}
+
+/**
+ * Wait until the external-comment manager has finished its initial
+ * fetch-and-render cycle. The manager calls `loadAndRender()` from
+ * `_loadExternalComments` in pr.js after the diff is rendered; the row
+ * appears in the DOM only after that resolves.
+ */
+async function waitForExternalRowsRendered(page) {
+  await page.waitForFunction(() => {
+    return !!document.querySelector('.external-comment-row, .external-comment');
+  }, { timeout: 10000 });
+}
+
+/**
+ * Enable chat in the test environment. Mirrors the helper in chat-lines.spec.js.
+ * Without this, the chat panel is gated off by `[data-chat="disabled"]` CSS
+ * (no Pi binary in E2E), so `chatPanel.open()` adds the `--open` class but
+ * the container stays display:none.
+ */
+async function enableChat(page) {
+  await page.evaluate(() => {
+    document.documentElement.setAttribute('data-chat', 'available');
+    window.dispatchEvent(new CustomEvent('chat-state-changed', { detail: { state: 'available' } }));
+  });
+}
+
+// ---------------------------------------------------------------------
+// 1. Happy path render
+// ---------------------------------------------------------------------
+
+test.describe('External comments: happy path render', () => {
+  test('renders a thread row with root + reply, GitHub source classes, and visible bodies', async ({ page }) => {
+    await installExternalCommentMocks(page, { threads: [HAPPY_THREAD] });
+
+    await page.goto('/pr/test-owner/test-repo/1');
+    await waitForDiffToRender(page);
+    await waitForExternalRowsRendered(page);
+
+    // Exactly one external-comment-row for this thread
+    const rows = page.locator('.external-comment-row');
+    await expect(rows).toHaveCount(1);
+
+    // Two .external-comment elements inside (root + reply)
+    const row = rows.first();
+    const comments = row.locator('.external-comment');
+    await expect(comments).toHaveCount(2);
+
+    // Root has source-github but NOT is-reply
+    const root = comments.nth(0);
+    await expect(root).toHaveClass(/source-github/);
+    await expect(root).not.toHaveClass(/is-reply/);
+
+    // Reply has both source-github AND is-reply
+    const reply = comments.nth(1);
+    await expect(reply).toHaveClass(/source-github/);
+    await expect(reply).toHaveClass(/is-reply/);
+
+    // Visible blue accent contract: we test the class hook the CSS variables
+    // are bound to. Pixel-level color contracts shift; class contracts do
+    // not (per CLAUDE.md test guidance).
+    await expect(root).toHaveClass(/external-comment/);
+    await expect(root).toHaveClass(/source-github/);
+
+    // Both bodies render their text content. Markdown rendering may strip
+    // backticks (they become <code> tags), so we assert on the surrounding
+    // prose that is preserved verbatim.
+    await expect(row).toContainText('Should this be a');
+    await expect(row).toContainText('Reassignment seems unlikely');
+    await expect(row).toContainText('Good catch');
+  });
+});
+
+// ---------------------------------------------------------------------
+// 2. Outdated badge
+// ---------------------------------------------------------------------
+
+test.describe('External comments: outdated rendering', () => {
+  test('falls back to original_line_end and shows the outdated badge', async ({ page }) => {
+    await installExternalCommentMocks(page, { threads: [OUTDATED_THREAD] });
+
+    await page.goto('/pr/test-owner/test-repo/1');
+    await waitForDiffToRender(page);
+    await waitForExternalRowsRendered(page);
+
+    // The row should exist (anchored to original_line_end = 12)
+    const rows = page.locator('.external-comment-row');
+    await expect(rows).toHaveCount(1);
+
+    // is-outdated class is applied to the comment element
+    const outdatedComment = rows.first().locator('.external-comment.is-outdated');
+    await expect(outdatedComment).toHaveCount(1);
+
+    // Outdated badge present
+    const badge = rows.first().locator('.external-comment-outdated-badge');
+    await expect(badge).toBeVisible();
+
+    // Anchored to original_line_end (12) — verify the row appears within the
+    // src/main.js file wrapper rather than utils.js. The d2h diff renderer
+    // sets `data-file-name` on multiple elements (wrapper + each tr); pin
+    // the assertion to the `.d2h-file-wrapper` to avoid a strict-mode hit.
+    const mainFileSection = page.locator('.d2h-file-wrapper[data-file-name="src/main.js"]');
+    const externalRowInMain = mainFileSection.locator('.external-comment-row');
+    await expect(externalRowInMain).toHaveCount(1);
+  });
+});
+
+// ---------------------------------------------------------------------
+// 3. Chat about a single external comment
+// ---------------------------------------------------------------------
+
+test.describe('External comments: chat about a single comment', () => {
+  test('opens the chat panel with an external-comment context card', async ({ page }) => {
+    await installExternalCommentMocks(page, { threads: [HAPPY_THREAD] });
+
+    await page.goto('/pr/test-owner/test-repo/1');
+    await waitForDiffToRender(page);
+    await enableChat(page);
+    await waitForExternalRowsRendered(page);
+
+    // Click the per-comment chat-about button on the root.
+    // (The reply also has one; we click the first which is the root.)
+    const chatBtn = page.locator(
+      '.external-comment-row .external-comment .btn-chat-comment.external-comment-chat-btn'
+    ).first();
+    await expect(chatBtn).toBeVisible();
+    await chatBtn.click();
+
+    // Chat panel becomes visible
+    const chatPanel = page.locator('.chat-panel');
+    await expect(chatPanel).toBeVisible({ timeout: 5000 });
+
+    // The compact context card carries the external-comment classes.
+    // ChatPanel._addCommentContextCard builds: chat-panel__context-card +
+    // external-comment-context + source-github when ctx.source === 'external'.
+    const contextCard = page.locator(
+      '.chat-panel__context-card.external-comment-context.source-github'
+    );
+    await expect(contextCard).toBeVisible();
+
+    // Author and a fragment of the body should be visible in the card
+    await expect(contextCard).toContainText('reviewer-alice');
+    await expect(contextCard).toContainText('Should this be');
+
+    // Do NOT send a message — that would require running an AI provider.
+  });
+});
+
+// ---------------------------------------------------------------------
+// 4. Chat about a whole thread
+// ---------------------------------------------------------------------
+
+test.describe('External comments: chat about thread', () => {
+  test('opens the chat panel with a thread context card containing both comments', async ({ page }) => {
+    await installExternalCommentMocks(page, { threads: [HAPPY_THREAD] });
+
+    await page.goto('/pr/test-owner/test-repo/1');
+    await waitForDiffToRender(page);
+    await enableChat(page);
+    await waitForExternalRowsRendered(page);
+
+    // Click the thread-level chat-about button
+    const threadBtn = page.locator(
+      '.external-comment-row .external-comment-thread-actions .btn-chat-thread'
+    );
+    await expect(threadBtn).toBeVisible();
+    await threadBtn.click();
+
+    const chatPanel = page.locator('.chat-panel');
+    await expect(chatPanel).toBeVisible({ timeout: 5000 });
+
+    // Thread context card has the thread modifier class
+    const threadCard = page.locator(
+      '.chat-panel__context-card.chat-panel__context-card--thread.external-comment-context'
+    );
+    await expect(threadCard).toBeVisible();
+
+    // Both authors and both body fragments should be visible inside
+    await expect(threadCard).toContainText('reviewer-alice');
+    await expect(threadCard).toContainText('reviewer-bob');
+    await expect(threadCard).toContainText('Should this be');
+    await expect(threadCard).toContainText('Good catch');
+  });
+});
+
+// ---------------------------------------------------------------------
+// 5. Refresh button
+// ---------------------------------------------------------------------
+
+test.describe('External comments: manual refresh', () => {
+  test('refresh button briefly disables, fires a new sync, and does not duplicate rows', async ({ page }) => {
+    let syncCallCount = 0;
+    await installExternalCommentMocks(page, {
+      threads: [HAPPY_THREAD],
+      onSync: () => { syncCallCount++; },
+    });
+
+    await page.goto('/pr/test-owner/test-repo/1');
+    await waitForDiffToRender(page);
+    await waitForExternalRowsRendered(page);
+
+    // Wait for the initial page-load sync to settle
+    await page.waitForFunction(() => {
+      // The pr.js code clears the is-refreshing class in the finally block
+      const btn = document.getElementById('refresh-external-comments-btn');
+      return btn && !btn.classList.contains('is-refreshing') && !btn.disabled;
+    }, { timeout: 10000 });
+
+    const initialRowCount = await page.locator('.external-comment-row').count();
+    expect(initialRowCount).toBe(1);
+
+    const initialSyncCount = syncCallCount;
+    expect(initialSyncCount).toBeGreaterThanOrEqual(1);
+
+    // Click the refresh button. Use a request-wait to confirm the new sync
+    // POST is fired by the click itself.
+    const syncReq = page.waitForRequest(
+      (req) => /\/api\/reviews\/[^/]+\/external-comments\/sync/.test(req.url())
+               && req.method() === 'POST',
+      { timeout: 5000 }
+    );
+
+    const refreshBtn = page.locator('#refresh-external-comments-btn');
+    await expect(refreshBtn).toBeVisible();
+    await refreshBtn.click();
+
+    await syncReq;
+    expect(syncCallCount).toBeGreaterThan(initialSyncCount);
+
+    // Refresh should clear the is-refreshing state once done
+    await page.waitForFunction(() => {
+      const btn = document.getElementById('refresh-external-comments-btn');
+      return btn && !btn.classList.contains('is-refreshing') && !btn.disabled;
+    }, { timeout: 10000 });
+
+    // Same dataset returned — exactly one row, no duplicates
+    await expect(page.locator('.external-comment-row')).toHaveCount(1);
+  });
+});
+
+// ---------------------------------------------------------------------
+// 6. Coexistence with user comments + AI suggestions on the same diff line
+// ---------------------------------------------------------------------
+
+test.describe('External comments: coexistence with user + AI rows', () => {
+  test('AI / user / external rows all render on the same line in the right order', async ({ page }) => {
+    await installExternalCommentMocks(page, { threads: [HAPPY_THREAD] });
+
+    await page.goto('/pr/test-owner/test-repo/1');
+    await waitForDiffToRender(page);
+
+    // Seed an AI suggestion on src/utils.js line 3 by hitting the mock
+    // analyses endpoint, which inserts mockAISuggestions into the DB. The
+    // existing seed includes suggestion id 1001 anchored to utils.js line 3.
+    await page.evaluate(async () => {
+      const res = await fetch('/api/pr/test-owner/test-repo/1/analyses', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
+      });
+      return res.ok;
+    });
+
+    // Seed a user comment on src/utils.js line 3 via the normal comments API.
+    // Reading the current pr-manager's review id keeps us in sync with whatever
+    // the test server assigned (id=1 in the standard seed).
+    await page.evaluate(async () => {
+      const reviewId = window.prManager?.currentPR?.id || 1;
+      await fetch(`/api/reviews/${reviewId}/comments`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          file: 'src/utils.js',
+          line_start: 3,
+          line_end: 3,
+          side: 'RIGHT',
+          body: 'User note on line 3.',
+        }),
+      });
+    });
+
+    // Reload to force all three managers (AI suggestions, user comments,
+    // external comments) to render together.
+    await page.reload();
+    await waitForDiffToRender(page);
+    await waitForExternalRowsRendered(page);
+
+    // Wait for user-comment rows too (loadUserComments fires async).
+    await page.waitForSelector('.user-comment-row', { timeout: 10000 });
+
+    // All three row types should be present
+    expect(await page.locator('.ai-suggestion-row').count()).toBeGreaterThan(0);
+    expect(await page.locator('.user-comment-row').count()).toBeGreaterThan(0);
+    expect(await page.locator('.external-comment-row').count()).toBe(1);
+
+    // Scope to the utils.js file wrapper and verify ordering on line 3:
+    //   AI suggestion row  ->  user comment row  ->  external comment row
+    // (CLAUDE.md hazard rule: AI -> user -> external.)
+    // The d2h diff renderer uses `[data-file-name]` on multiple elements
+    // (wrapper, comments-zone, every `<tr>`); the `.d2h-file-wrapper` is the
+    // outer container that owns the actual diff table.
+    const utilsFile = page.locator('.d2h-file-wrapper[data-file-name="src/utils.js"]');
+
+    const orderedClasses = await utilsFile.evaluate((root) => {
+      // Walk every tr in document order; record any of the three row types
+      // we find. Filter the result down to the three types and check that
+      // their relative order matches the contract.
+      const rows = Array.from(root.querySelectorAll('tr'));
+      return rows
+        .filter((tr) =>
+          tr.classList.contains('ai-suggestion-row') ||
+          tr.classList.contains('user-comment-row') ||
+          tr.classList.contains('external-comment-row')
+        )
+        .map((tr) => {
+          if (tr.classList.contains('ai-suggestion-row')) return 'ai';
+          if (tr.classList.contains('user-comment-row')) return 'user';
+          return 'external';
+        });
+    });
+
+    // The external row should appear after BOTH any preceding AI row and any
+    // preceding user-comment row that targets the same line.
+    const externalIdx = orderedClasses.indexOf('external');
+    expect(externalIdx).toBeGreaterThan(-1);
+
+    // Slice up to the external row — every AI/user row that comes before it
+    // must be ai or user, never external (we've already checked there's only
+    // one external row).
+    const precedingTypes = orderedClasses.slice(0, externalIdx);
+    expect(precedingTypes).toContain('ai');
+    expect(precedingTypes).toContain('user');
+
+    // Last preceding row of either type should not be 'external' (sanity).
+    expect(precedingTypes.includes('external')).toBe(false);
+
+    // External rendering did NOT remove the other rows — counts already
+    // asserted above. Belt-and-suspenders: confirm the user + AI rows still
+    // sit in this same file section.
+    expect(await utilsFile.locator('.ai-suggestion-row').count()).toBeGreaterThan(0);
+    expect(await utilsFile.locator('.user-comment-row').count()).toBeGreaterThan(0);
+  });
+});
+
+// Local-mode coverage lives in tests/unit/pr-external-comments-wiring.test.js:
+// "local mode short-circuits: no fetch, no syncAndRender, no reviewId mutation".
+// That unit test sets `window.PAIR_REVIEW_LOCAL_MODE = true`, calls
+// `_loadExternalComments` directly, and asserts no fetch, no syncAndRender, no
+// loadAndRender, and no reviewId mutation. The earlier E2E variants of this
+// test were either trivial (loading /local/:id never instantiated the
+// external-comment manager, so the guard wasn't actually exercised) or
+// broken (loading /pr/... with LOCAL_MODE injected made PRManager skip
+// init() entirely, so waitForDiffToRender timed out and the guard still
+// wasn't reached). The unit-level coverage is strictly stronger; no E2E
+// equivalent here.

--- a/tests/e2e/external-comments.spec.js
+++ b/tests/e2e/external-comments.spec.js
@@ -383,10 +383,13 @@ test.describe('External comments: manual refresh', () => {
     await waitForDiffToRender(page);
     await waitForExternalRowsRendered(page);
 
-    // Wait for the initial page-load sync to settle
+    // Wait for the initial page-load sync to settle. The refresh button
+    // lives in the AI panel header; expand the panel so the button is in a
+    // visible region for click + interaction.
+    await page.evaluate(() => window.aiPanel?.expand());
     await page.waitForFunction(() => {
       // The pr.js code clears the is-refreshing class in the finally block
-      const btn = document.getElementById('refresh-external-comments-btn');
+      const btn = document.getElementById('refresh-external-comments-btn-panel');
       return btn && !btn.classList.contains('is-refreshing') && !btn.disabled;
     }, { timeout: 10000 });
 
@@ -404,7 +407,7 @@ test.describe('External comments: manual refresh', () => {
       { timeout: 5000 }
     );
 
-    const refreshBtn = page.locator('#refresh-external-comments-btn');
+    const refreshBtn = page.locator('#refresh-external-comments-btn-panel');
     await expect(refreshBtn).toBeVisible();
     await refreshBtn.click();
 
@@ -413,7 +416,7 @@ test.describe('External comments: manual refresh', () => {
 
     // Refresh should clear the is-refreshing state once done
     await page.waitForFunction(() => {
-      const btn = document.getElementById('refresh-external-comments-btn');
+      const btn = document.getElementById('refresh-external-comments-btn-panel');
       return btn && !btn.classList.contains('is-refreshing') && !btn.disabled;
     }, { timeout: 10000 });
 
@@ -688,7 +691,7 @@ test.describe('External segment in Review panel', () => {
         replies: [],
       },
     ];
-    await page.locator('#refresh-external-comments-btn').click();
+    await page.locator('#refresh-external-comments-btn-panel').click();
 
     // Wait for the panel to reflect the new count
     await expect(externalCount).toHaveText('(2)', { timeout: 5000 });

--- a/tests/e2e/global-setup.js
+++ b/tests/e2e/global-setup.js
@@ -713,8 +713,12 @@ async function globalSetup() {
       // Success — store the chosen port so Playwright tests can find it
       process.env.E2E_PORT = port.toString();
       process.env.E2E_SERVER_PID = process.pid.toString();
-      // Update the stored config to reflect the actual port
-      app.set('config', { github_token: 'test-token-e2e', port, theme: 'light', model: 'sonnet' });
+      // Update the stored config to reflect the actual port.
+      // external_comments is opt-in (production default is false) but the
+      // e2e specs assume the feature is enabled — explicitly opt in here so
+      // /runtime-config.js emits the enabled flag and the External segment +
+      // refresh button render for the assertions in external-comments.spec.js.
+      app.set('config', { github_token: 'test-token-e2e', port, theme: 'light', model: 'sonnet', external_comments: true });
       console.log(`E2E test server running on http://localhost:${port}`);
       return;
     } catch (err) {

--- a/tests/e2e/global-setup.js
+++ b/tests/e2e/global-setup.js
@@ -561,6 +561,20 @@ async function globalSetup() {
     });
   });
 
+  // Stub external-comments endpoints. The pr.js page wiring fires a
+  // fire-and-forget sync + fetch on every PR load (see _loadExternalComments).
+  // Without these stubs, the requests 404 against the catch-all error handler
+  // below, which surfaces as a leaking ".toast-error" and breaks unrelated
+  // tests that assert on toast visibility. Tests that exercise the real
+  // external-comment flow override these via `page.route(...)` — see
+  // tests/e2e/external-comments.spec.js.
+  app.post('/api/reviews/:reviewId/external-comments/sync', (req, res) => {
+    res.json({ count: 0, lostAnchors: 0, syncedAt: new Date().toISOString() });
+  });
+  app.get('/api/reviews/:reviewId/external-comments', (req, res) => {
+    res.json({ threads: [] });
+  });
+
   // Mock file-content-original endpoint for context expansion tests
   // Returns mock file content with predictable line contents for testing
   app.get('/api/file-content-original/:fileName(*)', (req, res) => {

--- a/tests/e2e/test-server.js
+++ b/tests/e2e/test-server.js
@@ -561,6 +561,20 @@ async function startTestServer(port) {
     });
   });
 
+  // Stub external-comments endpoints. The pr.js page wiring fires a
+  // fire-and-forget sync + fetch on every PR load (see _loadExternalComments).
+  // Without these stubs, the requests 404 against the catch-all error handler
+  // below, which surfaces as a leaking ".toast-error: Failed to load github
+  // review comments" toast and breaks unrelated tests that assert on toast
+  // visibility. Tests that exercise the real external-comment flow override
+  // these via `page.route(...)` — see tests/e2e/external-comments.spec.js.
+  app.post('/api/reviews/:reviewId/external-comments/sync', (req, res) => {
+    res.json({ count: 0, lostAnchors: 0, syncedAt: new Date().toISOString() });
+  });
+  app.get('/api/reviews/:reviewId/external-comments', (req, res) => {
+    res.json({ threads: [] });
+  });
+
   // Mock file-content-original endpoint for context expansion tests
   app.get('/api/file-content-original/:fileName(*)', (req, res) => {
     const fileName = decodeURIComponent(req.params.fileName);

--- a/tests/integration/database.test.js
+++ b/tests/integration/database.test.js
@@ -149,6 +149,377 @@ describe('Database Initialization', () => {
     // Local sessions listing index
     expect(indexNames).toContain('idx_reviews_type_updated');
   });
+
+  it('should create external_comments table with correct schema', async () => {
+    const tables = await query(db, `
+      SELECT name FROM sqlite_master WHERE type='table' AND name='external_comments'
+    `);
+    expect(tables).toHaveLength(1);
+
+    const columns = await query(db, 'PRAGMA table_info(external_comments)');
+    const columnNames = columns.map(c => c.name);
+
+    // Identity / FK columns
+    expect(columnNames).toContain('id');
+    expect(columnNames).toContain('review_id');
+    expect(columnNames).toContain('source');
+    expect(columnNames).toContain('external_id');
+    expect(columnNames).toContain('in_reply_to_id');
+    expect(columnNames).toContain('parent_id');
+    // Permalink / author
+    expect(columnNames).toContain('external_url');
+    expect(columnNames).toContain('author');
+    expect(columnNames).toContain('author_url');
+    // Anchor (current)
+    expect(columnNames).toContain('file');
+    expect(columnNames).toContain('side');
+    expect(columnNames).toContain('line_start');
+    expect(columnNames).toContain('line_end');
+    expect(columnNames).toContain('diff_position');
+    expect(columnNames).toContain('commit_sha');
+    expect(columnNames).toContain('is_outdated');
+    // Anchor (original — at creation time)
+    expect(columnNames).toContain('original_line_start');
+    expect(columnNames).toContain('original_line_end');
+    expect(columnNames).toContain('original_commit_sha');
+    // Body + timestamps
+    expect(columnNames).toContain('body');
+    expect(columnNames).toContain('external_created_at');
+    expect(columnNames).toContain('synced_at');
+
+    // NOT NULL constraints (per the spec) on the columns that must always be set
+    const notNullCols = columns.filter(c => c.notnull === 1).map(c => c.name);
+    expect(notNullCols).toContain('review_id');
+    expect(notNullCols).toContain('source');
+    expect(notNullCols).toContain('external_id');
+    expect(notNullCols).toContain('file');
+    expect(notNullCols).toContain('is_outdated');
+
+    // is_outdated should default to 0
+    const isOutdatedCol = columns.find(c => c.name === 'is_outdated');
+    expect(isOutdatedCol.dflt_value).toBe('0');
+  });
+
+  it('should create external_comments indexes with the expected names', async () => {
+    const indexes = await query(db, `
+      SELECT name FROM sqlite_master
+      WHERE type='index' AND tbl_name='external_comments' AND name NOT LIKE 'sqlite_%'
+    `);
+    const indexNames = indexes.map(i => i.name);
+
+    expect(indexNames).toContain('idx_external_comments_unique');
+    expect(indexNames).toContain('idx_external_comments_anchor');
+    expect(indexNames).toContain('idx_external_comments_parent_lookup');
+  });
+
+  it('should enforce UNIQUE(review_id, source, external_id) on external_comments', async () => {
+    const reviewId = seedTestReview(db);
+
+    await run(db, `
+      INSERT INTO external_comments (review_id, source, external_id, file)
+      VALUES (?, 'github', '12345', 'src/foo.js')
+    `, [reviewId]);
+
+    await expect(
+      run(db, `
+        INSERT INTO external_comments (review_id, source, external_id, file)
+        VALUES (?, 'github', '12345', 'src/foo.js')
+      `, [reviewId])
+    ).rejects.toThrow(/UNIQUE/i);
+  });
+
+  it('should cascade-delete external_comments when their review is deleted', async () => {
+    const reviewId = seedTestReview(db);
+
+    await run(db, `
+      INSERT INTO external_comments (review_id, source, external_id, file)
+      VALUES (?, 'github', 'ext-1', 'src/a.js')
+    `, [reviewId]);
+
+    await run(db, 'DELETE FROM reviews WHERE id = ?', [reviewId]);
+
+    const remaining = await query(db, 'SELECT * FROM external_comments WHERE review_id = ?', [reviewId]);
+    expect(remaining).toHaveLength(0);
+  });
+
+  it('should null out parent_id (not cascade) when an external_comments parent row is deleted', async () => {
+    // Regression for data-loss bug: parent_id used to CASCADE, which meant the
+    // sync route's prune step destroyed kept replies whenever their parent
+    // disappeared from the upstream snapshot. SET NULL preserves the reply
+    // and lets listThreadsByReview promote it via orphan handling.
+    const reviewId = seedTestReview(db);
+
+    const parent = await run(db, `
+      INSERT INTO external_comments (review_id, source, external_id, file)
+      VALUES (?, 'github', 'parent-1', 'src/a.js')
+    `, [reviewId]);
+
+    await run(db, `
+      INSERT INTO external_comments (review_id, source, external_id, file, parent_id, in_reply_to_id)
+      VALUES (?, 'github', 'reply-1', 'src/a.js', ?, 'parent-1')
+    `, [reviewId, parent.lastID]);
+
+    await run(db, 'DELETE FROM external_comments WHERE id = ?', [parent.lastID]);
+
+    const remaining = await query(db, 'SELECT * FROM external_comments WHERE review_id = ?', [reviewId]);
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0].external_id).toBe('reply-1');
+    expect(remaining[0].parent_id).toBeNull();
+  });
+});
+
+// ============================================================================
+// Migration-path tests — exercise individual migrations against a
+// representative pre-state instead of validating only the final schema.
+// Production upgrades run pending migrations from PRAGMA user_version
+// and DDL can fail even when the final-schema tests pass.
+// ============================================================================
+
+describe('Migration 45: create external_comments table', () => {
+  let db;
+  const Database = require('better-sqlite3');
+
+  beforeEach(() => {
+    // Pre-45 baseline: a database with the `reviews` table (so the FK can
+    // resolve) but no `external_comments` table.
+    db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    db.exec(`
+      CREATE TABLE reviews (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        pr_number INTEGER,
+        repository TEXT NOT NULL,
+        review_id TEXT,
+        status TEXT DEFAULT 'draft',
+        review_data TEXT,
+        custom_instructions TEXT,
+        summary TEXT,
+        review_type TEXT DEFAULT 'pr',
+        local_path TEXT,
+        local_head_sha TEXT,
+        local_head_branch TEXT,
+        local_uncommitted INTEGER DEFAULT 0,
+        name TEXT,
+        submitted_at TEXT,
+        created_at TEXT DEFAULT (datetime('now')),
+        updated_at TEXT DEFAULT (datetime('now'))
+      )
+    `);
+  });
+
+  afterEach(() => {
+    if (db) db.close();
+  });
+
+  it('creates external_comments with the expected columns', () => {
+    MIGRATIONS[45](db);
+
+    const table = db.prepare(
+      "SELECT name FROM sqlite_master WHERE type='table' AND name='external_comments'"
+    ).get();
+    expect(table).toBeTruthy();
+
+    const cols = db.prepare('PRAGMA table_info(external_comments)').all();
+    const colNames = cols.map(c => c.name);
+    expect(colNames).toEqual(expect.arrayContaining([
+      'id', 'review_id', 'source', 'external_id', 'in_reply_to_id', 'parent_id',
+      'external_url', 'author', 'author_url', 'file', 'side',
+      'line_start', 'line_end', 'diff_position', 'commit_sha',
+      'is_outdated', 'original_line_start', 'original_line_end', 'original_commit_sha',
+      'body', 'external_created_at', 'synced_at'
+    ]));
+  });
+
+  it('creates the canonical indexes by name', () => {
+    MIGRATIONS[45](db);
+
+    const idx = db.prepare(`
+      SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='external_comments' AND name NOT LIKE 'sqlite_%'
+    `).all().map(r => r.name);
+    expect(idx).toEqual(expect.arrayContaining([
+      'idx_external_comments_unique',
+      'idx_external_comments_anchor',
+      'idx_external_comments_parent_lookup',
+    ]));
+  });
+
+  it('FOREIGN KEY review_id → reviews(id) cascades on review delete', () => {
+    MIGRATIONS[45](db);
+
+    const reviewId = db.prepare(
+      "INSERT INTO reviews (pr_number, repository) VALUES (1, 'a/b') RETURNING id"
+    ).get().id;
+    db.prepare(
+      "INSERT INTO external_comments (review_id, source, external_id, file) VALUES (?, 'github', 'e1', 'a.js')"
+    ).run(reviewId);
+
+    db.prepare('DELETE FROM reviews WHERE id = ?').run(reviewId);
+    const rows = db.prepare('SELECT * FROM external_comments').all();
+    expect(rows).toHaveLength(0);
+  });
+});
+
+describe('Migration 46: rebuild external_comments with parent_id SET NULL', () => {
+  let db;
+  const Database = require('better-sqlite3');
+
+  /**
+   * Build a representative pre-46 database: external_comments table created
+   * with the OLD `parent_id ON DELETE CASCADE` constraint plus a couple of
+   * rows (parent + reply with resolved parent_id linkage).
+   */
+  function buildPre46Database() {
+    const d = new Database(':memory:');
+    d.pragma('foreign_keys = ON');
+    d.exec(`
+      CREATE TABLE reviews (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        pr_number INTEGER,
+        repository TEXT NOT NULL,
+        review_type TEXT DEFAULT 'pr'
+      );
+      CREATE TABLE external_comments (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        review_id INTEGER NOT NULL,
+        source TEXT NOT NULL,
+        external_id TEXT NOT NULL,
+        in_reply_to_id TEXT,
+        parent_id INTEGER,
+        external_url TEXT,
+        author TEXT,
+        author_url TEXT,
+        file TEXT NOT NULL,
+        side TEXT,
+        line_start INTEGER,
+        line_end INTEGER,
+        diff_position INTEGER,
+        commit_sha TEXT,
+        is_outdated INTEGER NOT NULL DEFAULT 0,
+        original_line_start INTEGER,
+        original_line_end INTEGER,
+        original_commit_sha TEXT,
+        body TEXT,
+        external_created_at TEXT,
+        synced_at TEXT,
+        FOREIGN KEY (review_id) REFERENCES reviews(id) ON DELETE CASCADE,
+        FOREIGN KEY (parent_id) REFERENCES external_comments(id) ON DELETE CASCADE
+      );
+      CREATE UNIQUE INDEX idx_external_comments_unique ON external_comments(review_id, source, external_id);
+      CREATE INDEX idx_external_comments_anchor ON external_comments(review_id, file, line_end);
+      CREATE INDEX idx_external_comments_parent_lookup ON external_comments(review_id, source, in_reply_to_id);
+    `);
+    return d;
+  }
+
+  beforeEach(() => {
+    db = buildPre46Database();
+  });
+
+  afterEach(() => {
+    if (db) db.close();
+  });
+
+  it('preserves all rows verbatim across the rebuild', () => {
+    const reviewId = db.prepare("INSERT INTO reviews (pr_number, repository) VALUES (1, 'a/b') RETURNING id").get().id;
+    const parentId = db.prepare(`
+      INSERT INTO external_comments (review_id, source, external_id, file, body)
+      VALUES (?, 'github', 'parent', 'a.js', 'p body') RETURNING id
+    `).get(reviewId).id;
+    db.prepare(`
+      INSERT INTO external_comments (review_id, source, external_id, in_reply_to_id, parent_id, file, body)
+      VALUES (?, 'github', 'reply', 'parent', ?, 'a.js', 'r body')
+    `).run(reviewId, parentId);
+
+    MIGRATIONS[46](db);
+
+    const rows = db.prepare('SELECT external_id, body, parent_id FROM external_comments ORDER BY external_id').all();
+    expect(rows).toEqual([
+      { external_id: 'parent', body: 'p body', parent_id: null },
+      { external_id: 'reply', body: 'r body', parent_id: parentId },
+    ]);
+  });
+
+  it('keeps the canonical indexes by name (and only those)', () => {
+    MIGRATIONS[46](db);
+    const idx = db.prepare(`
+      SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='external_comments' AND name NOT LIKE 'sqlite_%'
+    `).all().map(r => r.name).sort();
+    expect(idx).toEqual([
+      'idx_external_comments_anchor',
+      'idx_external_comments_parent_lookup',
+      'idx_external_comments_unique',
+    ]);
+  });
+
+  it('removes the temp/rebuild table', () => {
+    MIGRATIONS[46](db);
+    const temp = db.prepare(
+      "SELECT name FROM sqlite_master WHERE type='table' AND name='external_comments_new'"
+    ).get();
+    expect(temp).toBeFalsy();
+  });
+
+  it('flips parent_id from ON DELETE CASCADE to ON DELETE SET NULL', () => {
+    const reviewId = db.prepare("INSERT INTO reviews (pr_number, repository) VALUES (1, 'a/b') RETURNING id").get().id;
+    const parentId = db.prepare(`
+      INSERT INTO external_comments (review_id, source, external_id, file)
+      VALUES (?, 'github', 'p', 'a.js') RETURNING id
+    `).get(reviewId).id;
+    db.prepare(`
+      INSERT INTO external_comments (review_id, source, external_id, in_reply_to_id, parent_id, file)
+      VALUES (?, 'github', 'r', 'p', ?, 'a.js')
+    `).run(reviewId, parentId);
+
+    MIGRATIONS[46](db);
+
+    db.prepare('DELETE FROM external_comments WHERE id = ?').run(parentId);
+
+    // Reply must survive AND its parent_id must be nulled out (SET NULL).
+    const rows = db.prepare('SELECT external_id, parent_id FROM external_comments').all();
+    expect(rows).toEqual([{ external_id: 'r', parent_id: null }]);
+  });
+
+  it('restores foreign_keys pragma after the rebuild', () => {
+    expect(db.prepare('PRAGMA foreign_keys').get().foreign_keys).toBe(1);
+    MIGRATIONS[46](db);
+    // Migration toggles foreign_keys OFF/ON in a try/finally. After it
+    // runs, the pragma must be restored to whatever the caller had set.
+    expect(db.prepare('PRAGMA foreign_keys').get().foreign_keys).toBe(1);
+  });
+
+  it('is a no-op when external_comments table does not exist yet', () => {
+    // Fresh DB where migration 45 hasn't run yet — migration 46 must not throw.
+    const fresh = new Database(':memory:');
+    fresh.pragma('foreign_keys = ON');
+    try {
+      expect(() => MIGRATIONS[46](fresh)).not.toThrow();
+      const tables = fresh.prepare(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='external_comments'"
+      ).all();
+      expect(tables).toHaveLength(0);
+    } finally {
+      fresh.close();
+    }
+  });
+
+  it('is idempotent across a crashed-then-restarted rebuild (DROP TABLE IF EXISTS for temp)', () => {
+    // Simulate a previous mid-rebuild crash leaving the temp table behind.
+    // The migration must DROP IF EXISTS and finish cleanly.
+    db.exec(`
+      CREATE TABLE external_comments_new (
+        id INTEGER PRIMARY KEY,
+        review_id INTEGER,
+        source TEXT,
+        external_id TEXT,
+        file TEXT
+      );
+    `);
+    expect(() => MIGRATIONS[46](db)).not.toThrow();
+    const temp = db.prepare(
+      "SELECT name FROM sqlite_master WHERE type='table' AND name='external_comments_new'"
+    ).get();
+    expect(temp).toBeFalsy();
+  });
 });
 
 // ============================================================================

--- a/tests/integration/external-comment-repository.test.js
+++ b/tests/integration/external-comment-repository.test.js
@@ -1,0 +1,543 @@
+// Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { createTestDatabase, closeTestDatabase, seedTestReview } from '../utils/schema';
+
+const { ExternalCommentRepository } = require('../../src/database');
+
+/**
+ * Build a mappedRow object with sensible defaults for tests.
+ * Callers override only the fields they care about.
+ */
+function makeRow(overrides = {}) {
+  return {
+    external_id: '1',
+    in_reply_to_id: null,
+    external_url: 'https://github.com/owner/repo/pull/1#discussion_r1',
+    author: 'octocat',
+    author_url: 'https://github.com/octocat',
+    file: 'src/app.js',
+    side: 'RIGHT',
+    line_start: 10,
+    line_end: 10,
+    diff_position: 5,
+    commit_sha: 'abc1234',
+    is_outdated: false,
+    original_line_start: 10,
+    original_line_end: 10,
+    original_commit_sha: 'abc1234',
+    body: 'Looks good!',
+    external_created_at: '2026-01-01T00:00:00Z',
+    ...overrides
+  };
+}
+
+describe('ExternalCommentRepository', () => {
+  let db;
+  let repo;
+  let reviewId;
+
+  beforeEach(() => {
+    db = createTestDatabase();
+    repo = new ExternalCommentRepository(db);
+    reviewId = seedTestReview(db);
+  });
+
+  afterEach(() => {
+    if (db) {
+      closeTestDatabase(db);
+    }
+  });
+
+  // ----- upsert: insert path -----
+
+  describe('upsert insert path', () => {
+    it('inserts a new row and returns its local id with synced_at set and parent_id null', async () => {
+      const before = new Date().toISOString();
+      const id = await repo.upsert(reviewId, 'github', makeRow({
+        external_id: '101',
+        body: 'first comment'
+      }));
+      const after = new Date().toISOString();
+
+      expect(typeof id).toBe('number');
+      expect(id).toBeGreaterThan(0);
+
+      const row = db.prepare('SELECT * FROM external_comments WHERE id = ?').get(id);
+      expect(row).toBeTruthy();
+      expect(row.review_id).toBe(reviewId);
+      expect(row.source).toBe('github');
+      expect(row.external_id).toBe('101');
+      expect(row.body).toBe('first comment');
+      expect(row.parent_id).toBeNull();
+      expect(row.author).toBe('octocat');
+      expect(row.file).toBe('src/app.js');
+      expect(row.line_start).toBe(10);
+      expect(row.line_end).toBe(10);
+      expect(row.is_outdated).toBe(0);
+      // synced_at is an ISO timestamp within the test window
+      expect(row.synced_at).toBeTruthy();
+      expect(row.synced_at >= before).toBe(true);
+      expect(row.synced_at <= after).toBe(true);
+    });
+
+    it('coerces external_id to a string (GitHub returns numeric ids)', async () => {
+      // eslint-disable-next-line no-undef
+      const id = await repo.upsert(reviewId, 'github', makeRow({ external_id: 12345 }));
+      const row = db.prepare('SELECT external_id FROM external_comments WHERE id = ?').get(id);
+      expect(row.external_id).toBe('12345');
+    });
+
+    it('marks outdated rows correctly and tolerates null current anchors', async () => {
+      const id = await repo.upsert(reviewId, 'github', makeRow({
+        external_id: '200',
+        is_outdated: true,
+        line_start: null,
+        line_end: null,
+        diff_position: null,
+        original_line_start: 5,
+        original_line_end: 5
+      }));
+      const row = db.prepare('SELECT * FROM external_comments WHERE id = ?').get(id);
+      expect(row.is_outdated).toBe(1);
+      expect(row.line_start).toBeNull();
+      expect(row.line_end).toBeNull();
+      expect(row.original_line_start).toBe(5);
+    });
+  });
+
+  // ----- upsert: update path -----
+
+  describe('upsert update path', () => {
+    it('re-upserting the same (review_id, source, external_id) keeps the same id and updates fields', async () => {
+      const id1 = await repo.upsert(reviewId, 'github', makeRow({
+        external_id: '500',
+        body: 'original body',
+        is_outdated: false
+      }));
+
+      const id2 = await repo.upsert(reviewId, 'github', makeRow({
+        external_id: '500',
+        body: 'edited body',
+        is_outdated: true,
+        line_start: null,
+        line_end: null
+      }));
+
+      expect(id2).toBe(id1);
+
+      const row = db.prepare('SELECT * FROM external_comments WHERE id = ?').get(id1);
+      expect(row.body).toBe('edited body');
+      expect(row.is_outdated).toBe(1);
+      expect(row.line_start).toBeNull();
+
+      const total = db.prepare(
+        'SELECT COUNT(*) AS c FROM external_comments WHERE review_id = ? AND source = ?'
+      ).get(reviewId, 'github').c;
+      expect(total).toBe(1);
+    });
+
+    it('does not overwrite parent_id during update', async () => {
+      // First insert a row
+      const id = await repo.upsert(reviewId, 'github', makeRow({ external_id: '600' }));
+      // Manually set parent_id to mimic resolveParents having run
+      db.prepare('UPDATE external_comments SET parent_id = ? WHERE id = ?').run(id, id);
+
+      // Re-upsert with different fields
+      await repo.upsert(reviewId, 'github', makeRow({
+        external_id: '600',
+        body: 'updated'
+      }));
+
+      const row = db.prepare('SELECT parent_id, body FROM external_comments WHERE id = ?').get(id);
+      // parent_id should be preserved (not reset to null)
+      expect(row.parent_id).toBe(id);
+      expect(row.body).toBe('updated');
+    });
+  });
+
+  // ----- resolveParents -----
+
+  describe('resolveParents', () => {
+    it('resolves parent_id for a reply pointing to a sibling and returns count 1', async () => {
+      const rootId = await repo.upsert(reviewId, 'github', makeRow({
+        external_id: '10',
+        in_reply_to_id: null,
+        external_created_at: '2026-01-01T00:00:00Z'
+      }));
+      await repo.upsert(reviewId, 'github', makeRow({
+        external_id: '11',
+        in_reply_to_id: '10',
+        external_created_at: '2026-01-02T00:00:00Z'
+      }));
+
+      const count = await repo.resolveParents(reviewId, 'github');
+      expect(count).toBe(1);
+
+      const reply = db.prepare(
+        'SELECT parent_id FROM external_comments WHERE review_id = ? AND source = ? AND external_id = ?'
+      ).get(reviewId, 'github', '11');
+      expect(reply.parent_id).toBe(rootId);
+    });
+
+    it('is idempotent: running twice does not change anything beyond the first run', async () => {
+      const rootId = await repo.upsert(reviewId, 'github', makeRow({ external_id: '20' }));
+      await repo.upsert(reviewId, 'github', makeRow({
+        external_id: '21',
+        in_reply_to_id: '20'
+      }));
+
+      const first = await repo.resolveParents(reviewId, 'github');
+      const second = await repo.resolveParents(reviewId, 'github');
+
+      expect(first).toBe(1);
+      expect(second).toBe(1);
+
+      const reply = db.prepare(
+        'SELECT parent_id FROM external_comments WHERE review_id = ? AND source = ? AND external_id = ?'
+      ).get(reviewId, 'github', '21');
+      expect(reply.parent_id).toBe(rootId);
+    });
+
+    it('leaves parent_id NULL and returns 0 for orphan replies (no matching sibling)', async () => {
+      await repo.upsert(reviewId, 'github', makeRow({
+        external_id: '30',
+        in_reply_to_id: '999999' // no sibling has this external_id
+      }));
+
+      const count = await repo.resolveParents(reviewId, 'github');
+      expect(count).toBe(0);
+
+      const orphan = db.prepare(
+        'SELECT parent_id FROM external_comments WHERE external_id = ?'
+      ).get('30');
+      expect(orphan.parent_id).toBeNull();
+    });
+
+    it('preserves a previously-resolved parent_id when the reply\'s in_reply_to_id no longer matches a sibling', async () => {
+      // Regression: SQLite's correlated subquery returns NULL when no
+      // sibling matches the in_reply_to_id. Without the EXISTS guard, the
+      // UPDATE silently overwrites a previously-correct parent_id with
+      // NULL. Scenario: two rows exist (parent + reply with linked
+      // parent_id). The reply's in_reply_to_id then gets pointed at a
+      // non-existent sibling (e.g. upstream re-keys the parent). Without
+      // the guard the next resolveParents call would null out the linkage.
+      const parentLocalId = await repo.upsert(reviewId, 'github', makeRow({
+        external_id: 'root-keep',
+      }));
+      await repo.upsert(reviewId, 'github', makeRow({
+        external_id: 'reply-keep',
+        in_reply_to_id: 'root-keep',
+        line_end: 11,
+      }));
+
+      // First resolveParents links the reply.
+      await repo.resolveParents(reviewId, 'github');
+      const linked = db.prepare(
+        "SELECT parent_id FROM external_comments WHERE external_id = 'reply-keep'"
+      ).get();
+      expect(linked.parent_id).toBe(parentLocalId);
+
+      // Now break the linkage: change the reply's in_reply_to_id to point
+      // at an external_id that no longer matches any sibling in this
+      // batch. The parent row still exists (its local id is still valid),
+      // so parent_id stays referentially valid. The EXISTS guard prevents
+      // resolveParents from overwriting it with NULL.
+      db.prepare(
+        "UPDATE external_comments SET in_reply_to_id = 'no-such-sibling' WHERE external_id = 'reply-keep'"
+      ).run();
+
+      const count = await repo.resolveParents(reviewId, 'github');
+      // The reply still has a non-null parent_id (preserved by EXISTS guard).
+      expect(count).toBe(1);
+
+      const afterReply = db.prepare(
+        "SELECT parent_id FROM external_comments WHERE external_id = 'reply-keep'"
+      ).get();
+      expect(afterReply.parent_id).toBe(parentLocalId);
+    });
+
+    it('does not cross review_ids or sources', async () => {
+      const otherReviewId = seedTestReview(db, { prNumber: 2, repository: 'test/other' });
+
+      // Root in reviewId/github
+      await repo.upsert(reviewId, 'github', makeRow({ external_id: '40' }));
+      // Reply lives in otherReviewId/github but points to external_id 40
+      await repo.upsert(otherReviewId, 'github', makeRow({
+        external_id: '41',
+        in_reply_to_id: '40'
+      }));
+      // Reply lives in reviewId/gitlab but points to external_id 40
+      await repo.upsert(reviewId, 'gitlab', makeRow({
+        external_id: '42',
+        in_reply_to_id: '40'
+      }));
+
+      // Resolve only for reviewId+github: neither cross-review nor cross-source reply should resolve
+      const count = await repo.resolveParents(reviewId, 'github');
+      expect(count).toBe(0);
+
+      const crossReview = db.prepare(
+        'SELECT parent_id FROM external_comments WHERE review_id = ? AND external_id = ?'
+      ).get(otherReviewId, '41');
+      expect(crossReview.parent_id).toBeNull();
+
+      const crossSource = db.prepare(
+        'SELECT parent_id FROM external_comments WHERE review_id = ? AND source = ? AND external_id = ?'
+      ).get(reviewId, 'gitlab', '42');
+      expect(crossSource.parent_id).toBeNull();
+    });
+  });
+
+  // ----- listByReview -----
+
+  describe('listByReview', () => {
+    it('returns rows ordered by file, then COALESCE(line_end, original_line_end) NULLS LAST, then external_created_at', async () => {
+      // file=b.js line=5 -> should come last (b.js sorts after a.js)
+      await repo.upsert(reviewId, 'github', makeRow({
+        external_id: 'b-5',
+        file: 'b.js',
+        line_end: 5,
+        external_created_at: '2026-01-01T00:00:00Z'
+      }));
+      // file=a.js line=20
+      await repo.upsert(reviewId, 'github', makeRow({
+        external_id: 'a-20',
+        file: 'a.js',
+        line_end: 20,
+        external_created_at: '2026-01-01T00:00:00Z'
+      }));
+      // file=a.js BOTH line_end AND original_line_end null (true lost
+      // anchor) -> sinks to the bottom of its file group via NULLS LAST.
+      await repo.upsert(reviewId, 'github', makeRow({
+        external_id: 'a-null',
+        file: 'a.js',
+        line_start: null,
+        line_end: null,
+        original_line_start: null,
+        original_line_end: null,
+        is_outdated: true,
+        external_created_at: '2026-01-01T00:00:00Z'
+      }));
+      // file=a.js line=3 -> should be first
+      await repo.upsert(reviewId, 'github', makeRow({
+        external_id: 'a-3',
+        file: 'a.js',
+        line_end: 3,
+        external_created_at: '2026-01-01T00:00:00Z'
+      }));
+      // file=a.js line=3 (same line) but earlier created_at -> should beat a-3
+      await repo.upsert(reviewId, 'github', makeRow({
+        external_id: 'a-3-early',
+        file: 'a.js',
+        line_end: 3,
+        external_created_at: '2025-12-31T00:00:00Z'
+      }));
+
+      const rows = await repo.listByReview(reviewId);
+      const ids = rows.map(r => r.external_id);
+      expect(ids).toEqual(['a-3-early', 'a-3', 'a-20', 'a-null', 'b-5']);
+    });
+
+    it('sorts outdated rows by original_line_end via COALESCE, not at the bottom', async () => {
+      // Regression: ORDER BY used `line_end` directly with "NULLs last",
+      // so an outdated row with line_end=NULL but original_line_end=20
+      // sank to the bottom of its file group regardless of which line it
+      // was originally anchored to. COALESCE(line_end, original_line_end)
+      // restores a sensible position for outdated discussions.
+      await repo.upsert(reviewId, 'github', makeRow({
+        external_id: 'current-50',
+        file: 'a.js',
+        line_start: 50,
+        line_end: 50,
+        original_line_start: 50,
+        original_line_end: 50,
+      }));
+      await repo.upsert(reviewId, 'github', makeRow({
+        external_id: 'outdated-20',
+        file: 'a.js',
+        line_start: null,
+        line_end: null,
+        is_outdated: true,
+        original_line_start: 20,
+        original_line_end: 20,
+      }));
+
+      const rows = await repo.listByReview(reviewId);
+      // outdated-20 (effective anchor 20) sorts above current-50 (effective 50).
+      expect(rows.map(r => r.external_id)).toEqual(['outdated-20', 'current-50']);
+    });
+
+    it('filters by source when source option is provided', async () => {
+      await repo.upsert(reviewId, 'github', makeRow({ external_id: 'gh-1' }));
+      await repo.upsert(reviewId, 'github', makeRow({ external_id: 'gh-2', line_end: 20 }));
+      await repo.upsert(reviewId, 'gitlab', makeRow({ external_id: 'gl-1' }));
+
+      const all = await repo.listByReview(reviewId);
+      expect(all).toHaveLength(3);
+
+      const githubOnly = await repo.listByReview(reviewId, { source: 'github' });
+      expect(githubOnly).toHaveLength(2);
+      expect(githubOnly.every(r => r.source === 'github')).toBe(true);
+
+      const gitlabOnly = await repo.listByReview(reviewId, { source: 'gitlab' });
+      expect(gitlabOnly).toHaveLength(1);
+      expect(gitlabOnly[0].external_id).toBe('gl-1');
+    });
+  });
+
+  // ----- listThreadsByReview -----
+
+  describe('listThreadsByReview', () => {
+    it('groups root + two replies into one thread, replies ordered by external_created_at', async () => {
+      await repo.upsert(reviewId, 'github', makeRow({
+        external_id: 'root',
+        in_reply_to_id: null,
+        external_created_at: '2026-01-01T00:00:00Z'
+      }));
+      await repo.upsert(reviewId, 'github', makeRow({
+        external_id: 'reply-b',
+        in_reply_to_id: 'root',
+        external_created_at: '2026-01-03T00:00:00Z'
+      }));
+      await repo.upsert(reviewId, 'github', makeRow({
+        external_id: 'reply-a',
+        in_reply_to_id: 'root',
+        external_created_at: '2026-01-02T00:00:00Z'
+      }));
+      await repo.resolveParents(reviewId, 'github');
+
+      const threads = await repo.listThreadsByReview(reviewId);
+      expect(threads).toHaveLength(1);
+      expect(threads[0].external_id).toBe('root');
+      expect(threads[0].replies).toHaveLength(2);
+      // Ordered by external_created_at ascending
+      expect(threads[0].replies[0].external_id).toBe('reply-a');
+      expect(threads[0].replies[1].external_id).toBe('reply-b');
+    });
+
+    it('returns standalone roots with replies: []', async () => {
+      await repo.upsert(reviewId, 'github', makeRow({ external_id: 'solo' }));
+      await repo.resolveParents(reviewId, 'github');
+
+      const threads = await repo.listThreadsByReview(reviewId);
+      expect(threads).toHaveLength(1);
+      expect(threads[0].external_id).toBe('solo');
+      expect(threads[0].replies).toEqual([]);
+    });
+
+    it('promotes orphan replies (parent_id pointing to a row not in result set) to standalone roots', async () => {
+      // Simulate via the source filter: parent lives under source=gitlab but
+      // the reply somehow points to it. resolveParents would not cross-source
+      // resolve, but for the defensive-promotion test we directly set
+      // parent_id to a row that won't appear in the filtered result set.
+      const otherSourceId = await repo.upsert(reviewId, 'gitlab', makeRow({
+        external_id: 'gl-root'
+      }));
+      await repo.upsert(reviewId, 'github', makeRow({
+        external_id: 'gh-reply',
+        in_reply_to_id: 'gl-root'
+      }));
+      // Directly set parent_id to the gitlab row's local id. FK is satisfied
+      // (the row exists), but it will not appear when we filter the listing
+      // by source='github'.
+      db.prepare(
+        'UPDATE external_comments SET parent_id = ? WHERE external_id = ? AND source = ?'
+      ).run(otherSourceId, 'gh-reply', 'github');
+
+      // Filter by source=github so the parent is excluded → the reply should
+      // be promoted to a standalone root.
+      const threads = await repo.listThreadsByReview(reviewId, { source: 'github' });
+      expect(threads).toHaveLength(1);
+      expect(threads[0].external_id).toBe('gh-reply');
+      expect(threads[0].replies).toEqual([]);
+    });
+  });
+
+  // ----- countByReview -----
+
+  describe('countByReview', () => {
+    it('returns the total row count for review+source', async () => {
+      await repo.upsert(reviewId, 'github', makeRow({ external_id: 'c1' }));
+      await repo.upsert(reviewId, 'github', makeRow({ external_id: 'c2', line_end: 20 }));
+      await repo.upsert(reviewId, 'gitlab', makeRow({ external_id: 'g1' }));
+
+      expect(await repo.countByReview(reviewId, 'github')).toBe(2);
+      expect(await repo.countByReview(reviewId, 'gitlab')).toBe(1);
+      // No source filter → total across sources
+      expect(await repo.countByReview(reviewId)).toBe(3);
+    });
+
+    it('returns 0 when no rows exist', async () => {
+      expect(await repo.countByReview(reviewId, 'github')).toBe(0);
+    });
+  });
+
+  // ----- Cascade delete -----
+
+  describe('cascade on review delete', () => {
+    it('removes external_comments rows when the parent review is deleted (FK ON DELETE CASCADE)', async () => {
+      await repo.upsert(reviewId, 'github', makeRow({ external_id: 'd1' }));
+      await repo.upsert(reviewId, 'github', makeRow({ external_id: 'd2', line_end: 22 }));
+
+      const before = await repo.countByReview(reviewId, 'github');
+      expect(before).toBe(2);
+
+      db.prepare('DELETE FROM reviews WHERE id = ?').run(reviewId);
+
+      const after = await repo.countByReview(reviewId, 'github');
+      expect(after).toBe(0);
+
+      const rawCount = db.prepare(
+        'SELECT COUNT(*) AS c FROM external_comments WHERE review_id = ?'
+      ).get(reviewId).c;
+      expect(rawCount).toBe(0);
+    });
+  });
+
+  // ----- Parent SET NULL on prune -----
+
+  describe('deleteMissing preserves replies via ON DELETE SET NULL', () => {
+    it('prunes a parent while keeping its reply, nulling parent_id; orphan-promotion surfaces the reply in listThreadsByReview', async () => {
+      // Regression: parent_id used to CASCADE on delete, so when sync pruned a
+      // parent comment that disappeared from the upstream snapshot it
+      // silently destroyed every reply too — even replies that were still in
+      // the snapshot. SET NULL preserves the reply; listThreadsByReview then
+      // promotes it via orphan handling.
+      const parentLocalId = await repo.upsert(reviewId, 'github', makeRow({
+        external_id: 'parent-1',
+        body: 'parent comment'
+      }));
+      await repo.upsert(reviewId, 'github', makeRow({
+        external_id: 'reply-1',
+        in_reply_to_id: 'parent-1',
+        body: 'reply still here',
+        line_end: 11
+      }));
+      await repo.resolveParents(reviewId, 'github');
+
+      // Sanity: reply.parent_id resolves to parent's local id before prune.
+      const beforeReply = db.prepare(
+        "SELECT * FROM external_comments WHERE external_id = 'reply-1'"
+      ).get();
+      expect(beforeReply.parent_id).toBe(parentLocalId);
+
+      // Snapshot now contains only the reply — the parent is gone upstream.
+      const deleted = await repo.deleteMissing(reviewId, 'github', ['reply-1']);
+      expect(deleted).toBe(1);
+
+      // Reply survives, parent_id nulled by SET NULL.
+      const afterReply = db.prepare(
+        "SELECT * FROM external_comments WHERE external_id = 'reply-1'"
+      ).get();
+      expect(afterReply).toBeTruthy();
+      expect(afterReply.parent_id).toBeNull();
+      expect(afterReply.body).toBe('reply still here');
+
+      // Orphan-promotion: listThreadsByReview surfaces the reply as a thread root.
+      const threads = await repo.listThreadsByReview(reviewId, { source: 'github' });
+      expect(threads).toHaveLength(1);
+      expect(threads[0].external_id).toBe('reply-1');
+      expect(threads[0].replies).toEqual([]);
+    });
+  });
+});

--- a/tests/integration/external-comments-fetch.test.js
+++ b/tests/integration/external-comments-fetch.test.js
@@ -1,0 +1,256 @@
+// Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import { createTestDatabase, closeTestDatabase, seedTestReview } from '../utils/schema.js';
+
+// Mock logger so test output stays clean and we can assert on error paths.
+vi.mock('../../src/utils/logger', () => ({
+  default: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    success: vi.fn(),
+    section: vi.fn()
+  },
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+  success: vi.fn(),
+  section: vi.fn()
+}));
+
+const externalCommentsRoutes = require('../../src/routes/external-comments');
+const { ExternalCommentRepository } = require('../../src/database');
+
+/**
+ * Build a mappedRow object with sensible defaults for tests.
+ * Mirrors the helper in external-comment-repository.test.js so seeding
+ * stays familiar.
+ */
+function makeRow(overrides = {}) {
+  return {
+    external_id: '1',
+    in_reply_to_id: null,
+    external_url: 'https://github.com/owner/repo/pull/1#discussion_r1',
+    author: 'octocat',
+    author_url: 'https://github.com/octocat',
+    file: 'src/app.js',
+    side: 'RIGHT',
+    line_start: 10,
+    line_end: 10,
+    diff_position: 5,
+    commit_sha: 'abc1234',
+    is_outdated: false,
+    original_line_start: 10,
+    original_line_end: 10,
+    original_commit_sha: 'abc1234',
+    body: 'Looks good!',
+    external_created_at: '2026-01-01T00:00:00Z',
+    ...overrides
+  };
+}
+
+/**
+ * Build an Express app wired with the external-comments router and the
+ * given test database.
+ */
+function buildApp(db) {
+  const app = express();
+  app.use(express.json());
+  app.set('db', db);
+  app.use(externalCommentsRoutes);
+  return app;
+}
+
+describe('GET /api/reviews/:reviewId/external-comments', () => {
+  let db;
+  let app;
+  let repo;
+  let reviewId;
+
+  beforeEach(() => {
+    db = createTestDatabase();
+    repo = new ExternalCommentRepository(db);
+    reviewId = seedTestReview(db);
+    app = buildApp(db);
+  });
+
+  afterEach(() => {
+    closeTestDatabase(db);
+  });
+
+  it('returns empty threads array for a review with no external comments', async () => {
+    const res = await request(app).get(`/api/reviews/${reviewId}/external-comments`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ threads: [] });
+  });
+
+  it('returns one thread with empty replies for a single root comment', async () => {
+    await repo.upsert(reviewId, 'github', makeRow({
+      external_id: 'root-1',
+      body: 'standalone comment'
+    }));
+    await repo.resolveParents(reviewId, 'github');
+
+    const res = await request(app).get(`/api/reviews/${reviewId}/external-comments`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.threads).toHaveLength(1);
+    expect(res.body.threads[0].external_id).toBe('root-1');
+    expect(res.body.threads[0].body).toBe('standalone comment');
+    expect(res.body.threads[0].source).toBe('github');
+    expect(res.body.threads[0].replies).toEqual([]);
+  });
+
+  it('returns a thread with two replies ordered by external_created_at', async () => {
+    await repo.upsert(reviewId, 'github', makeRow({
+      external_id: 'root',
+      external_created_at: '2026-01-01T00:00:00Z'
+    }));
+    // Insert reply-b first so we can verify ordering comes from created_at, not insert order.
+    await repo.upsert(reviewId, 'github', makeRow({
+      external_id: 'reply-b',
+      in_reply_to_id: 'root',
+      external_created_at: '2026-01-03T00:00:00Z',
+      body: 'second reply'
+    }));
+    await repo.upsert(reviewId, 'github', makeRow({
+      external_id: 'reply-a',
+      in_reply_to_id: 'root',
+      external_created_at: '2026-01-02T00:00:00Z',
+      body: 'first reply'
+    }));
+    await repo.resolveParents(reviewId, 'github');
+
+    const res = await request(app).get(`/api/reviews/${reviewId}/external-comments`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.threads).toHaveLength(1);
+    const thread = res.body.threads[0];
+    expect(thread.external_id).toBe('root');
+    expect(thread.replies).toHaveLength(2);
+    expect(thread.replies[0].external_id).toBe('reply-a');
+    expect(thread.replies[1].external_id).toBe('reply-b');
+  });
+
+  it('returns threads from multiple files in file/line order', async () => {
+    await repo.upsert(reviewId, 'github', makeRow({
+      external_id: 'b-5', file: 'b.js', line_end: 5,
+      external_created_at: '2026-01-01T00:00:00Z'
+    }));
+    await repo.upsert(reviewId, 'github', makeRow({
+      external_id: 'a-20', file: 'a.js', line_end: 20,
+      external_created_at: '2026-01-01T00:00:00Z'
+    }));
+    await repo.upsert(reviewId, 'github', makeRow({
+      external_id: 'a-3', file: 'a.js', line_end: 3,
+      external_created_at: '2026-01-01T00:00:00Z'
+    }));
+    await repo.resolveParents(reviewId, 'github');
+
+    const res = await request(app).get(`/api/reviews/${reviewId}/external-comments`);
+
+    expect(res.status).toBe(200);
+    const ids = res.body.threads.map(t => t.external_id);
+    expect(ids).toEqual(['a-3', 'a-20', 'b-5']);
+  });
+
+  it('filters threads by source when ?source=github is provided', async () => {
+    await repo.upsert(reviewId, 'github', makeRow({ external_id: 'gh-1' }));
+    await repo.upsert(reviewId, 'github', makeRow({ external_id: 'gh-2', line_end: 20 }));
+    await repo.resolveParents(reviewId, 'github');
+
+    // Side-load a gitlab row directly into the table (no adapter registered
+    // for gitlab, so repo upsert is fine — adapter validation only runs in
+    // the route layer when the *query parameter* is set).
+    await repo.upsert(reviewId, 'gitlab', makeRow({ external_id: 'gl-1' }));
+
+    // No filter: all rows present
+    const allRes = await request(app).get(`/api/reviews/${reviewId}/external-comments`);
+    expect(allRes.status).toBe(200);
+    expect(allRes.body.threads).toHaveLength(3);
+
+    // Filtered to github
+    const filteredRes = await request(app)
+      .get(`/api/reviews/${reviewId}/external-comments`)
+      .query({ source: 'github' });
+    expect(filteredRes.status).toBe(200);
+    expect(filteredRes.body.threads).toHaveLength(2);
+    expect(filteredRes.body.threads.every(t => t.source === 'github')).toBe(true);
+  });
+
+  it('returns 400 with the source name when an unknown source is requested', async () => {
+    const res = await request(app)
+      .get(`/api/reviews/${reviewId}/external-comments`)
+      .query({ source: 'mystery-tracker' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Unknown external comment source: mystery-tracker');
+  });
+
+  it('returns is_outdated and original_* fields for outdated comments', async () => {
+    await repo.upsert(reviewId, 'github', makeRow({
+      external_id: 'outdated-1',
+      is_outdated: true,
+      line_start: null,
+      line_end: null,
+      diff_position: null,
+      original_line_start: 42,
+      original_line_end: 44,
+      original_commit_sha: 'oldsha'
+    }));
+    await repo.resolveParents(reviewId, 'github');
+
+    const res = await request(app).get(`/api/reviews/${reviewId}/external-comments`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.threads).toHaveLength(1);
+    const thread = res.body.threads[0];
+    expect(thread.is_outdated).toBe(1);
+    expect(thread.line_start).toBeNull();
+    expect(thread.line_end).toBeNull();
+    expect(thread.original_line_start).toBe(42);
+    expect(thread.original_line_end).toBe(44);
+    expect(thread.original_commit_sha).toBe('oldsha');
+  });
+
+  it('returns 404 when the review does not exist', async () => {
+    const res = await request(app).get('/api/reviews/999999/external-comments');
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe('Review not found');
+  });
+
+  it('returns 400 for an invalid (non-numeric) review id', async () => {
+    const res = await request(app).get('/api/reviews/not-a-number/external-comments');
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Invalid review ID');
+  });
+
+  it('returns 400 for a zero or negative review id', async () => {
+    const res = await request(app).get('/api/reviews/0/external-comments');
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Invalid review ID');
+  });
+
+  it('returns empty threads for a local-mode review even if rows were force-inserted', async () => {
+    // Promote the seeded review to local mode.
+    db.prepare(
+      "UPDATE reviews SET review_type = 'local', local_path = '/tmp/repo', pr_number = NULL WHERE id = ?"
+    ).run(reviewId);
+
+    // Force a row in. The route should NOT surface it for a local review.
+    await repo.upsert(reviewId, 'github', makeRow({ external_id: 'should-not-show' }));
+
+    const res = await request(app).get(`/api/reviews/${reviewId}/external-comments`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ threads: [] });
+  });
+});

--- a/tests/integration/external-comments-sync.test.js
+++ b/tests/integration/external-comments-sync.test.js
@@ -1,0 +1,703 @@
+// Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import { createTestDatabase, closeTestDatabase, seedTestReview } from '../utils/schema';
+
+const externalCommentsRoutes = require('../../src/routes/external-comments');
+const { GitHubApiError } = require('../../src/github/client');
+
+/**
+ * Helpers
+ */
+
+/**
+ * Build a fake GitHub review-comment API row, mirroring the keys that
+ * `src/external/github-adapter.js` consumes.
+ */
+function makeApiRow({
+  id,
+  in_reply_to_id = null,
+  body = 'a comment',
+  path = 'src/app.js',
+  line = 10,
+  start_line = null,
+  side = 'RIGHT',
+  position = 5,
+  original_position = 5,
+  original_line = 10,
+  original_start_line = null,
+  commit_id = 'abc1234',
+  original_commit_id = 'abc1234',
+  user = { login: 'octocat', html_url: 'https://github.com/octocat' },
+  html_url = null,
+  created_at = '2026-01-01T00:00:00Z'
+}) {
+  return {
+    id,
+    in_reply_to_id,
+    body,
+    path,
+    line,
+    start_line,
+    side,
+    position,
+    original_position,
+    original_line,
+    original_start_line,
+    commit_id,
+    original_commit_id,
+    user,
+    html_url: html_url || `https://github.com/owner/repo/pull/1#discussion_r${id}`,
+    created_at
+  };
+}
+
+/**
+ * Build a fake GitHubClient class whose `listReviewComments` returns the
+ * supplied API rows. `_calls` records each invocation for assertions.
+ */
+function makeFakeClient(rows) {
+  const calls = [];
+  class FakeGitHubClient {
+    constructor(token) {
+      this.token = token;
+    }
+    async listReviewComments(params) {
+      calls.push(params);
+      return rows;
+    }
+  }
+  return { FakeGitHubClient, calls };
+}
+
+/**
+ * Build a fake GitHubClient class whose `listReviewComments` throws the
+ * supplied error. Used for error-path tests.
+ */
+function makeThrowingClient(error) {
+  const calls = [];
+  class FakeGitHubClient {
+    constructor(token) {
+      this.token = token;
+    }
+    async listReviewComments(params) {
+      calls.push(params);
+      throw error;
+    }
+  }
+  return { FakeGitHubClient, calls };
+}
+
+/**
+ * Build a fake GitHubClient class whose `listReviewComments` returns a
+ * promise that resolves only when the test calls `resolve()`. Lets us
+ * test the in-flight concurrent-sync guard.
+ */
+function makeBlockingClient(rows) {
+  const calls = [];
+  let resolveFn;
+  const gate = new Promise((resolve) => { resolveFn = resolve; });
+  class FakeGitHubClient {
+    constructor(token) {
+      this.token = token;
+    }
+    async listReviewComments(params) {
+      calls.push(params);
+      await gate;
+      return rows;
+    }
+  }
+  return { FakeGitHubClient, calls, release: () => resolveFn() };
+}
+
+/**
+ * Build a minimal Express app that mounts ONLY the external-comments router
+ * and lets tests inject `_deps` via `app.set('externalCommentsDeps', ...)`.
+ */
+function createTestApp(db, deps = {}) {
+  const app = express();
+  app.use(express.json());
+  app.set('db', db);
+  app.set('config', { github_token: 'test-token' });
+  app.set('externalCommentsDeps', {
+    getGitHubToken: () => 'test-token',
+    ...deps
+  });
+  app.use('/', externalCommentsRoutes);
+  return app;
+}
+
+/**
+ * Tests
+ */
+
+describe('POST /api/reviews/:reviewId/external-comments/sync', () => {
+  let db;
+  let reviewId;
+
+  beforeEach(() => {
+    db = createTestDatabase();
+    reviewId = seedTestReview(db, { prNumber: 42, repository: 'owner/repo' });
+    // Clear in-flight registry between tests so isolated cases don't leak.
+    externalCommentsRoutes._inFlight.clear();
+  });
+
+  afterEach(() => {
+    externalCommentsRoutes._inFlight.clear();
+    if (db) {
+      closeTestDatabase(db);
+    }
+  });
+
+  // --- Happy paths ---
+
+  it('fresh sync: upserts two comments + one reply with resolved parent_id', async () => {
+    const rows = [
+      makeApiRow({ id: 101, body: 'first' }),
+      makeApiRow({ id: 102, body: 'second' }),
+      makeApiRow({ id: 103, body: 'reply to first', in_reply_to_id: 101 })
+    ];
+    const { FakeGitHubClient } = makeFakeClient(rows);
+
+    const app = createTestApp(db, { GitHubClient: FakeGitHubClient });
+    const res = await request(app)
+      .post(`/api/reviews/${reviewId}/external-comments/sync`)
+      .query({ source: 'github' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.count).toBe(3);
+    expect(res.body.lostAnchors).toBe(0);
+    expect(typeof res.body.syncedAt).toBe('string');
+
+    const allRows = db.prepare('SELECT * FROM external_comments WHERE review_id = ? ORDER BY external_id').all(reviewId);
+    expect(allRows).toHaveLength(3);
+
+    const parent = allRows.find(r => r.external_id === '101');
+    const reply = allRows.find(r => r.external_id === '103');
+    expect(reply.parent_id).toBe(parent.id);
+  });
+
+  it('re-sync is idempotent: second call updates rather than duplicating', async () => {
+    const rows = [
+      makeApiRow({ id: 201, body: 'before edit' })
+    ];
+    const { FakeGitHubClient } = makeFakeClient(rows);
+
+    const app = createTestApp(db, { GitHubClient: FakeGitHubClient });
+
+    const first = await request(app)
+      .post(`/api/reviews/${reviewId}/external-comments/sync`)
+      .query({ source: 'github' });
+    expect(first.status).toBe(200);
+    expect(first.body.count).toBe(1);
+
+    // Mutate the row body before the second call to verify update happens.
+    rows[0].body = 'after edit';
+
+    const second = await request(app)
+      .post(`/api/reviews/${reviewId}/external-comments/sync`)
+      .query({ source: 'github' });
+    expect(second.status).toBe(200);
+    expect(second.body.count).toBe(1);
+
+    const stored = db.prepare('SELECT * FROM external_comments WHERE review_id = ?').all(reviewId);
+    expect(stored).toHaveLength(1);
+    expect(stored[0].body).toBe('after edit');
+  });
+
+  it('outdated comment: position=null but original_position set → upserted with is_outdated=1', async () => {
+    const rows = [
+      makeApiRow({
+        id: 301,
+        body: 'outdated comment',
+        position: null,
+        line: null,
+        original_line: 7,
+        original_position: 9
+      })
+    ];
+    const { FakeGitHubClient } = makeFakeClient(rows);
+
+    const app = createTestApp(db, { GitHubClient: FakeGitHubClient });
+    const res = await request(app)
+      .post(`/api/reviews/${reviewId}/external-comments/sync`)
+      .query({ source: 'github' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.count).toBe(1);
+    expect(res.body.lostAnchors).toBe(0);
+
+    const row = db.prepare('SELECT * FROM external_comments WHERE external_id = ?').get('301');
+    expect(row.is_outdated).toBe(1);
+    expect(row.line_end).toBeNull();
+    expect(row.diff_position).toBeNull();
+    expect(row.original_line_end).toBe(7);
+  });
+
+  it('lost anchor: both current and original null → NOT inserted; lostAnchors=1', async () => {
+    const rows = [
+      makeApiRow({ id: 401, body: 'good' }),
+      makeApiRow({
+        id: 402,
+        body: 'lost',
+        position: null,
+        line: null,
+        original_line: null,
+        original_position: null,
+        original_start_line: null
+      })
+    ];
+    const { FakeGitHubClient } = makeFakeClient(rows);
+
+    const app = createTestApp(db, { GitHubClient: FakeGitHubClient });
+    const res = await request(app)
+      .post(`/api/reviews/${reviewId}/external-comments/sync`)
+      .query({ source: 'github' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.count).toBe(1);
+    expect(res.body.lostAnchors).toBe(1);
+
+    const stored = db.prepare('SELECT external_id FROM external_comments WHERE review_id = ?').all(reviewId);
+    expect(stored.map(r => r.external_id)).toEqual(['401']);
+  });
+
+  it('threaded reply: parent later in API response — parent resolution still works', async () => {
+    // Reply appears first in the API response; parent comes second.
+    const rows = [
+      makeApiRow({ id: 503, body: 'reply', in_reply_to_id: 501 }),
+      makeApiRow({ id: 501, body: 'root' })
+    ];
+    const { FakeGitHubClient } = makeFakeClient(rows);
+
+    const app = createTestApp(db, { GitHubClient: FakeGitHubClient });
+    const res = await request(app)
+      .post(`/api/reviews/${reviewId}/external-comments/sync`)
+      .query({ source: 'github' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.count).toBe(2);
+
+    const stored = db.prepare('SELECT * FROM external_comments WHERE review_id = ? ORDER BY external_id').all(reviewId);
+    const parent = stored.find(r => r.external_id === '501');
+    const reply = stored.find(r => r.external_id === '503');
+    expect(reply.parent_id).toBe(parent.id);
+  });
+
+  it('concurrent sync: two parallel calls share one GitHub round-trip', async () => {
+    const rows = [makeApiRow({ id: 601, body: 'shared' })];
+    const { FakeGitHubClient, calls, release } = makeBlockingClient(rows);
+
+    const app = createTestApp(db, { GitHubClient: FakeGitHubClient });
+
+    // Start the first request and wait for it to enter the GitHub client
+    // call (blocking gate). This guarantees the in-flight entry is set
+    // before the second request arrives — otherwise the second request
+    // could be scheduled before the first reaches the inFlight map.
+    const p1 = request(app)
+      .post(`/api/reviews/${reviewId}/external-comments/sync`)
+      .query({ source: 'github' })
+      .then(r => r);
+
+    // Spin until the fake client receives its first call. This proves the
+    // first request is inside `executeSync` and has already populated the
+    // inFlight map for the (reviewId, source) key.
+    const deadline = Date.now() + 2000;
+    while (calls.length === 0 && Date.now() < deadline) {
+      await new Promise(resolve => setImmediate(resolve));
+    }
+    expect(calls.length).toBe(1);
+    // Sanity check: in-flight Map MUST have an entry for this (reviewId, source).
+    expect(externalCommentsRoutes._inFlight.size).toBe(1);
+
+    // Now launch the second request — it should fold into the existing
+    // in-flight promise instead of making a second GitHub call.
+    const p2 = request(app)
+      .post(`/api/reviews/${reviewId}/external-comments/sync`)
+      .query({ source: 'github' })
+      .then(r => r);
+
+    // Give p2 a chance to hit the route handler and consult the registry.
+    // Multiple microtask ticks because supertest layers add their own.
+    for (let i = 0; i < 10; i++) {
+      await new Promise(resolve => setImmediate(resolve));
+    }
+    // While p1 is still blocked on the gate, the in-flight map MUST still
+    // hold a single entry — both requests must observe the same promise.
+    expect(externalCommentsRoutes._inFlight.size).toBe(1);
+
+    // Release the blocking fetch, then await both responses.
+    release();
+    const [r1, r2] = await Promise.all([p1, p2]);
+
+    expect(r1.status).toBe(200);
+    expect(r2.status).toBe(200);
+    expect(r1.body.count).toBe(1);
+    expect(r2.body.count).toBe(1);
+    // Same syncedAt — proves both responses came from the same promise.
+    expect(r1.body.syncedAt).toBe(r2.body.syncedAt);
+
+    // CRITICAL: GitHub client should only have been hit ONCE despite two
+    // concurrent requests. This is the whole point of the in-flight guard.
+    expect(calls).toHaveLength(1);
+  });
+
+  // --- Error paths ---
+
+  it('malformed review.repository: returns 400 via BadRequestError, not 500', async () => {
+    // Regression: a review row with a malformed `repository` value (no '/')
+    // used to throw a plain Error → catch-all 500. Now it throws
+    // BadRequestError → 400 so the route surfaces a client-correctable
+    // problem with the right status.
+    const malformedReviewId = Number(db.prepare(
+      `INSERT INTO reviews (pr_number, repository, status, review_type)
+       VALUES (99, 'no-slash-here', 'draft', 'pr')`
+    ).run().lastInsertRowid);
+
+    const { FakeGitHubClient } = makeFakeClient([]);
+    const app = createTestApp(db, { GitHubClient: FakeGitHubClient });
+
+    const res = await request(app)
+      .post(`/api/reviews/${malformedReviewId}/external-comments/sync`)
+      .query({ source: 'github' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/Invalid review\.repository/);
+    expect(res.body.error).toMatch(/owner\/repo/);
+  });
+
+  it('local-mode review: returns 400 with a clear message', async () => {
+    const localReviewId = Number(db.prepare(
+      `INSERT INTO reviews (repository, status, review_type, local_path)
+       VALUES ('owner/repo', 'draft', 'local', '/tmp/local')`
+    ).run().lastInsertRowid);
+
+    const { FakeGitHubClient } = makeFakeClient([]);
+    const app = createTestApp(db, { GitHubClient: FakeGitHubClient });
+
+    const res = await request(app)
+      .post(`/api/reviews/${localReviewId}/external-comments/sync`)
+      .query({ source: 'github' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/PR mode/i);
+  });
+
+  it('unknown source: returns 400 echoing the source name', async () => {
+    const { FakeGitHubClient } = makeFakeClient([]);
+    const app = createTestApp(db, { GitHubClient: FakeGitHubClient });
+
+    const res = await request(app)
+      .post(`/api/reviews/${reviewId}/external-comments/sync`)
+      .query({ source: 'gitlab' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/Unknown external comment source: gitlab/);
+  });
+
+  it('unknown review: returns 404', async () => {
+    const { FakeGitHubClient } = makeFakeClient([]);
+    const app = createTestApp(db, { GitHubClient: FakeGitHubClient });
+
+    const res = await request(app)
+      .post('/api/reviews/999999/external-comments/sync')
+      .query({ source: 'github' });
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toMatch(/Review not found/);
+  });
+
+  it('GitHub 404 (PR not found): propagates 404 status', async () => {
+    const err = new GitHubApiError('Pull request #42 not found in repository owner/repo', 404);
+    const { FakeGitHubClient } = makeThrowingClient(err);
+
+    const app = createTestApp(db, { GitHubClient: FakeGitHubClient });
+    const res = await request(app)
+      .post(`/api/reviews/${reviewId}/external-comments/sync`)
+      .query({ source: 'github' });
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toMatch(/not found/i);
+  });
+
+  it('GitHub 429 (rate limit): propagates 429 status with rate-limit message', async () => {
+    const err = new GitHubApiError('GitHub API rate limit exceeded. Retrying in 60 seconds...', 429);
+    const { FakeGitHubClient } = makeThrowingClient(err);
+
+    const app = createTestApp(db, { GitHubClient: FakeGitHubClient });
+    const res = await request(app)
+      .post(`/api/reviews/${reviewId}/external-comments/sync`)
+      .query({ source: 'github' });
+
+    expect(res.status).toBe(429);
+    expect(res.body.error).toMatch(/rate limit/i);
+    // Regression: the body must carry the retry-after info from the
+    // underlying GitHubApiError.message — we deleted a dead `retryAfter`
+    // branch that was overwriting this with a generic suffix.
+    expect(res.body.error).toMatch(/60 seconds/);
+  });
+
+  // --- Credential resolution (ITEM 5/6) ---
+
+  it('missing token: returns 401 via the REAL adapter (no inline override)', async () => {
+    // The previous version of this test duplicated adapter behavior inline,
+    // violating CLAUDE.md. Now we flow through the real github adapter via
+    // the dispatcher and only override `getGitHubToken` (config lookup —
+    // not adapter contract). resolveCredentials throws the typed 401
+    // before any GitHub client is constructed; the integration test pins
+    // the route's HTTP mapping. Adapter contract coverage lives in the
+    // unit test (tests/unit/external/github-adapter.test.js).
+    const FakeGitHubClient = vi.fn();
+
+    const app = createTestApp(db, {
+      // No `getAdapter` override — real github adapter handles this end-to-end.
+      GitHubClient: FakeGitHubClient,
+      getGitHubToken: () => '',
+    });
+
+    const res = await request(app)
+      .post(`/api/reviews/${reviewId}/external-comments/sync`)
+      .query({ source: 'github' });
+
+    expect(res.status).toBe(401);
+    expect(res.body.error).toMatch(/token not configured/i);
+    // GitHubClient must not be constructed when credentials are missing.
+    expect(FakeGitHubClient).not.toHaveBeenCalled();
+  });
+
+  it('GitHub 401 from fetch: propagates 401 with auth-failure message', async () => {
+    const err = new GitHubApiError('GitHub authentication failed. Check your token.', 401);
+    const { FakeGitHubClient } = makeThrowingClient(err);
+
+    const app = createTestApp(db, { GitHubClient: FakeGitHubClient });
+    const res = await request(app)
+      .post(`/api/reviews/${reviewId}/external-comments/sync`)
+      .query({ source: 'github' });
+
+    expect(res.status).toBe(401);
+    expect(res.body.error).toMatch(/authentication failed/i);
+  });
+
+  it('GitHub 403 (forbidden): propagates 403 status', async () => {
+    const err = new GitHubApiError('Insufficient permissions to read PR.', 403);
+    const { FakeGitHubClient } = makeThrowingClient(err);
+
+    const app = createTestApp(db, { GitHubClient: FakeGitHubClient });
+    const res = await request(app)
+      .post(`/api/reviews/${reviewId}/external-comments/sync`)
+      .query({ source: 'github' });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toMatch(/permissions/i);
+  });
+
+  it('GitHub 503 (network): propagates 503 status', async () => {
+    const err = new GitHubApiError('Network error: ENOTFOUND', 503);
+    const { FakeGitHubClient } = makeThrowingClient(err);
+
+    const app = createTestApp(db, { GitHubClient: FakeGitHubClient });
+    const res = await request(app)
+      .post(`/api/reviews/${reviewId}/external-comments/sync`)
+      .query({ source: 'github' });
+
+    expect(res.status).toBe(503);
+    expect(res.body.error).toMatch(/network/i);
+  });
+
+  it('plain Error from fetchComments: returns 500 via catch-all', async () => {
+    const err = new Error('Unexpected client failure');
+    const { FakeGitHubClient } = makeThrowingClient(err);
+
+    const app = createTestApp(db, { GitHubClient: FakeGitHubClient });
+    const res = await request(app)
+      .post(`/api/reviews/${reviewId}/external-comments/sync`)
+      .query({ source: 'github' });
+
+    expect(res.status).toBe(500);
+    expect(res.body.error).toMatch(/Unexpected client failure|Failed to sync/i);
+  });
+
+  // --- Prune logic (ITEM 3) ---
+
+  it('prune on re-sync: a row deleted upstream is removed locally', async () => {
+    // First sync: two rows in the snapshot.
+    const initialRows = [
+      makeApiRow({ id: 700, body: 'first' }),
+      makeApiRow({ id: 701, body: 'second' }),
+    ];
+    let currentRows = initialRows;
+
+    class FakeGitHubClient {
+      constructor(token) { this.token = token; }
+      async listReviewComments() { return currentRows; }
+    }
+
+    const app = createTestApp(db, { GitHubClient: FakeGitHubClient });
+
+    const first = await request(app)
+      .post(`/api/reviews/${reviewId}/external-comments/sync`)
+      .query({ source: 'github' });
+    expect(first.status).toBe(200);
+    expect(first.body.count).toBe(2);
+    expect(db.prepare('SELECT COUNT(*) AS c FROM external_comments WHERE review_id = ?').get(reviewId).c).toBe(2);
+
+    // Upstream deletes id=701. Second sync should prune it from local mirror.
+    currentRows = [makeApiRow({ id: 700, body: 'first' })];
+    externalCommentsRoutes._inFlight.clear();
+
+    const second = await request(app)
+      .post(`/api/reviews/${reviewId}/external-comments/sync`)
+      .query({ source: 'github' });
+    expect(second.status).toBe(200);
+    expect(second.body.count).toBe(1);
+    expect(second.body.deleted).toBe(1);
+
+    const stored = db.prepare(
+      'SELECT external_id FROM external_comments WHERE review_id = ?'
+    ).all(reviewId);
+    expect(stored.map(r => r.external_id)).toEqual(['700']);
+  });
+
+  it('prune on re-sync: a row that lost its anchor is removed locally', async () => {
+    // First sync: row 800 is anchored normally.
+    let currentRows = [makeApiRow({ id: 800, body: 'anchored' })];
+
+    class FakeGitHubClient {
+      constructor(token) { this.token = token; }
+      async listReviewComments() { return currentRows; }
+    }
+    const app = createTestApp(db, { GitHubClient: FakeGitHubClient });
+
+    const first = await request(app)
+      .post(`/api/reviews/${reviewId}/external-comments/sync`)
+      .query({ source: 'github' });
+    expect(first.status).toBe(200);
+    expect(first.body.count).toBe(1);
+
+    // Now row 800 loses BOTH its current and original anchors. The mapper
+    // accepts it, but the route filters it as a lost anchor. After ITEM 4,
+    // a sync whose `seenExternalIds` set is empty (every row filtered out)
+    // is treated as a no-op — we don't prune the previously-mirrored row
+    // based on a snapshot we couldn't usefully read. lostAnchors is still
+    // reported so the UI can surface the gap.
+    currentRows = [
+      makeApiRow({
+        id: 800,
+        body: 'anchored',
+        position: null,
+        line: null,
+        original_position: null,
+        original_line: null,
+        original_start_line: null,
+      })
+    ];
+    externalCommentsRoutes._inFlight.clear();
+
+    const second = await request(app)
+      .post(`/api/reviews/${reviewId}/external-comments/sync`)
+      .query({ source: 'github' });
+    expect(second.status).toBe(200);
+    expect(second.body.count).toBe(0);
+    expect(second.body.lostAnchors).toBe(1);
+    expect(second.body.deleted).toBe(0);
+
+    // The previously-mirrored row survives — caller still sees the cached anchor.
+    expect(db.prepare(
+      'SELECT COUNT(*) AS c FROM external_comments WHERE review_id = ?'
+    ).get(reviewId).c).toBe(1);
+  });
+
+  it('empty snapshot is treated as a no-op: previously-mirrored rows are preserved', async () => {
+    // Regression: an empty response from upstream (e.g. transient GitHub
+    // outage returning []) used to wipe the entire local mirror, causing
+    // permanent data loss. The prune step now requires a non-empty seen set
+    // so an empty response is a no-op — local rows survive.
+    let currentRows = [
+      makeApiRow({ id: 900, body: 'a' }),
+      makeApiRow({ id: 901, body: 'b' }),
+    ];
+
+    class FakeGitHubClient {
+      constructor(token) { this.token = token; }
+      async listReviewComments() { return currentRows; }
+    }
+    const app = createTestApp(db, { GitHubClient: FakeGitHubClient });
+
+    await request(app)
+      .post(`/api/reviews/${reviewId}/external-comments/sync`)
+      .query({ source: 'github' });
+    expect(db.prepare(
+      'SELECT COUNT(*) AS c FROM external_comments WHERE review_id = ?'
+    ).get(reviewId).c).toBe(2);
+
+    // Upstream now returns an empty list.
+    currentRows = [];
+    externalCommentsRoutes._inFlight.clear();
+
+    const second = await request(app)
+      .post(`/api/reviews/${reviewId}/external-comments/sync`)
+      .query({ source: 'github' });
+    expect(second.status).toBe(200);
+    expect(second.body.count).toBe(0);
+    // No rows deleted — empty-snapshot prune is intentionally skipped.
+    expect(second.body.deleted).toBe(0);
+
+    // Original two rows are still present in the mirror.
+    expect(db.prepare(
+      'SELECT COUNT(*) AS c FROM external_comments WHERE review_id = ?'
+    ).get(reviewId).c).toBe(2);
+  });
+
+  it('concurrent syncs for DIFFERENT reviews both complete without transaction collision', async () => {
+    // Regression: better-sqlite3 cannot nest BEGIN…COMMIT. Two syncs for
+    // different (reviewId, source) pairs share the same connection and
+    // could call withTransaction concurrently, throwing
+    // "cannot start a transaction within a transaction". The sync route
+    // serializes write phases through a module-level promise chain so the
+    // collision can't happen.
+    const otherReviewId = seedTestReview(db, { prNumber: 84, repository: 'owner/other' });
+
+    // Latch that releases when both syncs have entered the fetch phase.
+    // Both must reach withTransaction concurrently before either resolves
+    // — otherwise the serializer never has anything to serialize.
+    let resolveAll;
+    const gate = new Promise((r) => { resolveAll = r; });
+    let entered = 0;
+    class FakeGitHubClient {
+      constructor(token) { this.token = token; }
+      async listReviewComments({ pull_number }) {
+        entered++;
+        if (entered >= 2) resolveAll();
+        await gate;
+        return [makeApiRow({ id: pull_number * 1000, body: `from ${pull_number}` })];
+      }
+    }
+    const app = createTestApp(db, { GitHubClient: FakeGitHubClient });
+
+    const p1 = request(app)
+      .post(`/api/reviews/${reviewId}/external-comments/sync`)
+      .query({ source: 'github' });
+    const p2 = request(app)
+      .post(`/api/reviews/${otherReviewId}/external-comments/sync`)
+      .query({ source: 'github' });
+
+    const [r1, r2] = await Promise.all([p1, p2]);
+
+    expect(r1.status).toBe(200);
+    expect(r2.status).toBe(200);
+    expect(r1.body.count).toBe(1);
+    expect(r2.body.count).toBe(1);
+
+    // Both reviews' rows landed in the mirror — neither write was lost to
+    // a collision-induced rollback.
+    const r1Rows = db.prepare(
+      'SELECT external_id FROM external_comments WHERE review_id = ?'
+    ).all(reviewId);
+    const r2Rows = db.prepare(
+      'SELECT external_id FROM external_comments WHERE review_id = ?'
+    ).all(otherReviewId);
+    expect(r1Rows.map(r => r.external_id)).toEqual(['42000']);
+    expect(r2Rows.map(r => r.external_id)).toEqual(['84000']);
+  });
+});

--- a/tests/integration/routes.test.js
+++ b/tests/integration/routes.test.js
@@ -148,7 +148,11 @@ function createTestApp(db) {
     github_token: 'test-token',
     port: 7247,
     theme: 'light',
-    model: 'sonnet'
+    model: 'sonnet',
+    // Match the production DEFAULT_CONFIG opt-in: external_comments is
+    // disabled unless a config file explicitly enables it. Tests that need
+    // the feature on must opt in via `app.set('config', { ..., external_comments: true })`.
+    external_comments: false,
   });
 
   // Mount routes in the same order as server.js
@@ -3263,6 +3267,43 @@ describe('Config Endpoints', () => {
         .get('/api/config');
 
       expect(response.body.chat_enter_to_send).toBe(false);
+    });
+
+    it('returns external_comments as false by default (opt-in feature)', async () => {
+      const response = await request(app).get('/api/config');
+      expect(response.status).toBe(200);
+      expect(response.body.external_comments).toBe(false);
+    });
+
+    it('returns external_comments as true when explicitly enabled', async () => {
+      app.set('config', { ...app.get('config'), external_comments: true });
+      const response = await request(app).get('/api/config');
+      expect(response.body.external_comments).toBe(true);
+    });
+  });
+
+  describe('GET /runtime-config.js', () => {
+    it('serves a JS file that sets PAIR_REVIEW_RUNTIME_CONFIG (disabled by default — opt-in feature)', async () => {
+      const response = await request(app).get('/runtime-config.js');
+      expect(response.status).toBe(200);
+      expect(response.headers['content-type']).toMatch(/javascript/);
+      expect(response.headers['cache-control']).toMatch(/no-store/);
+      expect(response.text).toContain('window.PAIR_REVIEW_RUNTIME_CONFIG');
+      expect(response.text).toContain('"external_comments_enabled":false');
+      // Disabled state MUST add the documentElement class so CSS hides the
+      // External UI before paint.
+      expect(response.text).toContain("classList.add('external-comments-disabled')");
+    });
+
+    it('emits external_comments_enabled:true when explicitly enabled', async () => {
+      app.set('config', { ...app.get('config'), external_comments: true });
+      const response = await request(app).get('/runtime-config.js');
+      expect(response.status).toBe(200);
+      expect(response.text).toContain('"external_comments_enabled":true');
+      // The class-add code remains in the script but is gated by the
+      // runtime check, so it should still appear in the body even when
+      // enabled — it just no-ops.
+      expect(response.text).toContain('if (!window.PAIR_REVIEW_RUNTIME_CONFIG.external_comments_enabled)');
     });
   });
 

--- a/tests/unit/ai-panel-external-segment.test.js
+++ b/tests/unit/ai-panel-external-segment.test.js
@@ -1,0 +1,944 @@
+// Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+/**
+ * Unit tests for the External segment in the Review (AI) panel.
+ *
+ * Covers:
+ *  - setExternalThreads() stores state and updates segment counts.
+ *  - getFilteredItems() returns external threads when segment is 'external'
+ *    and includes them in 'all'.
+ *  - _normalizeExternalThread() handles outdated → original_line_* fallback.
+ *  - renderExternalThreadItem() produces the expected DOM hooks.
+ *  - sortItemsByFileOrder() interleaves external + finding + comment items.
+ *  - restoreSegmentSelection() falls back to 'ai' when 'external' is hidden
+ *    (Local mode) even if localStorage has the value.
+ *
+ * Uses Object.create(AIPanel.prototype) to test the actual production
+ * methods without triggering the constructor's DOM dependencies. Matches
+ * the pattern established in ai-panel-collapse.test.js.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Minimal globals required for AIPanel module to load
+global.window = {};
+// renderExternalThreadItem uses window.escapeHtmlAttribute for every value
+// it interpolates into a quoted HTML attribute (title, data-*, class). The
+// production helper is published on window by public/js/utils/markdown.js;
+// stub the same shape here so AIPanel.renderExternalThreadItem can build
+// its HTML without depending on the browser bundle load order.
+global.window.escapeHtmlAttribute = (text) => {
+  if (!text) return '';
+  return String(text)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+};
+global.document = {
+  getElementById: vi.fn(() => null),
+  addEventListener: vi.fn(),
+  createElement: vi.fn(() => ({
+    className: '', innerHTML: '', title: '',
+    classList: { add: vi.fn(), remove: vi.fn(), toggle: vi.fn() },
+    setAttribute: vi.fn(),
+    addEventListener: vi.fn(),
+    querySelector: vi.fn(() => null),
+    querySelectorAll: vi.fn(() => []),
+    insertBefore: vi.fn(),
+    appendChild: vi.fn(),
+  })),
+  documentElement: { style: { setProperty: vi.fn() }, getAttribute: vi.fn(() => null) },
+  querySelector: vi.fn(() => null),
+  querySelectorAll: vi.fn(() => []),
+  dispatchEvent: vi.fn(),
+};
+global.localStorage = {
+  getItem: vi.fn(() => null),
+  setItem: vi.fn(),
+  removeItem: vi.fn(),
+};
+global.CustomEvent = class CustomEvent {};
+
+const { AIPanel } = require('../../public/js/components/AIPanel.js');
+
+// -----------------------------------------------------------------------
+// Helpers
+// -----------------------------------------------------------------------
+
+let mockLocalStorage;
+
+/**
+ * Create a minimal AIPanel instance via Object.create to skip the
+ * constructor's DOM initialization. Sets up just enough surface for
+ * setExternalThreads / getFilteredItems / renderFindings to run.
+ */
+function createTestPanel(overrides = {}) {
+  const panel = Object.create(AIPanel.prototype);
+
+  panel.isCollapsed = false;
+  panel.currentPRKey = 'owner/repo#1';
+  panel.findings = [];
+  panel.comments = [];
+  panel.externalThreads = [];
+  panel.selectedSegment = 'ai';
+  panel.selectedLevel = 'final';
+  panel.analysisState = 'unknown';
+  panel.currentIndex = -1;
+  panel.selectedItemKey = null;
+  panel.fileOrder = new Map();
+
+  // DOM stubs — methods we don't care about in these tests are no-ops.
+  panel.panel = {
+    classList: { add: vi.fn(), remove: vi.fn(), contains: vi.fn(() => false) },
+  };
+  panel.findingsList = {
+    innerHTML: '',
+    querySelectorAll: vi.fn(() => []),
+    querySelector: vi.fn(() => null),
+  };
+  panel.segmentBtns = [];
+
+  // Inert helpers we don't want to invoke
+  panel.updateFindingsHeader = vi.fn();
+  panel.highlightCurrentItem = vi.fn();
+  panel.updateNavigationCounter = vi.fn();
+  panel.saveCurrentSelection = vi.fn();
+  panel.restoreSelection = vi.fn(() => false);
+  panel.autoSelectFirst = vi.fn();
+
+  // Override escapeHtml with a deterministic implementation that does not
+  // rely on document.createElement. The global document is a mock without
+  // a real `<div>` implementation, so the production escapeHtml would
+  // return empty strings. The semantic contract we care about is "escape
+  // HTML-significant characters" — model it directly.
+  panel.escapeHtml = function (text) {
+    if (text == null) return '';
+    return String(text)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  };
+
+  Object.assign(panel, overrides);
+  return panel;
+}
+
+function makeThread(overrides = {}) {
+  return {
+    id: 100,
+    source: 'github',
+    external_id: 'gh-100',
+    author: 'reviewer-alice',
+    file: 'src/utils.js',
+    side: 'RIGHT',
+    line_start: 5,
+    line_end: 5,
+    is_outdated: 0,
+    original_line_start: 5,
+    original_line_end: 5,
+    body: 'Looks good but consider edge case X',
+    replies: [],
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  mockLocalStorage = {};
+  global.localStorage = {
+    getItem: vi.fn((key) => mockLocalStorage[key] ?? null),
+    setItem: vi.fn((key, val) => { mockLocalStorage[key] = val; }),
+    removeItem: vi.fn((key) => { delete mockLocalStorage[key]; }),
+  };
+});
+
+// -----------------------------------------------------------------------
+// setExternalThreads
+// -----------------------------------------------------------------------
+
+describe('AIPanel.setExternalThreads', () => {
+  it('stores the array on this.externalThreads', () => {
+    const panel = createTestPanel();
+    panel.updateSegmentCounts = vi.fn();
+    panel.renderFindings = vi.fn();
+
+    const threads = [makeThread(), makeThread({ id: 101 })];
+    panel.setExternalThreads(threads);
+
+    expect(panel.externalThreads).toHaveLength(2);
+    expect(panel.externalThreads[0].id).toBe(100);
+    expect(panel.externalThreads[1].id).toBe(101);
+  });
+
+  it('replaces previous state on each call (not append)', () => {
+    const panel = createTestPanel({ externalThreads: [makeThread()] });
+    panel.updateSegmentCounts = vi.fn();
+    panel.renderFindings = vi.fn();
+
+    panel.setExternalThreads([makeThread({ id: 200 })]);
+    expect(panel.externalThreads).toHaveLength(1);
+    expect(panel.externalThreads[0].id).toBe(200);
+  });
+
+  it('treats null / undefined / non-array input as empty', () => {
+    const panel = createTestPanel({ externalThreads: [makeThread()] });
+    panel.updateSegmentCounts = vi.fn();
+    panel.renderFindings = vi.fn();
+
+    panel.setExternalThreads(null);
+    expect(panel.externalThreads).toEqual([]);
+
+    panel.setExternalThreads(undefined);
+    expect(panel.externalThreads).toEqual([]);
+
+    panel.setExternalThreads('not an array');
+    expect(panel.externalThreads).toEqual([]);
+  });
+
+  it('updates segment counts and re-renders the list', () => {
+    const panel = createTestPanel();
+    const updateSpy = vi.fn();
+    const renderSpy = vi.fn();
+    panel.updateSegmentCounts = updateSpy;
+    panel.renderFindings = renderSpy;
+
+    panel.setExternalThreads([makeThread()]);
+
+    expect(updateSpy).toHaveBeenCalled();
+    expect(renderSpy).toHaveBeenCalled();
+  });
+
+  it('preserves selection key for restore across re-render', () => {
+    const panel = createTestPanel();
+    panel.updateSegmentCounts = vi.fn();
+    panel.renderFindings = vi.fn();
+    panel.saveCurrentSelection = vi.fn();
+
+    panel.setExternalThreads([makeThread()]);
+    expect(panel.saveCurrentSelection).toHaveBeenCalled();
+  });
+});
+
+// -----------------------------------------------------------------------
+// updateSegmentCounts
+// -----------------------------------------------------------------------
+
+describe('AIPanel.updateSegmentCounts', () => {
+  function makeSegmentBtn(segment, countText = '(0)') {
+    const span = { textContent: countText, classList: { toggle: vi.fn() } };
+    return {
+      dataset: { segment },
+      querySelector: vi.fn(() => span),
+      _countSpan: span,
+    };
+  }
+
+  it('writes the external count to the External button', () => {
+    const externalBtn = makeSegmentBtn('external');
+    const panel = createTestPanel({
+      externalThreads: [makeThread(), makeThread({ id: 2 })],
+      segmentBtns: [makeSegmentBtn('ai'), makeSegmentBtn('comments'), externalBtn, makeSegmentBtn('all')],
+    });
+    panel.updateSegmentCounts();
+    expect(externalBtn._countSpan.textContent).toBe('(2)');
+  });
+
+  it('includes external threads in the All count', () => {
+    const allBtn = makeSegmentBtn('all');
+    const panel = createTestPanel({
+      findings: [{ id: 1 }, { id: 2 }],
+      comments: [{ id: 10 }],
+      externalThreads: [makeThread(), makeThread({ id: 2 }), makeThread({ id: 3 })],
+      segmentBtns: [makeSegmentBtn('ai'), makeSegmentBtn('comments'), makeSegmentBtn('external'), allBtn],
+    });
+    panel.updateSegmentCounts();
+    // 2 findings + 1 comment + 3 external = 6
+    expect(allBtn._countSpan.textContent).toBe('(6)');
+  });
+
+  it('dims the External count when zero', () => {
+    const externalBtn = makeSegmentBtn('external');
+    const panel = createTestPanel({
+      externalThreads: [],
+      segmentBtns: [externalBtn],
+    });
+    panel.updateSegmentCounts();
+    expect(externalBtn._countSpan.classList.toggle).toHaveBeenCalledWith('segment-count--zero', true);
+  });
+});
+
+// -----------------------------------------------------------------------
+// getFilteredItems
+// -----------------------------------------------------------------------
+
+describe('AIPanel.getFilteredItems', () => {
+  it('returns only external threads when segment is "external"', () => {
+    const panel = createTestPanel({
+      selectedSegment: 'external',
+      findings: [{ id: 1, file: 'a.js', line_start: 1 }],
+      comments: [{ id: 10, file: 'a.js', line_start: 1 }],
+      externalThreads: [makeThread()],
+    });
+    const items = panel.getFilteredItems();
+    expect(items).toHaveLength(1);
+    expect(items[0]._itemType).toBe('external');
+    expect(items[0].id).toBe(100);
+  });
+
+  it('marks each external item with _itemType="external"', () => {
+    const panel = createTestPanel({
+      selectedSegment: 'external',
+      externalThreads: [makeThread(), makeThread({ id: 101 })],
+    });
+    const items = panel.getFilteredItems();
+    for (const item of items) {
+      expect(item._itemType).toBe('external');
+    }
+  });
+
+  it('includes external threads in the "all" segment', () => {
+    const panel = createTestPanel({
+      selectedSegment: 'all',
+      findings: [{ id: 1, file: 'a.js', line_start: 1 }],
+      comments: [{ id: 10, file: 'a.js', line_start: 2 }],
+      externalThreads: [makeThread({ file: 'a.js', line_start: 3 })],
+    });
+    const items = panel.getFilteredItems();
+    expect(items).toHaveLength(3);
+    const types = items.map(i => i._itemType).sort();
+    expect(types).toEqual(['comment', 'external', 'finding']);
+  });
+
+  it('returns an empty list when external segment has no threads', () => {
+    const panel = createTestPanel({
+      selectedSegment: 'external',
+      externalThreads: [],
+    });
+    expect(panel.getFilteredItems()).toEqual([]);
+  });
+
+  it('does not include external threads in the "ai" segment', () => {
+    const panel = createTestPanel({
+      selectedSegment: 'ai',
+      findings: [{ id: 1, file: 'a.js', line_start: 1 }],
+      externalThreads: [makeThread()],
+    });
+    const items = panel.getFilteredItems();
+    expect(items.every(i => i._itemType !== 'external')).toBe(true);
+  });
+
+  it('does not include external threads in the "comments" segment', () => {
+    const panel = createTestPanel({
+      selectedSegment: 'comments',
+      comments: [{ id: 10, file: 'a.js', line_start: 1 }],
+      externalThreads: [makeThread()],
+    });
+    const items = panel.getFilteredItems();
+    expect(items.every(i => i._itemType !== 'external')).toBe(true);
+  });
+});
+
+// -----------------------------------------------------------------------
+// _normalizeExternalThread
+// -----------------------------------------------------------------------
+
+describe('AIPanel._normalizeExternalThread', () => {
+  it('prefers live line_start when not outdated', () => {
+    const panel = createTestPanel();
+    const item = panel._normalizeExternalThread(makeThread({
+      is_outdated: 0,
+      line_start: 7,
+      line_end: 7,
+      original_line_start: 3,
+      original_line_end: 3,
+    }));
+    expect(item.line_start).toBe(7);
+    expect(item.line_end).toBe(7);
+    expect(item.is_outdated).toBe(false);
+  });
+
+  it('falls back to original_line_start when outdated', () => {
+    const panel = createTestPanel();
+    const item = panel._normalizeExternalThread(makeThread({
+      is_outdated: 1,
+      line_start: null,
+      line_end: null,
+      original_line_start: 12,
+      original_line_end: 14,
+    }));
+    expect(item.line_start).toBe(12);
+    expect(item.line_end).toBe(14);
+    expect(item.is_outdated).toBe(true);
+  });
+
+  it('falls back to live coordinate when outdated but original missing', () => {
+    const panel = createTestPanel();
+    const item = panel._normalizeExternalThread(makeThread({
+      is_outdated: 1,
+      line_start: 9,
+      original_line_start: null,
+    }));
+    expect(item.line_start).toBe(9);
+  });
+
+  it('returns null line_start when both live and original are missing', () => {
+    const panel = createTestPanel();
+    const item = panel._normalizeExternalThread(makeThread({
+      line_start: null,
+      line_end: null,
+      original_line_start: null,
+      original_line_end: null,
+    }));
+    expect(item.line_start).toBeNull();
+    expect(item.line_end).toBeNull();
+  });
+
+  it('returns _itemType="external" for null thread input', () => {
+    const panel = createTestPanel();
+    const item = panel._normalizeExternalThread(null);
+    expect(item._itemType).toBe('external');
+  });
+});
+
+// -----------------------------------------------------------------------
+// sortItemsByFileOrder with mixed item types
+// -----------------------------------------------------------------------
+
+describe('AIPanel.sortItemsByFileOrder with mixed item types', () => {
+  it('interleaves external + finding + comment items by file and line', () => {
+    const panel = createTestPanel({
+      fileOrder: new Map([['src/a.js', 0], ['src/b.js', 1]]),
+    });
+    const items = [
+      { _itemType: 'finding', file: 'src/b.js', line_start: 10 },
+      { _itemType: 'comment', file: 'src/a.js', line_start: 5 },
+      { _itemType: 'external', file: 'src/a.js', line_start: 2 },
+      { _itemType: 'finding', file: 'src/a.js', line_start: 8 },
+      { _itemType: 'external', file: 'src/b.js', line_start: 3 },
+    ];
+    const sorted = panel.sortItemsByFileOrder(items);
+    expect(sorted.map(i => `${i.file}:${i.line_start}:${i._itemType}`)).toEqual([
+      'src/a.js:2:external',
+      'src/a.js:5:comment',
+      'src/a.js:8:finding',
+      'src/b.js:3:external',
+      'src/b.js:10:finding',
+    ]);
+  });
+
+  it('handles items missing line_start (treated as 0 / file-level)', () => {
+    const panel = createTestPanel({
+      fileOrder: new Map([['src/a.js', 0]]),
+    });
+    const items = [
+      { _itemType: 'external', file: 'src/a.js', line_start: 5 },
+      { _itemType: 'external', file: 'src/a.js' /* no line */ },
+    ];
+    const sorted = panel.sortItemsByFileOrder(items);
+    // Missing line_start (`?? 0`) sorts before the explicit line 5.
+    expect(sorted[0].line_start).toBeUndefined();
+    expect(sorted[1].line_start).toBe(5);
+  });
+});
+
+// -----------------------------------------------------------------------
+// renderExternalThreadItem
+// -----------------------------------------------------------------------
+
+describe('AIPanel.renderExternalThreadItem', () => {
+  it('renders source-github class for GitHub threads', () => {
+    const panel = createTestPanel();
+    const html = panel.renderExternalThreadItem(
+      panel._normalizeExternalThread(makeThread()),
+      0
+    );
+    expect(html).toContain('source-github');
+    expect(html).toContain('ai-panel__list-item--external');
+  });
+
+  it('writes data-thread-id, data-source, data-item-type, data-file, data-line', () => {
+    const panel = createTestPanel();
+    const thread = panel._normalizeExternalThread(makeThread({
+      id: 555,
+      source: 'github',
+      file: 'src/utils.js',
+      line_start: 9,
+      line_end: 9,
+    }));
+    const html = panel.renderExternalThreadItem(thread, 2);
+    expect(html).toContain('data-thread-id="555"');
+    expect(html).toContain('data-source="github"');
+    expect(html).toContain('data-item-type="external"');
+    expect(html).toContain('data-file="src/utils.js"');
+    expect(html).toContain('data-line="9"');
+    expect(html).toContain('data-index="2"');
+  });
+
+  it('shows total comment count (root + replies) when replies exist', () => {
+    const panel = createTestPanel();
+    const html = panel.renderExternalThreadItem(
+      panel._normalizeExternalThread(makeThread({
+        replies: [
+          { id: 11, body: 'r1' },
+          { id: 12, body: 'r2' },
+        ],
+      })),
+      0
+    );
+    // Root (1) + 2 replies = 3
+    expect(html).toContain('external-list-count');
+    expect(html).toContain('>3<');
+  });
+
+  it('always shows the count badge, including "1" for a thread with no replies', () => {
+    const panel = createTestPanel();
+    const html = panel.renderExternalThreadItem(
+      panel._normalizeExternalThread(makeThread({ replies: [] })),
+      0
+    );
+    expect(html).toContain('external-list-count');
+    expect(html).toContain('>1<');
+  });
+
+  it('renders the is-outdated class when the thread is outdated', () => {
+    const panel = createTestPanel();
+    const html = panel.renderExternalThreadItem(
+      panel._normalizeExternalThread(makeThread({ is_outdated: 1 })),
+      0
+    );
+    expect(html).toContain('is-outdated');
+    expect(html).toContain('external-list-outdated-badge');
+  });
+
+  it('shows author and body snippet (markdown stripped)', () => {
+    const panel = createTestPanel();
+    const html = panel.renderExternalThreadItem(
+      panel._normalizeExternalThread(makeThread({
+        author: 'octocat',
+        body: 'This is **bold** plus `code` text',
+      })),
+      0
+    );
+    expect(html).toContain('octocat');
+    // stripMarkdown removes ** and ` formatting
+    expect(html).toContain('This is bold plus code text');
+    expect(html).not.toContain('**');
+  });
+
+  it('escapes potentially hostile fields safely', () => {
+    const panel = createTestPanel();
+    const html = panel.renderExternalThreadItem(
+      panel._normalizeExternalThread(makeThread({
+        author: '<script>alert(1)</script>',
+        body: '<img src=x onerror=alert(1)>',
+      })),
+      0
+    );
+    expect(html).not.toContain('<script>');
+    expect(html).not.toContain('<img src=x');
+  });
+});
+
+// -----------------------------------------------------------------------
+// restoreSegmentSelection — falls back when External is hidden
+// -----------------------------------------------------------------------
+
+describe('AIPanel.restoreSegmentSelection with hidden external button', () => {
+  function makeBtn(segment, hidden = false) {
+    return {
+      dataset: { segment },
+      classList: { toggle: vi.fn() },
+      hasAttribute: (name) => name === 'hidden' && hidden,
+      setAttribute: vi.fn(),
+      removeAttribute: vi.fn(),
+    };
+  }
+
+  it('falls back to "ai" when stored value is "external" but button is hidden (Local mode)', () => {
+    mockLocalStorage['reviewPanelSegment_owner/repo#1'] = 'external';
+    const panel = createTestPanel({
+      segmentBtns: [
+        makeBtn('ai'),
+        makeBtn('comments'),
+        makeBtn('external', /* hidden */ true),
+        makeBtn('all'),
+      ],
+      levelFilter: { classList: { add: vi.fn() } },
+    });
+    panel.renderFindings = vi.fn();
+    panel.restoreSegmentSelection();
+    expect(panel.selectedSegment).toBe('ai');
+  });
+
+  it('honors "external" when the button is visible (PR mode)', () => {
+    mockLocalStorage['reviewPanelSegment_owner/repo#1'] = 'external';
+    const panel = createTestPanel({
+      segmentBtns: [
+        makeBtn('ai'),
+        makeBtn('comments'),
+        makeBtn('external', /* hidden */ false),
+        makeBtn('all'),
+      ],
+      levelFilter: { classList: { add: vi.fn() } },
+    });
+    panel.renderFindings = vi.fn();
+    panel.restoreSegmentSelection();
+    expect(panel.selectedSegment).toBe('external');
+  });
+
+  it('falls back to "ai" for any unknown legacy stored value', () => {
+    mockLocalStorage['reviewPanelSegment_owner/repo#1'] = 'some-future-segment';
+    const panel = createTestPanel({
+      segmentBtns: [makeBtn('ai'), makeBtn('comments'), makeBtn('all')],
+      levelFilter: { classList: { add: vi.fn() } },
+    });
+    panel.renderFindings = vi.fn();
+    panel.restoreSegmentSelection();
+    expect(panel.selectedSegment).toBe('ai');
+  });
+});
+
+// -----------------------------------------------------------------------
+// scrollToExternalThread
+// -----------------------------------------------------------------------
+
+describe('AIPanel.scrollToExternalThread', () => {
+  let originalDocument;
+
+  beforeEach(() => {
+    originalDocument = global.document;
+    global.window = { ...global.window };
+  });
+
+  afterEach(() => {
+    global.document = originalDocument;
+  });
+
+  function setupDocumentWithRow({ threadId = '101', source = 'github' } = {}) {
+    const focusedClass = { add: vi.fn(), remove: vi.fn() };
+    const row = {
+      classList: focusedClass,
+      scrollIntoView: vi.fn(),
+      closest: vi.fn(() => null),
+    };
+
+    global.document = {
+      ...originalDocument,
+      querySelector: vi.fn((selector) => {
+        // Match the (threadId, source) compound selector
+        if (selector.includes(`data-thread-id="${threadId}"`)) return row;
+        return null;
+      }),
+      querySelectorAll: vi.fn(() => []),
+    };
+    return { row, focusedClass };
+  }
+
+  it('finds the row by (threadId, source) and scrolls it into view', () => {
+    const { row } = setupDocumentWithRow({ threadId: '42', source: 'github' });
+    const panel = createTestPanel();
+    panel.expandFileIfCollapsed = vi.fn(() => false);
+
+    panel.scrollToExternalThread('42', 'github', 'src/utils.js', 5);
+
+    expect(row.scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth', block: 'center' });
+  });
+
+  it('adds a transient .external-comment-row--focused class', () => {
+    vi.useFakeTimers();
+    const { focusedClass } = setupDocumentWithRow({ threadId: '7' });
+    const panel = createTestPanel();
+    panel.expandFileIfCollapsed = vi.fn(() => false);
+
+    panel.scrollToExternalThread('7', 'github', 'src/x.js', 1);
+    expect(focusedClass.add).toHaveBeenCalledWith('external-comment-row--focused');
+
+    vi.advanceTimersByTime(2000);
+    expect(focusedClass.remove).toHaveBeenCalledWith('external-comment-row--focused');
+
+    vi.useRealTimers();
+  });
+
+  it('is a no-op when no matching row is in the DOM', () => {
+    global.document = {
+      ...originalDocument,
+      querySelector: vi.fn(() => null),
+      querySelectorAll: vi.fn(() => []),
+    };
+    const panel = createTestPanel();
+    panel.expandFileIfCollapsed = vi.fn(() => false);
+    expect(() => panel.scrollToExternalThread('999', 'github', 'src/x.js', 1)).not.toThrow();
+  });
+});
+
+// -----------------------------------------------------------------------
+// Segment overflow scroll
+// -----------------------------------------------------------------------
+
+describe('AIPanel.updateSegmentScrollChevrons', () => {
+  function makeScrollContainer({ scrollWidth, clientWidth, scrollLeft = 0 }) {
+    return { scrollWidth, clientWidth, scrollLeft };
+  }
+  function makeChevron() {
+    const attrs = {};
+    return {
+      setAttribute: vi.fn((k, v) => { attrs[k] = v; }),
+      removeAttribute: vi.fn((k) => { delete attrs[k]; }),
+      _attrs: attrs,
+    };
+  }
+
+  it('hides both chevrons when content fits the container', () => {
+    const panel = createTestPanel({
+      segmentControlScroll: makeScrollContainer({ scrollWidth: 200, clientWidth: 300 }),
+      segmentScrollLeft: makeChevron(),
+      segmentScrollRight: makeChevron(),
+    });
+    panel.updateSegmentScrollChevrons();
+    expect(panel.segmentScrollLeft.setAttribute).toHaveBeenCalledWith('hidden', '');
+    expect(panel.segmentScrollRight.setAttribute).toHaveBeenCalledWith('hidden', '');
+  });
+
+  it('shows the right chevron and hides the left when at scroll start', () => {
+    const panel = createTestPanel({
+      segmentControlScroll: makeScrollContainer({ scrollWidth: 600, clientWidth: 300, scrollLeft: 0 }),
+      segmentScrollLeft: makeChevron(),
+      segmentScrollRight: makeChevron(),
+    });
+    panel.updateSegmentScrollChevrons();
+    expect(panel.segmentScrollLeft.setAttribute).toHaveBeenCalledWith('hidden', '');
+    expect(panel.segmentScrollRight.removeAttribute).toHaveBeenCalledWith('hidden');
+  });
+
+  it('shows both chevrons when scrolled into the middle', () => {
+    const panel = createTestPanel({
+      segmentControlScroll: makeScrollContainer({ scrollWidth: 600, clientWidth: 300, scrollLeft: 100 }),
+      segmentScrollLeft: makeChevron(),
+      segmentScrollRight: makeChevron(),
+    });
+    panel.updateSegmentScrollChevrons();
+    expect(panel.segmentScrollLeft.removeAttribute).toHaveBeenCalledWith('hidden');
+    expect(panel.segmentScrollRight.removeAttribute).toHaveBeenCalledWith('hidden');
+  });
+
+  it('hides the right chevron when at the end of scroll', () => {
+    const panel = createTestPanel({
+      segmentControlScroll: makeScrollContainer({ scrollWidth: 600, clientWidth: 300, scrollLeft: 300 }),
+      segmentScrollLeft: makeChevron(),
+      segmentScrollRight: makeChevron(),
+    });
+    panel.updateSegmentScrollChevrons();
+    expect(panel.segmentScrollLeft.removeAttribute).toHaveBeenCalledWith('hidden');
+    expect(panel.segmentScrollRight.setAttribute).toHaveBeenCalledWith('hidden', '');
+  });
+
+  it('is a no-op when there is no scroll container', () => {
+    const panel = createTestPanel({
+      segmentControlScroll: null,
+      segmentScrollLeft: makeChevron(),
+      segmentScrollRight: makeChevron(),
+    });
+    expect(() => panel.updateSegmentScrollChevrons()).not.toThrow();
+  });
+});
+
+describe('AIPanel.scrollSegmentRow', () => {
+  it('scrolls right by ~150px', () => {
+    const scrollBy = vi.fn();
+    const panel = createTestPanel({
+      segmentControlScroll: { scrollBy, scrollLeft: 0 },
+    });
+    panel.scrollSegmentRow(1);
+    expect(scrollBy).toHaveBeenCalledWith({ left: 150, behavior: 'smooth' });
+  });
+
+  it('scrolls left by ~150px', () => {
+    const scrollBy = vi.fn();
+    const panel = createTestPanel({
+      segmentControlScroll: { scrollBy, scrollLeft: 200 },
+    });
+    panel.scrollSegmentRow(-1);
+    expect(scrollBy).toHaveBeenCalledWith({ left: -150, behavior: 'smooth' });
+  });
+
+  it('falls back to scrollLeft assignment when scrollBy is missing', () => {
+    const container = { scrollLeft: 0 };
+    const panel = createTestPanel({ segmentControlScroll: container });
+    panel.scrollSegmentRow(1);
+    expect(container.scrollLeft).toBe(150);
+  });
+
+  it('is a no-op when there is no scroll container', () => {
+    const panel = createTestPanel({ segmentControlScroll: null });
+    expect(() => panel.scrollSegmentRow(1)).not.toThrow();
+  });
+});
+
+// -----------------------------------------------------------------------
+// getItemKey — disambiguation for external threads on the same line
+// -----------------------------------------------------------------------
+
+// -----------------------------------------------------------------------
+// Chat button on external thread items
+// -----------------------------------------------------------------------
+
+describe('AIPanel.renderExternalThreadItem chat button', () => {
+  let originalDocumentElement;
+
+  beforeEach(() => {
+    originalDocumentElement = global.document.documentElement;
+    global.document.documentElement = {
+      style: { setProperty: vi.fn() },
+      getAttribute: vi.fn((name) => (name === 'data-chat' ? 'available' : null)),
+    };
+  });
+
+  afterEach(() => {
+    global.document.documentElement = originalDocumentElement;
+  });
+
+  it('renders a chat button when data-chat is "available"', () => {
+    const panel = createTestPanel();
+    const html = panel.renderExternalThreadItem(
+      panel._normalizeExternalThread(makeThread()),
+      0
+    );
+    expect(html).toContain('quick-action-chat');
+    expect(html).toContain('data-thread-id="100"');
+    expect(html).toContain('data-source="github"');
+    expect(html).toContain('data-item-type="external"');
+  });
+
+  it('does not render a chat button when data-chat is not available', () => {
+    global.document.documentElement.getAttribute = vi.fn(() => null);
+    const panel = createTestPanel();
+    const html = panel.renderExternalThreadItem(
+      panel._normalizeExternalThread(makeThread()),
+      0
+    );
+    expect(html).not.toContain('quick-action-chat');
+  });
+});
+
+describe('AIPanel.openQuickActionChat for external threads', () => {
+  it('dispatches threadContext with replies for the external thread', () => {
+    const open = vi.fn();
+    global.window = { ...global.window, chatPanel: { open }, prManager: { currentPR: { id: 5 } } };
+
+    const panel = createTestPanel({
+      externalThreads: [
+        {
+          id: 42,
+          source: 'github',
+          author: 'octocat',
+          body: 'Root body',
+          file: 'src/a.js',
+          side: 'RIGHT',
+          line_start: 7,
+          line_end: 7,
+          is_outdated: 0,
+          external_url: 'https://example.com/c/42',
+          external_created_at: '2026-01-01',
+          replies: [
+            { author: 'rev', body: 'Reply 1', is_outdated: 0 },
+          ],
+        },
+      ],
+    });
+
+    panel.openQuickActionChat({
+      dataset: {
+        itemType: 'external',
+        threadId: '42',
+        source: 'github',
+      },
+    });
+
+    expect(open).toHaveBeenCalledTimes(1);
+    const arg = open.mock.calls[0][0];
+    expect(arg.reviewId).toBe(5);
+    expect(arg.threadContext).toMatchObject({
+      rootId: 42,
+      source: 'external',
+      externalSource: 'github',
+      file: 'src/a.js',
+      side: 'RIGHT',
+      line_start: 7,
+      line_end: 7,
+    });
+    expect(arg.threadContext.comments).toHaveLength(2);
+    expect(arg.threadContext.comments[0].body).toBe('Root body');
+    expect(arg.threadContext.comments[1].body).toBe('Reply 1');
+  });
+
+  it('uses original_line_* when the thread is outdated', () => {
+    const open = vi.fn();
+    global.window = { ...global.window, chatPanel: { open }, prManager: { currentPR: { id: 1 } } };
+
+    const panel = createTestPanel({
+      externalThreads: [
+        {
+          id: 9,
+          source: 'github',
+          file: 'src/b.js',
+          side: 'RIGHT',
+          line_start: null,
+          line_end: null,
+          original_line_start: 20,
+          original_line_end: 22,
+          is_outdated: 1,
+          replies: [],
+        },
+      ],
+    });
+
+    panel.openQuickActionChat({
+      dataset: { itemType: 'external', threadId: '9', source: 'github' },
+    });
+
+    const arg = open.mock.calls[0][0];
+    expect(arg.threadContext.line_start).toBe(20);
+    expect(arg.threadContext.line_end).toBe(22);
+    expect(arg.threadContext.comments[0].isOutdated).toBe(true);
+  });
+
+  it('is a no-op when no matching thread is in state', () => {
+    const open = vi.fn();
+    global.window = { ...global.window, chatPanel: { open }, prManager: null };
+    const panel = createTestPanel({ externalThreads: [] });
+    panel.openQuickActionChat({
+      dataset: { itemType: 'external', threadId: '999', source: 'github' },
+    });
+    expect(open).not.toHaveBeenCalled();
+  });
+});
+
+describe('AIPanel.getItemKey', () => {
+  it('produces distinct keys for two external threads on the same (file, line)', () => {
+    const panel = createTestPanel();
+    const a = panel._normalizeExternalThread(makeThread({
+      id: 1, external_id: 'gh-1', file: 'a.js', line_start: 5,
+    }));
+    const b = panel._normalizeExternalThread(makeThread({
+      id: 2, external_id: 'gh-2', file: 'a.js', line_start: 5,
+    }));
+    expect(panel.getItemKey(a)).not.toEqual(panel.getItemKey(b));
+  });
+
+  it('falls back to thread.id when external_id is missing', () => {
+    const panel = createTestPanel();
+    const a = panel._normalizeExternalThread(makeThread({
+      id: 7, external_id: null, file: 'a.js', line_start: 5,
+    }));
+    expect(panel.getItemKey(a)).toContain(':7');
+  });
+
+  it('preserves stable keys across re-normalization', () => {
+    const panel = createTestPanel();
+    const t = makeThread({ id: 9, external_id: 'gh-9', file: 'a.js', line_start: 5 });
+    const k1 = panel.getItemKey(panel._normalizeExternalThread(t));
+    const k2 = panel.getItemKey(panel._normalizeExternalThread(t));
+    expect(k1).toEqual(k2);
+  });
+});

--- a/tests/unit/chat-panel.test.js
+++ b/tests/unit/chat-panel.test.js
@@ -887,6 +887,384 @@ describe('ChatPanel', () => {
       const card = chatPanel.messagesEl.appendChild.mock.calls[0][0];
       expect(card.innerHTML).toContain('Comment');
     });
+
+    it('should NOT add external-* classes when source is undefined or "user"', () => {
+      const ctx = { commentId: '1', body: 'Hi', file: 'a.js', line_start: 5, isFileLevel: false };
+      chatPanel._addCommentContextCard(ctx);
+
+      const card = chatPanel.messagesEl.appendChild.mock.calls[0][0];
+      expect(card.className).toBe('chat-panel__context-card');
+      expect(card.className).not.toContain('external-comment-context');
+      expect(card.className).not.toContain('source-');
+    });
+
+    it('should apply external-comment-context and source-github classes for source=external/externalSource=github', () => {
+      const ctx = {
+        commentId: 'g-1',
+        body: 'GitHub comment body',
+        file: 'a.js',
+        line_start: 5,
+        isFileLevel: false,
+        source: 'external',
+        externalSource: 'github',
+        externalUrl: 'https://github.com/example/repo/pull/1#discussion_r1',
+        author: 'octocat',
+        isOutdated: false,
+      };
+      chatPanel._addCommentContextCard(ctx);
+
+      const card = chatPanel.messagesEl.appendChild.mock.calls[0][0];
+      expect(card.className).toContain('chat-panel__context-card');
+      expect(card.className).toContain('external-comment-context');
+      expect(card.className).toContain('source-github');
+      // Author rendered as a link to externalUrl
+      expect(card.innerHTML).toContain('href="https://github.com/example/repo/pull/1#discussion_r1"');
+      expect(card.innerHTML).toContain('octocat');
+      expect(card.innerHTML).toContain('target="_blank"');
+      // No outdated badge when isOutdated is false
+      expect(card.innerHTML).not.toContain('outdated');
+    });
+
+    it('should render outdated badge when isOutdated=true and add is-outdated class', () => {
+      const ctx = {
+        commentId: 'g-2',
+        body: 'Old comment',
+        file: 'a.js',
+        line_start: null,
+        source: 'external',
+        externalSource: 'github',
+        externalUrl: 'https://github.com/example/repo/pull/1#discussion_r2',
+        author: 'octocat',
+        isOutdated: true,
+      };
+      chatPanel._addCommentContextCard(ctx);
+
+      const card = chatPanel.messagesEl.appendChild.mock.calls[0][0];
+      expect(card.className).toContain('is-outdated');
+      expect(card.innerHTML).toContain('outdated');
+    });
+
+    it('should render author as plain span when externalUrl is missing', () => {
+      const ctx = {
+        commentId: 'g-3',
+        body: 'No link',
+        file: 'a.js',
+        line_start: 5,
+        source: 'external',
+        externalSource: 'github',
+        externalUrl: null,
+        author: 'octocat',
+        isOutdated: false,
+      };
+      chatPanel._addCommentContextCard(ctx);
+
+      const card = chatPanel.messagesEl.appendChild.mock.calls[0][0];
+      expect(card.innerHTML).toContain('octocat');
+      expect(card.innerHTML).not.toContain('href=');
+    });
+
+    it('XSS: javascript: externalUrl renders author as plain text with no href, body escapes script tags', () => {
+      // Regression: the single-comment card previously emitted a live <a href>
+      // whenever externalUrl was truthy — including javascript: URLs. Mirror
+      // the scheme allowlist used by the thread path and external-comment-manager.
+      const origMd = global.window.renderMarkdown;
+      const escaper = (text) => String(text)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+      global.window.renderMarkdown = (text) => `<p>${escaper(text)}</p>`;
+      try {
+        const ctx = {
+          commentId: 'g-xss',
+          body: '<script>alert(1)</script><img src=x onerror=alert(1)>',
+          file: 'a.js',
+          line_start: 5,
+          isFileLevel: false,
+          source: 'external',
+          externalSource: 'github',
+          externalUrl: 'javascript:alert(1)',
+          author: 'octocat',
+          isOutdated: false,
+        };
+        chatPanel._addCommentContextCard(ctx);
+
+        const card = chatPanel.messagesEl.appendChild.mock.calls[0][0];
+        // No live href= attribute survives — the URL failed _isSafeUrl, so
+        // the author renders as a plain span.
+        expect(card.innerHTML).not.toMatch(/href=["']javascript:/i);
+        expect(card.innerHTML).not.toMatch(/<a\s[^>]*href=/i);
+        expect(card.innerHTML).toContain('<span class="chat-panel__context-author">octocat</span>');
+        // No live <script> tag and no live onerror attribute in any element.
+        expect(card.innerHTML).not.toMatch(/<script[^>]*>/i);
+        expect(card.innerHTML).not.toMatch(/<[^>]*\sonerror\s*=/i);
+        expect(card.innerHTML).not.toMatch(/<img\b/i);
+      } finally {
+        global.window.renderMarkdown = origMd;
+      }
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // _sendCommentContextMessage with external source
+  // -----------------------------------------------------------------------
+  describe('_sendCommentContextMessage (external source)', () => {
+    it('should mark source as external and persist external fields in contextData', () => {
+      const ctx = {
+        commentId: 'g-100',
+        body: 'External feedback',
+        file: 'src/app.js',
+        line_start: 12,
+        line_end: 12,
+        source: 'external',
+        externalSource: 'github',
+        externalUrl: 'https://github.com/example/repo/pull/1#discussion_r100',
+        author: 'octocat',
+        isOutdated: false,
+        isFileLevel: false,
+      };
+
+      chatPanel._sendCommentContextMessage(ctx);
+
+      expect(chatPanel._getActiveTab().pendingContextData).toHaveLength(1);
+      const data = chatPanel._getActiveTab().pendingContextData[0];
+      expect(data.source).toBe('external');
+      expect(data.externalSource).toBe('github');
+      expect(data.externalUrl).toBe('https://github.com/example/repo/pull/1#discussion_r100');
+      expect(data.author).toBe('octocat');
+      expect(data.isOutdated).toBe(false);
+    });
+
+    it('should mention GitHub and author in the AI-facing prompt', () => {
+      const ctx = {
+        commentId: 'g-101',
+        body: 'Pls fix',
+        file: 'src/app.js',
+        line_start: 10,
+        line_end: 10,
+        source: 'external',
+        externalSource: 'github',
+        externalUrl: 'https://github.com/example/repo/pull/1#discussion_r101',
+        author: 'octocat',
+        isOutdated: false,
+        isFileLevel: false,
+      };
+
+      chatPanel._sendCommentContextMessage(ctx);
+
+      const prompt = chatPanel._getActiveTab().pendingContext[0];
+      expect(prompt).toContain('GitHub');
+      expect(prompt).toContain('octocat');
+      expect(prompt).toContain('https://github.com/example/repo/pull/1#discussion_r101');
+      expect(prompt).toContain('Pls fix');
+    });
+
+    it('should mention outdated status in the AI-facing prompt when isOutdated=true', () => {
+      const ctx = {
+        commentId: 'g-102',
+        body: 'Stale',
+        file: 'src/app.js',
+        line_start: null,
+        line_end: null,
+        source: 'external',
+        externalSource: 'github',
+        externalUrl: null,
+        author: 'octocat',
+        isOutdated: true,
+        isFileLevel: false,
+      };
+
+      chatPanel._sendCommentContextMessage(ctx);
+
+      const prompt = chatPanel._getActiveTab().pendingContext[0];
+      expect(prompt.toLowerCase()).toContain('outdated');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // _sendThreadContextMessage / _addThreadContextCard
+  // -----------------------------------------------------------------------
+  describe('_sendThreadContextMessage', () => {
+    it('should render a thread card with one entry per comment and mention count in prompt', () => {
+      const threadContext = {
+        rootId: 5,
+        source: 'external',
+        externalSource: 'github',
+        file: 'src/app.js',
+        line_start: 42,
+        line_end: 42,
+        comments: [
+          { author: 'alice', body: 'First comment', isOutdated: false, externalUrl: 'https://github.com/example/repo/pull/1#discussion_r1', externalCreatedAt: '2025-01-01T00:00:00Z' },
+          { author: 'bob', body: 'Second comment', isOutdated: false, externalUrl: 'https://github.com/example/repo/pull/1#discussion_r2', externalCreatedAt: '2025-01-02T00:00:00Z' },
+          { author: 'carol', body: 'Third comment', isOutdated: false, externalUrl: 'https://github.com/example/repo/pull/1#discussion_r3', externalCreatedAt: '2025-01-03T00:00:00Z' },
+        ],
+      };
+
+      chatPanel._sendThreadContextMessage(threadContext);
+
+      // Pending data captured
+      expect(chatPanel._getActiveTab().pendingContextData).toHaveLength(1);
+      const data = chatPanel._getActiveTab().pendingContextData[0];
+      expect(data.type).toBe('thread');
+      expect(data.source).toBe('external');
+      expect(data.externalSource).toBe('github');
+      expect(data.comments).toHaveLength(3);
+      expect(data.comments[0].author).toBe('alice');
+      expect(data.comments[0].body).toBe('First comment');
+
+      // AI-facing prompt mentions thread and count
+      const prompt = chatPanel._getActiveTab().pendingContext[0];
+      expect(prompt).toContain('thread');
+      expect(prompt).toContain('3 comment');
+      expect(prompt).toContain('GitHub');
+      expect(prompt).toContain('alice');
+      expect(prompt).toContain('First comment');
+
+      // Card rendered
+      expect(chatPanel.messagesEl.appendChild).toHaveBeenCalled();
+      const card = chatPanel.messagesEl.appendChild.mock.calls[0][0];
+      expect(card.className).toContain('chat-panel__context-card--thread');
+      expect(card.className).toContain('external-comment-context');
+      expect(card.className).toContain('source-github');
+      // All three authors present in card markup
+      expect(card.innerHTML).toContain('alice');
+      expect(card.innerHTML).toContain('bob');
+      expect(card.innerHTML).toContain('carol');
+    });
+
+    it('should not crash when comments is empty or missing (defensive)', () => {
+      const threadContext = {
+        rootId: 9,
+        source: 'external',
+        externalSource: 'github',
+        file: 'src/a.js',
+        line_start: 1,
+        line_end: 1,
+        // comments omitted
+      };
+
+      expect(() => chatPanel._sendThreadContextMessage(threadContext)).not.toThrow();
+
+      const data = chatPanel._getActiveTab().pendingContextData[0];
+      expect(data.comments).toEqual([]);
+      const prompt = chatPanel._getActiveTab().pendingContext[0];
+      expect(prompt).toContain('0 comment');
+    });
+
+    it('renders multi-line range anchor as "file:start-end", not just end', () => {
+      // Regression: the card previously appended ":line_end" when both bounds
+      // were set, silently dropping line_start from the displayed anchor.
+      const threadContext = {
+        rootId: 11,
+        source: 'external',
+        externalSource: 'github',
+        file: 'src/app.js',
+        line_start: 10,
+        line_end: 15,
+        comments: [
+          { author: 'a', body: 'b', isOutdated: false, externalUrl: null, externalCreatedAt: null },
+        ],
+      };
+
+      chatPanel._sendThreadContextMessage(threadContext);
+      const card = chatPanel.messagesEl.appendChild.mock.calls[0][0];
+      expect(card.innerHTML).toContain('src/app.js:10-15');
+      expect(card.innerHTML).not.toContain('src/app.js:15');
+    });
+
+    it('renders single-line anchor as "file:line", not "file:line-line"', () => {
+      const threadContext = {
+        rootId: 12,
+        source: 'external',
+        externalSource: 'github',
+        file: 'src/app.js',
+        line_start: 7,
+        line_end: 7,
+        comments: [
+          { author: 'a', body: 'b', isOutdated: false, externalUrl: null, externalCreatedAt: null },
+        ],
+      };
+
+      chatPanel._sendThreadContextMessage(threadContext);
+      const card = chatPanel.messagesEl.appendChild.mock.calls[0][0];
+      expect(card.innerHTML).toContain('src/app.js:7');
+      expect(card.innerHTML).not.toContain('7-7');
+    });
+
+    it('XSS: javascript: externalUrl renders as plain text with no href', () => {
+      // Swap window.renderMarkdown for an escaping stub so a regression
+      // where body escaping is removed in production would still be caught.
+      const origMd = global.window.renderMarkdown;
+      const escaper = (text) => String(text)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+      global.window.renderMarkdown = (text) => `<p>${escaper(text)}</p>`;
+      try {
+        const threadContext = {
+          rootId: 13,
+          source: 'external',
+          externalSource: 'github',
+          file: 'src/app.js',
+          line_start: 1,
+          line_end: 1,
+          comments: [
+            {
+              author: 'alice',
+              body: '<script>alert(1)</script><img src=x onerror=alert(1)>',
+              isOutdated: false,
+              externalUrl: 'javascript:alert(1)',
+              externalCreatedAt: null,
+            },
+          ],
+        };
+
+        chatPanel._sendThreadContextMessage(threadContext);
+        const card = chatPanel.messagesEl.appendChild.mock.calls[0][0];
+
+        // No live <script> tag survives in the rendered HTML.
+        expect(card.innerHTML).not.toMatch(/<script[^>]*>/i);
+        // No live onerror=... attribute survives (the literal pattern would
+        // only ever appear escaped inside text — never as `<tag onerror=...>`).
+        expect(card.innerHTML).not.toMatch(/<[^>]*\sonerror\s*=/i);
+        // No live <img ...> tag — the production code escapes the body, so
+        // the only `<img` substring should be inside escaped text (&lt;img).
+        expect(card.innerHTML).not.toMatch(/<img\b/i);
+        // javascript: URL must NOT appear as an href. Plain-text presence
+        // in escaped text is acceptable, but href="javascript:..." is not.
+        expect(card.innerHTML).not.toMatch(/href=["']javascript:/i);
+        // Author still appears in text.
+        expect(card.innerHTML).toContain('alice');
+      } finally {
+        global.window.renderMarkdown = origMd;
+      }
+    });
+
+    it('should render outdated badge per outdated comment entry', () => {
+      const threadContext = {
+        rootId: 7,
+        source: 'external',
+        externalSource: 'github',
+        file: 'src/app.js',
+        line_start: null,
+        line_end: null,
+        comments: [
+          { author: 'alice', body: 'A', isOutdated: true, externalUrl: null, externalCreatedAt: null },
+          { author: 'bob', body: 'B', isOutdated: false, externalUrl: null, externalCreatedAt: null },
+          { author: 'carol', body: 'C', isOutdated: true, externalUrl: null, externalCreatedAt: null },
+        ],
+      };
+
+      chatPanel._sendThreadContextMessage(threadContext);
+
+      const card = chatPanel.messagesEl.appendChild.mock.calls[0][0];
+      // The "outdated" badge text should appear twice (for alice and carol)
+      const matches = card.innerHTML.match(/outdated/g) || [];
+      expect(matches.length).toBeGreaterThanOrEqual(2);
+    });
   });
 
   // -----------------------------------------------------------------------

--- a/tests/unit/chat-panel.test.js
+++ b/tests/unit/chat-panel.test.js
@@ -117,6 +117,19 @@ function createMockElement(tag = 'div', overrides = {}) {
     focus: vi.fn(),
     blur: vi.fn(),
 
+    // Minimal attribute storage so production code that uses
+    // setAttribute/getAttribute (e.g. title tooltips on context cards)
+    // works against the mock the same way it would in a real DOM.
+    _attrs: {},
+    setAttribute: vi.fn(function (name, value) { this._attrs[name] = String(value); }),
+    getAttribute: vi.fn(function (name) {
+      return Object.prototype.hasOwnProperty.call(this._attrs, name) ? this._attrs[name] : null;
+    }),
+    hasAttribute: vi.fn(function (name) {
+      return Object.prototype.hasOwnProperty.call(this._attrs, name);
+    }),
+    removeAttribute: vi.fn(function (name) { delete this._attrs[name]; }),
+
     // Allow property spreading from overrides
     ...overrides
   };
@@ -1121,16 +1134,21 @@ describe('ChatPanel', () => {
       expect(prompt).toContain('alice');
       expect(prompt).toContain('First comment');
 
-      // Card rendered
+      // Card rendered — compact single-line layout with full thread content
+      // exposed via the native title tooltip (hover).
       expect(chatPanel.messagesEl.appendChild).toHaveBeenCalled();
       const card = chatPanel.messagesEl.appendChild.mock.calls[0][0];
-      expect(card.className).toContain('chat-panel__context-card--thread');
+      expect(card.className).toContain('chat-panel__context-card');
       expect(card.className).toContain('external-comment-context');
       expect(card.className).toContain('source-github');
-      // All three authors present in card markup
-      expect(card.innerHTML).toContain('alice');
-      expect(card.innerHTML).toContain('bob');
-      expect(card.innerHTML).toContain('carol');
+      // All three authors live in the title attribute (hover surface).
+      const tooltip = card.getAttribute('title') || '';
+      expect(tooltip).toContain('alice');
+      expect(tooltip).toContain('bob');
+      expect(tooltip).toContain('carol');
+      // The visible row carries a "GITHUB THREAD" label and a count badge.
+      expect(card.innerHTML).toContain('GITHUB THREAD');
+      expect(card.innerHTML).toContain('3 comment');
     });
 
     it('should not crash when comments is empty or missing (defensive)', () => {
@@ -1225,25 +1243,22 @@ describe('ChatPanel', () => {
         chatPanel._sendThreadContextMessage(threadContext);
         const card = chatPanel.messagesEl.appendChild.mock.calls[0][0];
 
-        // No live <script> tag survives in the rendered HTML.
+        // Compact card: body is in the title tooltip (plain text attribute,
+        // automatically escaped), not the DOM. No live tags should survive
+        // anywhere in the rendered HTML.
         expect(card.innerHTML).not.toMatch(/<script[^>]*>/i);
-        // No live onerror=... attribute survives (the literal pattern would
-        // only ever appear escaped inside text — never as `<tag onerror=...>`).
         expect(card.innerHTML).not.toMatch(/<[^>]*\sonerror\s*=/i);
-        // No live <img ...> tag — the production code escapes the body, so
-        // the only `<img` substring should be inside escaped text (&lt;img).
         expect(card.innerHTML).not.toMatch(/<img\b/i);
-        // javascript: URL must NOT appear as an href. Plain-text presence
-        // in escaped text is acceptable, but href="javascript:..." is not.
+        // javascript: URL must NOT appear as an href.
         expect(card.innerHTML).not.toMatch(/href=["']javascript:/i);
-        // Author still appears in text.
-        expect(card.innerHTML).toContain('alice');
+        // Author appears in the tooltip (full thread surface for hover).
+        expect(card.getAttribute('title') || '').toContain('alice');
       } finally {
         global.window.renderMarkdown = origMd;
       }
     });
 
-    it('should render outdated badge per outdated comment entry', () => {
+    it('flags each outdated comment in the title tooltip', () => {
       const threadContext = {
         rootId: 7,
         source: 'external',
@@ -1261,9 +1276,10 @@ describe('ChatPanel', () => {
       chatPanel._sendThreadContextMessage(threadContext);
 
       const card = chatPanel.messagesEl.appendChild.mock.calls[0][0];
-      // The "outdated" badge text should appear twice (for alice and carol)
-      const matches = card.innerHTML.match(/outdated/g) || [];
-      expect(matches.length).toBeGreaterThanOrEqual(2);
+      const tooltip = card.getAttribute('title') || '';
+      // Tooltip marks alice and carol (outdated), but not bob.
+      const matches = tooltip.match(/\(outdated\)/g) || [];
+      expect(matches.length).toBe(2);
     });
   });
 

--- a/tests/unit/comment-minimizer.test.js
+++ b/tests/unit/comment-minimizer.test.js
@@ -425,10 +425,11 @@ describe('CommentMinimizer', () => {
   // -------------------------------------------------------------------------
   describe('refreshIndicators', () => {
     /** Set up document.querySelectorAll to return the given rows by selector. */
-    function mockQuerySelectorAll(commentRows, suggestionRows) {
+    function mockQuerySelectorAll(commentRows, suggestionRows, externalRows = []) {
       global.document.querySelectorAll = vi.fn((selector) => {
         if (selector === '.user-comment-row') return commentRows;
         if (selector === '.ai-suggestion-row') return suggestionRows;
+        if (selector === '.external-comment-row') return externalRows;
         if (selector === '.comment-indicator') return [];
         if (selector === '.comment-expanded') return [];
         return [];
@@ -661,6 +662,125 @@ describe('CommentMinimizer', () => {
 
       const btn = codeCell.children[0];
       expect(btn.classList.contains('expanded')).toBe(true);
+    });
+
+    it('should re-apply .comment-expanded to rebuilt rows on refresh when the diff line is in _expandedLines', () => {
+      // Regression: external-comment refresh tears down and rebuilds
+      // `.external-comment-row` elements. The rebuilt rows have no
+      // expanded class. _injectIndicator was setting btn.expanded based
+      // on _expandedLines but never re-applying `.comment-expanded` to
+      // the new rows, leaving the indicator "open" while the rows stayed
+      // hidden by the `.comments-minimized .external-comment-row` rule.
+      const codeCell = buildCodeCell();
+      // Fresh external-comment-row after rebuild — has NO comment-expanded yet.
+      const rebuiltExternal = {
+        classList: {
+          _set: new Set(['external-comment-row']),
+          add(c) { this._set.add(c); },
+          remove(c) { this._set.delete(c); },
+          contains(c) { return this._set.has(c); },
+        },
+      };
+      // The thread bubble children so the indicator path still works.
+      const bubble = {
+        classList: { _set: new Set(['external-comment']), contains(c) { return this._set.has(c); } },
+      };
+      const rows = buildRows([
+        { classes: ['d2h-cntx'], children: { '.d2h-code-line-ctn': codeCell } },
+      ]);
+      // Wire rebuiltExternal as a sibling of rows[0] using the same shape buildRows uses.
+      rebuiltExternal.previousElementSibling = rows[0];
+      rebuiltExternal.nextElementSibling = null;
+      rows[0].nextElementSibling = rebuiltExternal;
+      rebuiltExternal.querySelectorAll = (selector) => {
+        if (selector === '.external-comment') return [bubble];
+        return [];
+      };
+
+      mockQuerySelectorAll([], [], [rebuiltExternal]);
+
+      const cm = new CommentMinimizer();
+      cm._active = true;
+      // User had previously expanded this line — the Set survives the rebuild,
+      // even though .comment-expanded has been wiped from the rebuilt rows.
+      cm._expandedLines.add(rows[0]);
+      cm.refreshIndicators();
+
+      // Indicator button reflects "expanded"
+      const btn = codeCell.children[0];
+      expect(btn.classList.contains('expanded')).toBe(true);
+      // Rebuilt row must regain .comment-expanded so it becomes visible
+      // again via the `.comments-minimized .external-comment-row.comment-expanded`
+      // display: table-row override.
+      expect(rebuiltExternal.classList.contains('comment-expanded')).toBe(true);
+    });
+
+    it('should inject an external-comment indicator and count the bubbles in the thread card', () => {
+      // Regression: external-comment-row was previously excluded from the
+      // minimizer. The row stayed visible while user/AI rows were hidden,
+      // and no indicator counted toward the per-line badge total.
+      const bubble1 = {
+        classList: { _set: new Set(['external-comment']), contains(c) { return this._set.has(c); } },
+      };
+      const bubble2 = {
+        classList: { _set: new Set(['external-comment']), contains(c) { return this._set.has(c); } },
+      };
+      const bubble3 = {
+        classList: { _set: new Set(['external-comment']), contains(c) { return this._set.has(c); } },
+      };
+      const codeCell = buildCodeCell();
+
+      const rows = buildRows([
+        { classes: ['d2h-cntx'], children: { '.d2h-code-line-ctn': codeCell } },
+        { classes: ['external-comment-row'] },
+      ]);
+      rows[1].querySelectorAll = (selector) => {
+        if (selector === '.external-comment') return [bubble1, bubble2, bubble3];
+        return [];
+      };
+
+      mockQuerySelectorAll([], [], [rows[1]]);
+
+      const cm = new CommentMinimizer();
+      cm._active = true;
+      cm.refreshIndicators();
+
+      expect(codeCell.children.length).toBe(1);
+      const btn = codeCell.children[0];
+      expect(btn.innerHTML).toContain('indicator-external');
+      // The thread card has 3 bubbles (root + 2 replies); the count reflects that.
+      expect(btn.innerHTML).toContain('<span class="indicator-count">3</span>');
+      expect(btn.title).toBe('3 external comments');
+    });
+
+    it('mixes external counts into the total alongside user/AI rows', () => {
+      const externalBubble = {
+        classList: { _set: new Set(['external-comment']), contains(c) { return this._set.has(c); } },
+      };
+      const codeCell = buildCodeCell();
+
+      const rows = buildRows([
+        { classes: ['d2h-cntx'], children: { '.d2h-code-line-ctn': codeCell } },
+        { classes: ['user-comment-row'] },
+        { classes: ['external-comment-row'] },
+      ]);
+      rows[2].querySelectorAll = (selector) => {
+        if (selector === '.external-comment') return [externalBubble];
+        return [];
+      };
+
+      mockQuerySelectorAll([rows[1]], [], [rows[2]]);
+
+      const cm = new CommentMinimizer();
+      cm._active = true;
+      cm.refreshIndicators();
+
+      const btn = codeCell.children[0];
+      expect(btn.innerHTML).toContain('indicator-user');
+      expect(btn.innerHTML).toContain('indicator-external');
+      // 1 user + 1 external = 2
+      expect(btn.innerHTML).toContain('<span class="indicator-count">2</span>');
+      expect(btn.title).toBe('1 comment, 1 external comment');
     });
   });
 

--- a/tests/unit/config.test.js
+++ b/tests/unit/config.test.js
@@ -1304,6 +1304,29 @@ describe('config.js', () => {
       expect(config.monorepos).toBeUndefined();
     });
 
+    // --- external_comments feature toggle (opt-in, defaults to false) ---
+
+    it('defaults external_comments to false when nothing sets it', async () => {
+      mockReadFile({ global: { port: 7247 } });
+      const { config } = await loadConfig();
+      expect(config.external_comments).toBe(false);
+    });
+
+    it('respects global config opting into external_comments', async () => {
+      mockReadFile({ global: { external_comments: true } });
+      const { config } = await loadConfig();
+      expect(config.external_comments).toBe(true);
+    });
+
+    it('lets project config override global external_comments either way', async () => {
+      mockReadFile({
+        global: { external_comments: true },
+        project: { external_comments: false },
+      });
+      const { config } = await loadConfig();
+      expect(config.external_comments).toBe(false);
+    });
+
     it('should collapse case-differing monorepos and repos keys with repos taking precedence', async () => {
       mockReadFile({
         global: {

--- a/tests/unit/external-comment-manager.test.js
+++ b/tests/unit/external-comment-manager.test.js
@@ -1,0 +1,929 @@
+// Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+// @vitest-environment jsdom
+/**
+ * Unit tests for ExternalCommentManager — the read-only renderer for
+ * external review-comment threads in the diff view.
+ *
+ * Covers:
+ *  - empty / single root / multi-reply rendering
+ *  - outdated comments with original_line_end fallback
+ *  - chat-about-comment + chat-about-thread payload shapes
+ *  - clear() touches only `.external-comment-row` rows
+ *  - ordering when AI / user comment rows already exist after the target
+ *  - defensive skip when both line_end and original_line_end are null
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+// Production code expects `window.renderMarkdown` and `window.toast`; leave
+// them off by default so the module's fallback paths are exercised, then
+// individual tests can install spies as needed.
+const { ExternalCommentManager } = require('../../public/js/modules/external-comment-manager.js');
+
+/**
+ * Build a minimal diff-like table with a single file wrapper containing
+ * a tbody and rows for the given (lineNumber, side) pairs.
+ *
+ *   <div class="d2h-file-wrapper" data-file-name=file>
+ *     <table>
+ *       <tbody>
+ *         <tr data-line-number="..." data-side="..." />
+ *         ...
+ *       </tbody>
+ *     </table>
+ *   </div>
+ */
+function buildDiffTable({ file = 'src/app.js', lines = [{ line: 10, side: 'RIGHT' }] } = {}) {
+  const wrapper = document.createElement('div');
+  wrapper.className = 'd2h-file-wrapper';
+  wrapper.dataset.fileName = file;
+
+  const table = document.createElement('table');
+  const tbody = document.createElement('tbody');
+
+  const rowsByKey = new Map();
+  for (const { line, side } of lines) {
+    const tr = document.createElement('tr');
+    tr.dataset.lineNumber = String(line);
+    tr.dataset.side = side;
+    if (side === 'RIGHT') tr.dataset.newLineNumber = String(line);
+    if (side === 'LEFT') tr.dataset.oldLineNumber = String(line);
+    // Four diff cells to mimic colspan layout (line nums, gutter, code, etc.)
+    for (let i = 0; i < 4; i++) tr.appendChild(document.createElement('td'));
+    tbody.appendChild(tr);
+    rowsByKey.set(`${file}:${line}:${side}`, tr);
+  }
+
+  table.appendChild(tbody);
+  wrapper.appendChild(table);
+  document.body.appendChild(wrapper);
+  return { wrapper, tbody, rowsByKey };
+}
+
+function makeComment(overrides = {}) {
+  return {
+    id: 1,
+    source: 'github',
+    external_id: 'gh-1',
+    in_reply_to_id: null,
+    parent_id: null,
+    external_url: 'https://github.com/o/r/pull/1#discussion_r1',
+    author: 'octocat',
+    author_url: 'https://github.com/octocat',
+    file: 'src/app.js',
+    side: 'RIGHT',
+    line_start: 10,
+    line_end: 10,
+    diff_position: 5,
+    commit_sha: 'abc',
+    is_outdated: 0,
+    original_line_start: 10,
+    original_line_end: 10,
+    original_commit_sha: 'abc',
+    body: 'Looks good to me',
+    external_created_at: new Date(Date.now() - 60_000).toISOString(),
+    synced_at: new Date().toISOString(),
+    replies: [],
+    ...overrides,
+  };
+}
+
+function makeManager({ reviewId = 'rev-1', chatPanel = { open: vi.fn() }, sources = ['github'] } = {}) {
+  return new ExternalCommentManager({ reviewId, chatPanel, sources });
+}
+
+describe('ExternalCommentManager.render', async () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+    vi.restoreAllMocks();
+  });
+
+  it('renders nothing when there are no threads', async () => {
+    buildDiffTable();
+    const mgr = makeManager();
+    mgr.threadsBySource.set('github', []);
+    await mgr.render();
+    expect(document.querySelectorAll('.external-comment-row').length).toBe(0);
+  });
+
+  it('renders a single root thread after the target diff line', async () => {
+    const { rowsByKey } = buildDiffTable({ lines: [{ line: 10, side: 'RIGHT' }] });
+    const target = rowsByKey.get('src/app.js:10:RIGHT');
+
+    const mgr = makeManager();
+    mgr.threadsBySource.set('github', [makeComment({ id: 7, body: 'Hello' })]);
+    await mgr.render();
+
+    const rows = document.querySelectorAll('.external-comment-row');
+    expect(rows.length).toBe(1);
+    // Inserted immediately after the target diff row
+    expect(target.nextSibling).toBe(rows[0]);
+    // Contains exactly one comment element (no replies)
+    expect(rows[0].querySelectorAll('.external-comment').length).toBe(1);
+    expect(rows[0].querySelector('.external-comment').classList.contains('source-github')).toBe(true);
+    // Body text rendered as plaintext (no renderMarkdown installed) — fallback uses textContent
+    expect(rows[0].querySelector('.external-comment-body').textContent).toBe('Hello');
+  });
+
+  it('renders a root with two replies as nested is-reply elements in one row', async () => {
+    const { rowsByKey } = buildDiffTable({ lines: [{ line: 10, side: 'RIGHT' }] });
+    const target = rowsByKey.get('src/app.js:10:RIGHT');
+
+    const root = makeComment({
+      id: 1,
+      body: 'root',
+      replies: [
+        makeComment({ id: 2, body: 'reply 1', parent_id: 1, in_reply_to_id: 'gh-1' }),
+        makeComment({ id: 3, body: 'reply 2', parent_id: 1, in_reply_to_id: 'gh-1' }),
+      ],
+    });
+    const mgr = makeManager();
+    mgr.threadsBySource.set('github', [root]);
+    await mgr.render();
+
+    const rows = document.querySelectorAll('.external-comment-row');
+    expect(rows.length).toBe(1);
+    expect(target.nextSibling).toBe(rows[0]);
+
+    const thread = rows[0].querySelector('.external-comment-thread');
+    const comments = thread.querySelectorAll('.external-comment');
+    expect(comments.length).toBe(3);
+    expect(comments[0].classList.contains('is-reply')).toBe(false);
+    expect(comments[1].classList.contains('is-reply')).toBe(true);
+    expect(comments[2].classList.contains('is-reply')).toBe(true);
+  });
+
+  it('uses original_line_end and shows outdated badge for outdated threads', async () => {
+    // Diff currently shows line 20 — the outdated comment was made against line 20 originally.
+    const { rowsByKey } = buildDiffTable({ lines: [{ line: 20, side: 'RIGHT' }] });
+    const target = rowsByKey.get('src/app.js:20:RIGHT');
+
+    const root = makeComment({
+      id: 9,
+      is_outdated: 1,
+      line_start: null,
+      line_end: null,
+      original_line_start: 20,
+      original_line_end: 20,
+      body: 'stale feedback',
+    });
+    const mgr = makeManager();
+    mgr.threadsBySource.set('github', [root]);
+    await mgr.render();
+
+    const rows = document.querySelectorAll('.external-comment-row');
+    expect(rows.length).toBe(1);
+    expect(target.nextSibling).toBe(rows[0]);
+    const c = rows[0].querySelector('.external-comment');
+    expect(c.classList.contains('is-outdated')).toBe(true);
+    expect(rows[0].querySelector('.external-comment-outdated-badge')).not.toBeNull();
+  });
+
+  it('skips threads with no anchor and warns once', async () => {
+    buildDiffTable({ lines: [{ line: 10, side: 'RIGHT' }] });
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const root = makeComment({ id: 5, line_end: null, original_line_end: null, is_outdated: 0 });
+    const mgr = makeManager();
+    mgr.threadsBySource.set('github', [root]);
+    await mgr.render();
+
+    expect(document.querySelectorAll('.external-comment-row').length).toBe(0);
+    expect(warn).toHaveBeenCalled();
+  });
+
+  it('renders author as a link when author_url is present and plain text otherwise', async () => {
+    const { rowsByKey } = buildDiffTable({ lines: [
+      { line: 10, side: 'RIGHT' },
+      { line: 11, side: 'RIGHT' },
+    ] });
+    const mgr = makeManager();
+    mgr.threadsBySource.set('github', [
+      makeComment({ id: 1, line_start: 10, line_end: 10, author: 'octocat', author_url: 'https://github.com/octocat' }),
+      makeComment({ id: 2, line_start: 11, line_end: 11, author: 'ghost', author_url: null }),
+    ]);
+    await mgr.render();
+
+    expect(rowsByKey.get('src/app.js:10:RIGHT').nextSibling.querySelector('a.external-comment-author').textContent).toBe('octocat');
+    expect(rowsByKey.get('src/app.js:11:RIGHT').nextSibling.querySelector('span.external-comment-author').textContent).toBe('ghost');
+  });
+});
+
+describe('ExternalCommentManager chat buttons', async () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+  afterEach(() => {
+    document.body.innerHTML = '';
+    vi.restoreAllMocks();
+  });
+
+  it('chat-about-comment button click invokes chatPanel.open with commentContext shape', async () => {
+    buildDiffTable({ lines: [{ line: 10, side: 'RIGHT' }] });
+    const chatPanel = { open: vi.fn() };
+    const mgr = makeManager({ chatPanel });
+    const comment = makeComment({
+      id: 42,
+      body: 'inline body',
+      author: 'octocat',
+      external_url: 'https://example.com/c/42',
+      parent_id: null,
+    });
+    mgr.threadsBySource.set('github', [comment]);
+    await mgr.render();
+
+    const btn = document.querySelector('.external-comment-chat-btn');
+    expect(btn).not.toBeNull();
+    btn.click();
+
+    expect(chatPanel.open).toHaveBeenCalledTimes(1);
+    const arg = chatPanel.open.mock.calls[0][0];
+    expect(arg).toEqual({
+      commentContext: {
+        commentId: 42,
+        body: 'inline body',
+        file: 'src/app.js',
+        side: 'RIGHT',
+        line_start: 10,
+        line_end: 10,
+        source: 'external',
+        externalSource: 'github',
+        author: 'octocat',
+        externalUrl: 'https://example.com/c/42',
+        isOutdated: false,
+      },
+    });
+  });
+
+  it('chat-about-comment for outdated uses original_line_* and isOutdated=true', async () => {
+    buildDiffTable({ lines: [{ line: 20, side: 'RIGHT' }] });
+    const chatPanel = { open: vi.fn() };
+    const mgr = makeManager({ chatPanel });
+    mgr.threadsBySource.set('github', [
+      makeComment({
+        id: 9,
+        is_outdated: 1,
+        line_start: null,
+        line_end: null,
+        original_line_start: 20,
+        original_line_end: 20,
+      }),
+    ]);
+    await mgr.render();
+
+    const btn = document.querySelector('.external-comment-chat-btn');
+    btn.click();
+    const arg = chatPanel.open.mock.calls[0][0];
+    expect(arg.commentContext.isOutdated).toBe(true);
+    expect(arg.commentContext.line_start).toBe(20);
+    expect(arg.commentContext.line_end).toBe(20);
+  });
+
+  it('chat-about-thread button click invokes chatPanel.open with threadContext shape', async () => {
+    buildDiffTable({ lines: [{ line: 10, side: 'RIGHT' }] });
+    const chatPanel = { open: vi.fn() };
+    const mgr = makeManager({ chatPanel });
+
+    const root = makeComment({
+      id: 1,
+      body: 'root body',
+      external_created_at: '2026-01-01T00:00:00Z',
+      replies: [
+        makeComment({ id: 2, body: 'reply body', is_outdated: 0, external_url: 'https://example.com/c/2', external_created_at: '2026-01-02T00:00:00Z', author: 'alice' }),
+      ],
+    });
+    mgr.threadsBySource.set('github', [root]);
+    await mgr.render();
+
+    const threadBtn = document.querySelector('.external-comment-chat-thread-btn');
+    expect(threadBtn).not.toBeNull();
+    threadBtn.click();
+
+    expect(chatPanel.open).toHaveBeenCalledTimes(1);
+    const arg = chatPanel.open.mock.calls[0][0];
+    expect(arg).toEqual({
+      threadContext: {
+        rootId: 1,
+        source: 'external',
+        externalSource: 'github',
+        file: 'src/app.js',
+        side: 'RIGHT',
+        line_start: 10,
+        line_end: 10,
+        comments: [
+          {
+            author: 'octocat',
+            body: 'root body',
+            isOutdated: false,
+            externalUrl: 'https://github.com/o/r/pull/1#discussion_r1',
+            externalCreatedAt: '2026-01-01T00:00:00Z',
+          },
+          {
+            author: 'alice',
+            body: 'reply body',
+            isOutdated: false,
+            externalUrl: 'https://example.com/c/2',
+            externalCreatedAt: '2026-01-02T00:00:00Z',
+          },
+        ],
+      },
+    });
+  });
+});
+
+describe('ExternalCommentManager.clear', async () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+  afterEach(() => {
+    document.body.innerHTML = '';
+    vi.restoreAllMocks();
+  });
+
+  it('removes only external-comment-row rows, leaving user-comment-row and ai-suggestion-row intact', async () => {
+    const { rowsByKey, tbody } = buildDiffTable({ lines: [{ line: 10, side: 'RIGHT' }] });
+    const target = rowsByKey.get('src/app.js:10:RIGHT');
+
+    // Manually place sibling rows owned by other renderers
+    const aiRow = document.createElement('tr');
+    aiRow.className = 'ai-suggestion-row';
+    const userRow = document.createElement('tr');
+    userRow.className = 'user-comment-row';
+    tbody.insertBefore(aiRow, target.nextSibling);
+    tbody.insertBefore(userRow, aiRow.nextSibling);
+
+    const mgr = makeManager();
+    mgr.threadsBySource.set('github', [makeComment({ id: 1 })]);
+    await mgr.render();
+
+    expect(document.querySelectorAll('.external-comment-row').length).toBe(1);
+
+    mgr.clear();
+
+    expect(document.querySelectorAll('.external-comment-row').length).toBe(0);
+    expect(document.querySelectorAll('.ai-suggestion-row').length).toBe(1);
+    expect(document.querySelectorAll('.user-comment-row').length).toBe(1);
+  });
+});
+
+describe('ExternalCommentManager ordering rule', async () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+  afterEach(() => {
+    document.body.innerHTML = '';
+    vi.restoreAllMocks();
+  });
+
+  it('inserts external-comment-row BELOW pre-existing user-comment-row at the same diff line', async () => {
+    const { rowsByKey, tbody } = buildDiffTable({ lines: [{ line: 10, side: 'RIGHT' }] });
+    const target = rowsByKey.get('src/app.js:10:RIGHT');
+
+    // Existing user-comment-row sits immediately after the diff line
+    const userRow = document.createElement('tr');
+    userRow.className = 'user-comment-row';
+    tbody.insertBefore(userRow, target.nextSibling);
+
+    const mgr = makeManager();
+    mgr.threadsBySource.set('github', [makeComment({ id: 1 })]);
+    await mgr.render();
+
+    const externalRow = document.querySelector('.external-comment-row');
+    expect(externalRow).not.toBeNull();
+    // Order: target -> userRow -> externalRow
+    expect(target.nextSibling).toBe(userRow);
+    expect(userRow.nextSibling).toBe(externalRow);
+  });
+
+  it('inserts external-comment-row BELOW pre-existing ai-suggestion-row AND user-comment-row at the same diff line', async () => {
+    const { rowsByKey, tbody } = buildDiffTable({ lines: [{ line: 10, side: 'RIGHT' }] });
+    const target = rowsByKey.get('src/app.js:10:RIGHT');
+
+    const aiRow = document.createElement('tr');
+    aiRow.className = 'ai-suggestion-row';
+    tbody.insertBefore(aiRow, target.nextSibling);
+    const userRow = document.createElement('tr');
+    userRow.className = 'user-comment-row';
+    tbody.insertBefore(userRow, aiRow.nextSibling);
+
+    const mgr = makeManager();
+    mgr.threadsBySource.set('github', [makeComment({ id: 1 })]);
+    await mgr.render();
+
+    const externalRow = document.querySelector('.external-comment-row');
+    expect(target.nextSibling).toBe(aiRow);
+    expect(aiRow.nextSibling).toBe(userRow);
+    expect(userRow.nextSibling).toBe(externalRow);
+  });
+});
+
+describe('ExternalCommentManager.loadAndRender in-flight guard', async () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+  afterEach(() => {
+    document.body.innerHTML = '';
+    vi.restoreAllMocks();
+    delete global.fetch;
+  });
+
+  it('coalesces concurrent loadAndRender calls into a single fetch', async () => {
+    buildDiffTable({ lines: [{ line: 10, side: 'RIGHT' }] });
+    const threads = [makeComment({ id: 1 })];
+
+    // Block the fetch on a manual promise so we can fire two callers
+    // while the first is still in flight.
+    let resolveFetch;
+    const gate = new Promise((r) => { resolveFetch = r; });
+    global.fetch = vi.fn().mockImplementation(() => gate.then(() => ({
+      ok: true,
+      json: vi.fn().mockResolvedValue({ threads }),
+    })));
+
+    const mgr = makeManager({ reviewId: 'r-1' });
+
+    const p1 = mgr.loadAndRender();
+    const p2 = mgr.loadAndRender();
+    // While the gate is closed, both callers must observe the same promise
+    expect(p1).toBe(p2);
+    expect(mgr._inflight).toBe(p1);
+
+    resolveFetch();
+    const [r1, r2] = await Promise.all([p1, p2]);
+
+    expect(r1).toBe(r2);
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(mgr._inflight).toBeNull();
+    // Render did happen exactly once
+    expect(document.querySelectorAll('.external-comment-row').length).toBe(1);
+  });
+
+  it('a third call AFTER the first settles makes a new fetch', async () => {
+    buildDiffTable({ lines: [{ line: 10, side: 'RIGHT' }] });
+    const threads = [makeComment({ id: 1 })];
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({ threads }),
+    });
+
+    const mgr = makeManager({ reviewId: 'r-1' });
+    await mgr.loadAndRender();
+    await mgr.loadAndRender();
+
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('syncAndRender runs syncFn BEFORE the GET, and a concurrent loadAndRender joins the in-flight promise', async () => {
+    // Regression: between sync POST and GET render, a GET-only caller
+    // (analysis rebuild, whitespace toggle) hitting loadAndRender used to
+    // race the POST with a stale GET. Both methods now share `_inflight`,
+    // so the GET-only caller joins the full sync+load promise.
+    buildDiffTable({ lines: [{ line: 10, side: 'RIGHT' }] });
+    const threads = [makeComment({ id: 1 })];
+
+    // Order recorder: confirm POST ran before GET.
+    const order = [];
+    let resolveSync;
+    const syncGate = new Promise((r) => { resolveSync = r; });
+    const syncFn = vi.fn(async () => {
+      order.push('sync:start');
+      await syncGate;
+      order.push('sync:end');
+      return { count: 1, lostAnchors: 0, deleted: 0, syncedAt: 'now' };
+    });
+
+    global.fetch = vi.fn().mockImplementation(() => {
+      order.push('get');
+      return Promise.resolve({
+        ok: true,
+        json: vi.fn().mockResolvedValue({ threads }),
+      });
+    });
+
+    const mgr = makeManager({ reviewId: 'r-1' });
+
+    const p1 = mgr.syncAndRender({ syncFn });
+    // While sync is blocked, a GET-only caller arrives.
+    const p2 = mgr.loadAndRender();
+    // Both must observe the same in-flight promise.
+    expect(p2).toBe(p1);
+    expect(mgr._inflight).toBe(p1);
+
+    resolveSync();
+    const [r1, r2] = await Promise.all([p1, p2]);
+
+    expect(r1).toBe(r2);
+    expect(syncFn).toHaveBeenCalledTimes(1);
+    // GET fired exactly once and AFTER sync completed.
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(order).toEqual(['sync:start', 'sync:end', 'get']);
+    expect(r1.syncResult).toEqual({ count: 1, lostAnchors: 0, deleted: 0, syncedAt: 'now' });
+    expect(r1.syncError).toBeNull();
+  });
+
+  it('syncAndRender: sync failure does not block render — syncError surfaced, render still happens', async () => {
+    buildDiffTable({ lines: [{ line: 10, side: 'RIGHT' }] });
+    const threads = [makeComment({ id: 1 })];
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({ threads }),
+    });
+    const syncErr = Object.assign(new Error('boom'), { status: 429 });
+    const syncFn = vi.fn().mockRejectedValue(syncErr);
+
+    const mgr = makeManager({ reviewId: 'r-1' });
+    const result = await mgr.syncAndRender({ syncFn });
+
+    expect(result.syncError).toBe(syncErr);
+    expect(result.syncResult).toBeNull();
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(document.querySelectorAll('.external-comment-row').length).toBe(1);
+  });
+});
+
+describe('ExternalCommentManager outdated comment ensureLinesVisible fallback', async () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    delete window.prManager;
+  });
+  afterEach(() => {
+    document.body.innerHTML = '';
+    delete window.prManager;
+    vi.restoreAllMocks();
+  });
+
+  it('calls prManager.ensureLinesVisible with items-array shape, awaits it, then re-looks-up', async () => {
+    // Regression: the call previously used positional args and wasn't
+    // awaited. Production PRManager.ensureLinesVisible takes an array of
+    // `{file, line_start, line_end, side}` items and returns a Promise.
+    // If the call isn't awaited the row isn't in the DOM at re-lookup time.
+    const { wrapper, tbody, rowsByKey } = buildDiffTable({ lines: [{ line: 30, side: 'RIGHT' }] });
+    const target30 = rowsByKey.get('src/app.js:30:RIGHT');
+
+    let expandedRow = null;
+    let ensureLinesVisibleResolved = false;
+    window.prManager = {
+      ensureLinesVisible: vi.fn(async (items) => {
+        // Defer DOM mutation to the next microtask so the test would FAIL
+        // if the production code forgot to await this Promise — the
+        // re-lookup would run before this hook materializes the row.
+        await Promise.resolve();
+        const item = Array.isArray(items) ? items[0] : null;
+        if (!item) return;
+        const tr = document.createElement('tr');
+        tr.dataset.lineNumber = String(item.line_start);
+        tr.dataset.side = (item.side || 'RIGHT').toString();
+        tr.dataset.newLineNumber = String(item.line_start);
+        for (let i = 0; i < 4; i++) tr.appendChild(document.createElement('td'));
+        tbody.insertBefore(tr, target30);
+        expandedRow = tr;
+        ensureLinesVisibleResolved = true;
+      }),
+    };
+
+    const outdated = makeComment({
+      id: 99,
+      is_outdated: 1,
+      line_start: null,
+      line_end: null,
+      original_line_start: 20,
+      original_line_end: 20,
+      body: 'old discussion',
+    });
+
+    const mgr = makeManager();
+    mgr.threadsBySource.set('github', [outdated]);
+    await mgr.render();
+
+    // Production contract: items-array call shape, awaited so the new row
+    // is in the DOM before re-lookup.
+    expect(window.prManager.ensureLinesVisible).toHaveBeenCalledTimes(1);
+    expect(window.prManager.ensureLinesVisible).toHaveBeenCalledWith([
+      { file: 'src/app.js', line_start: 20, line_end: 20, side: 'RIGHT' }
+    ]);
+    expect(ensureLinesVisibleResolved).toBe(true);
+
+    const rows = document.querySelectorAll('.external-comment-row');
+    expect(rows.length).toBe(1);
+    expect(expandedRow.nextSibling).toBe(rows[0]);
+    expect(wrapper.contains(rows[0])).toBe(true);
+  });
+
+  it('falls back to file-level when ensureLinesVisible cannot materialize the anchor', async () => {
+    // Diff has no anchor row for the target line; ensureLinesVisible is a no-op.
+    const { wrapper } = buildDiffTable({ lines: [{ line: 999, side: 'RIGHT' }] });
+    window.prManager = {
+      ensureLinesVisible: vi.fn(async () => {}),
+    };
+
+    const outdated = makeComment({
+      id: 77,
+      is_outdated: 1,
+      line_start: null,
+      line_end: null,
+      original_line_start: 20,
+      original_line_end: 20,
+    });
+
+    const mgr = makeManager();
+    mgr.threadsBySource.set('github', [outdated]);
+    await mgr.render();
+
+    // Still rendered, at the file fallback location.
+    const rows = wrapper.querySelectorAll('.external-comment-row');
+    expect(rows.length).toBe(1);
+    expect(rows[0].classList.contains('external-comment-row--file-fallback')).toBe(true);
+  });
+});
+
+describe('ExternalCommentManager URL safety (isSafeUrl)', async () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+  afterEach(() => {
+    document.body.innerHTML = '';
+    vi.restoreAllMocks();
+  });
+
+  it('javascript: author_url renders as plain text and no href', async () => {
+    buildDiffTable({ lines: [{ line: 10, side: 'RIGHT' }] });
+    const mgr = makeManager();
+    mgr.threadsBySource.set('github', [makeComment({
+      id: 1,
+      author: 'octocat',
+      author_url: 'javascript:alert(1)',
+    })]);
+    await mgr.render();
+
+    const row = document.querySelector('.external-comment-row');
+    expect(row).not.toBeNull();
+    expect(row.querySelector('a.external-comment-author')).toBeNull();
+    const span = row.querySelector('span.external-comment-author');
+    expect(span).not.toBeNull();
+    expect(span.textContent).toBe('octocat');
+    // No element in the rendered card carries a javascript: href.
+    const hrefs = Array.from(row.querySelectorAll('[href]')).map(el => el.getAttribute('href'));
+    for (const h of hrefs) expect(h).not.toMatch(/^javascript:/i);
+  });
+
+  it('javascript: external_url drops the permalink button entirely', async () => {
+    buildDiffTable({ lines: [{ line: 10, side: 'RIGHT' }] });
+    const mgr = makeManager();
+    mgr.threadsBySource.set('github', [makeComment({
+      id: 1,
+      external_url: 'javascript:alert(1)',
+    })]);
+    await mgr.render();
+
+    const row = document.querySelector('.external-comment-row');
+    expect(row.querySelector('.external-comment-permalink')).toBeNull();
+  });
+
+  it('https URLs are still rendered as links', async () => {
+    buildDiffTable({ lines: [{ line: 10, side: 'RIGHT' }] });
+    const mgr = makeManager();
+    mgr.threadsBySource.set('github', [makeComment({
+      id: 1,
+      author_url: 'https://github.com/octocat',
+      external_url: 'https://github.com/example',
+    })]);
+    await mgr.render();
+
+    const row = document.querySelector('.external-comment-row');
+    expect(row.querySelector('a.external-comment-author')).not.toBeNull();
+    expect(row.querySelector('.external-comment-permalink')).not.toBeNull();
+  });
+});
+
+describe('ExternalCommentManager minimizer refresh', async () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    delete window.prManager;
+  });
+  afterEach(() => {
+    document.body.innerHTML = '';
+    delete window.prManager;
+    vi.restoreAllMocks();
+  });
+
+  it('invokes prManager.commentMinimizer.refreshIndicators after rendering', async () => {
+    // Regression: external rows were not feeding the minimize-comments
+    // indicator pipeline, so toggling minimize mode dropped the external
+    // bubble count from per-line badges. Mirror what comment-manager and
+    // suggestion-manager do — call refreshIndicators on render completion.
+    buildDiffTable({ lines: [{ line: 10, side: 'RIGHT' }] });
+    const refreshSpy = vi.fn();
+    window.prManager = {
+      commentMinimizer: { refreshIndicators: refreshSpy }
+    };
+
+    const mgr = makeManager();
+    mgr.threadsBySource.set('github', [makeComment({ id: 1 })]);
+    await mgr.render();
+
+    expect(refreshSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not throw when prManager or commentMinimizer is missing', async () => {
+    buildDiffTable({ lines: [{ line: 10, side: 'RIGHT' }] });
+    const mgr = makeManager();
+    mgr.threadsBySource.set('github', [makeComment({ id: 1 })]);
+    // window.prManager intentionally absent.
+    await expect(mgr.render()).resolves.toBeUndefined();
+  });
+});
+
+describe('ExternalCommentManager passes side to chat context', async () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+  afterEach(() => {
+    document.body.innerHTML = '';
+    vi.restoreAllMocks();
+  });
+
+  it('LEFT side flows through to commentContext', async () => {
+    buildDiffTable({ lines: [{ line: 5, side: 'LEFT' }] });
+    const chatPanel = { open: vi.fn() };
+    const mgr = makeManager({ chatPanel });
+
+    mgr.threadsBySource.set('github', [makeComment({
+      id: 50,
+      side: 'LEFT',
+      line_start: 5,
+      line_end: 5,
+    })]);
+    await mgr.render();
+
+    document.querySelector('.external-comment-chat-btn').click();
+    expect(chatPanel.open).toHaveBeenCalledTimes(1);
+    expect(chatPanel.open.mock.calls[0][0].commentContext.side).toBe('LEFT');
+  });
+
+  it('LEFT side flows through to threadContext', async () => {
+    buildDiffTable({ lines: [{ line: 5, side: 'LEFT' }] });
+    const chatPanel = { open: vi.fn() };
+    const mgr = makeManager({ chatPanel });
+
+    mgr.threadsBySource.set('github', [makeComment({
+      id: 51,
+      side: 'LEFT',
+      line_start: 5,
+      line_end: 5,
+      replies: [],
+    })]);
+    await mgr.render();
+
+    document.querySelector('.external-comment-chat-thread-btn').click();
+    expect(chatPanel.open).toHaveBeenCalledTimes(1);
+    expect(chatPanel.open.mock.calls[0][0].threadContext.side).toBe('LEFT');
+  });
+
+  it('missing chat panel surfaces a toast instead of silently dropping', async () => {
+    buildDiffTable({ lines: [{ line: 10, side: 'RIGHT' }] });
+    const toastSpy = vi.fn();
+    const origToast = window.toast;
+    const origChatPanel = window.chatPanel;
+    window.toast = { showWarning: toastSpy };
+    delete window.chatPanel;
+
+    const mgr = makeManager({ chatPanel: null });
+    mgr.threadsBySource.set('github', [makeComment({ id: 1 })]);
+    await mgr.render();
+
+    document.querySelector('.external-comment-chat-btn').click();
+    expect(toastSpy).toHaveBeenCalledWith(expect.stringMatching(/Chat is unavailable/));
+    window.toast = origToast;
+    if (origChatPanel !== undefined) window.chatPanel = origChatPanel;
+  });
+});
+
+describe('ExternalCommentManager._resolveAnchor fallback (forward-compat)', async () => {
+  // Future GitLab/Linear adapters may not couple is_outdated with the
+  // current vs. original anchor in the same way GitHub does. `_resolveAnchor`
+  // treats is_outdated as a hint about which anchor to PREFER, not as a
+  // strict switch — falling back to the other anchor when the preferred
+  // one is missing keeps borderline cells renderable.
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+  afterEach(() => {
+    document.body.innerHTML = '';
+    vi.restoreAllMocks();
+  });
+
+  it('(a) outdated + only original_line_end set → uses original_line_end', () => {
+    const mgr = makeManager();
+    const a = mgr._resolveAnchor({
+      file: 'a.js',
+      side: 'RIGHT',
+      is_outdated: 1,
+      line_end: null,
+      original_line_end: 20,
+    });
+    expect(a).toEqual({ file: 'a.js', line: 20, side: 'RIGHT' });
+  });
+
+  it('(b) non-outdated + only line_end set → uses line_end', () => {
+    const mgr = makeManager();
+    const a = mgr._resolveAnchor({
+      file: 'a.js',
+      side: 'RIGHT',
+      is_outdated: 0,
+      line_end: 10,
+      original_line_end: null,
+    });
+    expect(a).toEqual({ file: 'a.js', line: 10, side: 'RIGHT' });
+  });
+
+  it('(c) outdated + only line_end set → falls back to live anchor', () => {
+    // Adapter reported is_outdated=1 but only line_end is populated. Strict
+    // switching would return null and silently drop the row. The fallback
+    // uses line_end so the comment still renders.
+    const mgr = makeManager();
+    const a = mgr._resolveAnchor({
+      file: 'a.js',
+      side: 'RIGHT',
+      is_outdated: 1,
+      line_end: 7,
+      original_line_end: null,
+    });
+    expect(a).toEqual({ file: 'a.js', line: 7, side: 'RIGHT' });
+  });
+
+  it('(d) non-outdated + only original_line_end set → falls back to original', () => {
+    const mgr = makeManager();
+    const a = mgr._resolveAnchor({
+      file: 'a.js',
+      side: 'RIGHT',
+      is_outdated: 0,
+      line_end: null,
+      original_line_end: 33,
+    });
+    expect(a).toEqual({ file: 'a.js', line: 33, side: 'RIGHT' });
+  });
+
+  it('(e) both null → returns null', () => {
+    const mgr = makeManager();
+    const a = mgr._resolveAnchor({
+      file: 'a.js',
+      side: 'RIGHT',
+      is_outdated: 1,
+      line_end: null,
+      original_line_end: null,
+    });
+    expect(a).toBeNull();
+  });
+
+  it('returns null when comment.file is missing', () => {
+    const mgr = makeManager();
+    expect(mgr._resolveAnchor({ line_end: 5 })).toBeNull();
+    expect(mgr._resolveAnchor(null)).toBeNull();
+  });
+
+  it('defaults side to RIGHT when comment.side is missing', () => {
+    const mgr = makeManager();
+    const a = mgr._resolveAnchor({ file: 'a.js', line_end: 5 });
+    expect(a.side).toBe('RIGHT');
+  });
+});
+
+describe('ExternalCommentManager.fetch', async () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+  afterEach(() => {
+    document.body.innerHTML = '';
+    vi.restoreAllMocks();
+    delete global.fetch;
+  });
+
+  it('hits the correct URL and stores returned threads', async () => {
+    const threads = [makeComment({ id: 99 })];
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({ threads }),
+    });
+
+    const mgr = makeManager({ reviewId: 'r-42' });
+    const got = await mgr.fetch('github');
+
+    expect(global.fetch).toHaveBeenCalledWith('/api/reviews/r-42/external-comments?source=github');
+    expect(got).toBe(threads);
+    expect(mgr.threadsBySource.get('github')).toBe(threads);
+  });
+
+  it('surfaces a toast when the API returns non-ok', async () => {
+    global.fetch = vi.fn().mockResolvedValue({ ok: false, status: 500, json: vi.fn() });
+    window.toast = { showError: vi.fn() };
+
+    const mgr = makeManager();
+    await expect(mgr.fetch('github')).rejects.toThrow(/Failed to fetch external comments/);
+    expect(window.toast.showError).toHaveBeenCalled();
+    delete window.toast;
+  });
+});

--- a/tests/unit/external-comment-manager.test.js
+++ b/tests/unit/external-comment-manager.test.js
@@ -222,23 +222,39 @@ describe('ExternalCommentManager chat buttons', async () => {
     vi.restoreAllMocks();
   });
 
-  it('chat-about-comment button click invokes chatPanel.open with commentContext shape', async () => {
+  // After the "consolidate chat buttons" change there is no separate
+  // `.external-comment-chat-thread-btn` element. The per-comment chat
+  // icon (`.external-comment-chat-btn`) dispatches:
+  //   - on the thread root  → threadContext (whole thread + replies)
+  //   - on a reply          → commentContext (that single reply)
+  // The tests below assert each branch and pin the per-comment fields
+  // (id/body/line/side/isOutdated) so coverage from the prior contract
+  // is preserved on the threadContext root entry.
+
+  it('chat button on a reply invokes chatPanel.open with commentContext shape', async () => {
     buildDiffTable({ lines: [{ line: 10, side: 'RIGHT' }] });
     const chatPanel = { open: vi.fn() };
     const mgr = makeManager({ chatPanel });
-    const comment = makeComment({
-      id: 42,
-      body: 'inline body',
-      author: 'octocat',
-      external_url: 'https://example.com/c/42',
-      parent_id: null,
+    const root = makeComment({
+      id: 1,
+      body: 'root body',
+      replies: [
+        makeComment({
+          id: 42,
+          body: 'inline body',
+          author: 'octocat',
+          external_url: 'https://example.com/c/42',
+          parent_id: 1,
+          in_reply_to_id: 'gh-1',
+        }),
+      ],
     });
-    mgr.threadsBySource.set('github', [comment]);
+    mgr.threadsBySource.set('github', [root]);
     await mgr.render();
 
-    const btn = document.querySelector('.external-comment-chat-btn');
-    expect(btn).not.toBeNull();
-    btn.click();
+    const replyBtn = document.querySelector('.external-comment.is-reply .external-comment-chat-btn');
+    expect(replyBtn).not.toBeNull();
+    replyBtn.click();
 
     expect(chatPanel.open).toHaveBeenCalledTimes(1);
     const arg = chatPanel.open.mock.calls[0][0];
@@ -259,31 +275,45 @@ describe('ExternalCommentManager chat buttons', async () => {
     });
   });
 
-  it('chat-about-comment for outdated uses original_line_* and isOutdated=true', async () => {
+  it('chat button on an outdated reply uses original_line_* and isOutdated=true', async () => {
     buildDiffTable({ lines: [{ line: 20, side: 'RIGHT' }] });
     const chatPanel = { open: vi.fn() };
     const mgr = makeManager({ chatPanel });
-    mgr.threadsBySource.set('github', [
-      makeComment({
-        id: 9,
-        is_outdated: 1,
-        line_start: null,
-        line_end: null,
-        original_line_start: 20,
-        original_line_end: 20,
-      }),
-    ]);
+    const root = makeComment({
+      id: 1,
+      // Root must be outdated too — the row anchors on the root's anchor
+      // and a non-outdated root with null lines would be skipped.
+      is_outdated: 1,
+      line_start: null,
+      line_end: null,
+      original_line_start: 20,
+      original_line_end: 20,
+      replies: [
+        makeComment({
+          id: 9,
+          parent_id: 1,
+          in_reply_to_id: 'gh-1',
+          is_outdated: 1,
+          line_start: null,
+          line_end: null,
+          original_line_start: 20,
+          original_line_end: 20,
+        }),
+      ],
+    });
+    mgr.threadsBySource.set('github', [root]);
     await mgr.render();
 
-    const btn = document.querySelector('.external-comment-chat-btn');
-    btn.click();
+    const replyBtn = document.querySelector('.external-comment.is-reply .external-comment-chat-btn');
+    expect(replyBtn).not.toBeNull();
+    replyBtn.click();
     const arg = chatPanel.open.mock.calls[0][0];
     expect(arg.commentContext.isOutdated).toBe(true);
     expect(arg.commentContext.line_start).toBe(20);
     expect(arg.commentContext.line_end).toBe(20);
   });
 
-  it('chat-about-thread button click invokes chatPanel.open with threadContext shape', async () => {
+  it('chat button on the thread root invokes chatPanel.open with threadContext shape', async () => {
     buildDiffTable({ lines: [{ line: 10, side: 'RIGHT' }] });
     const chatPanel = { open: vi.fn() };
     const mgr = makeManager({ chatPanel });
@@ -299,12 +329,21 @@ describe('ExternalCommentManager chat buttons', async () => {
     mgr.threadsBySource.set('github', [root]);
     await mgr.render();
 
-    const threadBtn = document.querySelector('.external-comment-chat-thread-btn');
-    expect(threadBtn).not.toBeNull();
-    threadBtn.click();
+    // Root chat button = the first `.external-comment-chat-btn` that is
+    // NOT inside `.is-reply`. After consolidation it replaces the prior
+    // standalone `.external-comment-chat-thread-btn` element.
+    const rootBtn = document.querySelector('.external-comment:not(.is-reply) .external-comment-chat-btn');
+    expect(rootBtn).not.toBeNull();
+    rootBtn.click();
 
     expect(chatPanel.open).toHaveBeenCalledTimes(1);
     const arg = chatPanel.open.mock.calls[0][0];
+    // Per-comment id/line/side coverage on the root entry — equivalent to
+    // the prior commentContext root assertions.
+    expect(arg.threadContext.rootId).toBe(1);
+    expect(arg.threadContext.line_start).toBe(10);
+    expect(arg.threadContext.line_end).toBe(10);
+    expect(arg.threadContext.side).toBe('RIGHT');
     expect(arg).toEqual({
       threadContext: {
         rootId: 1,
@@ -746,25 +785,35 @@ describe('ExternalCommentManager passes side to chat context', async () => {
     vi.restoreAllMocks();
   });
 
-  it('LEFT side flows through to commentContext', async () => {
+  it('LEFT side flows through to commentContext (reply chat button)', async () => {
     buildDiffTable({ lines: [{ line: 5, side: 'LEFT' }] });
     const chatPanel = { open: vi.fn() };
     const mgr = makeManager({ chatPanel });
 
     mgr.threadsBySource.set('github', [makeComment({
-      id: 50,
+      id: 49,
       side: 'LEFT',
       line_start: 5,
       line_end: 5,
+      replies: [
+        makeComment({
+          id: 50,
+          side: 'LEFT',
+          line_start: 5,
+          line_end: 5,
+          parent_id: 49,
+          in_reply_to_id: 'gh-1',
+        }),
+      ],
     })]);
     await mgr.render();
 
-    document.querySelector('.external-comment-chat-btn').click();
+    document.querySelector('.external-comment.is-reply .external-comment-chat-btn').click();
     expect(chatPanel.open).toHaveBeenCalledTimes(1);
     expect(chatPanel.open.mock.calls[0][0].commentContext.side).toBe('LEFT');
   });
 
-  it('LEFT side flows through to threadContext', async () => {
+  it('LEFT side flows through to threadContext (root chat button)', async () => {
     buildDiffTable({ lines: [{ line: 5, side: 'LEFT' }] });
     const chatPanel = { open: vi.fn() };
     const mgr = makeManager({ chatPanel });
@@ -778,7 +827,7 @@ describe('ExternalCommentManager passes side to chat context', async () => {
     })]);
     await mgr.render();
 
-    document.querySelector('.external-comment-chat-thread-btn').click();
+    document.querySelector('.external-comment:not(.is-reply) .external-comment-chat-btn').click();
     expect(chatPanel.open).toHaveBeenCalledTimes(1);
     expect(chatPanel.open.mock.calls[0][0].threadContext.side).toBe('LEFT');
   });
@@ -925,5 +974,158 @@ describe('ExternalCommentManager.fetch', async () => {
     await expect(mgr.fetch('github')).rejects.toThrow(/Failed to fetch external comments/);
     expect(window.toast.showError).toHaveBeenCalled();
     delete window.toast;
+  });
+});
+
+// =======================================================================
+// Review-panel handoff (External segment in AIPanel)
+//
+// The manager flattens threadsBySource into a single array via
+// getAllThreads(), and pushes it onto the panel after each
+// _fetchAllAndRender via setExternalThreads. The panel surface is
+// described in tests/unit/ai-panel-external-segment.test.js — these tests
+// only verify the producer side of the contract.
+// =======================================================================
+describe('ExternalCommentManager.getAllThreads', () => {
+  it('returns an empty array when no sources are loaded', () => {
+    const mgr = makeManager();
+    expect(mgr.getAllThreads()).toEqual([]);
+  });
+
+  it('flattens threads from every source into a single array', () => {
+    const mgr = makeManager({ sources: ['github', 'gitlab'] });
+    const ghThreads = [makeComment({ id: 1 }), makeComment({ id: 2 })];
+    const glThreads = [makeComment({ id: 3, source: 'gitlab' })];
+    mgr.threadsBySource.set('github', ghThreads);
+    mgr.threadsBySource.set('gitlab', glThreads);
+
+    const all = mgr.getAllThreads();
+    expect(all).toHaveLength(3);
+    expect(all.map(t => t.id).sort()).toEqual([1, 2, 3]);
+  });
+
+  it('skips entries that are not arrays defensively', () => {
+    const mgr = makeManager();
+    mgr.threadsBySource.set('github', [makeComment({ id: 1 })]);
+    mgr.threadsBySource.set('broken', null);
+    mgr.threadsBySource.set('also-broken', 'not an array');
+
+    const all = mgr.getAllThreads();
+    expect(all).toHaveLength(1);
+    expect(all[0].id).toBe(1);
+  });
+});
+
+describe('ExternalCommentManager._notifyPanel', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    delete window.aiPanel;
+  });
+  afterEach(() => {
+    document.body.innerHTML = '';
+    delete window.aiPanel;
+    vi.restoreAllMocks();
+  });
+
+  it('calls window.aiPanel.setExternalThreads with the flattened thread list', () => {
+    const setExternalThreads = vi.fn();
+    window.aiPanel = { setExternalThreads };
+
+    const mgr = makeManager();
+    mgr.threadsBySource.set('github', [makeComment({ id: 1 }), makeComment({ id: 2 })]);
+
+    mgr._notifyPanel();
+
+    expect(setExternalThreads).toHaveBeenCalledTimes(1);
+    const arg = setExternalThreads.mock.calls[0][0];
+    expect(Array.isArray(arg)).toBe(true);
+    expect(arg.map(t => t.id).sort()).toEqual([1, 2]);
+  });
+
+  it('is a no-op when window.aiPanel is not present', () => {
+    const mgr = makeManager();
+    mgr.threadsBySource.set('github', [makeComment({ id: 1 })]);
+    expect(() => mgr._notifyPanel()).not.toThrow();
+  });
+
+  it('is a no-op when window.aiPanel is missing setExternalThreads', () => {
+    window.aiPanel = { /* no setExternalThreads */ };
+    const mgr = makeManager();
+    mgr.threadsBySource.set('github', [makeComment({ id: 1 })]);
+    expect(() => mgr._notifyPanel()).not.toThrow();
+  });
+
+  it('survives setExternalThreads throwing without rejecting render', () => {
+    const setExternalThreads = vi.fn(() => { throw new Error('boom'); });
+    window.aiPanel = { setExternalThreads };
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const mgr = makeManager();
+    mgr.threadsBySource.set('github', [makeComment({ id: 1 })]);
+    expect(() => mgr._notifyPanel()).not.toThrow();
+    expect(warn).toHaveBeenCalled();
+  });
+});
+
+describe('ExternalCommentManager._fetchAllAndRender → panel handoff', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    delete window.aiPanel;
+    delete global.fetch;
+  });
+  afterEach(() => {
+    document.body.innerHTML = '';
+    delete window.aiPanel;
+    vi.restoreAllMocks();
+    delete global.fetch;
+  });
+
+  it('pushes the flattened thread list to the panel after a successful fetch+render', async () => {
+    buildDiffTable({ lines: [{ line: 10, side: 'RIGHT' }] });
+
+    const threads = [makeComment({ id: 1 }), makeComment({ id: 2 })];
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({ threads }),
+    });
+
+    const setExternalThreads = vi.fn();
+    window.aiPanel = { setExternalThreads };
+
+    const mgr = makeManager();
+    await mgr._fetchAllAndRender();
+
+    expect(setExternalThreads).toHaveBeenCalledTimes(1);
+    const arg = setExternalThreads.mock.calls[0][0];
+    expect(arg.map(t => t.id)).toEqual([1, 2]);
+  });
+
+  it('still pushes to the panel when one source fetch fails', async () => {
+    // Two sources, first fails, second succeeds. Errors are collected and
+    // rendering proceeds, so the panel should still see whatever did load.
+    let callIdx = 0;
+    global.fetch = vi.fn().mockImplementation(() => {
+      callIdx += 1;
+      if (callIdx === 1) {
+        return Promise.resolve({ ok: false, status: 500, json: vi.fn() });
+      }
+      return Promise.resolve({
+        ok: true,
+        json: vi.fn().mockResolvedValue({ threads: [makeComment({ id: 99, source: 'gitlab' })] }),
+      });
+    });
+
+    const setExternalThreads = vi.fn();
+    window.aiPanel = { setExternalThreads };
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const mgr = makeManager({ sources: ['github', 'gitlab'] });
+    await mgr._fetchAllAndRender();
+
+    expect(setExternalThreads).toHaveBeenCalledTimes(1);
+    const arg = setExternalThreads.mock.calls[0][0];
+    // Only the successful source contributed threads
+    expect(arg).toHaveLength(1);
+    expect(arg[0].id).toBe(99);
   });
 });

--- a/tests/unit/external/dispatcher.test.js
+++ b/tests/unit/external/dispatcher.test.js
@@ -1,0 +1,59 @@
+// Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+import { describe, it, expect } from 'vitest';
+
+const { getAdapter, adapters } = require('../../../src/external');
+const githubAdapter = require('../../../src/external/github-adapter');
+
+describe('external dispatcher', () => {
+  it('getAdapter("github") returns the GitHub adapter', () => {
+    const adapter = getAdapter('github');
+    expect(adapter).toBe(githubAdapter);
+    expect(adapter.name).toBe('github');
+    expect(typeof adapter.fetchComments).toBe('function');
+    expect(typeof adapter.mapComment).toBe('function');
+  });
+
+  it('getAdapter("unknown") throws with the source name in the message', () => {
+    expect(() => getAdapter('unknown')).toThrow(
+      /Unknown external comment source: unknown/
+    );
+  });
+
+  it('getAdapter throws when called with an empty string', () => {
+    expect(() => getAdapter('')).toThrow(
+      /Unknown external comment source:/
+    );
+  });
+
+  it('adapters registry exposes github by name', () => {
+    expect(adapters.github).toBe(githubAdapter);
+  });
+
+  it('getAdapter("toString") throws (own-property guard against inherited members)', () => {
+    // Regression: `adapters` is a plain object, so `adapters['toString']`
+    // would resolve to `Object.prototype.toString` (a function) without
+    // the hasOwnProperty guard. The route depends on this function
+    // throwing for unknown sources.
+    expect(() => getAdapter('toString')).toThrow(
+      /Unknown external comment source: toString/
+    );
+  });
+
+  it('getAdapter("__proto__") throws', () => {
+    expect(() => getAdapter('__proto__')).toThrow(
+      /Unknown external comment source: __proto__/
+    );
+  });
+
+  it('getAdapter("hasOwnProperty") throws', () => {
+    expect(() => getAdapter('hasOwnProperty')).toThrow(
+      /Unknown external comment source: hasOwnProperty/
+    );
+  });
+
+  it('getAdapter(non-string) throws', () => {
+    expect(() => getAdapter(null)).toThrow(/Unknown external comment source:/);
+    expect(() => getAdapter(undefined)).toThrow(/Unknown external comment source:/);
+    expect(() => getAdapter(123)).toThrow(/Unknown external comment source:/);
+  });
+});

--- a/tests/unit/external/github-adapter.test.js
+++ b/tests/unit/external/github-adapter.test.js
@@ -1,0 +1,328 @@
+// Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+import { describe, it, expect, vi } from 'vitest';
+
+const githubAdapter = require('../../../src/external/github-adapter');
+
+describe('github-adapter', () => {
+  describe('name', () => {
+    it('is "github"', () => {
+      expect(githubAdapter.name).toBe('github');
+    });
+  });
+
+  describe('fetchComments', () => {
+    it('delegates to client.listReviewComments with { owner, repo, pull_number }', async () => {
+      const rows = [{ id: 1 }, { id: 2 }];
+      const client = {
+        listReviewComments: vi.fn().mockResolvedValue(rows),
+      };
+
+      const result = await githubAdapter.fetchComments({
+        client,
+        owner: 'octocat',
+        repo: 'hello-world',
+        pull_number: 42,
+      });
+
+      expect(client.listReviewComments).toHaveBeenCalledTimes(1);
+      expect(client.listReviewComments).toHaveBeenCalledWith({
+        owner: 'octocat',
+        repo: 'hello-world',
+        pull_number: 42,
+      });
+      expect(result).toBe(rows);
+    });
+  });
+
+  describe('credentialEnvVar', () => {
+    it('advertises GITHUB_TOKEN', () => {
+      // Surfaced in credential-missing errors so the user is told which env
+      // var to set. Future adapters declare their own.
+      expect(githubAdapter.credentialEnvVar).toBe('GITHUB_TOKEN');
+    });
+  });
+
+  describe('resolveCredentials', () => {
+    it('happy path: returns { client } constructed with the resolved token', () => {
+      const FakeGitHubClient = vi.fn(function (tok) { this.tok = tok; });
+      const getGitHubToken = vi.fn(() => 'ghp_test_token');
+
+      const result = githubAdapter.resolveCredentials(
+        { github_token: 'ghp_test_token' },
+        { GitHubClient: FakeGitHubClient, getGitHubToken }
+      );
+
+      expect(getGitHubToken).toHaveBeenCalledTimes(1);
+      expect(getGitHubToken).toHaveBeenCalledWith({ github_token: 'ghp_test_token' });
+      expect(FakeGitHubClient).toHaveBeenCalledWith('ghp_test_token');
+      expect(result.client).toBeInstanceOf(FakeGitHubClient);
+      expect(result.client.tok).toBe('ghp_test_token');
+    });
+
+    it('missing token: throws GitHubApiError(status=401) naming GITHUB_TOKEN', () => {
+      const FakeGitHubClient = vi.fn();
+      const getGitHubToken = vi.fn(() => '');
+
+      let captured = null;
+      try {
+        githubAdapter.resolveCredentials(
+          {},
+          { GitHubClient: FakeGitHubClient, getGitHubToken }
+        );
+      } catch (err) {
+        captured = err;
+      }
+
+      // Use the canonical error type so the route's catch ladder can
+      // instanceof-match without string sniffing.
+      const { GitHubApiError } = require('../../../src/github/client');
+      expect(captured).toBeInstanceOf(GitHubApiError);
+      expect(captured.status).toBe(401);
+      expect(captured.message).toContain('GITHUB_TOKEN');
+      // Client must NOT be constructed when credentials are missing.
+      expect(FakeGitHubClient).not.toHaveBeenCalled();
+    });
+
+    it('null config: still calls getGitHubToken with an empty object', () => {
+      const getGitHubToken = vi.fn(() => 'tok');
+      const FakeGitHubClient = vi.fn();
+
+      githubAdapter.resolveCredentials(
+        null,
+        { GitHubClient: FakeGitHubClient, getGitHubToken }
+      );
+
+      expect(getGitHubToken).toHaveBeenCalledWith({});
+    });
+
+    it('uses module defaults when _deps is omitted (production code path)', () => {
+      // No _deps argument — this exercises the production defaults: the
+      // real getGitHubToken (which reads from config) and the real
+      // GitHubClient. Pass a config with the token to drive resolution
+      // without touching env vars.
+      const result = githubAdapter.resolveCredentials({ github_token: 'real-tok' });
+      const { GitHubClient } = require('../../../src/github/client');
+      expect(result.client).toBeInstanceOf(GitHubClient);
+    });
+  });
+
+  describe('mapComment', () => {
+    function baseRow(overrides = {}) {
+      return {
+        id: 100,
+        in_reply_to_id: null,
+        html_url: 'https://github.com/octocat/hello-world/pull/42#discussion_r100',
+        user: {
+          login: 'octocat',
+          html_url: 'https://github.com/octocat',
+        },
+        path: 'src/file.js',
+        side: 'RIGHT',
+        start_line: null,
+        line: 17,
+        position: 5,
+        commit_id: 'abc123',
+        original_start_line: null,
+        original_line: 17,
+        original_commit_id: 'def456',
+        body: 'Nice work here.',
+        created_at: '2026-01-02T03:04:05Z',
+        ...overrides,
+      };
+    }
+
+    it('happy path: maps a typical single-line comment', () => {
+      const row = baseRow();
+      const mapped = githubAdapter.mapComment(row);
+
+      expect(mapped).toEqual({
+        external_id: '100',
+        in_reply_to_id: null,
+        external_url: 'https://github.com/octocat/hello-world/pull/42#discussion_r100',
+        author: 'octocat',
+        author_url: 'https://github.com/octocat',
+        file: 'src/file.js',
+        side: 'RIGHT',
+        line_start: 17,
+        line_end: 17,
+        diff_position: 5,
+        commit_sha: 'abc123',
+        is_outdated: 0,
+        original_line_start: 17,
+        original_line_end: 17,
+        original_commit_sha: 'def456',
+        body: 'Nice work here.',
+        external_created_at: '2026-01-02T03:04:05Z',
+      });
+      expect(mapped).not.toHaveProperty('source');
+      expect(mapped).not.toHaveProperty('synced_at');
+      expect(mapped).not.toHaveProperty('parent_id');
+    });
+
+    it('multi-line comment: start_line populated, line is the end', () => {
+      const row = baseRow({
+        start_line: 12,
+        line: 17,
+        original_start_line: 12,
+        original_line: 17,
+      });
+      const mapped = githubAdapter.mapComment(row);
+
+      expect(mapped.line_start).toBe(12);
+      expect(mapped.line_end).toBe(17);
+      expect(mapped.original_line_start).toBe(12);
+      expect(mapped.original_line_end).toBe(17);
+    });
+
+    it('reply: in_reply_to_id is stringified', () => {
+      const row = baseRow({ id: 200, in_reply_to_id: 100 });
+      const mapped = githubAdapter.mapComment(row);
+
+      expect(mapped.external_id).toBe('200');
+      expect(mapped.in_reply_to_id).toBe('100');
+      expect(typeof mapped.in_reply_to_id).toBe('string');
+    });
+
+    it('outdated comment: position null → is_outdated 1, current line fields null, original fields populated', () => {
+      const row = baseRow({
+        position: null,
+        line: null,
+        start_line: null,
+        commit_id: null,
+        original_start_line: 12,
+        original_line: 17,
+        original_commit_id: 'old-sha',
+      });
+      const mapped = githubAdapter.mapComment(row);
+
+      expect(mapped.is_outdated).toBe(1);
+      expect(mapped.diff_position).toBeNull();
+      expect(mapped.line_start).toBeNull();
+      expect(mapped.line_end).toBeNull();
+      expect(mapped.commit_sha).toBeNull();
+      expect(mapped.original_line_start).toBe(12);
+      expect(mapped.original_line_end).toBe(17);
+      expect(mapped.original_commit_sha).toBe('old-sha');
+    });
+
+    it('outdated with leftover line: position null but line populated → line_* still nulled, original_* preserved', () => {
+      // GitHub sometimes returns `line` populated even when `position` is
+      // null. The adapter must treat position=null as the source of truth
+      // for "outdated" and null out current-anchor fields, otherwise the
+      // row carries two contradictory truths (line_end set AND is_outdated=1)
+      // and the lost-anchor filter under-counts.
+      const row = baseRow({
+        position: null,
+        line: 42,
+        start_line: 40,
+        original_start_line: 12,
+        original_line: 17,
+      });
+      const mapped = githubAdapter.mapComment(row);
+
+      expect(mapped.is_outdated).toBe(1);
+      expect(mapped.line_start).toBeNull();
+      expect(mapped.line_end).toBeNull();
+      expect(mapped.diff_position).toBeNull();
+      expect(mapped.original_line_start).toBe(12);
+      expect(mapped.original_line_end).toBe(17);
+    });
+
+    it('lost anchor: position and original_position both null still produces a row, no throw', () => {
+      const row = baseRow({
+        position: null,
+        original_position: null,
+        line: null,
+        start_line: null,
+        original_line: null,
+        original_start_line: null,
+        commit_id: null,
+        original_commit_id: null,
+      });
+
+      let mapped;
+      expect(() => {
+        mapped = githubAdapter.mapComment(row);
+      }).not.toThrow();
+
+      expect(mapped.is_outdated).toBe(1);
+      expect(mapped.line_start).toBeNull();
+      expect(mapped.line_end).toBeNull();
+      expect(mapped.diff_position).toBeNull();
+      expect(mapped.original_line_start).toBeNull();
+      expect(mapped.original_line_end).toBeNull();
+      // Still has identity / body / file
+      expect(mapped.external_id).toBe('100');
+      expect(mapped.file).toBe('src/file.js');
+    });
+
+    it('deleted user: user: null → author and author_url null, no throw', () => {
+      const row = baseRow({ user: null });
+      const mapped = githubAdapter.mapComment(row);
+
+      expect(mapped.author).toBeNull();
+      expect(mapped.author_url).toBeNull();
+    });
+
+    it('missing path: throws with a clear message', () => {
+      const row = baseRow();
+      delete row.path;
+
+      expect(() => githubAdapter.mapComment(row)).toThrow(
+        /GitHub adapter: comment missing required field "path"/
+      );
+    });
+
+    it('null apiRow: throws with a clear message', () => {
+      expect(() => githubAdapter.mapComment(null)).toThrow(
+        /GitHub adapter: comment missing required field "path"/
+      );
+    });
+
+    it('missing id: throws with a clear message (prevents String(undefined) UNIQUE collision)', () => {
+      // Regression: without this validation, `String(undefined)` becomes
+      // the literal 'undefined' and gets upserted as a valid external_id.
+      // Multiple bad rows would then UNIQUE-collide on 'undefined' and
+      // overwrite each other.
+      const row = baseRow();
+      delete row.id;
+      expect(() => githubAdapter.mapComment(row)).toThrow(
+        /GitHub adapter: comment missing required field "id"/
+      );
+    });
+
+    it('id === null: throws with a clear message', () => {
+      const row = baseRow({ id: null });
+      expect(() => githubAdapter.mapComment(row)).toThrow(
+        /GitHub adapter: comment missing required field "id"/
+      );
+    });
+
+    it('missing body: defaults to empty string', () => {
+      const row = baseRow();
+      delete row.body;
+      const mapped = githubAdapter.mapComment(row);
+      expect(mapped.body).toBe('');
+    });
+
+    it('missing optional fields: yields nulls without throwing', () => {
+      const row = {
+        id: 999,
+        path: 'a/b.js',
+        user: { login: 'u' }, // no html_url
+      };
+      const mapped = githubAdapter.mapComment(row);
+      expect(mapped.external_id).toBe('999');
+      expect(mapped.author).toBe('u');
+      expect(mapped.author_url).toBeNull();
+      expect(mapped.side).toBeNull();
+      expect(mapped.line_start).toBeNull();
+      expect(mapped.line_end).toBeNull();
+      expect(mapped.diff_position).toBeNull();
+      expect(mapped.commit_sha).toBeNull();
+      expect(mapped.external_url).toBeNull();
+      expect(mapped.external_created_at).toBeNull();
+      expect(mapped.is_outdated).toBe(1);
+    });
+  });
+});

--- a/tests/unit/github-client.test.js
+++ b/tests/unit/github-client.test.js
@@ -1477,6 +1477,146 @@ describe('GitHubClient', () => {
     });
   });
 
+  describe('listReviewComments', () => {
+    it('should return raw paginated comment array for a PR', async () => {
+      const client = new GitHubClient('test-token');
+      const apiComments = [
+        {
+          id: 101,
+          pull_request_review_id: 9001,
+          in_reply_to_id: undefined,
+          body: 'First comment',
+          user: { login: 'alice', html_url: 'https://github.com/alice' },
+          path: 'src/index.js',
+          commit_id: 'abc123',
+          original_commit_id: 'abc123',
+          position: 5,
+          original_position: 5,
+          line: 42,
+          start_line: null,
+          original_line: 42,
+          original_start_line: null,
+          side: 'RIGHT',
+          start_side: null,
+          html_url: 'https://github.com/owner/repo/pull/42#discussion_r101',
+          created_at: '2026-05-10T12:00:00Z',
+          updated_at: '2026-05-10T12:00:00Z'
+        },
+        {
+          id: 102,
+          pull_request_review_id: 9002,
+          in_reply_to_id: 101,
+          body: 'Reply to first',
+          user: { login: 'bob', html_url: 'https://github.com/bob' },
+          path: 'src/index.js',
+          commit_id: 'abc123',
+          original_commit_id: 'abc123',
+          position: null,
+          original_position: 5,
+          line: null,
+          start_line: null,
+          original_line: 42,
+          original_start_line: null,
+          side: 'RIGHT',
+          start_side: null,
+          html_url: 'https://github.com/owner/repo/pull/42#discussion_r102',
+          created_at: '2026-05-11T09:00:00Z',
+          updated_at: '2026-05-11T09:00:00Z'
+        }
+      ];
+      const mockPaginate = vi.fn().mockResolvedValue(apiComments);
+      client.octokit.paginate = mockPaginate;
+
+      const result = await client.listReviewComments({
+        owner: 'owner',
+        repo: 'repo',
+        pull_number: 42
+      });
+
+      // Returned raw, unchanged
+      expect(result).toBe(apiComments);
+      expect(result).toHaveLength(2);
+      expect(result[0].id).toBe(101);
+      expect(result[1].in_reply_to_id).toBe(101);
+
+      // paginate called with the rest endpoint and correct params
+      expect(mockPaginate).toHaveBeenCalledTimes(1);
+      expect(mockPaginate).toHaveBeenCalledWith(
+        expect.any(Function),
+        { owner: 'owner', repo: 'repo', pull_number: 42, per_page: 100 }
+      );
+      // The first arg should be the listReviewComments endpoint reference
+      expect(mockPaginate.mock.calls[0][0]).toBe(client.octokit.rest.pulls.listReviewComments);
+    });
+
+    it('should return empty array for a PR with no review comments', async () => {
+      const client = new GitHubClient('test-token');
+      client.octokit.paginate = vi.fn().mockResolvedValue([]);
+
+      const result = await client.listReviewComments({
+        owner: 'owner',
+        repo: 'repo',
+        pull_number: 1
+      });
+
+      expect(result).toEqual([]);
+    });
+
+    it('should throw GitHubApiError with status 404 when PR is not found', async () => {
+      const client = new GitHubClient('test-token');
+      const notFoundError = new Error('Not Found');
+      notFoundError.status = 404;
+      client.octokit.paginate = vi.fn().mockRejectedValue(notFoundError);
+
+      try {
+        await client.listReviewComments({ owner: 'owner', repo: 'repo', pull_number: 999 });
+        throw new Error('Expected listReviewComments to throw');
+      } catch (error) {
+        expect(error).toBeInstanceOf(GitHubApiError);
+        expect(error.status).toBe(404);
+        expect(error.message).toContain('Pull request #999 not found');
+      }
+    });
+
+    it('should throw GitHubApiError with status 429 on rate limit (403 + zero remaining)', async () => {
+      const client = new GitHubClient('test-token');
+      const rateLimitError = new Error('API rate limit exceeded');
+      rateLimitError.status = 403;
+      rateLimitError.response = {
+        headers: {
+          'x-ratelimit-remaining': '0',
+          'x-ratelimit-reset': String(Math.floor(Date.now() / 1000) + 60)
+        }
+      };
+      client.octokit.paginate = vi.fn().mockRejectedValue(rateLimitError);
+
+      try {
+        await client.listReviewComments({ owner: 'owner', repo: 'repo', pull_number: 7 });
+        throw new Error('Expected listReviewComments to throw');
+      } catch (error) {
+        expect(error).toBeInstanceOf(GitHubApiError);
+        expect(error.status).toBe(429);
+        expect(error.message).toContain('rate limit');
+      }
+    });
+
+    it('should propagate network errors as GitHubApiError with status 503', async () => {
+      const client = new GitHubClient('test-token');
+      const networkError = new Error('getaddrinfo ENOTFOUND api.github.com');
+      networkError.code = 'ENOTFOUND';
+      client.octokit.paginate = vi.fn().mockRejectedValue(networkError);
+
+      try {
+        await client.listReviewComments({ owner: 'owner', repo: 'repo', pull_number: 3 });
+        throw new Error('Expected listReviewComments to throw');
+      } catch (error) {
+        expect(error).toBeInstanceOf(GitHubApiError);
+        expect(error.status).toBe(503);
+        expect(error.message).toContain('Network error');
+      }
+    });
+  });
+
   describe('GitHubApiError', () => {
     it('should be an instance of Error', () => {
       const error = new GitHubApiError('test message', 401);
@@ -1533,6 +1673,120 @@ describe('GitHubClient', () => {
         expect(error.status).toBe(429);
         expect(error.message).toContain('rate limit');
       }
+    });
+
+    it('should throw GitHubApiError with status 403 for permission errors (non-rate-limit)', async () => {
+      // Regression: a 403 with empty rate-limit headers (real permission /
+      // scope failure) used to fall through to the generic `new Error()`
+      // branch and route handlers mapped it to 500, hiding the real cause.
+      // Now it surfaces as a typed GitHubApiError(status=403).
+      const client = new GitHubClient('test-token');
+      const permError = new Error('Forbidden');
+      permError.status = 403;
+      // No x-ratelimit-remaining header — this is NOT a rate-limit failure.
+      permError.response = { headers: {} };
+
+      let captured = null;
+      try {
+        await client.handleApiError(permError, 'owner', 'repo', 7);
+      } catch (error) {
+        captured = error;
+      }
+      expect(captured).toBeInstanceOf(GitHubApiError);
+      expect(captured.status).toBe(403);
+      expect(captured.message).toMatch(/permissions|scopes/i);
+      expect(captured.message).toContain('owner/repo');
+    });
+
+    it('should throw GitHubApiError with status 403 when response is missing entirely', async () => {
+      // Defensive: some Octokit error paths don't attach `.response` at all.
+      const client = new GitHubClient('test-token');
+      const permError = new Error('Forbidden');
+      permError.status = 403;
+
+      let captured = null;
+      try {
+        await client.handleApiError(permError, 'owner', 'repo', 1);
+      } catch (error) {
+        captured = error;
+      }
+      expect(captured).toBeInstanceOf(GitHubApiError);
+      expect(captured.status).toBe(403);
+    });
+
+    it('should map 403 with retry-after header to a 429 rate-limit error (secondary rate limit)', async () => {
+      // Regression: secondary rate limits / abuse detection return 403
+      // WITHOUT the standard rate-limit headers but WITH a `retry-after`
+      // header. Without this branch they were misclassified as permission
+      // failures.
+      const client = new GitHubClient('test-token');
+      const secondaryRateLimitError = new Error('You have exceeded a secondary rate limit.');
+      secondaryRateLimitError.status = 403;
+      secondaryRateLimitError.response = { headers: { 'retry-after': '30' } };
+
+      let captured = null;
+      try {
+        await client.handleApiError(secondaryRateLimitError, 'owner', 'repo', 1);
+      } catch (error) {
+        captured = error;
+      }
+      expect(captured).toBeInstanceOf(GitHubApiError);
+      expect(captured.status).toBe(429);
+      expect(captured.message).toMatch(/rate limit/i);
+      expect(captured.message).toContain('30');
+    });
+
+    it('should map 403 with "secondary rate limit" in the message to a 429 rate-limit error', async () => {
+      const client = new GitHubClient('test-token');
+      const secondary = new Error('Secondary rate limit triggered. Try again later.');
+      secondary.status = 403;
+      secondary.response = { headers: {} };
+
+      let captured = null;
+      try {
+        await client.handleApiError(secondary, 'owner', 'repo', 1);
+      } catch (error) {
+        captured = error;
+      }
+      expect(captured).toBeInstanceOf(GitHubApiError);
+      expect(captured.status).toBe(429);
+      expect(captured.message).toMatch(/rate limit/i);
+    });
+
+    it('should map 403 with "abuse" in the message to a 429 rate-limit error', async () => {
+      const client = new GitHubClient('test-token');
+      const abuse = new Error('You have triggered an abuse detection mechanism.');
+      abuse.status = 403;
+      abuse.response = { headers: {} };
+
+      let captured = null;
+      try {
+        await client.handleApiError(abuse, 'owner', 'repo', 1);
+      } catch (error) {
+        captured = error;
+      }
+      expect(captured).toBeInstanceOf(GitHubApiError);
+      expect(captured.status).toBe(429);
+      expect(captured.message).toMatch(/rate limit/i);
+    });
+
+    it('should still classify a plain "Forbidden" 403 as a permission error (regression)', async () => {
+      // Make sure ITEM 9 didn't accidentally swallow legitimate permission
+      // failures into the rate-limit branch.
+      const client = new GitHubClient('test-token');
+      const permError = new Error('Forbidden');
+      permError.status = 403;
+      permError.response = { headers: {} };
+
+      let captured = null;
+      try {
+        await client.handleApiError(permError, 'owner', 'repo', 1);
+      } catch (error) {
+        captured = error;
+      }
+      expect(captured).toBeInstanceOf(GitHubApiError);
+      expect(captured.status).toBe(403);
+      expect(captured.message).toMatch(/permissions|scopes/i);
     });
 
     it('should throw GitHubApiError with status 404 for not found errors', async () => {

--- a/tests/unit/pr-external-comments-wiring.test.js
+++ b/tests/unit/pr-external-comments-wiring.test.js
@@ -196,6 +196,34 @@ describe('PRManager._loadExternalComments', () => {
     expect(externalCommentManagerStub.reviewId).toBeUndefined();
   });
 
+  it('external_comments feature toggle off: no fetch, no syncAndRender, no reviewId mutation', async () => {
+    // Mirror the production wiring: runtime-config.js sets this object
+    // synchronously before pr.js loads. When the flag is false, every
+    // entry point into the external-comments subsystem must no-op.
+    window.PAIR_REVIEW_RUNTIME_CONFIG = { external_comments_enabled: false };
+    const prManager = createTestPRManager();
+
+    await prManager._loadExternalComments();
+
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(externalCommentManagerStub.syncAndRender).not.toHaveBeenCalled();
+    expect(externalCommentManagerStub.loadAndRender).not.toHaveBeenCalled();
+    expect(externalCommentManagerStub.reviewId).toBeUndefined();
+  });
+
+  it('external_comments enabled (default): proceeds normally when flag is true', async () => {
+    window.PAIR_REVIEW_RUNTIME_CONFIG = { external_comments_enabled: true };
+    const prManager = createTestPRManager();
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: vi.fn().mockResolvedValue({ count: 0, lostAnchors: 0, syncedAt: 'now' }),
+    });
+
+    await prManager._loadExternalComments();
+
+    expect(externalCommentManagerStub.syncAndRender).toHaveBeenCalledTimes(1);
+  });
+
   it('short-circuits when externalCommentManager singleton is not present', async () => {
     window.externalCommentManager = null;
     const prManager = createTestPRManager();
@@ -357,6 +385,40 @@ describe('Refresh external-comments button wiring', () => {
     resolveLoad();
     await inflight;
     expect(refreshButton.getAttribute('aria-busy')).toBeNull();
+  });
+
+  it('does nothing when external_comments feature toggle is off', async () => {
+    // Defensive guard: even if a stale caller (or test) invokes the handler
+    // with the feature disabled, it must not touch the button state or call
+    // through to _loadExternalComments.
+    window.PAIR_REVIEW_RUNTIME_CONFIG = { external_comments_enabled: false };
+    const prManager = makePRManager();
+
+    await prManager._handleExternalCommentsRefreshClick({ button: refreshButton });
+
+    expect(prManager._loadExternalComments).not.toHaveBeenCalled();
+    expect(refreshButton.disabled).toBe(false);
+    expect(refreshButton.classList.contains('is-refreshing')).toBe(false);
+  });
+});
+
+describe('PRManager._externalCommentsEnabled', () => {
+  it('returns true when runtime config is absent', () => {
+    delete window.PAIR_REVIEW_RUNTIME_CONFIG;
+    const prManager = createTestPRManager();
+    expect(prManager._externalCommentsEnabled()).toBe(true);
+  });
+
+  it('returns true when runtime config flag is true', () => {
+    window.PAIR_REVIEW_RUNTIME_CONFIG = { external_comments_enabled: true };
+    const prManager = createTestPRManager();
+    expect(prManager._externalCommentsEnabled()).toBe(true);
+  });
+
+  it('returns false when runtime config flag is explicitly false', () => {
+    window.PAIR_REVIEW_RUNTIME_CONFIG = { external_comments_enabled: false };
+    const prManager = createTestPRManager();
+    expect(prManager._externalCommentsEnabled()).toBe(false);
   });
 });
 

--- a/tests/unit/pr-external-comments-wiring.test.js
+++ b/tests/unit/pr-external-comments-wiring.test.js
@@ -9,7 +9,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
  *   - _loadExternalComments: sets reviewId on the singleton, syncs, and
  *     calls loadAndRender regardless of sync success.
  *   - Local-mode short-circuit: no sync, no loadAndRender.
- *   - Refresh button: clicking #refresh-external-comments-btn invokes
+ *   - Refresh button: clicking #refresh-external-comments-btn-panel invokes
  *     _loadExternalComments and toggles disabled state.
  */
 
@@ -285,7 +285,7 @@ describe('PRManager._loadExternalComments', () => {
 describe('Refresh external-comments button wiring', () => {
   /**
    * Exercise the production click handler attached in setupEventListeners()
-   * for #refresh-external-comments-btn. Per CLAUDE.md we test the real
+   * for #refresh-external-comments-btn-panel. Per CLAUDE.md we test the real
    * method (`_handleExternalCommentsRefreshClick`) rather than duplicating
    * its behavior in the test file.
    */

--- a/tests/unit/pr-external-comments-wiring.test.js
+++ b/tests/unit/pr-external-comments-wiring.test.js
@@ -1,0 +1,492 @@
+// Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+/**
+ * Unit tests for the external review-comment lifecycle wiring on PRManager.
+ *
+ * Covers:
+ *   - _syncExternalComments: POSTs the sync endpoint and parses the response.
+ *   - _loadExternalComments: sets reviewId on the singleton, syncs, and
+ *     calls loadAndRender regardless of sync success.
+ *   - Local-mode short-circuit: no sync, no loadAndRender.
+ *   - Refresh button: clicking #refresh-external-comments-btn invokes
+ *     _loadExternalComments and toggles disabled state.
+ */
+
+const { PRManager } = require('../../public/js/pr.js');
+
+const mockFetch = vi.fn();
+
+let externalCommentManagerStub;
+let refreshButton;
+
+beforeEach(() => {
+  vi.resetAllMocks();
+
+  global.fetch = mockFetch;
+
+  // Stub stays close to the real manager shape. `_loadExternalComments`
+  // now routes through `syncAndRender`; the stub implements it by
+  // invoking the injected syncFn (so the existing fetch-based tests for
+  // `_syncExternalComments` still exercise the POST) and resolving with
+  // the canonical `{ errors, syncResult, syncError }` shape. GET-only
+  // callers still hit `loadAndRender`.
+  externalCommentManagerStub = {
+    reviewId: undefined,
+    sources: ['github'],
+    loadAndRender: vi.fn().mockResolvedValue({ errors: [] }),
+    syncAndRender: vi.fn(async ({ syncFn } = {}) => {
+      let syncResult = null;
+      let syncError = null;
+      if (typeof syncFn === 'function') {
+        try {
+          syncResult = await syncFn();
+        } catch (err) {
+          syncError = err;
+        }
+      }
+      return { errors: [], syncResult, syncError };
+    }),
+    clear: vi.fn(),
+  };
+
+  refreshButton = {
+    disabled: false,
+    _listeners: {},
+    classList: {
+      _set: new Set(),
+      add(cls) { this._set.add(cls); },
+      remove(cls) { this._set.delete(cls); },
+      contains(cls) { return this._set.has(cls); },
+    },
+    addEventListener: vi.fn(function (event, handler) {
+      this._listeners[event] = handler;
+    }),
+    click() {
+      const handler = this._listeners.click;
+      if (handler) return handler();
+    },
+  };
+
+  global.window = {
+    externalCommentManager: externalCommentManagerStub,
+    PAIR_REVIEW_LOCAL_MODE: false,
+  };
+
+  global.document = {
+    getElementById: vi.fn(() => null),
+    querySelector: vi.fn(() => null),
+    querySelectorAll: vi.fn(() => []),
+    addEventListener: vi.fn(),
+  };
+
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  delete global.window;
+  delete global.document;
+  delete global.fetch;
+});
+
+function createTestPRManager() {
+  const prManager = Object.create(PRManager.prototype);
+  prManager.currentPR = {
+    owner: 'octo',
+    repo: 'pair-review',
+    number: 42,
+    id: 7,
+  };
+  return prManager;
+}
+
+describe('PRManager._syncExternalComments', () => {
+  it('POSTs the sync endpoint and returns the parsed body', async () => {
+    const prManager = createTestPRManager();
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: vi.fn().mockResolvedValue({ count: 3, lostAnchors: 0, syncedAt: '2026-05-17T12:00:00Z' }),
+    });
+
+    const result = await prManager._syncExternalComments();
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [url, opts] = mockFetch.mock.calls[0];
+    expect(url).toBe('/api/reviews/7/external-comments/sync?source=github');
+    expect(opts).toEqual({ method: 'POST' });
+    expect(result).toEqual({ count: 3, lostAnchors: 0, syncedAt: '2026-05-17T12:00:00Z' });
+  });
+
+  it('throws on non-OK responses, surfacing the server error message', async () => {
+    const prManager = createTestPRManager();
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 502,
+      json: vi.fn().mockResolvedValue({ error: 'GitHub unreachable' }),
+    });
+
+    await expect(prManager._syncExternalComments()).rejects.toMatchObject({
+      message: 'GitHub unreachable',
+      status: 502,
+    });
+  });
+
+  it('throws with a default message when error body is not JSON', async () => {
+    const prManager = createTestPRManager();
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      json: vi.fn().mockRejectedValue(new Error('parse')),
+    });
+
+    await expect(prManager._syncExternalComments()).rejects.toMatchObject({
+      message: 'Sync failed with status 500',
+      status: 500,
+    });
+  });
+});
+
+describe('PRManager._loadExternalComments', () => {
+  it('happy path: sets reviewId, syncs through manager.syncAndRender', async () => {
+    const prManager = createTestPRManager();
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: vi.fn().mockResolvedValue({ count: 1, lostAnchors: 0, syncedAt: 'now' }),
+    });
+
+    await prManager._loadExternalComments();
+
+    expect(externalCommentManagerStub.reviewId).toBe(7);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    // _loadExternalComments now goes through the manager's canonical
+    // sync+load entry point. The stub forwards the injected syncFn so the
+    // POST still fires via the fetch mock above.
+    expect(externalCommentManagerStub.syncAndRender).toHaveBeenCalledTimes(1);
+    expect(externalCommentManagerStub.loadAndRender).not.toHaveBeenCalled();
+  });
+
+  it('sync failure: syncAndRender resolves with syncError; render still happens via the manager', async () => {
+    const prManager = createTestPRManager();
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 502,
+      json: vi.fn().mockResolvedValue({ error: 'upstream' }),
+    });
+
+    await prManager._loadExternalComments();
+
+    // syncAndRender is the single entry point; it owns the in-flight guard
+    // for the full sync+load sequence.
+    expect(externalCommentManagerStub.syncAndRender).toHaveBeenCalledTimes(1);
+    expect(console.warn).toHaveBeenCalled();
+  });
+
+  it('local mode short-circuits: no fetch, no syncAndRender, no reviewId mutation', async () => {
+    window.PAIR_REVIEW_LOCAL_MODE = true;
+    const prManager = createTestPRManager();
+
+    await prManager._loadExternalComments();
+
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(externalCommentManagerStub.syncAndRender).not.toHaveBeenCalled();
+    expect(externalCommentManagerStub.loadAndRender).not.toHaveBeenCalled();
+    expect(externalCommentManagerStub.reviewId).toBeUndefined();
+  });
+
+  it('short-circuits when externalCommentManager singleton is not present', async () => {
+    window.externalCommentManager = null;
+    const prManager = createTestPRManager();
+
+    await prManager._loadExternalComments();
+
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('short-circuits when no PR is loaded', async () => {
+    const prManager = createTestPRManager();
+    prManager.currentPR = null;
+
+    await prManager._loadExternalComments();
+
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(externalCommentManagerStub.syncAndRender).not.toHaveBeenCalled();
+  });
+
+  it('swallows syncAndRender errors so a failure cannot bubble out of page-load', async () => {
+    const prManager = createTestPRManager();
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: vi.fn().mockResolvedValue({ count: 0, lostAnchors: 0, syncedAt: 'now' }),
+    });
+    externalCommentManagerStub.syncAndRender.mockRejectedValueOnce(new Error('render boom'));
+
+    await expect(prManager._loadExternalComments()).resolves.toBeUndefined();
+    expect(console.warn).toHaveBeenCalled();
+  });
+
+  it('surfaces lostAnchors > 0 via _showExternalLostAnchorsToast(n)', async () => {
+    // Regression: the sync result body was previously discarded, so the
+    // reviewer had no signal when comments lost their anchors upstream.
+    const prManager = createTestPRManager();
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: vi.fn().mockResolvedValue({ count: 5, lostAnchors: 3, syncedAt: 'now' }),
+    });
+    const toastSpy = vi.spyOn(prManager, '_showExternalLostAnchorsToast').mockImplementation(() => {});
+
+    await prManager._loadExternalComments();
+
+    expect(toastSpy).toHaveBeenCalledTimes(1);
+    expect(toastSpy).toHaveBeenCalledWith(3);
+  });
+
+  for (const status of [401, 403, 429, 502]) {
+    it(`sync failure status ${status}: calls _showExternalSyncErrorToast with the error and marks refresh-error state`, async () => {
+      // Regression: round-2 added status-aware toasting via the
+      // _showExternalSyncErrorToast/_markExternalRefreshErrorState helpers,
+      // but the only "sync failure" test asserted nothing beyond
+      // loadAndRender + console.warn. Pin the actual helper wiring.
+      const prManager = createTestPRManager();
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status,
+        json: vi.fn().mockResolvedValue({ error: `boom ${status}` }),
+      });
+      const toastSpy = vi.spyOn(prManager, '_showExternalSyncErrorToast').mockImplementation(() => {});
+      const markSpy = vi.spyOn(prManager, '_markExternalRefreshErrorState').mockImplementation(() => {});
+
+      await prManager._loadExternalComments();
+
+      expect(toastSpy).toHaveBeenCalledTimes(1);
+      const err = toastSpy.mock.calls[0][0];
+      expect(err).toBeInstanceOf(Error);
+      expect(err.status).toBe(status);
+      expect(markSpy).toHaveBeenCalledTimes(1);
+    });
+  }
+
+  it('does NOT call _showExternalLostAnchorsToast when lostAnchors=0', async () => {
+    const prManager = createTestPRManager();
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: vi.fn().mockResolvedValue({ count: 5, lostAnchors: 0, syncedAt: 'now' }),
+    });
+    const toastSpy = vi.spyOn(prManager, '_showExternalLostAnchorsToast').mockImplementation(() => {});
+
+    await prManager._loadExternalComments();
+
+    expect(toastSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('Refresh external-comments button wiring', () => {
+  /**
+   * Exercise the production click handler attached in setupEventListeners()
+   * for #refresh-external-comments-btn. Per CLAUDE.md we test the real
+   * method (`_handleExternalCommentsRefreshClick`) rather than duplicating
+   * its behavior in the test file.
+   */
+  function makePRManager() {
+    const prManager = createTestPRManager();
+    prManager._loadExternalComments = vi.fn().mockResolvedValue(undefined);
+    // Mimic real attribute handling on the test stub.
+    refreshButton._attrs = {};
+    refreshButton.setAttribute = vi.fn(function (k, v) { this._attrs[k] = String(v); });
+    refreshButton.removeAttribute = vi.fn(function (k) { delete this._attrs[k]; });
+    refreshButton.getAttribute = vi.fn(function (k) { return this._attrs[k] || null; });
+    return prManager;
+  }
+
+  it('click triggers _loadExternalComments exactly once', async () => {
+    const prManager = makePRManager();
+    await prManager._handleExternalCommentsRefreshClick({ button: refreshButton });
+    expect(prManager._loadExternalComments).toHaveBeenCalledTimes(1);
+  });
+
+  it('button is re-enabled and aria-busy cleared after the call completes', async () => {
+    const prManager = makePRManager();
+    await prManager._handleExternalCommentsRefreshClick({ button: refreshButton });
+    expect(refreshButton.disabled).toBe(false);
+    expect(refreshButton.classList.contains('is-refreshing')).toBe(false);
+    expect(refreshButton.getAttribute('aria-busy')).toBeNull();
+    expect(prManager._loadExternalComments).toHaveBeenCalled();
+  });
+
+  it('button is re-enabled even when _loadExternalComments rejects', async () => {
+    const prManager = makePRManager();
+    prManager._loadExternalComments.mockRejectedValueOnce(new Error('boom'));
+
+    await expect(
+      prManager._handleExternalCommentsRefreshClick({ button: refreshButton })
+    ).rejects.toThrow('boom');
+
+    expect(refreshButton.disabled).toBe(false);
+    expect(refreshButton.classList.contains('is-refreshing')).toBe(false);
+    expect(refreshButton.getAttribute('aria-busy')).toBeNull();
+  });
+
+  it('double-click while in-flight does not stack calls', async () => {
+    const prManager = makePRManager();
+    let resolveLoad;
+    prManager._loadExternalComments.mockImplementationOnce(
+      () => new Promise((r) => { resolveLoad = r; })
+    );
+
+    const first = prManager._handleExternalCommentsRefreshClick({ button: refreshButton });
+    // While the first is in-flight the button is disabled — second short-circuits.
+    const second = prManager._handleExternalCommentsRefreshClick({ button: refreshButton });
+
+    resolveLoad();
+    await Promise.all([first, second]);
+
+    expect(prManager._loadExternalComments).toHaveBeenCalledTimes(1);
+  });
+
+  it('sets aria-busy=true while the call is in flight', async () => {
+    const prManager = makePRManager();
+    let resolveLoad;
+    prManager._loadExternalComments.mockImplementationOnce(
+      () => new Promise((r) => { resolveLoad = r; })
+    );
+
+    const inflight = prManager._handleExternalCommentsRefreshClick({ button: refreshButton });
+    expect(refreshButton.getAttribute('aria-busy')).toBe('true');
+    resolveLoad();
+    await inflight;
+    expect(refreshButton.getAttribute('aria-busy')).toBeNull();
+  });
+});
+
+describe('PRManager.handleWhitespaceToggle re-renders external comments', () => {
+  it('routes through _rerenderAllOverlays so external rows survive the DOM rebuild', async () => {
+    // Regression: handleWhitespaceToggle rebuilds the diff DOM (which drops
+    // every .external-comment-row) but originally only re-anchored user
+    // comments + AI suggestions. External rows silently disappeared until a
+    // full PR refresh. Now whitespace toggle and post-analysis refresh both
+    // route through _rerenderAllOverlays, which calls externalCommentManager.
+    const prManager = createTestPRManager();
+    prManager.loadUserComments = vi.fn().mockResolvedValue(undefined);
+    prManager.loadAISuggestions = vi.fn().mockResolvedValue(undefined);
+    prManager.loadAndDisplayFiles = vi.fn().mockResolvedValue(undefined);
+    prManager.selectedRunId = 'run-7';
+
+    global.window.scrollY = 0;
+    global.window.scrollTo = vi.fn();
+    global.window.requestAnimationFrame = (cb) => cb();
+    global.requestAnimationFrame = (cb) => cb();
+
+    await prManager.handleWhitespaceToggle(true);
+
+    expect(prManager.hideWhitespace).toBe(true);
+    expect(prManager.loadAndDisplayFiles).toHaveBeenCalledTimes(1);
+    expect(prManager.loadUserComments).toHaveBeenCalledTimes(1);
+    expect(prManager.loadAISuggestions).toHaveBeenCalledWith(null, 'run-7');
+    expect(externalCommentManagerStub.loadAndRender).toHaveBeenCalledTimes(1);
+    expect(externalCommentManagerStub.reviewId).toBe(7);
+  });
+
+  it('short-circuits when no PR is loaded', async () => {
+    const prManager = createTestPRManager();
+    prManager.currentPR = null;
+    prManager.loadAndDisplayFiles = vi.fn();
+
+    await prManager.handleWhitespaceToggle(true);
+
+    expect(prManager.loadAndDisplayFiles).not.toHaveBeenCalled();
+    expect(externalCommentManagerStub.loadAndRender).not.toHaveBeenCalled();
+  });
+});
+
+describe('PRManager._reloadAfterAnalysis re-renders external comments', () => {
+  it('post-analysis auto-refresh routes through _rerenderAllOverlays', async () => {
+    // Regression: _reloadAfterAnalysis (fired by review:analysis_completed
+    // and the visibilitychange dirty-analysis branch) previously reloaded
+    // only AI + user comments. After this fix it goes through the shared
+    // helper so external rows stay in sync.
+    const prManager = createTestPRManager();
+    prManager.loadUserComments = vi.fn().mockResolvedValue(undefined);
+    prManager.loadAISuggestions = vi.fn().mockResolvedValue(undefined);
+
+    await prManager._reloadAfterAnalysis();
+
+    expect(prManager.loadUserComments).toHaveBeenCalledTimes(1);
+    expect(prManager.loadAISuggestions).toHaveBeenCalledTimes(1);
+    expect(externalCommentManagerStub.loadAndRender).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('PRManager._rerenderAllOverlays', () => {
+  it('re-renders user comments, AI suggestions, AND external comments via GET-only path by default', async () => {
+    // Regression: refreshPR previously rebuilt the diff DOM and re-ran AI
+    // suggestions + user comments, but forgot to re-run external comments,
+    // so refreshing the PR silently dropped every blue external-comment row.
+    // Without `syncExternal: true` the helper takes the GET-only path so
+    // analysis rebuilds and whitespace toggles don't pay for a sync POST.
+    const prManager = createTestPRManager();
+    prManager.loadUserComments = vi.fn().mockResolvedValue(undefined);
+    prManager.loadAISuggestions = vi.fn().mockResolvedValue(undefined);
+
+    await prManager._rerenderAllOverlays({ analysisRunId: 'run-1' });
+
+    expect(prManager.loadUserComments).toHaveBeenCalledTimes(1);
+    expect(prManager.loadAISuggestions).toHaveBeenCalledWith(null, 'run-1');
+    expect(externalCommentManagerStub.loadAndRender).toHaveBeenCalledTimes(1);
+    // GET-only path: no sync POST.
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(externalCommentManagerStub.syncAndRender).not.toHaveBeenCalled();
+    // External-comment manager must have its reviewId pinned before rendering.
+    expect(externalCommentManagerStub.reviewId).toBe(7);
+  });
+
+  it('fires the sync POST when called with syncExternal: true', async () => {
+    // Regression for refreshPR: when refresh fetches a fresh diff the commit
+    // SHA may have changed, so cached anchors and outdated flags must be
+    // re-evaluated against the new HEAD. `syncExternal: true` routes the
+    // external-comment path through `_loadExternalComments` (full sync+load)
+    // instead of `loadAndRender` (GET-only).
+    const prManager = createTestPRManager();
+    prManager.loadUserComments = vi.fn().mockResolvedValue(undefined);
+    prManager.loadAISuggestions = vi.fn().mockResolvedValue(undefined);
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: vi.fn().mockResolvedValue({ count: 0, lostAnchors: 0, deleted: 0, syncedAt: 'now' }),
+    });
+
+    await prManager._rerenderAllOverlays({ analysisRunId: 'run-2', syncExternal: true });
+
+    // The sync POST fired exactly once and a render still happened — both
+    // via the manager's syncAndRender (which the stub forwards to syncFn).
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(externalCommentManagerStub.syncAndRender).toHaveBeenCalledTimes(1);
+    expect(externalCommentManagerStub.loadAndRender).not.toHaveBeenCalled();
+  });
+
+  it('_reloadAfterAnalysis (post-analysis path) stays on the GET-only flavor', async () => {
+    // Regression: _reloadAfterAnalysis must not double the sync POST. The
+    // post-analysis path re-anchors against the existing diff DOM; no
+    // upstream snapshot has changed.
+    const prManager = createTestPRManager();
+    prManager.loadUserComments = vi.fn().mockResolvedValue(undefined);
+    prManager.loadAISuggestions = vi.fn().mockResolvedValue(undefined);
+
+    await prManager._reloadAfterAnalysis();
+
+    expect(externalCommentManagerStub.loadAndRender).toHaveBeenCalledTimes(1);
+    expect(externalCommentManagerStub.syncAndRender).not.toHaveBeenCalled();
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('does not throw when external-comment manager is missing', async () => {
+    window.externalCommentManager = null;
+    const prManager = createTestPRManager();
+    prManager.loadUserComments = vi.fn().mockResolvedValue(undefined);
+    prManager.loadAISuggestions = vi.fn().mockResolvedValue(undefined);
+
+    await expect(prManager._rerenderAllOverlays({})).resolves.toBeUndefined();
+    expect(prManager.loadUserComments).toHaveBeenCalledTimes(1);
+    expect(prManager.loadAISuggestions).toHaveBeenCalled();
+  });
+});

--- a/tests/unit/refresh-comments-reload.test.js
+++ b/tests/unit/refresh-comments-reload.test.js
@@ -284,9 +284,10 @@ describe('Local mode: refreshDiff() reloads comments after diff refresh', () => 
 });
 
 describe('PR mode: refreshPR() call ordering matches loadPR()', () => {
-  it('should reload comments similarly to how loadPR does on initial load', async () => {
-    // This test ensures refreshPR() follows the same pattern as loadPR()
-    // for re-populating comments after rendering the diff.
+  it('should reload all overlays via _rerenderAllOverlays after rebuilding the diff', async () => {
+    // refreshPR now delegates to _rerenderAllOverlays, which centralizes
+    // re-rendering of AI suggestions, user comments, AND external comments
+    // so adding a fourth overlay only requires updating that helper.
     const fs = require('fs');
     const path = require('path');
     const prSource = fs.readFileSync(
@@ -294,29 +295,28 @@ describe('PR mode: refreshPR() call ordering matches loadPR()', () => {
       'utf-8'
     );
 
-    // In loadPR: loadAndDisplayFiles -> loadUserComments -> loadAISuggestions
-    // In refreshPR: loadAndDisplayFiles -> loadUserComments -> loadAISuggestions
-    // Both should follow the same pattern.
-
-    // Find refreshPR method
     const refreshPRMatch = prSource.match(
       /async refreshPR\(\)\s*\{[\s\S]*?(?=\n  (?:async\s)?\w+\s*\(|\n\})/
     );
     expect(refreshPRMatch).toBeTruthy();
     const refreshPRBody = refreshPRMatch[0];
 
-    // Verify the reload calls exist in refreshPR
     const displayIdx = refreshPRBody.indexOf('loadAndDisplayFiles');
-    const commentsIdx = refreshPRBody.indexOf('loadUserComments');
-    const suggestionsIdx = refreshPRBody.indexOf('loadAISuggestions');
+    const overlaysIdx = refreshPRBody.indexOf('_rerenderAllOverlays');
 
     expect(displayIdx).toBeGreaterThan(-1);
-    expect(commentsIdx).toBeGreaterThan(-1);
-    expect(suggestionsIdx).toBeGreaterThan(-1);
+    expect(overlaysIdx).toBeGreaterThan(-1);
+    expect(overlaysIdx).toBeGreaterThan(displayIdx);
 
-    // Verify order
-    expect(commentsIdx).toBeGreaterThan(displayIdx);
-    expect(suggestionsIdx).toBeGreaterThan(commentsIdx);
+    // The shared overlay helper must touch all three renderers.
+    const overlaysMatch = prSource.match(
+      /async _rerenderAllOverlays\([\s\S]*?\)\s*\{[\s\S]*?(?=\n  (?:async\s)?\w+\s*\(|\n\})/
+    );
+    expect(overlaysMatch).toBeTruthy();
+    const overlaysBody = overlaysMatch[0];
+    expect(overlaysBody).toMatch(/loadUserComments/);
+    expect(overlaysBody).toMatch(/loadAISuggestions/);
+    expect(overlaysBody).toMatch(/externalCommentManager/);
   });
 });
 

--- a/tests/utils/schema.js
+++ b/tests/utils/schema.js
@@ -267,6 +267,35 @@ const SCHEMA_SQL = {
       last_fetched_at TEXT,
       created_at TEXT NOT NULL
     )
+  `,
+
+  external_comments: `
+    CREATE TABLE IF NOT EXISTS external_comments (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      review_id INTEGER NOT NULL,
+      source TEXT NOT NULL,
+      external_id TEXT NOT NULL,
+      in_reply_to_id TEXT,
+      parent_id INTEGER,
+      external_url TEXT,
+      author TEXT,
+      author_url TEXT,
+      file TEXT NOT NULL,
+      side TEXT,
+      line_start INTEGER,
+      line_end INTEGER,
+      diff_position INTEGER,
+      commit_sha TEXT,
+      is_outdated INTEGER NOT NULL DEFAULT 0,
+      original_line_start INTEGER,
+      original_line_end INTEGER,
+      original_commit_sha TEXT,
+      body TEXT,
+      external_created_at TEXT,
+      synced_at TEXT,
+      FOREIGN KEY (review_id) REFERENCES reviews(id) ON DELETE CASCADE,
+      FOREIGN KEY (parent_id) REFERENCES external_comments(id) ON DELETE SET NULL
+    )
   `
 };
 
@@ -311,7 +340,11 @@ const INDEX_SQL = [
   // Worktree pool indexes
   'CREATE INDEX IF NOT EXISTS idx_worktree_pool_repo ON worktree_pool(repository)',
   'CREATE INDEX IF NOT EXISTS idx_worktree_pool_status ON worktree_pool(repository, status)',
-  'CREATE INDEX IF NOT EXISTS idx_worktree_pool_lru ON worktree_pool(repository, status, last_switched_at)'
+  'CREATE INDEX IF NOT EXISTS idx_worktree_pool_lru ON worktree_pool(repository, status, last_switched_at)',
+  // External comments indexes (read-only mirror of GitHub/etc. PR review comments)
+  'CREATE UNIQUE INDEX IF NOT EXISTS idx_external_comments_unique ON external_comments(review_id, source, external_id)',
+  'CREATE INDEX IF NOT EXISTS idx_external_comments_anchor ON external_comments(review_id, file, line_end)',
+  'CREATE INDEX IF NOT EXISTS idx_external_comments_parent_lookup ON external_comments(review_id, source, in_reply_to_id)'
 ];
 
 /**


### PR DESCRIPTION
## Summary
- Mirrors existing GitHub PR review comments into the local database via a new source-agnostic adapter layer (`src/external/`), with the GitHub adapter as the first implementation. Sync upserts current rows, prunes upstream deletions, and preserves cached data when the snapshot is empty.
- Renders external comments inline in the diff alongside AI suggestions and user comments, with a distinct blue theme, threaded replies (parent_id `ON DELETE SET NULL` preserves replies through pruning), outdated-comment fallback to original anchor, and the `comment-minimizer` indicator integration.
- Adds a chat-about button per comment and per thread that pipes the context (including `side` for LEFT-anchored deleted-line comments) into ChatPanel so reviewers can discuss the comment with the AI agent.

## Test plan
- [x] `pnpm test` — 6529 / 6529 passing across 159 files
- [ ] Manual: open a PR with existing review comments, confirm the blue rows render at the right anchors with outdated comments falling back to original lines
- [ ] Manual: minimize comments, confirm the external-comment indicator shows in blue and expanding works
- [ ] Manual: open the chat-about button on a single comment and on a thread, confirm the AI receives the comment body and hunk context
- [ ] Manual: refresh the PR diff (e.g. via the header refresh button), confirm external rows re-render and are not lost
- [ ] Manual: trigger a 401 (bad GITHUB_TOKEN) and 429 (rate-limited) sync, confirm status-aware toasts appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)