### PR TITLE
Add multi-tab chat sessions

### DIFF
--- a/.changeset/multi-tab-chat-sessions.md
+++ b/.changeset/multi-tab-chat-sessions.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": minor
+---
+
+Run multiple chat conversations side-by-side. The chat panel now shows a tab strip — use the `+` button to start a new conversation and the `x` on each tab to close one. A status dot on each tab signals idle, streaming, or error at a glance, so background conversations keep working while you read another. Open tabs and the focused conversation are remembered across page reloads, and the session history dropdown marks already-open conversations so picking one focuses its tab instead of duplicating it.

--- a/public/css/pr.css
+++ b/public/css/pr.css
@@ -11772,6 +11772,32 @@ body.resizing * {
   background: var(--color-bg-secondary, #f6f8fa);
 }
 
+/* Already-open sessions in another tab — reduced opacity + open tag */
+.chat-panel__session-item--open .chat-panel__session-preview,
+.chat-panel__session-item--open .chat-panel__session-meta {
+  opacity: 0.55;
+}
+
+.chat-panel__session-open-tag {
+  display: inline-block;
+  margin-left: 6px;
+  padding: 0 5px;
+  font-size: 10px;
+  font-weight: 500;
+  line-height: 14px;
+  color: var(--color-text-secondary, #59636e);
+  background: var(--color-bg-tertiary, rgba(128, 128, 128, 0.12));
+  border-radius: 3px;
+  vertical-align: middle;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+[data-theme="dark"] .chat-panel__session-open-tag {
+  color: var(--color-text-secondary, #8b949e);
+  background: rgba(128, 128, 128, 0.18);
+}
+
 .chat-panel__session-item--active::before {
   content: '';
   position: absolute;
@@ -11908,6 +11934,178 @@ body.resizing * {
   color: var(--color-text-primary);
 }
 
+/* Chat Tab Strip */
+.chat-panel__tab-strip {
+  display: flex;
+  align-items: stretch;
+  gap: 4px;
+  padding: 4px 8px;
+  border-bottom: 1px solid var(--chat-border);
+  background: var(--color-bg-secondary, transparent);
+  flex-shrink: 0;
+  overflow-x: hidden;
+}
+
+.chat-panel__tab-strip--empty {
+  /* Keep the strip visible (so the + button is always reachable) */
+}
+
+.chat-panel__tab-strip-items {
+  display: flex;
+  align-items: stretch;
+  gap: 4px;
+  flex: 1;
+  min-width: 0;
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+
+.chat-panel__tab-strip-items::-webkit-scrollbar {
+  display: none;
+}
+
+.chat-panel__tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 8px 4px 10px;
+  font-size: 12px;
+  line-height: 1.4;
+  color: var(--color-text-secondary, #59636e);
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 6px 6px 0 0;
+  cursor: pointer;
+  max-width: 180px;
+  min-width: 70px;
+  user-select: none;
+  position: relative;
+  transition: background 0.12s ease, color 0.12s ease, border-color 0.12s ease;
+}
+
+.chat-panel__tab:hover {
+  background: var(--color-bg-tertiary, rgba(128, 128, 128, 0.08));
+  color: var(--color-text-primary, #1f2328);
+}
+
+.chat-panel__tab--active {
+  color: var(--color-text-primary, #1f2328);
+  background: var(--color-bg-primary, #fff);
+  border-color: var(--chat-border, var(--color-border-primary, #d0d7de));
+  border-bottom-color: var(--color-bg-primary, #fff);
+  margin-bottom: -1px;
+  z-index: 1;
+}
+
+[data-theme="dark"] .chat-panel__tab--active {
+  background: var(--color-bg-primary, #0d1117);
+  border-bottom-color: var(--color-bg-primary, #0d1117);
+}
+
+.chat-panel__tab-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  background: var(--color-accent-primary);
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.04) inset;
+}
+
+.chat-panel__tab-dot--idle { background: var(--color-accent-primary); }
+.chat-panel__tab-dot--streaming {
+  background: #d97706;
+  animation: chat-tab-dot-pulse 1.2s ease-in-out infinite;
+}
+.chat-panel__tab-dot--error { background: #cf222e; }
+
+[data-theme="dark"] .chat-panel__tab-dot--streaming { background: #d29922; }
+[data-theme="dark"] .chat-panel__tab-dot--error { background: #f85149; }
+
+@keyframes chat-tab-dot-pulse {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50% { opacity: 0.55; transform: scale(0.85); }
+}
+
+.chat-panel__tab-title {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex: 1;
+  min-width: 0;
+  font-weight: 500;
+}
+
+.chat-panel__tab-close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: inherit;
+  border-radius: 4px;
+  opacity: 0.55;
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: background 0.12s ease, opacity 0.12s ease;
+}
+
+.chat-panel__tab-close:hover {
+  background: var(--color-bg-tertiary, rgba(128, 128, 128, 0.12));
+  opacity: 1;
+}
+
+.chat-panel__tab-new-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  align-self: center;
+  border: 1px dashed var(--color-border-primary, #d0d7de);
+  background: transparent;
+  color: var(--color-text-secondary, #59636e);
+  border-radius: 6px;
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: background 0.12s ease, color 0.12s ease, border-color 0.12s ease;
+}
+
+.chat-panel__tab-new-btn:hover {
+  background: var(--color-bg-tertiary, rgba(128, 128, 128, 0.08));
+  color: var(--color-text-primary, #1f2328);
+  border-color: var(--color-text-tertiary, #6e7681);
+}
+
+.chat-panel__empty-new-btn {
+  margin-top: 12px;
+  padding: 6px 14px;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--color-text-primary, #1f2328);
+  background: var(--color-bg-secondary, #f6f8fa);
+  border: 1px solid var(--color-border-primary, #d0d7de);
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background 0.12s ease, border-color 0.12s ease;
+}
+
+.chat-panel__empty-new-btn:hover {
+  background: var(--color-bg-tertiary, rgba(128, 128, 128, 0.08));
+  border-color: var(--color-text-tertiary, #6e7681);
+}
+
+.chat-panel__tab:focus-visible,
+.chat-panel__tab-close:focus-visible,
+.chat-panel__tab-new-btn:focus-visible,
+.chat-panel__empty-new-btn:focus-visible {
+  outline: 2px solid var(--color-accent-primary);
+  outline-offset: 1px;
+}
+
 /* Chat Messages Area */
 .chat-panel__messages-wrapper {
   flex: 1;
@@ -11915,6 +12113,19 @@ body.resizing * {
   overflow: hidden;
   display: flex;
   flex-direction: column;
+  min-height: 0;
+}
+
+.chat-panel__messages-stack {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  position: relative;
+}
+
+.chat-panel__messages-stack > .chat-panel__messages {
+  flex: 1;
   min-height: 0;
 }
 

--- a/public/css/pr.css
+++ b/public/css/pr.css
@@ -12011,6 +12011,7 @@ body.resizing * {
   box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.04) inset;
 }
 
+.chat-panel__tab-dot--pending { background: #8c959f; }
 .chat-panel__tab-dot--idle { background: var(--color-accent-primary); }
 .chat-panel__tab-dot--streaming {
   background: #d97706;
@@ -12018,6 +12019,7 @@ body.resizing * {
 }
 .chat-panel__tab-dot--error { background: #cf222e; }
 
+[data-theme="dark"] .chat-panel__tab-dot--pending { background: #6e7681; }
 [data-theme="dark"] .chat-panel__tab-dot--streaming { background: #d29922; }
 [data-theme="dark"] .chat-panel__tab-dot--error { background: #f85149; }
 

--- a/public/js/components/ChatPanel.js
+++ b/public/js/components/ChatPanel.js
@@ -1253,9 +1253,9 @@ class ChatPanel {
     // First-time open behaviour:
     //   1. If localStorage has a tab list for this review, restore those tabs.
     //   2. Else, fall back to the legacy single-tab + MRU-load path.
-    //   3. Explicit context (Ask about this / Chat about this file) always
-    //      opens a fresh "New Chat" tab on top — that's the user requesting
-    //      a new conversation about a specific item.
+    // Explicit context (Ask about this / Chat about this file) lands in the
+    // currently-active tab — the user is augmenting the conversation they're
+    // already in. Only spin up a fresh tab when there isn't one yet.
     if (this.tabs.length === 0) {
       let restored = false;
       if (this.reviewId && !hasExplicitContext) {
@@ -1270,21 +1270,6 @@ class ChatPanel {
         if (!hasExplicitContext) {
           await this._loadMRUSession();
         }
-      }
-    }
-
-    // Explicit context ("Ask about this" / file context / comment context)
-    // must always land in a FRESH tab so we don't bleed it into whatever
-    // conversation the user has been chatting in. Reuse only a tab that is
-    // truly empty (no messages, no pending context).
-    if (hasExplicitContext) {
-      const active = this._getActiveTab();
-      const canReuseEmptyTab = active &&
-        active.messages.length === 0 &&
-        active.pendingContext.length === 0;
-      if (!canReuseEmptyTab) {
-        const tab = this._createTab({ provider: this._activeProvider });
-        this._appendTab(tab, { focus: true });
       }
     }
 

--- a/public/js/components/ChatPanel.js
+++ b/public/js/components/ChatPanel.js
@@ -105,7 +105,10 @@ class ChatPanel {
       sessionId: init.sessionId ?? null,
       _localKey: this._tabKeyCounter--,
       title: init.title || _nextNewTabTitle(),
-      status: 'idle',
+      // 'pending' = fresh tab, no messages exchanged yet (gray dot).
+      // Transitions to 'idle'/'streaming'/'error' once the conversation
+      // is underway. See _updateTabStatus for the demote rule.
+      status: 'pending',
       errorMessage: null,
       messages: [],
       isStreaming: false,
@@ -450,11 +453,18 @@ class ChatPanel {
   /**
    * Update a tab's status (and its dot in the strip).
    * @param {ChatTab} tab
-   * @param {'idle'|'streaming'|'error'} status
+   * @param {'pending'|'idle'|'streaming'|'error'} status
    */
   _updateTabStatus(tab, status) {
     if (!tab) return;
     if (status === 'idle') tab.errorMessage = null;
+    // A tab with no exchanged messages stays in the 'pending' (gray) state
+    // even when callers request 'idle' — the conversation hasn't started yet,
+    // so the active-affordance blue would over-signal. 'streaming' and
+    // 'error' always win.
+    if (status === 'idle' && (tab.messages?.length ?? 0) === 0) {
+      status = 'pending';
+    }
     tab.status = status;
     if (this.tabStripItemsEl) {
       const dot = this.tabStripItemsEl.querySelector(`.chat-panel__tab[data-tab-key="${this._tabKey(tab)}"] .chat-panel__tab-dot`);
@@ -1587,6 +1597,13 @@ class ChatPanel {
         }
       }
     });
+
+    // The tab was initialized as 'pending' (gray dot) before history loaded.
+    // Now that messages exist, promote to 'idle' (blue dot) — but don't
+    // override a streaming/error state that may have started up in parallel.
+    if (tab.status === 'pending' && tab.messages.length > 0) {
+      this._updateTabStatus(tab, 'idle');
+    }
   }
 
   /**

--- a/public/js/components/ChatPanel.js
+++ b/public/js/components/ChatPanel.js
@@ -17,39 +17,745 @@ function getChatSpinnerHTML() {
   return window.__pairReview?.chatSpinner === 'loop' ? LOOP_SPINNER_HTML : DOTS_SPINNER_HTML;
 }
 
+/**
+ * @typedef {Object} ChatTab
+ * @property {number|null} sessionId - Backend session ID (null for an unsaved new tab)
+ * @property {string} title - Tab title shown in the strip
+ * @property {'idle'|'streaming'|'error'} status - Drives the status dot color
+ * @property {string|null} errorMessage - Last error, cleared on next successful send
+ * @property {Array<{role: string, content: string, id?: number}>} messages
+ * @property {boolean} isStreaming
+ * @property {string} streamingContent - Accumulated stream text (delta concatenation)
+ * @property {boolean} sessionWarm - True once the session has been used this page load (ACP resume flag)
+ * @property {string} provider - Provider id assigned to this tab when its session was created
+ * @property {string|null} model - Model id for header label
+ * @property {string|null} contextSource - 'suggestion' | 'user' | 'line' | 'file' | null
+ * @property {(string|number)|null} contextItemId
+ * @property {Object|null} contextLineMeta - { file, line_start, line_end }
+ * @property {Object|null} pendingActionContext - Set by action buttons, consumed in sendMessage
+ * @property {string[]} pendingContext - Unsent context text blocks for next send
+ * @property {Object[]} pendingContextData - Structured context data parallel to pendingContext
+ * @property {string|null} latestDiffState - Latest diff snapshot (idempotent, overwrites)
+ * @property {string[]} pendingUserActionHints - Ordered log of UI actions, drained on send
+ * @property {boolean} analysisContextRemoved
+ * @property {string|null} sessionAnalysisRunId
+ * @property {HTMLElement} messagesEl - Per-tab scrollable messages container
+ * @property {HTMLElement|null} streamingMsgEl - Reference to the in-progress assistant bubble
+ * @property {boolean} userScrolledAway - Auto-scroll engagement flag
+ * @property {Function|null} wsUnsub - Unsubscribe handle for the per-session WS topic
+ * @property {Promise<void>|null} historyLoadPromise - Set while history is loading
+ */
+
+let _newTabCounter = 0;
+function _nextNewTabTitle() {
+  _newTabCounter += 1;
+  return _newTabCounter === 1 ? 'New Chat' : `New Chat ${_newTabCounter}`;
+}
+
 class ChatPanel {
   constructor(containerId) {
     this.containerId = containerId;
     this.container = document.getElementById(containerId);
-    this.currentSessionId = null;
     this.reviewId = null;
     this.isOpen = false;
-    this.isStreaming = false;
-    this._chatUnsub = null;
     this._reviewUnsub = null;
-    this.messages = [];
-    this._streamingContent = '';
-    this._pendingContext = [];
-    this._pendingContextData = [];
-    this._pendingDiffStateNotifications = [];
-    this._pendingUserActionHints = [];
-    this._contextSource = null;   // 'suggestion' or 'user' — set when opened with context
-    this._contextItemId = null;   // suggestion ID or comment ID from context
-    this._contextLineMeta = null;  // { file, line_start, line_end } — set when opened with line context
-    this._pendingActionContext = null;  // { type, itemId } — set by action button handlers, consumed by sendMessage
     this._resizeConfig = ChatPanel.RESIZE_CONFIG;
-    this._analysisContextRemoved = false;
-    this._sessionAnalysisRunId = null; // tracks which AI run ID's context is loaded in the current session
-    this._openPromise = null; // concurrency guard for open()
-    this._sessionWarm = false; // true once the session has been used in this page load
+    this._openPromise = null;
     this._activeProvider = window.__pairReview?.chatProvider || 'pi';
     this._chatProviders = window.__pairReview?.chatProviders || [];
     this._enterToSend = window.__pairReview?.chatEnterToSend ?? true;
+
+    /** @type {ChatTab[]} Open tabs, in display order (left to right). */
+    this.tabs = [];
+    /** @type {number|null} Sentinel ID of the active tab; matches sessionId once saved. */
+    this.activeTabKey = null;
+    /** Counter used as a sentinel key for tabs that haven't been assigned a sessionId yet. */
+    this._tabKeyCounter = -1;
 
     this._render();
     this._bindEvents();
     this._initContextTooltip();
     this._updateTitle();
+  }
+
+  // ── Tab helpers ─────────────────────────────────────────────────────────
+
+  _getActiveTab() {
+    if (this.activeTabKey == null) return null;
+    return this.tabs.find(t => this._tabKey(t) === this.activeTabKey) || null;
+  }
+
+  _tabKey(tab) {
+    return tab.sessionId != null ? tab.sessionId : tab._localKey;
+  }
+
+  _findTabBySessionId(sessionId) {
+    if (sessionId == null) return null;
+    return this.tabs.find(t => t.sessionId === sessionId) || null;
+  }
+
+  /**
+   * Allocate a per-tab descriptor with sensible defaults. Caller is responsible
+   * for appending it to this.tabs and creating its messagesEl.
+   * @param {Object} [init]
+   * @returns {ChatTab}
+   */
+  _createTab(init = {}) {
+    const tab = {
+      sessionId: init.sessionId ?? null,
+      _localKey: this._tabKeyCounter--,
+      title: init.title || _nextNewTabTitle(),
+      status: 'idle',
+      errorMessage: null,
+      messages: [],
+      isStreaming: false,
+      streamingContent: '',
+      sessionWarm: !!init.sessionWarm,
+      provider: init.provider || this._activeProvider,
+      model: init.model || null,
+      contextSource: null,
+      contextItemId: null,
+      contextLineMeta: null,
+      pendingActionContext: null,
+      pendingContext: [],
+      pendingContextData: [],
+      latestDiffState: init.latestDiffState !== undefined ? init.latestDiffState : (this._initialDiffState || null),
+      pendingUserActionHints: [],
+      analysisContextRemoved: false,
+      sessionAnalysisRunId: null,
+      messagesEl: null,
+      streamingMsgEl: null,
+      userScrolledAway: false,
+      wsUnsub: null,
+      titleFromUser: false,
+      historyLoadPromise: null,
+    };
+    return tab;
+  }
+
+  // ── Per-tab state delegation (SYNC ONLY) ────────────────────────────────
+  //
+  // These getters/setters forward to the active tab so synchronous helpers
+  // (context-card builders, sync handler callers) don't need a tab parameter.
+  // SYNC ONLY — do NOT read across awaits. Async code paths (`sendMessage`,
+  // `_handleChatMessageForTab`, WS reconnect) capture `tab` at function entry
+  // and write through `tab.*` directly.
+  //
+  // Array-valued state (`tab.messages`, `tab.pendingContext`,
+  // `tab.pendingContextData`, `tab.pendingActionContext`,
+  // `tab.pendingUserActionHints`) and per-tab snapshot state
+  // (`tab.latestDiffState`) are deliberately NOT exposed via shims —
+  // callers must use the explicit tab reference to avoid silent cross-tab
+  // bleed across awaits.
+
+  get currentSessionId() {
+    return this._getActiveTab()?.sessionId ?? null;
+  }
+  set currentSessionId(v) {
+    const tab = this._getActiveTab();
+    if (!tab) return;
+    const prev = tab.sessionId;
+    tab.sessionId = v;
+    if (prev !== v) {
+      this.activeTabKey = this._tabKey(tab);
+      this._renderTabStrip();
+    }
+  }
+  get isStreaming() {
+    return this._getActiveTab()?.isStreaming ?? false;
+  }
+  set isStreaming(v) {
+    const tab = this._getActiveTab();
+    if (!tab) return;
+    tab.isStreaming = v;
+    this._updateTabStatus(tab, v ? 'streaming' : (tab.errorMessage ? 'error' : 'idle'));
+  }
+  get _streamingContent() {
+    return this._getActiveTab()?.streamingContent ?? '';
+  }
+  set _streamingContent(v) {
+    const tab = this._getActiveTab();
+    if (tab) tab.streamingContent = v;
+  }
+  get _sessionWarm() {
+    return this._getActiveTab()?.sessionWarm ?? false;
+  }
+  set _sessionWarm(v) {
+    const tab = this._getActiveTab();
+    if (tab) tab.sessionWarm = v;
+  }
+  get _contextSource() {
+    return this._getActiveTab()?.contextSource ?? null;
+  }
+  set _contextSource(v) {
+    const tab = this._getActiveTab();
+    if (tab) tab.contextSource = v;
+  }
+  get _contextItemId() {
+    return this._getActiveTab()?.contextItemId ?? null;
+  }
+  set _contextItemId(v) {
+    const tab = this._getActiveTab();
+    if (tab) tab.contextItemId = v;
+  }
+  get _contextLineMeta() {
+    return this._getActiveTab()?.contextLineMeta ?? null;
+  }
+  set _contextLineMeta(v) {
+    const tab = this._getActiveTab();
+    if (tab) tab.contextLineMeta = v;
+  }
+  get _analysisContextRemoved() {
+    return this._getActiveTab()?.analysisContextRemoved ?? false;
+  }
+  set _analysisContextRemoved(v) {
+    const tab = this._getActiveTab();
+    if (tab) tab.analysisContextRemoved = v;
+  }
+  get _sessionAnalysisRunId() {
+    return this._getActiveTab()?.sessionAnalysisRunId ?? null;
+  }
+  set _sessionAnalysisRunId(v) {
+    const tab = this._getActiveTab();
+    if (tab) tab.sessionAnalysisRunId = v;
+  }
+  get _userScrolledAway() {
+    return this._getActiveTab()?.userScrolledAway ?? false;
+  }
+  set _userScrolledAway(v) {
+    const tab = this._getActiveTab();
+    if (tab) tab.userScrolledAway = v;
+  }
+  get messagesEl() {
+    return this._getActiveTab()?.messagesEl || null;
+  }
+
+  /**
+   * Allocate a new <div class="chat-panel__messages"> for a tab and append it
+   * into the stack. Hidden by default; _switchToTab toggles the .--active class.
+   */
+  _createTabMessagesEl(tab) {
+    const el = document.createElement('div');
+    el.className = 'chat-panel__messages';
+    el.dataset.tabKey = String(this._tabKey(tab));
+    el.style.display = 'none';
+    el.innerHTML = `
+      <div class="chat-panel__empty">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" width="32" height="32">
+          <path d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09z"/>
+        </svg>
+        <p>Ask questions about this review, or the changes</p>
+      </div>
+    `;
+    let lastScrollTop = 0;
+    el.addEventListener('scroll', () => {
+      const { scrollTop, scrollHeight, clientHeight } = el;
+      const distance = scrollHeight - scrollTop - clientHeight;
+      if (scrollTop < lastScrollTop && distance >= NEAR_BOTTOM_THRESHOLD) {
+        tab.userScrolledAway = true;
+        if (this._getActiveTab() === tab) this._showNewContentPill();
+      } else if (distance < NEAR_BOTTOM_THRESHOLD) {
+        tab.userScrolledAway = false;
+        if (this._getActiveTab() === tab) this._hideNewContentPill();
+      }
+      lastScrollTop = scrollTop;
+    }, { passive: true });
+    tab.messagesEl = el;
+    return el;
+  }
+
+  /**
+   * Insert a new tab into the strip and the messages stack.
+   * @param {ChatTab} tab
+   * @param {{focus?: boolean, position?: number}} [opts]
+   */
+  _appendTab(tab, { focus = true, position } = {}) {
+    const el = this._createTabMessagesEl(tab);
+    if (typeof position === 'number' && position < this.tabs.length) {
+      this.tabs.splice(position, 0, tab);
+    } else {
+      this.tabs.push(tab);
+    }
+    this.messagesStackEl.appendChild(el);
+    if (focus) {
+      this._switchToTab(this._tabKey(tab));
+    } else {
+      this._renderTabStrip();
+    }
+    this._updateNoTabsEmptyState();
+    // Persist if the tab already has a sessionId (history-picker restore path).
+    // For new tabs that get a session async, persistence fires from the place
+    // that assigns sessionId.
+    if (tab.sessionId != null) this._persistOpenTabs();
+    return tab;
+  }
+
+  /**
+   * Activate a tab by key. Hides other tabs' message containers without
+   * tearing down their state or subscriptions.
+   * @param {number} key
+   */
+  _switchToTab(key) {
+    const tab = this.tabs.find(t => this._tabKey(t) === key);
+    if (!tab) return;
+    if (this.activeTabKey === key && tab.messagesEl?.style.display !== 'none') {
+      this._renderTabStrip();
+      return;
+    }
+    this.activeTabKey = key;
+    this._persistOpenTabs();
+    // Toggle visibility of message containers
+    for (const t of this.tabs) {
+      if (!t.messagesEl) continue;
+      t.messagesEl.style.display = (t === tab) ? '' : 'none';
+    }
+    // Header should reflect the focused tab's provider/model
+    if (tab.provider) {
+      this._activeProvider = tab.provider;
+      this._updateTitle(tab.provider, tab.model);
+    } else {
+      this._updateTitle();
+    }
+    this._renderTabStrip();
+    this._updateActionButtons();
+    // Adjust send/stop buttons to reflect the new active tab's streaming state
+    this.sendBtn.style.display = tab.isStreaming ? 'none' : '';
+    this.stopBtn.style.display = tab.isStreaming ? '' : 'none';
+    this.sendBtn.disabled = tab.isStreaming || !this.inputEl?.value?.trim();
+    // Re-anchor scroll
+    if (!tab.userScrolledAway) this.scrollToBottom({ force: true });
+  }
+
+  /**
+   * Close a tab: kills its bridge, removes its DOM, unsubscribes from its
+   * WebSocket topic. If it was active, focuses the rightmost remaining tab
+   * (or shows the empty state if none).
+   * @param {number} key
+   */
+  async _closeTab(key) {
+    const idx = this.tabs.findIndex(t => this._tabKey(t) === key);
+    if (idx === -1) return;
+    const tab = this.tabs[idx];
+    this._removeTabFromDom(tab);
+  }
+
+  /**
+   * Remove a tab from the strip and the DOM without contacting the backend.
+   * Shared by _closeTab (which additionally fires the DELETE) and the 404
+   * branch in _loadMessageHistory (which must NOT, since the session is
+   * already gone). Idempotent: a no-op for tabs that have already been
+   * removed.
+   *
+   * Always preserves the "no tabs left → reset Send/Stop" behavior so the
+   * input chrome doesn't get stranded in a streaming state.
+   *
+   * @param {ChatTab} tab
+   * @param {{ skipDelete?: boolean }} [opts]
+   */
+  _removeTabFromDom(tab, { skipDelete = false } = {}) {
+    if (!tab) return;
+    const idx = this.tabs.indexOf(tab);
+    if (idx === -1) return; // already removed
+
+    const key = this._tabKey(tab);
+
+    // Unsubscribe immediately so we stop receiving events for this session
+    if (tab.wsUnsub) { try { tab.wsUnsub(); } catch { /* noop */ } tab.wsUnsub = null; }
+
+    // Fire-and-forget DELETE — server-side closeSession is idempotent
+    if (!skipDelete && tab.sessionId != null) {
+      fetch(`/api/chat/session/${tab.sessionId}`, { method: 'DELETE' })
+        .catch(err => console.warn('[ChatPanel] Failed to close session:', err));
+    }
+
+    // Remove the DOM container
+    if (tab.messagesEl?.parentNode) {
+      tab.messagesEl.parentNode.removeChild(tab.messagesEl);
+    }
+
+    // Remove from the array
+    this.tabs.splice(idx, 1);
+    this._persistOpenTabs();
+
+    if (this.activeTabKey === key) {
+      // Focus the tab to the right (or last) if any remain
+      const next = this.tabs[idx] || this.tabs[idx - 1] || this.tabs[this.tabs.length - 1] || null;
+      if (next) {
+        this._switchToTab(this._tabKey(next));
+      } else {
+        this.activeTabKey = null;
+        this._renderTabStrip();
+        this._updateNoTabsEmptyState();
+        this._updateTitle();
+        this._updateActionButtons();
+        this.sendBtn.style.display = '';
+        this.stopBtn.style.display = 'none';
+        this.sendBtn.disabled = true;
+      }
+    } else {
+      this._renderTabStrip();
+    }
+  }
+
+  /**
+   * Render or re-render the tab strip from this.tabs.
+   */
+  _renderTabStrip() {
+    if (!this.tabStripItemsEl) return;
+    if (this.tabs.length === 0) {
+      this.tabStripItemsEl.innerHTML = '';
+      this.tabStripEl.classList.add('chat-panel__tab-strip--empty');
+      return;
+    }
+    this.tabStripEl.classList.remove('chat-panel__tab-strip--empty');
+    const items = this.tabs.map((tab) => {
+      const key = this._tabKey(tab);
+      const isActive = key === this.activeTabKey;
+      const dotClass = `chat-panel__tab-dot chat-panel__tab-dot--${tab.status || 'idle'}`;
+      const tooltip = tab.errorMessage
+        ? `${this._escapeAttr(tab.title)} (error: ${this._escapeAttr(tab.errorMessage)})`
+        : this._escapeAttr(tab.title);
+      const sessionIdAttr = tab.sessionId != null ? ` data-session-id="${tab.sessionId}"` : '';
+      return `
+        <div class="chat-panel__tab${isActive ? ' chat-panel__tab--active' : ''}"
+             role="tab"
+             data-tab-key="${key}"${sessionIdAttr}
+             title="${tooltip}">
+          <span class="${dotClass}" aria-hidden="true"></span>
+          <span class="chat-panel__tab-title">${this._escapeHtml(tab.title)}</span>
+          <button class="chat-panel__tab-close" title="Close conversation" data-tab-key="${key}" aria-label="Close conversation">
+            <svg viewBox="0 0 16 16" fill="currentColor" width="10" height="10"><path d="M3.72 3.72a.75.75 0 0 1 1.06 0L8 6.94l3.22-3.22a.75.75 0 1 1 1.06 1.06L9.06 8l3.22 3.22a.75.75 0 1 1-1.06 1.06L8 9.06l-3.22 3.22a.75.75 0 0 1-1.06-1.06L6.94 8 3.72 4.78a.75.75 0 0 1 0-1.06Z"/></svg>
+          </button>
+        </div>
+      `;
+    }).join('');
+    this.tabStripItemsEl.innerHTML = items;
+    // Bind click handlers
+    this.tabStripItemsEl.querySelectorAll('.chat-panel__tab').forEach((el) => {
+      const key = parseInt(el.dataset.tabKey, 10);
+      el.addEventListener('click', (e) => {
+        if (e.target.closest('.chat-panel__tab-close')) return;
+        this._switchToTab(key);
+      });
+    });
+    this.tabStripItemsEl.querySelectorAll('.chat-panel__tab-close').forEach((btn) => {
+      const key = parseInt(btn.dataset.tabKey, 10);
+      btn.addEventListener('click', (e) => {
+        e.stopPropagation();
+        this._closeTab(key);
+      });
+    });
+  }
+
+  /**
+   * Update a tab's status (and its dot in the strip).
+   * @param {ChatTab} tab
+   * @param {'idle'|'streaming'|'error'} status
+   */
+  _updateTabStatus(tab, status) {
+    if (!tab) return;
+    if (status === 'idle') tab.errorMessage = null;
+    tab.status = status;
+    if (this.tabStripItemsEl) {
+      const dot = this.tabStripItemsEl.querySelector(`.chat-panel__tab[data-tab-key="${this._tabKey(tab)}"] .chat-panel__tab-dot`);
+      if (dot) {
+        dot.className = `chat-panel__tab-dot chat-panel__tab-dot--${status}`;
+      }
+    }
+  }
+
+  /**
+   * Update a tab's title (and re-render the strip).
+   * @param {ChatTab} tab
+   * @param {string} title
+   */
+  _setTabTitle(tab, title) {
+    if (!tab || !title) return;
+    tab.title = title;
+    if (this.tabStripItemsEl) {
+      const titleEl = this.tabStripItemsEl.querySelector(`.chat-panel__tab[data-tab-key="${this._tabKey(tab)}"] .chat-panel__tab-title`);
+      if (titleEl) titleEl.textContent = title;
+      const tabEl = this.tabStripItemsEl.querySelector(`.chat-panel__tab[data-tab-key="${this._tabKey(tab)}"]`);
+      if (tabEl) tabEl.title = this._escapeAttr(title);
+    }
+  }
+
+  /**
+   * Show or hide the "no tabs open" empty state.
+   */
+  _updateNoTabsEmptyState() {
+    const noTabsEmpty = this.messagesStackEl?.querySelector('.chat-panel__empty--no-tabs');
+    if (!noTabsEmpty) return;
+    noTabsEmpty.style.display = this.tabs.length === 0 ? '' : 'none';
+  }
+
+  // ── Persistence (open tabs in localStorage) ────────────────────────────
+  //
+  // Per-review key holds an ordered list of session IDs plus the active one.
+  // Format: { version: 1, tabs: [sessionId, ...], activeSessionId: number|null }
+  // Writes are debounced (100ms trailing) to coalesce bursts during open/restore.
+  // Reads/writes are wrapped in try/catch — localStorage failures are soft.
+
+  _chatTabsStorageKey() {
+    if (!this.reviewId) return null;
+    return `pair-review:chat-tabs:${this.reviewId}`;
+  }
+
+  /**
+   * Serialize open tabs and schedule a write. Only tabs with a saved sessionId
+   * are persisted — unsaved (just-opened, pre-session) tabs are ignored.
+   */
+  _persistOpenTabs() {
+    const key = this._chatTabsStorageKey();
+    if (!key) return;
+    if (this._persistTimer) {
+      clearTimeout(this._persistTimer);
+    }
+    this._persistTimer = setTimeout(() => {
+      this._persistTimer = null;
+      try {
+        const ids = this.tabs.map(t => t.sessionId).filter(id => id != null);
+        if (ids.length === 0) {
+          window.localStorage.removeItem(key);
+          return;
+        }
+        const active = this._getActiveTab();
+        const activeSessionId = active?.sessionId ?? null;
+        const payload = { version: 1, tabs: ids, activeSessionId };
+        window.localStorage.setItem(key, JSON.stringify(payload));
+      } catch (err) {
+        console.warn('[ChatPanel] Failed to persist open tabs:', err);
+      }
+    }, 100);
+  }
+
+  /**
+   * Read the persisted tab list for the current reviewId. Returns null when
+   * absent, malformed, or the wrong shape.
+   * @returns {{ tabs: number[], activeSessionId: number|null }|null}
+   */
+  _loadPersistedTabs() {
+    const key = this._chatTabsStorageKey();
+    if (!key) return null;
+    try {
+      const raw = window.localStorage.getItem(key);
+      if (!raw) return null;
+      const parsed = JSON.parse(raw);
+      if (!parsed || parsed.version !== 1 || !Array.isArray(parsed.tabs)) return null;
+      const tabs = parsed.tabs
+        .map(n => parseInt(n, 10))
+        .filter(n => Number.isFinite(n));
+      if (tabs.length === 0) return null;
+      const active = Number.isFinite(parsed.activeSessionId)
+        ? parseInt(parsed.activeSessionId, 10)
+        : null;
+      return { tabs, activeSessionId: active };
+    } catch (err) {
+      console.warn('[ChatPanel] Failed to read persisted tabs:', err);
+      return null;
+    }
+  }
+
+  /**
+   * Restore tabs from a persisted descriptor. Fetches session metadata from
+   * the review's sessions list (for first-message titles, provider, model)
+   * and renders each tab. Stale session IDs (404 from messages endpoint) are
+   * silently dropped and the storage entry is rewritten without them.
+   *
+   * Returns true if at least one tab was restored.
+   *
+   * @param {{ tabs: number[], activeSessionId: number|null }} saved
+   * @returns {Promise<boolean>}
+   */
+  async _restoreTabs(saved) {
+    if (!saved || !this.reviewId) return false;
+
+    // Fetch all sessions for this review once for metadata lookup
+    const sessions = await this._fetchSessions();
+    const sessionById = new Map(sessions.map(s => [s.id, s]));
+
+    const surviving = [];
+    for (const sid of saved.tabs) {
+      const meta = sessionById.get(sid);
+      // If the session doesn't appear in the sessions list, it's been deleted
+      // out-of-band. Skip it — it'll be pruned from storage by the write at
+      // the end of this function.
+      if (!meta) continue;
+
+      const tab = this._createTab({
+        sessionId: sid,
+        provider: meta.provider || this._activeProvider,
+        model: meta.model || null,
+        sessionWarm: false,
+      });
+      if (meta.first_message) {
+        tab.title = this._truncate(meta.first_message, 28);
+        tab.titleFromUser = true;
+      }
+      // Append without focus — we focus the chosen tab in one go below
+      this._appendTab(tab, { focus: false });
+      this._subscribeTab(tab);
+
+      // Load history without blocking other tabs — race-guarded load knows how
+      // to discard responses that arrive after the tab has been closed/swapped.
+      // Track the in-flight promise on the tab so sendMessage can await before
+      // mutating its message list.
+      if (meta.message_count > 0) {
+        const p = this._loadMessageHistory(sid, tab)
+          .catch(err => console.warn('[ChatPanel] Restore: history load failed for', sid, err))
+          .finally(() => {
+            if (tab.historyLoadPromise === p) tab.historyLoadPromise = null;
+          });
+        tab.historyLoadPromise = p;
+      }
+
+      surviving.push({ tab, meta });
+    }
+
+    if (surviving.length === 0) return false;
+
+    // Choose which tab gets focus: prefer the saved activeSessionId, else
+    // the rightmost restored tab.
+    let focusTab = null;
+    if (saved.activeSessionId != null) {
+      const found = surviving.find(s => s.meta.id === saved.activeSessionId);
+      if (found) focusTab = found.tab;
+    }
+    if (!focusTab) focusTab = surviving[surviving.length - 1].tab;
+    this._switchToTab(this._tabKey(focusTab));
+
+    // Re-persist to prune any stale IDs that were dropped above
+    this._persistOpenTabs();
+
+    // Await the focused tab's history before returning so the panel doesn't
+    // expose an empty conversation to the user mid-load.
+    if (focusTab.historyLoadPromise) {
+      try { await focusTab.historyLoadPromise; } catch { /* swallow */ }
+    }
+    // A 404 in _loadMessageHistory silently closes the tab via the in-line
+    // removal path. If the focused tab was the casualty (or every tab was),
+    // signal failure so the caller falls through to _loadMRUSession.
+    if (this.tabs.length === 0 || !this.tabs.includes(focusTab)) {
+      return false;
+    }
+    return true;
+  }
+
+  /**
+   * Escape a string for safe use in an HTML attribute value.
+   */
+  _escapeAttr(text) {
+    if (!text) return '';
+    return String(text)
+      .replace(/&/g, '&amp;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;');
+  }
+
+  /**
+   * Open a fresh tab and focus it. Does NOT eagerly POST to the backend —
+   * the session is lazily created on first send by sendMessage. Side effects:
+   *   - Allocates a tab descriptor with sessionId=null.
+   *   - Appends it to the strip and focuses it.
+   *   - Surfaces analysis context (when one is available locally) so the user
+   *     sees the card before they ever type a message.
+   * @returns {Promise<void>}
+   */
+  async _openNewTab() {
+    if (!this.reviewId) {
+      console.warn('[ChatPanel] _openNewTab: no reviewId yet');
+      return;
+    }
+    const tab = this._createTab({ provider: this._activeProvider });
+    this._appendTab(tab, { focus: true });
+    // No session yet, so _showAnalysisContextIfPresent gets a null sessionData.
+    // We still want the auto-detected analysis card surfaced on the fresh tab
+    // — that's what _ensureAnalysisContext handles. Route it through the
+    // captured tab so a focus change can't bleed the card elsewhere.
+    this._ensureAnalysisContext(tab);
+    if (this.isOpen) this.inputEl?.focus();
+  }
+
+  /**
+   * Create a backend chat session bound to a specific tab. Subscribes the tab
+   * to its session's WebSocket topic and updates the tab's sessionId.
+   * @param {ChatTab} tab
+   * @returns {Promise<Object|null>}
+   */
+  async _createSessionForTab(tab) {
+    if (!this.reviewId) return null;
+    if (!tab) return null;
+    // Capture the provider at entry. If the user swaps providers on this tab
+    // while the POST is in flight, the response describes a session for the
+    // wrong provider — we must abandon it and let the next send (with the new
+    // provider) start fresh.
+    const capturedProvider = tab.provider;
+    const isAcp = this._getProviderType(capturedProvider) === 'acp';
+    if (isAcp) this._showStatusFlash('Starting Agent Client Protocol');
+    try {
+      const body = { provider: capturedProvider, reviewId: this.reviewId };
+      if (tab.analysisContextRemoved) body.skipAnalysisContext = true;
+      const response = await fetch('/api/chat/session', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body)
+      });
+      if (isAcp) this._hideStatusFlash();
+      if (!response.ok) {
+        const err = await response.json().catch(() => ({}));
+        throw new Error(err.error || 'Failed to create chat session');
+      }
+      const result = await response.json();
+      // The tab may have been closed while the POST was in flight. Hand the
+      // server-side session back so it can be cleaned up, and bail.
+      if (!this.tabs.includes(tab)) {
+        fetch(`/api/chat/session/${result.data.id}`, { method: 'DELETE' }).catch(() => {});
+        return null;
+      }
+      // Provider was swapped between our captured snapshot and the response.
+      // The session belongs to capturedProvider — let it be cleaned up and
+      // signal failure so the caller's lazy-create path can retry under the
+      // new provider.
+      if (tab.provider !== capturedProvider) {
+        fetch(`/api/chat/session/${result.data.id}`, { method: 'DELETE' }).catch(() => {});
+        return null;
+      }
+      tab.sessionId = result.data.id;
+      tab.sessionWarm = true;
+      if (tab.messagesEl) tab.messagesEl.dataset.tabKey = String(tab.sessionId);
+      // Re-key the active marker if this is the focused tab (so getters work)
+      if (this.activeTabKey === tab._localKey) this.activeTabKey = tab.sessionId;
+      this._subscribeTab(tab);
+      this._renderTabStrip();
+      this._persistOpenTabs();
+      return result.data;
+    } catch (error) {
+      if (isAcp) this._hideStatusFlash();
+      console.error('[ChatPanel] Error creating session:', error);
+      this._showError('Failed to start chat session. ' + error.message, tab);
+      return null;
+    }
+  }
+
+  /**
+   * Subscribe a tab to its session's WebSocket topic. Idempotent: if a
+   * subscription handle already exists, it is left in place.
+   * @param {ChatTab} tab
+   */
+  _subscribeTab(tab) {
+    if (!tab || tab.sessionId == null) return;
+    if (tab.wsUnsub) return;
+    window.wsClient.connect();
+    tab.wsUnsub = window.wsClient.subscribe('chat:' + tab.sessionId, (msg) => {
+      this._handleChatMessageForTab(tab, msg);
+    });
+  }
+
+  _getProviderType(providerId) {
+    const entry = this._chatProviders.find(p => p.id === providerId);
+    return entry?.type;
   }
 
   /**
@@ -83,11 +789,6 @@ class ChatPanel {
                 <path d="m.427 1.927 1.215 1.215a8.002 8.002 0 1 1-1.6 5.685.75.75 0 1 1 1.493-.154 6.5 6.5 0 1 0 1.18-4.458l1.358 1.358A.25.25 0 0 1 3.896 6H.25A.25.25 0 0 1 0 5.75V2.104a.25.25 0 0 1 .427-.177ZM7.75 4a.75.75 0 0 1 .75.75v2.992l2.028.812a.75.75 0 0 1-.557 1.392l-2.5-1A.751.751 0 0 1 7 8.25v-3.5A.75.75 0 0 1 7.75 4Z"/>
               </svg>
             </button>
-            <button class="chat-panel__new-btn" title="New conversation">
-              <svg viewBox="0 0 16 16" fill="currentColor" width="14" height="14">
-                <path d="M7.75 2a.75.75 0 0 1 .75.75V7h4.25a.75.75 0 0 1 0 1.5H8.5v4.25a.75.75 0 0 1-1.5 0V8.5H2.75a.75.75 0 0 1 0-1.5H7V2.75A.75.75 0 0 1 7.75 2Z"/>
-              </svg>
-            </button>
             <button class="chat-panel__close-btn" title="Close">
               <svg viewBox="0 0 16 16" fill="currentColor" width="14" height="14">
                 <path d="M3.72 3.72a.75.75 0 0 1 1.06 0L8 6.94l3.22-3.22a.75.75 0 1 1 1.06 1.06L9.06 8l3.22 3.22a.75.75 0 1 1-1.06 1.06L8 9.06l-3.22 3.22a.75.75 0 0 1-1.06-1.06L6.94 8 3.72 4.78a.75.75 0 0 1 0-1.06Z"/>
@@ -95,16 +796,25 @@ class ChatPanel {
             </button>
           </div>
         </div>
+        <div class="chat-panel__tab-strip" role="tablist">
+          <div class="chat-panel__tab-strip-items"></div>
+          <button class="chat-panel__tab-new-btn" title="New conversation">
+            <svg viewBox="0 0 16 16" fill="currentColor" width="12" height="12">
+              <path d="M7.75 2a.75.75 0 0 1 .75.75V7h4.25a.75.75 0 0 1 0 1.5H8.5v4.25a.75.75 0 0 1-1.5 0V8.5H2.75a.75.75 0 0 1 0-1.5H7V2.75A.75.75 0 0 1 7.75 2Z"/>
+            </svg>
+          </button>
+        </div>
         <div class="chat-panel__status-flash" style="display:none">
           <span class="chat-panel__status-flash-text">Starting Agent Client Protocol</span>
         </div>
         <div class="chat-panel__messages-wrapper">
-          <div class="chat-panel__messages" id="chat-messages">
-            <div class="chat-panel__empty">
+          <div class="chat-panel__messages-stack" id="chat-messages-stack">
+            <div class="chat-panel__empty chat-panel__empty--no-tabs">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" width="32" height="32">
                 <path d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09z"/>
               </svg>
-              <p>Ask questions about this review, or the changes</p>
+              <p>No conversation open.</p>
+              <button class="chat-panel__empty-new-btn">Start a new chat</button>
             </div>
           </div>
           <button class="chat-panel__new-content-pill" style="display:none">\u2193 New content</button>
@@ -163,12 +873,15 @@ class ChatPanel {
 
     // Cache element references
     this.panel = this.container.querySelector('#chat-panel');
-    this.messagesEl = this.container.querySelector('#chat-messages');
+    this.messagesStackEl = this.container.querySelector('#chat-messages-stack');
+    this.tabStripEl = this.container.querySelector('.chat-panel__tab-strip');
+    this.tabStripItemsEl = this.container.querySelector('.chat-panel__tab-strip-items');
+    this.tabNewBtn = this.container.querySelector('.chat-panel__tab-new-btn');
     this.inputEl = this.container.querySelector('.chat-panel__input');
     this.sendBtn = this.container.querySelector('.chat-panel__send-btn');
     this.stopBtn = this.container.querySelector('.chat-panel__stop-btn');
     this.closeBtn = this.container.querySelector('.chat-panel__close-btn');
-    this.newBtn = this.container.querySelector('.chat-panel__new-btn');
+    this.emptyNewBtn = this.container.querySelector('.chat-panel__empty-new-btn');
     this.actionBar = this.container.querySelector('.chat-panel__action-bar');
     this.adoptBtn = this.container.querySelector('.chat-panel__action-btn--adopt');
     this.updateBtn = this.container.querySelector('.chat-panel__action-btn--update');
@@ -196,8 +909,9 @@ class ChatPanel {
     // Close button
     this.closeBtn.addEventListener('click', () => this.close());
 
-    // New conversation button
-    this.newBtn.addEventListener('click', () => this._startNewConversation());
+    // New tab button (in tab strip)
+    this.tabNewBtn?.addEventListener('click', () => this._openNewTab());
+    this.emptyNewBtn?.addEventListener('click', () => this._openNewTab());
 
     // Provider picker button
     this.providerPickerBtn.addEventListener('click', () => this._toggleProviderDropdown());
@@ -222,26 +936,6 @@ class ChatPanel {
     // New-content pill: click to scroll to bottom
     if (this.newContentPill) {
       this.newContentPill.addEventListener('click', () => this.scrollToBottom({ force: true }));
-    }
-
-    // Track scroll direction to disengage/re-engage auto-scroll
-    if (this.messagesEl) {
-      let lastScrollTop = 0;
-      this.messagesEl.addEventListener('scroll', () => {
-        const { scrollTop, scrollHeight, clientHeight } = this.messagesEl;
-        const distance = scrollHeight - scrollTop - clientHeight;
-
-        if (scrollTop < lastScrollTop && distance >= NEAR_BOTTOM_THRESHOLD) {
-          // Scrolling UP and not near bottom — disengage
-          this._userScrolledAway = true;
-          this._showNewContentPill();
-        } else if (distance < NEAR_BOTTOM_THRESHOLD) {
-          // Back near bottom — re-engage
-          this._userScrolledAway = false;
-          this._hideNewContentPill();
-        }
-        lastScrollTop = scrollTop;
-      }, { passive: true });
     }
 
     // Textarea input handling
@@ -294,8 +988,8 @@ class ChatPanel {
     };
     document.addEventListener('keydown', this._onKeydown);
 
-    // Chat file link click handler (event delegation)
-    this.messagesEl?.addEventListener('click', (e) => {
+    // Chat file link click handler (event delegation on the per-tab stack)
+    this.messagesStackEl?.addEventListener('click', (e) => {
       const link = e.target.closest('.chat-file-link');
       if (link) {
         e.preventDefault();
@@ -550,15 +1244,57 @@ class ChatPanel {
     this.panel.classList.remove('chat-panel--closed');
     this.panel.classList.add('chat-panel--open');
 
-    // Ensure WebSocket subscriptions are active (but don't create a session yet — lazy creation)
+    // Ensure review-scope subscription is active. Per-tab subscriptions are
+    // attached as tabs are created/restored.
     this._ensureSubscriptions();
 
-    // Load MRU session with message history (if any previous sessions exist).
-    // Skip when opening with explicit context (suggestion/comment/file) — the
-    // user wants a *new* conversation about that item, not to resume the last one.
     const hasExplicitContext = !!(options.suggestionContext || options.commentContext || options.fileContext);
-    if (!this.currentSessionId && !hasExplicitContext) {
-      await this._loadMRUSession();
+
+    // First-time open behaviour:
+    //   1. If localStorage has a tab list for this review, restore those tabs.
+    //   2. Else, fall back to the legacy single-tab + MRU-load path.
+    //   3. Explicit context (Ask about this / Chat about this file) always
+    //      opens a fresh "New Chat" tab on top — that's the user requesting
+    //      a new conversation about a specific item.
+    if (this.tabs.length === 0) {
+      let restored = false;
+      if (this.reviewId && !hasExplicitContext) {
+        const saved = this._loadPersistedTabs();
+        if (saved) {
+          restored = await this._restoreTabs(saved);
+        }
+      }
+      if (!restored) {
+        const tab = this._createTab({ provider: this._activeProvider });
+        this._appendTab(tab, { focus: true });
+        if (!hasExplicitContext) {
+          await this._loadMRUSession();
+        }
+      }
+    }
+
+    // Explicit context ("Ask about this" / file context / comment context)
+    // must always land in a FRESH tab so we don't bleed it into whatever
+    // conversation the user has been chatting in. Reuse only a tab that is
+    // truly empty (no messages, no pending context).
+    if (hasExplicitContext) {
+      const active = this._getActiveTab();
+      const canReuseEmptyTab = active &&
+        active.messages.length === 0 &&
+        active.pendingContext.length === 0;
+      if (!canReuseEmptyTab) {
+        const tab = this._createTab({ provider: this._activeProvider });
+        this._appendTab(tab, { focus: true });
+      }
+    }
+
+    // Resync the Send/Stop controls from the active tab's streaming state on
+    // every open so a reopen mid-stream shows the Stop button.
+    const activeOnOpen = this._getActiveTab();
+    if (activeOnOpen) {
+      this.sendBtn.style.display = activeOnOpen.isStreaming ? 'none' : '';
+      this.stopBtn.style.display = activeOnOpen.isStreaming ? '' : 'none';
+      this.sendBtn.disabled = activeOnOpen.isStreaming || !this.inputEl?.value?.trim();
     }
 
     // Ensure analysis context is added on every expand — not just when opening
@@ -620,11 +1356,14 @@ class ChatPanel {
     this.isOpen = false;
     this.panel.classList.remove('chat-panel--open');
     this.panel.classList.add('chat-panel--closed');
-    this._pendingContext = [];
-    this._pendingContextData = [];
-    this._contextSource = null;
-    this._contextItemId = null;
-    this._contextLineMeta = null;
+    const closeTab = this._getActiveTab();
+    if (closeTab) {
+      closeTab.pendingContext = [];
+      closeTab.pendingContextData = [];
+      closeTab.contextSource = null;
+      closeTab.contextItemId = null;
+      closeTab.contextLineMeta = null;
+    }
     // Zero out CSS variable so max-width calcs don't reserve space (mirrors AIPanel.collapse)
     document.documentElement.style.setProperty('--chat-panel-width', '0px');
     // Preserve _analysisContextRemoved and _sessionAnalysisRunId across
@@ -646,73 +1385,15 @@ class ChatPanel {
   }
 
   /**
-   * Start a new conversation (reset session)
-   * Preserves any unsent pending context cards and re-adds them to the new conversation.
+   * Start a new conversation by opening a fresh tab.
+   * Unlike the legacy single-tab implementation this no longer destroys the
+   * current conversation — it simply adds a new tab and focuses it. Any
+   * unsent pending context is left on the previous tab.
    */
   async _startNewConversation() {
     this._hideProviderDropdown();
     this._hideSessionDropdown();
-    // 1. Snapshot pending context before clearing (these are unsent context cards)
-    const savedContext = this._pendingContext.slice();
-    const savedContextData = this._pendingContextData.slice();
-    const savedContextSource = this._contextSource;
-    const savedContextItemId = this._contextItemId;
-    const savedContextLineMeta = this._contextLineMeta;
-
-    // 2. Clear everything as normal
-    this._finalizeStreaming();
-    this.currentSessionId = null;
-    this._resubscribeChat(); // Unsubscribe old chat topic
-    this.messages = [];
-    this._streamingContent = '';
-    this._pendingContext = [];
-    this._pendingContextData = [];
-    this._pendingDiffStateNotifications = [];
-    this._pendingUserActionHints = [];
-    this._contextSource = null;
-    this._contextItemId = null;
-    this._contextLineMeta = null;
-    this._analysisContextRemoved = false;
-    this._sessionAnalysisRunId = null;
-    this._clearMessages();
-    this._updateActionButtons();
-    this._updateTitle(); // Reset title for new conversation
-
-    // 3. Re-add analysis context (appears first, handled separately from pending arrays)
-    this._ensureAnalysisContext();
-
-    // 4. Re-add saved pending context cards (if any were unsent)
-    if (savedContext.length > 0) {
-      // Remove empty state since we're about to add context cards
-      const emptyState = this.messagesEl.querySelector('.chat-panel__empty');
-      if (emptyState) emptyState.remove();
-
-      // Restore context metadata
-      this._contextSource = savedContextSource;
-      this._contextItemId = savedContextItemId;
-      this._contextLineMeta = savedContextLineMeta;
-
-      for (let i = 0; i < savedContextData.length; i++) {
-        const ctxData = savedContextData[i];
-        this._pendingContext.push(savedContext[i]);
-        this._pendingContextData.push(ctxData);
-
-        // Render the appropriate card type based on the context data
-        if (ctxData.type === 'file') {
-          this._addFileContextCard(ctxData, { removable: true });
-        } else if (ctxData.type === 'line') {
-          this._addLineContextCard(ctxData, { removable: true });
-        } else if (ctxData.type === 'comment') {
-          this._addCommentContextCard(ctxData, { removable: true });
-        } else if (ctxData.type === 'analysis-run') {
-          this._addAnalysisRunContextCard(ctxData, { removable: true });
-        } else {
-          this._addContextCard(ctxData, { removable: true });
-        }
-      }
-
-      this._updateActionButtons();
-    }
+    await this._openNewTab();
   }
 
   /**
@@ -734,29 +1415,87 @@ class ChatPanel {
   }
 
   /**
-   * Load the most recently used session for the current review.
-   * Picks the first session (MRU) and loads its message history.
+   * Load the most recently used session into the active tab.
+   * Picks the first session (MRU) and loads its message history. Assumes the
+   * caller has already created an active tab via _appendTab().
    */
   async _loadMRUSession() {
-    if (!this.reviewId) return;
+    const tab = this._getActiveTab();
+    if (!tab || !this.reviewId) return;
+    // Capture the messagesEl reference for the race-guard after the fetch.
+    const capturedEl = tab.messagesEl;
 
     try {
       const sessions = await this._fetchSessions();
       if (sessions.length === 0) return;
 
-      const mru = sessions[0];
-      this.currentSessionId = mru.id;
-      this._sessionWarm = false;
-      this._resubscribeChat();
+      // Race guard: by the time _fetchSessions resolved, the user may have
+      // closed this tab or swapped its session. If anything looks stale,
+      // abandon the load.
+      if (!this.tabs.includes(tab)) return;
+      if (tab.sessionId != null) return; // tab was assigned a session by another path
+      if (tab.messagesEl !== capturedEl) return;
+      if (!capturedEl?.isConnected) return;
+
+      // Skip MRU candidates already open in another tab — picking one would
+      // create a duplicate. Walk down the list (most-recent first) until we
+      // find one that no surviving tab is bound to.
+      let mru = null;
+      for (const candidate of sessions) {
+        if (!this._findTabBySessionId(candidate.id)) {
+          mru = candidate;
+          break;
+        }
+      }
+      if (!mru) {
+        // Every recent session is already open — focus the most recent one
+        // and drop the empty placeholder so we don't litter the strip.
+        const firstOpen = this._findTabBySessionId(sessions[0].id);
+        if (firstOpen && firstOpen !== tab) {
+          this._switchToTab(this._tabKey(firstOpen));
+          // The placeholder may be the originating `tab`. Remove it so the
+          // user doesn't see an empty extra tab alongside the focused one.
+          if (this.tabs.includes(tab) && tab.sessionId == null) {
+            this._removeTabFromDom(tab, { skipDelete: true });
+          }
+        }
+        return;
+      }
+
+      tab.sessionId = mru.id;
+      // Re-key the active marker only if this tab is still the active one
+      // (don't yank focus from a tab the user switched to during the fetch).
+      const wasActive = this.activeTabKey === tab._localKey;
+      if (wasActive) this.activeTabKey = mru.id;
+      tab.sessionWarm = false;
+      if (tab.messagesEl) tab.messagesEl.dataset.tabKey = String(tab.sessionId);
+      this._subscribeTab(tab);
+      this._persistOpenTabs();
       console.debug('[ChatPanel] Loaded MRU session:', mru.id, 'messages:', mru.message_count);
 
       if (mru.provider) {
-        this._updateTitle(mru.provider, mru.model);
-        this._activeProvider = mru.provider;
+        tab.provider = mru.provider;
+        tab.model = mru.model;
+        // Only update the global header/active provider when this tab is in the
+        // foreground; otherwise a stale MRU load would yank the header out from
+        // under the user's currently focused tab.
+        if (this._getActiveTab() === tab) {
+          this._activeProvider = mru.provider;
+          this._updateTitle(mru.provider, mru.model);
+        }
       }
 
+      // Title heuristic: prefer first user message preview if available
+      if (mru.first_message) {
+        tab.titleFromUser = true;
+        this._setTabTitle(tab, this._truncate(mru.first_message, 28));
+      } else {
+        this._setTabTitle(tab, tab.title);
+      }
+      this._renderTabStrip();
+
       if (mru.message_count > 0) {
-        await this._loadMessageHistory(mru.id);
+        await this._loadMessageHistory(mru.id, tab);
       }
     } catch (err) {
       console.warn('[ChatPanel] Failed to load MRU session:', err);
@@ -766,21 +1505,79 @@ class ChatPanel {
   /**
    * Load and render message history for a session.
    * Fetches messages from the API and renders context cards and message bubbles.
-   * @param {number} sessionId
+   *
+   * Race-safe: captures the target tab at call time. If the response arrives
+   * after the user switched tabs, closed this tab, or swapped its session via
+   * the history picker, the write is abandoned and the response is discarded.
+   *
+   * Stale-tolerant: a 404 (session deleted out-of-band) prunes the tab from
+   * the persisted list and silently closes it. Other errors are warned.
+   *
+   * @param {number} sessionId - Session ID to fetch messages for
+   * @param {ChatTab} [targetTab] - Tab to render into. Defaults to the active
+   *   tab at call time. Tests + the restore path pass this explicitly so the
+   *   tab is not derived from the active-tab getter.
    */
-  async _loadMessageHistory(sessionId) {
+  async _loadMessageHistory(sessionId, targetTab) {
+    const tab = targetTab || this._getActiveTab();
+    if (!tab) return;
+    // Capture the messagesEl reference at call time. If the tab is later
+    // closed, messagesEl is detached from the DOM — we check via isConnected
+    // before writing.
+    const capturedEl = tab.messagesEl;
+    if (!capturedEl) return;
+
+    let response;
     try {
-      const response = await fetch(`/api/chat/session/${sessionId}/messages`);
-      if (!response.ok) return;
+      response = await fetch(`/api/chat/session/${sessionId}/messages`);
+    } catch (err) {
+      console.warn('[ChatPanel] Failed to load message history:', err);
+      return;
+    }
 
-      const result = await response.json();
-      const messages = result.data?.messages || [];
-      if (messages.length === 0) return;
+    // Stale-session tolerance: the session was deleted out-of-band.
+    if (response.status === 404) {
+      // Apply the same captured-tab guards as the success branch below — the
+      // tab may have been closed, repointed to a different session, or had
+      // its messagesEl re-created while the request was in flight.
+      if (!this.tabs.includes(tab)) return;
+      if (tab.sessionId !== sessionId) return;
+      if (tab.messagesEl !== capturedEl) return;
+      if (!capturedEl.isConnected) return;
+      console.debug('[ChatPanel] Session', sessionId, 'returned 404, removing tab');
+      this._removeTabFromDom(tab, { skipDelete: true });
+      return;
+    }
+    if (!response.ok) return;
 
-      // Remove empty state
-      const emptyState = this.messagesEl.querySelector('.chat-panel__empty');
-      if (emptyState) emptyState.remove();
+    let result;
+    try {
+      result = await response.json();
+    } catch (err) {
+      console.warn('[ChatPanel] Failed to parse message history:', err);
+      return;
+    }
+    const messages = result.data?.messages || [];
+    if (messages.length === 0) return;
 
+    // Race guard: by the time the fetch resolved, the tab may have been
+    // closed, had its session swapped via the history picker, or had its
+    // messagesEl re-created. Bail in any of those cases.
+    if (!this.tabs.includes(tab)) return;
+    if (tab.sessionId !== sessionId) return;
+    if (tab.messagesEl !== capturedEl) return;
+    if (!capturedEl.isConnected) return;
+
+    // Remove empty state
+    const emptyState = capturedEl.querySelector('.chat-panel__empty');
+    if (emptyState) emptyState.remove();
+
+    // Render into the target tab. The helper methods (_addContextCard,
+    // addMessage, etc.) read `this.messagesEl` via the active-tab getter, so
+    // we temporarily redirect the active marker for the synchronous render
+    // loop. _switchToTab toggles visibility — we use a lower-level swap
+    // (_renderInTab) so the user's actual focused tab stays focused.
+    this._renderInTab(tab, () => {
       for (const msg of messages) {
         if (msg.type === 'context') {
           // Render context card from stored context data
@@ -804,8 +1601,35 @@ class ChatPanel {
           this.addMessage(msg.role, msg.content, msg.id);
         }
       }
-    } catch (err) {
-      console.warn('[ChatPanel] Failed to load message history:', err);
+    });
+  }
+
+  /**
+   * Synchronously run a render block as if `tab` were the active tab so the
+   * shared render helpers (which read `this.messagesEl` via the active-tab
+   * getter) write into the right per-tab container. Restores the original
+   * active marker after the block.
+   *
+   * Strictly synchronous: do not pass an async function here. The visible
+   * focused tab is preserved because we touch only `activeTabKey`, not the
+   * DOM visibility toggles in `_switchToTab`.
+   *
+   * @param {ChatTab} tab - The tab to render into
+   * @param {Function} fn - Synchronous render callback
+   */
+  _renderInTab(tab, fn) {
+    if (!tab) return;
+    const prev = this.activeTabKey;
+    const key = this._tabKey(tab);
+    if (prev === key) {
+      fn();
+      return;
+    }
+    this.activeTabKey = key;
+    try {
+      fn();
+    } finally {
+      this.activeTabKey = prev;
     }
   }
 
@@ -901,14 +1725,46 @@ class ChatPanel {
   }
 
   /**
-   * Select a provider. Updates active provider and title. Only affects new sessions.
+   * Select a provider. Reuses the currently active tab when it is "fresh"
+   * (no messages, no streaming, no user-renamed title) — that's the common
+   * just-opened-a-tab case where spawning a sibling would just litter the
+   * strip. Otherwise opens a new tab so the prior conversation isn't lost.
+   *
+   * Note: with lazy session creation, a fresh tab typically has sessionId
+   * null and we simply swap `tab.provider`. If the tab already got a session
+   * (e.g. a previous lazy send just resolved), DELETE the old one so the
+   * next send creates a fresh session under the new provider.
+   *
    * @param {string} id - Provider ID to activate
    */
-  _selectProvider(id) {
+  async _selectProvider(id) {
     if (id === this._activeProvider) return;
     this._activeProvider = id;
     this._updateTitle();
-    this._startNewConversation();
+
+    const tab = this._getActiveTab();
+    const isFresh = tab
+      && tab.messages.length === 0
+      && !tab.isStreaming
+      && !tab.streamingContent
+      && !tab.titleFromUser;
+
+    if (!isFresh) {
+      await this._openNewTab();
+      return;
+    }
+
+    tab.provider = id;
+    if (tab.wsUnsub) { try { tab.wsUnsub(); } catch { /* noop */ } tab.wsUnsub = null; }
+    if (tab.sessionId != null) {
+      const staleId = tab.sessionId;
+      tab.sessionId = null;
+      tab.sessionWarm = false;
+      // Restore the active marker so getter delegation still finds this tab.
+      if (this.activeTabKey === staleId) this.activeTabKey = tab._localKey;
+      fetch(`/api/chat/session/${staleId}`, { method: 'DELETE' }).catch(() => {});
+    }
+    this._renderTabStrip();
   }
 
   // ── Session picker dropdown ────────────────────────────────────────────
@@ -977,8 +1833,17 @@ class ChatPanel {
       return;
     }
 
+    // Build a set of sessionIds currently open in any tab so the dropdown can
+    // mark them as "(open)" — clicking one focuses the existing tab rather
+    // than duplicating it into the active tab via _switchToSession.
+    const openSessionIds = new Set(
+      this.tabs.map(t => t.sessionId).filter(id => id != null)
+    );
+    const activeSessionId = this.currentSessionId;
+
     const items = sessions.map(s => {
-      const isActive = s.id === this.currentSessionId;
+      const isActive = s.id === activeSessionId;
+      const isOpenElsewhere = openSessionIds.has(s.id) && !isActive;
       const preview = s.first_message
         ? this._truncate(s.first_message, 60)
         : 'New conversation';
@@ -986,11 +1851,18 @@ class ChatPanel {
       const providerLabel = s.provider
         ? `<span class="chat-panel__session-provider">${this._escapeHtml(this._getProviderDisplayName(s.provider))}</span>`
         : '';
+      const openTag = (isActive || isOpenElsewhere)
+        ? '<span class="chat-panel__session-open-tag">open</span>'
+        : '';
+
+      const classes = ['chat-panel__session-item'];
+      if (isActive) classes.push('chat-panel__session-item--active');
+      if (isOpenElsewhere) classes.push('chat-panel__session-item--open');
 
       return `
-        <button class="chat-panel__session-item${isActive ? ' chat-panel__session-item--active' : ''}"
+        <button class="${classes.join(' ')}"
                 data-session-id="${s.id}">
-          <span class="chat-panel__session-preview">${this._escapeHtml(preview)}</span>
+          <span class="chat-panel__session-preview">${this._escapeHtml(preview)}${openTag}</span>
           <span class="chat-panel__session-meta">${providerLabel}${this._escapeHtml(timeAgo)}</span>
         </button>
       `;
@@ -1003,62 +1875,105 @@ class ChatPanel {
       btn.addEventListener('click', () => {
         const sessionId = parseInt(btn.dataset.sessionId, 10);
         const sessionData = sessions.find(s => s.id === sessionId);
-        if (sessionData) {
+        if (!sessionData) {
+          this._hideSessionDropdown();
+          return;
+        }
+        // If this session is already open in another tab, focus that tab
+        // instead of swapping the active tab's session (avoid duplicates).
+        const existingTab = this._findTabBySessionId(sessionId);
+        if (existingTab && this._tabKey(existingTab) !== this.activeTabKey) {
+          this._switchToTab(this._tabKey(existingTab));
+        } else if (!existingTab) {
+          // Not currently open — swap the active tab to it (legacy behavior)
           this._switchToSession(sessionId, sessionData);
         }
+        // If it's already the active tab, clicking is a no-op (re-focuses, but no work needed)
         this._hideSessionDropdown();
       });
     });
   }
 
   /**
-   * Switch to a different chat session.
-   * Tears down current state and loads the target session.
+   * Swap the active tab's session for a different one (e.g. via the history
+   * picker). Tears down current state on this tab and loads the target
+   * session's messages. Other tabs are untouched.
    * @param {number} sessionId - The session ID to switch to
    * @param {Object} sessionData - Session metadata (provider, model, message_count, etc.)
    */
   async _switchToSession(sessionId, sessionData) {
-    if (sessionId === this.currentSessionId) return;
+    const tab = this._getActiveTab();
+    if (!tab) return;
+    if (sessionId === tab.sessionId) return;
 
-    // 1. Finalize any active stream
+    // 1. Finalize any active stream on this tab
     this._finalizeStreaming();
 
-    // 2. Reset state
-    this.currentSessionId = sessionId;
-    this._sessionWarm = false;
-    this._resubscribeChat();
-    this.messages = [];
-    this._streamingContent = '';
-    this._pendingContext = [];
-    this._pendingContextData = [];
-    this._pendingDiffStateNotifications = [];
-    this._pendingUserActionHints = [];
-    this._contextSource = null;
-    this._contextItemId = null;
-    this._contextLineMeta = null;
-    this._pendingActionContext = null;
-    this._analysisContextRemoved = false;
-    this._sessionAnalysisRunId = null;
+    // 2. Tear down the existing subscription so events for the old session
+    //    don't keep flowing into this tab
+    if (tab.wsUnsub) { try { tab.wsUnsub(); } catch { /* noop */ } tab.wsUnsub = null; }
 
-    // 3. Clear UI
+    // 3. Reset per-tab state
+    tab.sessionId = sessionId;
+    this.activeTabKey = sessionId;
+    if (tab.messagesEl) tab.messagesEl.dataset.tabKey = String(sessionId);
+    tab.sessionWarm = false;
+    tab.messages = [];
+    tab.streamingContent = '';
+    tab.streamingMsgEl = null;
+    tab.pendingContext = [];
+    tab.pendingContextData = [];
+    tab.latestDiffState = null;
+    tab.pendingUserActionHints = [];
+    tab.contextSource = null;
+    tab.contextItemId = null;
+    tab.contextLineMeta = null;
+    tab.pendingActionContext = null;
+    tab.analysisContextRemoved = false;
+    tab.sessionAnalysisRunId = null;
+    tab.errorMessage = null;
+    tab.isStreaming = false;
+    tab.titleFromUser = !!sessionData.first_message;
+    this._updateTabStatus(tab, 'idle');
+
+    // 4. Subscribe to the new session
+    this._subscribeTab(tab);
+    this._persistOpenTabs();
+
+    // 5. Clear UI and update title
     this._clearMessages();
     this._updateActionButtons();
-
-    // 4. Update title
     if (sessionData.provider) {
-      this._updateTitle(sessionData.provider, sessionData.model);
+      tab.provider = sessionData.provider;
+      tab.model = sessionData.model;
       this._activeProvider = sessionData.provider;
+      this._updateTitle(sessionData.provider, sessionData.model);
     } else {
       this._updateTitle();
     }
 
-    // 5. Load message history
+    // 6. Update tab title from the session's first user message
+    if (sessionData.first_message) {
+      this._setTabTitle(tab, this._truncate(sessionData.first_message, 28));
+    } else {
+      this._setTabTitle(tab, _nextNewTabTitle());
+      tab.titleFromUser = false;
+    }
+    this._renderTabStrip();
+
+    // 7. Load message history (race-guarded — passes explicit tab so a
+    //    subsequent tab switch can't reroute the render)
     if (sessionData.message_count > 0) {
-      await this._loadMessageHistory(sessionId);
+      await this._loadMessageHistory(sessionId, tab);
     }
 
-    // 6. Ensure analysis context for the new session
-    this._ensureAnalysisContext();
+    // Re-check after the await: the user may have closed the tab or swapped
+    // it again. Route _ensureAnalysisContext through the captured tab so the
+    // analysis card lands on the right messages container.
+    if (!this.tabs.includes(tab) || tab.sessionId !== sessionId) return;
+
+    // 8. Ensure analysis context for the new session
+    this._ensureAnalysisContext(tab);
   }
 
   /**
@@ -1098,10 +2013,12 @@ class ChatPanel {
   }
 
   /**
-   * Clear all messages from the display and show empty state
+   * Clear all messages from the active tab's display and show empty state.
    */
   _clearMessages() {
-    this.messagesEl.innerHTML = `
+    const tab = this._getActiveTab();
+    if (!tab?.messagesEl) return;
+    tab.messagesEl.innerHTML = `
       <div class="chat-panel__empty">
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" width="32" height="32">
           <path d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09z"/>
@@ -1109,6 +2026,7 @@ class ChatPanel {
         <p>Ask questions about this review, or click "Ask about this" on any suggestion.</p>
       </div>
     `;
+    tab.streamingMsgEl = null;
   }
 
   /**
@@ -1147,40 +2065,65 @@ class ChatPanel {
       this._enableInput();
     }
 
-    // If the panel is already open, load the MRU session now
+    // If the panel is already open, restore tabs (or fall back to MRU load).
+    // open() may have ran before reviewId was bound; tabs in that case are
+    // empty or contain a single empty tab.
     if (this.isOpen && !this.currentSessionId) {
-      await this._loadMRUSession();
+      let restored = false;
+      const saved = this._loadPersistedTabs();
+      if (saved) {
+        // If a placeholder tab was created by open() with no sessionId, drop
+        // it so restored tabs don't appear alongside an unused "New Chat".
+        if (this.tabs.length === 1 && this.tabs[0].sessionId == null) {
+          const placeholder = this.tabs[0];
+          if (placeholder.messagesEl?.parentNode) {
+            placeholder.messagesEl.parentNode.removeChild(placeholder.messagesEl);
+          }
+          this.tabs = [];
+          this.activeTabKey = null;
+        }
+        restored = await this._restoreTabs(saved);
+      }
+      if (!restored) {
+        if (this.tabs.length === 0) {
+          const tab = this._createTab({ provider: this._activeProvider });
+          this._appendTab(tab, { focus: true });
+        }
+        await this._loadMRUSession();
+      }
       this._ensureAnalysisContext();
     }
   }
 
   /**
-   * Create a new chat session via API
+   * Create a new chat session via API for the active tab.
    * @param {number} contextCommentId - Optional AI suggestion ID for context
    * @returns {Object|null} Session data ({ id, status, context? }) or null on failure
    */
   async createSession(contextCommentId) {
+    // Ensure there is an active tab to bind the new session to. This happens
+    // for lazy-creation paths (first sendMessage on an empty panel).
+    if (!this._getActiveTab()) {
+      const tab = this._createTab({ provider: this._activeProvider });
+      this._appendTab(tab, { focus: true });
+    }
     if (!this.reviewId) {
       console.warn('[ChatPanel] No reviewId available');
       return null;
     }
+    const tab = this._getActiveTab();
+    if (!tab) return null;
 
     const isAcp = this._isAcpProvider();
-    if (isAcp) {
-      this._showStatusFlash('Starting Agent Client Protocol');
-    }
+    if (isAcp) this._showStatusFlash('Starting Agent Client Protocol');
 
     try {
       const body = {
-        provider: this._activeProvider,
+        provider: tab.provider || this._activeProvider,
         reviewId: this.reviewId
       };
-      if (contextCommentId) {
-        body.contextCommentId = contextCommentId;
-      }
-      if (this._analysisContextRemoved) {
-        body.skipAnalysisContext = true;
-      }
+      if (contextCommentId) body.contextCommentId = contextCommentId;
+      if (tab.analysisContextRemoved) body.skipAnalysisContext = true;
 
       console.debug('[ChatPanel] Creating session for review', this.reviewId);
       const response = await fetch('/api/chat/session', {
@@ -1197,87 +2140,129 @@ class ChatPanel {
       }
 
       const result = await response.json();
-      this.currentSessionId = result.data.id;
-      this._sessionWarm = true;
-      this._resubscribeChat();
-      console.debug('[ChatPanel] Session created:', this.currentSessionId);
+      if (!this.tabs.includes(tab)) {
+        fetch(`/api/chat/session/${result.data.id}`, { method: 'DELETE' }).catch(() => {});
+        return null;
+      }
+      tab.sessionId = result.data.id;
+      this.activeTabKey = result.data.id;
+      tab.sessionWarm = true;
+      if (tab.messagesEl) tab.messagesEl.dataset.tabKey = String(tab.sessionId);
+      this._subscribeTab(tab);
+      this._renderTabStrip();
+      this._persistOpenTabs();
+      console.debug('[ChatPanel] Session created:', tab.sessionId);
       return result.data;
     } catch (error) {
       if (isAcp) this._hideStatusFlash();
       console.error('[ChatPanel] Error creating session:', error);
-      this._showError('Failed to start chat session. ' + error.message);
+      this._showError('Failed to start chat session. ' + error.message, tab);
       return null;
     }
   }
 
   /**
-   * Send the current input text as a message
+   * Send the current input text as a message.
+   *
+   * Captures the originating tab once at entry. All subsequent state reads
+   * and writes go through that explicit reference so awaits cannot reroute
+   * the send to whichever tab is active when the promise resolves.
    */
   async sendMessage() {
     const content = this.inputEl.value.trim();
-    if (!content || this.isStreaming) return;
+    if (!content) return;
+
+    // Capture the originating tab BEFORE any awaits. Bail if no tab.
+    let tab = this._getActiveTab();
+    if (!tab) {
+      tab = this._createTab({ provider: this._activeProvider });
+      this._appendTab(tab, { focus: true });
+    }
+    if (tab.isStreaming) return;
 
     // Save message text before clearing (for error recovery)
     const messageText = content;
 
-    // Clear input
+    // Clear input UP FRONT — BEFORE the historyLoadPromise await — so a tab
+    // switch during the wait doesn't leave the typed content sitting in the
+    // shared textarea on someone else's tab. We only restore on error if the
+    // user hasn't moved on.
     this.inputEl.value = '';
     this._autoResizeTextarea();
     this.sendBtn.disabled = true;
 
+    // If history is still loading for this tab, wait for it to finish so we
+    // don't race with the renderer.
+    if (tab.historyLoadPromise) {
+      try { await tab.historyLoadPromise; } catch { /* swallow */ }
+      if (!this.tabs.includes(tab)) return;
+    }
+
     // Remove empty state if present
-    const emptyState = this.messagesEl.querySelector('.chat-panel__empty');
+    const emptyState = tab.messagesEl?.querySelector('.chat-panel__empty');
     if (emptyState) emptyState.remove();
 
     // Display user message (just the user's actual text)
-    const msgElRef = this.addMessage('user', content);
+    const msgElRef = this.addMessage('user', content, undefined, tab);
 
     // Lazy session creation: create on first message, not on panel open
-    if (!this.currentSessionId) {
+    if (tab.sessionId == null) {
       this._ensureSubscriptions();
-      const sessionData = await this.createSession();
+      const sessionData = await this._createSessionForTab(tab);
+      if (!this.tabs.includes(tab)) return;
       if (!sessionData) {
-        // Restore the user's message text into the input
-        this.inputEl.value = messageText;
-        this._autoResizeTextarea();
-        this.sendBtn.disabled = false;
+        // Restore the user's message text into the input — but ONLY if the
+        // user is still focused on the originating tab. Otherwise they may
+        // have moved on and typed something on a sibling; we mustn't clobber.
+        if (this._getActiveTab() === tab && !this.inputEl.value) {
+          this.inputEl.value = messageText;
+          this._autoResizeTextarea();
+          this.sendBtn.disabled = false;
+        }
         // Remove the phantom message bubble
         if (msgElRef) msgElRef.remove();
-        this.messages.pop();
+        tab.messages.pop();
         // Show error
-        this._showError('Unable to start chat session. Please try again.');
+        this._showError('Unable to start chat session. Please try again.', tab);
         return;
       }
-      this._showAnalysisContextIfPresent(sessionData);
+      // Route through the captured tab so a focus change between the POST
+      // and the response can't bleed the analysis card into a sibling tab.
+      this._showAnalysisContextIfPresent(sessionData, tab);
     }
-    // If currentSessionId is set (from MRU), just send — server auto-resumes
+    // If sessionId is set (from MRU), just send — server auto-resumes
 
-    // Prepare streaming UI
-    this.isStreaming = true;
-    this.sendBtn.disabled = true;
-    this.sendBtn.style.display = 'none';
-    this.stopBtn.style.display = '';
-    this._updateActionButtons();
-    this._streamingContent = '';
-    this._addStreamingPlaceholder();
+    // Prepare streaming UI. Clear any previous error on this tab.
+    tab.errorMessage = null;
+    tab.isStreaming = true;
+    this._updateTabStatus(tab, 'streaming');
+    if (this._getActiveTab() === tab) {
+      this.sendBtn.disabled = true;
+      this.sendBtn.style.display = 'none';
+      this.stopBtn.style.display = '';
+      this._updateActionButtons();
+    }
+    tab.streamingContent = '';
+    this._addStreamingPlaceholder(tab);
 
     // Build the API payload — may include pending context from "Ask about this"
     const payload = { content };
 
-    // Snapshot diff-state queue for error recovery (invisible to user, no UI cards)
-    const savedDiffState = this._pendingDiffStateNotifications.slice();
+    // Snapshot diff-state for error recovery (invisible to user, no UI cards).
+    // Diff state is a snapshot — one latest value per tab. Drain via copy-and-clear.
+    const savedDiffState = tab.latestDiffState;
     let diffStatePrefix = '';
-    if (this._pendingDiffStateNotifications.length > 0) {
-      diffStatePrefix = '[Diff State Update]\n' + this._pendingDiffStateNotifications.join('\n');
-      this._pendingDiffStateNotifications = [];
+    if (savedDiffState) {
+      diffStatePrefix = '[Diff State Update]\n' + savedDiffState;
+      tab.latestDiffState = null;
     }
 
-    // Snapshot user-action-hints queue for error recovery (invisible to user, no UI cards)
-    const savedUserActionHints = this._pendingUserActionHints.slice();
+    // Snapshot user-action-hints queue for error recovery (ordered, per-tab)
+    const savedUserActionHints = tab.pendingUserActionHints.slice();
     let userActionPrefix = '';
-    if (this._pendingUserActionHints.length > 0) {
-      userActionPrefix = '[User Action Hints]\n' + this._pendingUserActionHints.join('\n');
-      this._pendingUserActionHints = [];
+    if (tab.pendingUserActionHints.length > 0) {
+      userActionPrefix = '[User Action Hints]\n' + tab.pendingUserActionHints.join('\n');
+      tab.pendingUserActionHints = [];
     }
 
     // Combine invisible prefixes (diff state + user action hints)
@@ -1288,19 +2273,19 @@ class ChatPanel {
       invisiblePrefix = diffStatePrefix || userActionPrefix;
     }
 
-    const savedContext = this._pendingContext;
-    const savedContextData = this._pendingContextData;
-    if (this._pendingContext.length > 0) {
-      const userContext = this._pendingContext.join('\n\n');
+    const savedContext = tab.pendingContext.slice();
+    const savedContextData = tab.pendingContextData.slice();
+    if (tab.pendingContext.length > 0) {
+      const userContext = tab.pendingContext.join('\n\n');
       payload.context = invisiblePrefix
         ? invisiblePrefix + '\n\n' + userContext
         : userContext;
-      payload.contextData = this._pendingContextData;
-      this._pendingContext = [];
-      this._pendingContextData = [];
+      payload.contextData = tab.pendingContextData;
+      tab.pendingContext = [];
+      tab.pendingContextData = [];
 
       // Lock context cards — remove close buttons and index attributes
-      const removableCards = this.messagesEl.querySelectorAll('.chat-panel__context-card[data-context-index]');
+      const removableCards = tab.messagesEl?.querySelectorAll('.chat-panel__context-card[data-context-index]') || [];
       removableCards.forEach((card) => {
         const btn = card.querySelector('.chat-panel__context-remove');
         if (btn) btn.remove();
@@ -1311,54 +2296,60 @@ class ChatPanel {
     }
 
     // Lock analysis context card (not indexed, handled separately from pending context)
-    const analysisRemoveBtn = this.messagesEl.querySelector('.chat-panel__context-card[data-analysis] .chat-panel__context-remove');
+    const analysisRemoveBtn = tab.messagesEl?.querySelector('.chat-panel__context-card[data-analysis] .chat-panel__context-remove');
     if (analysisRemoveBtn) analysisRemoveBtn.remove();
 
     // Attach action context (set by action button handlers — adopt, update, dismiss)
-    if (this._pendingActionContext) {
-      payload.actionContext = this._pendingActionContext;
-      this._pendingActionContext = null;
+    const savedActionContext = tab.pendingActionContext;
+    if (tab.pendingActionContext) {
+      payload.actionContext = tab.pendingActionContext;
+      tab.pendingActionContext = null;
     }
 
     // Show ACP resume flash when the session may need server-side auto-resume
-    const acpResuming = this._isAcpProvider() && !this._sessionWarm;
+    const acpResuming = this._isAcpProvider() && !tab.sessionWarm;
     if (acpResuming) {
       this._showStatusFlash('Resuming Agent Client Protocol');
     }
 
     // Send to API
     try {
-      console.debug('[ChatPanel] Sending message to session', this.currentSessionId);
-      let response = await fetch(`/api/chat/session/${this.currentSessionId}/message`, {
+      console.debug('[ChatPanel] Sending message to session', tab.sessionId);
+      let response = await fetch(`/api/chat/session/${tab.sessionId}/message`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload)
       });
+      if (!this.tabs.includes(tab)) return;
 
       if (acpResuming) {
         this._hideStatusFlash();
-        this._sessionWarm = true;
+        tab.sessionWarm = true;
       }
 
-      // Handle 410 Gone: session is not resumable — transparently create a new one and retry once.
-      // Note: we do NOT call _hideStatusFlash() here. createSession() will call
-      // _showStatusFlash() which overwrites the pill text directly, avoiding a
-      // visible hide/show flicker during the transparent retry.
+      // Handle 410 Gone: session is not resumable — transparently create a new
+      // one bound to the SAME tab and retry once.
       if (response.status === 410) {
         console.debug('[ChatPanel] Session not resumable (410), creating new session and retrying');
-        this.currentSessionId = null;
-        this._resubscribeChat();
-        this._ensureSubscriptions();
-        const sessionData = await this.createSession();
+        if (tab.wsUnsub) { try { tab.wsUnsub(); } catch { /* noop */ } tab.wsUnsub = null; }
+        // Re-anchor the active marker to the tab's local key BEFORE nulling
+        // sessionId so _createSessionForTab can re-bind the SAME tab via the
+        // _localKey check (rather than orphaning this tab and spawning a new).
+        const wasActive = this._getActiveTab() === tab;
+        tab.sessionId = null;
+        if (wasActive) this.activeTabKey = tab._localKey;
+        const sessionData = await this._createSessionForTab(tab);
+        if (!this.tabs.includes(tab)) return;
         if (!sessionData) {
           throw new Error('Failed to create replacement session');
         }
 
-        response = await fetch(`/api/chat/session/${this.currentSessionId}/message`, {
+        response = await fetch(`/api/chat/session/${tab.sessionId}/message`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(payload)
         });
+        if (!this.tabs.includes(tab)) return;
       }
 
       if (!response.ok) {
@@ -1367,38 +2358,55 @@ class ChatPanel {
       }
       console.debug('[ChatPanel] Message accepted, waiting for WebSocket events');
     } catch (error) {
+      if (!this.tabs.includes(tab)) return;
       if (acpResuming) this._hideStatusFlash();
-      // Restore pending context so it's not lost
-      this._pendingContext = savedContext;
-      this._pendingContextData = savedContextData;
-      this._pendingDiffStateNotifications = [...savedDiffState, ...this._pendingDiffStateNotifications];
-      this._pendingUserActionHints = [...savedUserActionHints, ...this._pendingUserActionHints];
+      // Restore pending state on the originating tab so it's not lost.
+      tab.pendingContext = savedContext;
+      tab.pendingContextData = savedContextData;
+      // Only restore the snapshot if no newer one arrived during the send.
+      // Diff state is a snapshot — a freshly queued value supersedes the old.
+      if (savedDiffState && !tab.latestDiffState) tab.latestDiffState = savedDiffState;
+      tab.pendingUserActionHints = [...savedUserActionHints, ...tab.pendingUserActionHints];
+      if (savedActionContext && !tab.pendingActionContext) tab.pendingActionContext = savedActionContext;
       // Restore removability on context cards that were locked before the failed send
-      this._restoreRemovableCards();
+      this._restoreRemovableCards(tab);
       console.error('[ChatPanel] Error sending message:', error);
-      this._showError('Failed to send message. ' + error.message);
-      this._finalizeStreaming();
+      this._showError('Failed to send message. ' + error.message, tab);
+      this._finalizeStreaming(tab);
     }
   }
 
   /**
    * Queue an invisible diff-state notification for the chat agent.
-   * Unlike _pendingContext, these do NOT render UI cards and survive panel close.
-   * Drained into the context parameter on the next sendMessage() call.
+   *
+   * Diff state is a SNAPSHOT — every tab gets the same latest value, and a
+   * subsequent call overwrites the prior value rather than appending. Drained
+   * from the originating tab on its next sendMessage(). If no tabs are open
+   * yet, the value is stashed on the panel so the next tab created inherits
+   * it.
    * @param {string} message - Description of the diff state change
    */
   queueDiffStateNotification(message) {
-    this._pendingDiffStateNotifications.push(message);
+    // Always cache the latest snapshot so tabs created later inherit it.
+    // Without this, a tab opened between the first notification and the first
+    // send would never see the snapshot.
+    this._initialDiffState = message;
+    if (this.tabs.length === 0) return;
+    for (const tab of this.tabs) tab.latestDiffState = message;
   }
 
   /**
    * Queue an invisible user-action hint for the chat agent.
-   * Like diff-state notifications, these do NOT render UI cards and survive panel close.
-   * Drained into the context parameter on the next sendMessage() call.
-   * @param {string} message - Description of the user action (e.g., "[User Action: adopted suggestion 42]")
+   *
+   * Hints are ordered events and attribution matters: they belong to the tab
+   * that was active when the action happened. Background tabs never
+   * accumulate. Silent no-op when no active tab.
+   * @param {string} message - Description of the user action
    */
   queueUserActionHint(message) {
-    this._pendingUserActionHints.push(message);
+    const active = this._getActiveTab();
+    if (!active) return;
+    active.pendingUserActionHints.push(message);
   }
 
   /**
@@ -1409,8 +2417,10 @@ class ChatPanel {
    * @param {Object} ctx - Suggestion context {title, type, file, line_start, line_end, body}
    */
   _sendContextMessage(ctx) {
+    const tab = this._getActiveTab();
+    if (!tab) return;
     // Remove empty state if present
-    const emptyState = this.messagesEl.querySelector('.chat-panel__empty');
+    const emptyState = tab.messagesEl?.querySelector('.chat-panel__empty');
     if (emptyState) emptyState.remove();
 
     // Store structured context data for DB persistence (session resumption)
@@ -1423,7 +2433,7 @@ class ChatPanel {
       side: ctx.side || null,
       body: ctx.body || null
     };
-    this._pendingContextData.push(contextData);
+    tab.pendingContextData.push(contextData);
 
     // Build the plain text context for the agent (will be prepended to next message)
     const lines = ['The user wants to discuss this specific suggestion:'];
@@ -1458,7 +2468,7 @@ class ChatPanel {
       }
     }
 
-    this._pendingContext.push(lines.join('\n'));
+    tab.pendingContext.push(lines.join('\n'));
 
     // Render the compact context card in the UI
     this._addContextCard(ctx, { removable: true });
@@ -1473,8 +2483,10 @@ class ChatPanel {
    * @param {Object} ctx - Comment context {commentId, type, body, file, line_start, line_end, source, isFileLevel}
    */
   _sendCommentContextMessage(ctx) {
+    const tab = this._getActiveTab();
+    if (!tab) return;
     // Remove empty state if present
-    const emptyState = this.messagesEl.querySelector('.chat-panel__empty');
+    const emptyState = tab.messagesEl?.querySelector('.chat-panel__empty');
     if (emptyState) emptyState.remove();
 
     const isLine = ctx.type === 'line';
@@ -1494,7 +2506,7 @@ class ChatPanel {
       body: ctx.body || null,
       source: 'user'
     };
-    this._pendingContextData.push(contextData);
+    tab.pendingContextData.push(contextData);
 
     // Build the plain text context for the agent
     const lines = isLine
@@ -1537,7 +2549,7 @@ class ChatPanel {
       }
     }
 
-    this._pendingContext.push(lines.join('\n'));
+    tab.pendingContext.push(lines.join('\n'));
 
     // Render the compact context card in the UI
     if (isLine) {
@@ -1554,16 +2566,18 @@ class ChatPanel {
    * @param {string} fileContext.file - File path
    */
   _sendFileContextMessage(fileContext) {
+    const tab = this._getActiveTab();
+    if (!tab) return;
     let contextText = `The user wants to discuss ${fileContext.file}`;
 
     // Check for duplicate context (use startsWith because contextText may
     // get enriched with diff hunk ranges after this check)
-    const isDuplicate = this._pendingContext.some(c => c === contextText || c.startsWith(contextText)) ||
-      this.messages.some(m => m.role === 'context' && (m.content === contextText || m.content.startsWith(contextText)));
+    const isDuplicate = tab.pendingContext.some(c => c === contextText || c.startsWith(contextText)) ||
+      tab.messages.some(m => m.role === 'context' && (m.content === contextText || m.content.startsWith(contextText)));
     if (isDuplicate) return;
 
     // Remove empty state if present
-    const emptyState = this.messagesEl.querySelector('.chat-panel__empty');
+    const emptyState = tab.messagesEl?.querySelector('.chat-panel__empty');
     if (emptyState) emptyState.remove();
 
     // Store structured context data for DB persistence
@@ -1575,7 +2589,7 @@ class ChatPanel {
       line_end: null,
       body: null
     };
-    this._pendingContextData.push(contextData);
+    tab.pendingContextData.push(contextData);
 
     // Enrich with diff hunk ranges if available
     const patch = window.prManager?.filePatches?.get(fileContext.file);
@@ -1586,7 +2600,7 @@ class ChatPanel {
       }
     }
 
-    this._pendingContext.push(contextText);
+    tab.pendingContext.push(contextText);
 
     // Render the compact context card in the UI
     this._addFileContextCard(contextData, { removable: true });
@@ -1611,8 +2625,12 @@ class ChatPanel {
     // 2. Open panel if closed
     await this.open({ suppressFocus: true });
 
+    // Capture the tab AFTER open() so any restoration/new-tab work is done.
+    const tab = this._getActiveTab();
+    if (!tab) return;
+
     // Re-check: open() may have auto-added a card for this run via _ensureAnalysisContext
-    const existingCardPostOpen = this.messagesEl?.querySelector(
+    const existingCardPostOpen = tab.messagesEl?.querySelector(
       `[data-analysis-run-id="${runId}"]`
     );
     if (existingCardPostOpen) {
@@ -1622,15 +2640,17 @@ class ChatPanel {
 
     // 3. Fetch context from backend
     const response = await fetch(`/api/chat/analysis-context/${runId}?reviewId=${this.reviewId}`);
+    if (!this.tabs.includes(tab)) return;
     if (!response.ok) {
       console.error('[ChatPanel] Failed to fetch analysis context:', response.statusText);
       return;
     }
     const result = await response.json();
+    if (!this.tabs.includes(tab)) return;
     const data = result.data;
 
     // 4. Push to pending context arrays
-    this._pendingContext.push(data.text);
+    tab.pendingContext.push(data.text);
     const contextData = {
       type: 'analysis-run',
       aiRunId: runId,
@@ -1641,14 +2661,15 @@ class ChatPanel {
       configType: data.run.configType,
       completedAt: data.run.completedAt
     };
-    this._pendingContextData.push(contextData);
+    tab.pendingContextData.push(contextData);
 
     // 5. Remove empty state if present
-    const emptyState = this.messagesEl?.querySelector('.chat-panel__empty');
+    const emptyState = tab.messagesEl?.querySelector('.chat-panel__empty');
     if (emptyState) emptyState.remove();
 
-    // 6. Create the card and append
-    this._addAnalysisRunContextCard(contextData, { removable: true });
+    // 6. Create the card and append — pass captured tab so a focus change
+    //    during the fetch doesn't write the card into a sibling.
+    this._addAnalysisRunContextCard(contextData, { removable: true }, tab);
 
     // 7. Focus input
     if (this.inputEl) this.inputEl.focus();
@@ -1660,7 +2681,8 @@ class ChatPanel {
    * @param {HTMLElement} card - The context card element
    */
   _makeCardRemovable(card) {
-    const idx = this._pendingContextData.length - 1;
+    const tab = this._getActiveTab();
+    const idx = (tab?.pendingContextData.length ?? 0) - 1;
     card.dataset.contextIndex = idx;
     const removeBtn = document.createElement('button');
     removeBtn.className = 'chat-panel__context-remove';
@@ -1705,45 +2727,48 @@ class ChatPanel {
    * Detects new analysis runs by comparing the latest completed run ID
    * against the one already loaded in the session. Only adds if suggestions exist.
    */
-  _ensureAnalysisContext() {
+  _ensureAnalysisContext(targetTab) {
+    const tab = targetTab || this._getActiveTab();
+    if (!tab || !tab.messagesEl) return;
+
     // Determine the latest completed run ID from the analysis history manager or prManager
     const currentRunId = this._getLatestCompletedRunId();
 
     // Detect whether a NEW analysis run has appeared since we last loaded context.
     // If the run ID changed, we need to replace the old card with a new one.
-    // This handles the case where _sessionAnalysisRunId was explicitly set.
-    const isNewRunVsSession = currentRunId && this._sessionAnalysisRunId &&
-      String(currentRunId) !== String(this._sessionAnalysisRunId);
+    // This handles the case where sessionAnalysisRunId was explicitly set.
+    const isNewRunVsSession = currentRunId && tab.sessionAnalysisRunId &&
+      String(currentRunId) !== String(tab.sessionAnalysisRunId);
 
     if (isNewRunVsSession) {
-      console.debug('[ChatPanel] _ensureAnalysisContext: new run detected:', currentRunId, '(was:', this._sessionAnalysisRunId + ')');
+      console.debug('[ChatPanel] _ensureAnalysisContext: new run detected:', currentRunId, '(was:', tab.sessionAnalysisRunId + ')');
       // Remove the old analysis card from the DOM (if present)
-      const oldCard = this.messagesEl.querySelector('.chat-panel__context-card[data-analysis]');
+      const oldCard = tab.messagesEl.querySelector('.chat-panel__context-card[data-analysis]');
       if (oldCard) oldCard.remove();
       // Reset flags — the user removed the OLD run's context, but this is a different run
-      this._analysisContextRemoved = false;
-      this._sessionAnalysisRunId = null;
+      tab.analysisContextRemoved = false;
+      tab.sessionAnalysisRunId = null;
     }
 
     // Check for an existing card in the DOM (e.g., loaded from MRU session history).
-    // If _sessionAnalysisRunId is not set, this card may be stale — compare its
+    // If sessionAnalysisRunId is not set, this card may be stale — compare its
     // stamped run ID against the latest completed run to detect new analyses that
     // completed while the panel was closed.
-    const existingCard = this.messagesEl.querySelector('.chat-panel__context-card[data-analysis]');
+    const existingCard = tab.messagesEl.querySelector('.chat-panel__context-card[data-analysis]');
     if (existingCard) {
-      if (!this._sessionAnalysisRunId && currentRunId) {
+      if (!tab.sessionAnalysisRunId && currentRunId) {
         const cardRunId = existingCard.dataset.analysisRunId || null;
         if (cardRunId && String(cardRunId) === String(currentRunId)) {
           // Card matches the latest run — adopt its run ID so future opens can detect changes
           console.debug('[ChatPanel] _ensureAnalysisContext: adopting existing card runId:', cardRunId);
-          this._sessionAnalysisRunId = String(currentRunId);
+          tab.sessionAnalysisRunId = String(currentRunId);
           return;
         }
         // Card has no run ID stamp or a different run ID — it's stale.
         // Remove it so a fresh card for the current run is added below.
         console.debug('[ChatPanel] _ensureAnalysisContext: replacing stale DOM card (card:', cardRunId, 'latest:', currentRunId + ')');
         existingCard.remove();
-        this._analysisContextRemoved = false;
+        tab.analysisContextRemoved = false;
       } else {
         console.debug('[ChatPanel] _ensureAnalysisContext: skipped — card already in DOM');
         return;
@@ -1752,13 +2777,13 @@ class ChatPanel {
 
     // Skip if the current session already has analysis context loaded (by run ID)
     // and no new run was detected (handled above)
-    if (this._sessionAnalysisRunId) {
-      console.debug('[ChatPanel] _ensureAnalysisContext: skipped — runId already set:', this._sessionAnalysisRunId);
+    if (tab.sessionAnalysisRunId) {
+      console.debug('[ChatPanel] _ensureAnalysisContext: skipped — runId already set:', tab.sessionAnalysisRunId);
       return;
     }
 
     // Skip if analysis context was explicitly removed in this conversation
-    if (this._analysisContextRemoved) {
+    if (tab.analysisContextRemoved) {
       console.debug('[ChatPanel] _ensureAnalysisContext: skipped — explicitly removed');
       return;
     }
@@ -1775,7 +2800,7 @@ class ChatPanel {
     console.debug('[ChatPanel] _ensureAnalysisContext: adding card with', count, 'suggestions');
 
     // Remove empty state
-    const emptyState = this.messagesEl.querySelector('.chat-panel__empty');
+    const emptyState = tab.messagesEl.querySelector('.chat-panel__empty');
     if (emptyState) emptyState.remove();
 
     // Render the analysis context card (removable).
@@ -1786,16 +2811,22 @@ class ChatPanel {
     // Note: analysis card is NOT added to _pendingContext/_pendingContextData —
     // the backend includes full suggestion data via initialContext at session creation.
     // The card is a visual indicator that controls whether the backend includes it.
-    const hasExistingMessages = this.messagesEl.querySelectorAll('.chat-panel__message').length > 0;
+    const hasExistingMessages = tab.messagesEl.querySelectorAll('.chat-panel__message').length > 0;
     const contextData = this._buildAnalysisContextData(currentRunId, count);
-    this._addAnalysisContextCard(contextData, { removable: true, prepend: !hasExistingMessages });
+    this._renderInTab(tab, () => {
+      this._addAnalysisContextCard(contextData, { removable: true, prepend: !hasExistingMessages });
+    });
 
-    // Persist to DB so the card is restored on session reload
-    this._persistAnalysisContext(contextData);
+    // Persist to DB so the card is restored on session reload. Defer when the
+    // tab has no sessionId yet (lazy-create path) — the sendMessage flow will
+    // re-run _ensureAnalysisContext after the session is born.
+    if (tab.sessionId != null) {
+      this._persistAnalysisContext(contextData, tab.sessionId);
+    }
 
     // Mark that analysis context is loaded for this session.
     // Use the actual run ID if available, otherwise fall back to 'dom'.
-    this._sessionAnalysisRunId = currentRunId || 'dom';
+    tab.sessionAnalysisRunId = currentRunId || 'dom';
   }
 
   /**
@@ -1873,8 +2904,9 @@ class ChatPanel {
     cardEl.remove();
 
     // If no pending context, no messages, and no other context cards, restore empty state
-    if (this._pendingContext.length === 0 && this.messages.length === 0 &&
-        !this.messagesEl.querySelector('.chat-panel__context-card')) {
+    const tab = this._getActiveTab();
+    if (tab && tab.pendingContext.length === 0 && tab.messages.length === 0 &&
+        !tab.messagesEl?.querySelector('.chat-panel__context-card')) {
       this._clearMessages();
     }
   }
@@ -1988,10 +3020,14 @@ class ChatPanel {
   /**
    * Restore remove buttons and data-context-index on all pending context cards.
    * Called after a failed send to unlock cards that were locked prematurely.
+   * @param {ChatTab} [targetTab] - Defaults to active tab
    */
-  _restoreRemovableCards() {
+  _restoreRemovableCards(targetTab) {
+    const tab = targetTab || this._getActiveTab();
+    const messagesEl = tab?.messagesEl;
+    if (!messagesEl) return;
     // Restore analysis context card if it was locked
-    const analysisCard = this.messagesEl.querySelector('.chat-panel__context-card[data-analysis]');
+    const analysisCard = messagesEl.querySelector('.chat-panel__context-card[data-analysis]');
     if (analysisCard && !analysisCard.querySelector('.chat-panel__context-remove')) {
       const removeBtn = document.createElement('button');
       removeBtn.className = 'chat-panel__context-remove';
@@ -2004,7 +3040,7 @@ class ChatPanel {
       analysisCard.appendChild(removeBtn);
     }
 
-    const cards = this.messagesEl.querySelectorAll('.chat-panel__context-card:not([data-analysis])');
+    const cards = messagesEl.querySelectorAll('.chat-panel__context-card:not([data-analysis])');
     let idx = 0;
     cards.forEach((card) => {
       // Only restore cards that don't already have a remove button
@@ -2032,10 +3068,11 @@ class ChatPanel {
    * @param {HTMLElement} cardEl - The context card element to remove
    */
   _removeContextCard(cardEl) {
+    const tab = this._getActiveTab();
     const idx = parseInt(cardEl.dataset.contextIndex, 10);
-    if (!isNaN(idx) && idx >= 0 && idx < this._pendingContext.length) {
-      this._pendingContext.splice(idx, 1);
-      this._pendingContextData.splice(idx, 1);
+    if (tab && !isNaN(idx) && idx >= 0 && idx < tab.pendingContext.length) {
+      tab.pendingContext.splice(idx, 1);
+      tab.pendingContextData.splice(idx, 1);
     }
     // Hide context tooltip – mouseleave won't fire on a removed element
     clearTimeout(this._ctxTooltipTimer);
@@ -2044,14 +3081,17 @@ class ChatPanel {
     cardEl.remove();
 
     // Re-index remaining removable context cards
-    const remainingCards = this.messagesEl.querySelectorAll('.chat-panel__context-card[data-context-index]');
-    remainingCards.forEach((card, i) => {
-      card.dataset.contextIndex = i;
-    });
+    const messagesEl = tab?.messagesEl;
+    if (messagesEl) {
+      const remainingCards = messagesEl.querySelectorAll('.chat-panel__context-card[data-context-index]');
+      remainingCards.forEach((card, i) => {
+        card.dataset.contextIndex = i;
+      });
+    }
 
     // If no pending context, no messages, and no other context cards, restore empty state
-    if (this._pendingContext.length === 0 && this.messages.length === 0 &&
-        !this.messagesEl.querySelector('.chat-panel__context-card')) {
+    if (tab && tab.pendingContext.length === 0 && tab.messages.length === 0 &&
+        !tab.messagesEl?.querySelector('.chat-panel__context-card')) {
       this._clearMessages();
     }
   }
@@ -2059,11 +3099,20 @@ class ChatPanel {
   /**
    * Show analysis context card if the session response includes context metadata.
    * Removes the empty state first so the card appears as the first element.
-   * @param {Object} sessionData - Response data from createSession ({ id, status, context? })
+   * Accepts an explicit `tab` so the card lands in the originating tab even if
+   * the user switched focus while the session POST was in flight.
+   * @param {Object|null} sessionData - Response data from createSession
+   *   ({ id, status, context? }) — pass null when called before a session is
+   *   created (no-op in that case).
+   * @param {ChatTab} [targetTab] - Defaults to active tab
    */
-  _showAnalysisContextIfPresent(sessionData) {
-    if (sessionData.context && sessionData.context.suggestionCount > 0) {
-      const existingCard = this.messagesEl.querySelector('.chat-panel__context-card[data-analysis]');
+  _showAnalysisContextIfPresent(sessionData, targetTab) {
+    if (!sessionData || !sessionData.context || !(sessionData.context.suggestionCount > 0)) return;
+    const tab = targetTab || this._getActiveTab();
+    if (!tab || !tab.messagesEl) return;
+
+    const existingCard = tab.messagesEl.querySelector('.chat-panel__context-card[data-analysis]');
+    this._renderInTab(tab, () => {
       if (existingCard) {
         // Upgrade a bare-bones card (no metadata) with richer data from the backend.
         // Update IN-PLACE to preserve the card's DOM position (avoids jumping below user message).
@@ -2072,18 +3121,20 @@ class ChatPanel {
         if (!hasRicherContext) return;
         this._updateAnalysisCardContent(existingCard, sessionData.context);
       } else {
-        const emptyState = this.messagesEl.querySelector('.chat-panel__empty');
+        const emptyState = tab.messagesEl.querySelector('.chat-panel__empty');
         if (emptyState) emptyState.remove();
         this._addAnalysisContextCard(sessionData.context);
       }
+    });
 
-      // Persist richer analysis context to DB (includes provider, model, summary, etc.)
-      const contextData = { type: 'analysis', ...sessionData.context };
-      this._persistAnalysisContext(contextData);
-
-      // Track which run's context is loaded so _ensureAnalysisContext can skip if already present
-      this._sessionAnalysisRunId = sessionData.context.aiRunId || 'session';
+    // Persist richer analysis context to DB (includes provider, model, summary, etc.)
+    const contextData = { type: 'analysis', ...sessionData.context };
+    if (tab.sessionId != null) {
+      this._persistAnalysisContext(contextData, tab.sessionId);
     }
+
+    // Track which run's context is loaded so _ensureAnalysisContext can skip if already present
+    tab.sessionAnalysisRunId = sessionData.context.aiRunId || 'session';
   }
 
   /**
@@ -2160,16 +3211,22 @@ class ChatPanel {
    * @param {Object} [opts] - Options
    * @param {boolean} [opts.removable=false] - Whether the card should have a remove button
    */
-  _addAnalysisRunContextCard(ctxData, { removable = false } = {}) {
+  _addAnalysisRunContextCard(ctxData, { removable = false } = {}, targetTab) {
+    const tab = targetTab || this._getActiveTab();
+    if (!tab?.messagesEl) return;
     const card = document.createElement('div');
     card.className = 'chat-panel__context-card';
-    card.dataset.contextIndex = this._pendingContext.length - 1;
+    card.dataset.contextIndex = tab.pendingContext.length - 1;
     card.dataset.analysisRunId = ctxData.aiRunId;
     card.innerHTML = this._buildAnalysisCardInnerHTML(ctxData);
 
-    if (removable) this._makeCardRemovable(card);
+    // _makeCardRemovable reads `tab.pendingContextData.length` via the active
+    // tab getter, so re-route the active marker temporarily.
+    if (removable) {
+      this._renderInTab(tab, () => this._makeCardRemovable(card));
+    }
 
-    this.messagesEl.appendChild(card);
+    tab.messagesEl.appendChild(card);
     requestAnimationFrame(() => this.scrollToBottom({ force: true }));
   }
 
@@ -2221,13 +3278,19 @@ class ChatPanel {
    * Persist an analysis context card to the backend as a 'context' message.
    * Called immediately when an analysis context card is added, so it appears
    * in the conversation history on reload.
+   *
+   * Tab-aware callers pass an explicit sessionId so the persist write isn't
+   * routed to the active tab's session when focus has shifted between the
+   * card being added and the network call landing.
+   *
    * @param {Object} contextData - Analysis context metadata (type, suggestionCount, etc.)
+   * @param {number} [explicitSessionId] - Defaults to this.currentSessionId.
    */
-  async _persistAnalysisContext(contextData) {
-    if (!this.currentSessionId) return;
-
+  async _persistAnalysisContext(contextData, explicitSessionId) {
+    const sessionId = explicitSessionId != null ? explicitSessionId : this.currentSessionId;
+    if (!sessionId) return;
     try {
-      const response = await fetch(`/api/chat/session/${this.currentSessionId}/context`, {
+      const response = await fetch(`/api/chat/session/${sessionId}/context`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ contextData })
@@ -2241,14 +3304,13 @@ class ChatPanel {
   }
 
   /**
-   * Ensure WebSocket subscriptions are established for review and chat topics.
-   * Subscribes to review events (stable for page lifetime) and chat events
-   * (changes when session changes). Subsequent calls are no-ops if already subscribed.
+   * Ensure the review-scoped WebSocket subscription is established. Per-tab
+   * chat subscriptions are managed independently via _subscribeTab() as tabs
+   * are created.
    */
   _ensureSubscriptions() {
     window.wsClient.connect();
 
-    // Subscribe to review events (stable for page lifetime)
     if (this.reviewId && !this._reviewUnsub) {
       this._reviewUnsub = window.wsClient.subscribe('review:' + this.reviewId, (msg) => {
         if (msg.type?.startsWith('review:')) {
@@ -2259,15 +3321,14 @@ class ChatPanel {
       });
     }
 
-    // Subscribe to chat session
-    if (this.currentSessionId && !this._chatUnsub) {
-      this._chatUnsub = window.wsClient.subscribe('chat:' + this.currentSessionId, (msg) => {
-        this._handleChatMessage(msg);
-      });
+    // Resubscribe any open tabs that may have lost their handles (e.g. after
+    // late-binding a reviewId).
+    for (const tab of this.tabs) {
+      if (tab.sessionId != null && !tab.wsUnsub) {
+        this._subscribeTab(tab);
+      }
     }
 
-    // Listen for WebSocket reconnects — any deltas broadcast during the
-    // reconnect gap are lost, so we re-fetch via HTTP to recover the stream.
     if (!this._onReconnect) {
       this._onReconnect = () => { this._recoverAfterReconnect(); };
       window.addEventListener('wsReconnected', this._onReconnect);
@@ -2275,23 +3336,24 @@ class ChatPanel {
   }
 
   /**
-   * Recover streaming state after a WebSocket reconnect.
-   * If a stream was in progress when the connection dropped, deltas broadcast
-   * during the gap are lost. Re-fetch the full message history via HTTP and
-   * replace the partial `_streamingContent` with the complete last assistant
-   * message. When not streaming, no action is needed.
+   * Recover streaming state for every open tab after a WebSocket reconnect.
+   * Each tab independently re-fetches its latest assistant message if it was
+   * mid-stream when the connection dropped.
    */
   async _recoverAfterReconnect() {
-    if (!this.isStreaming || !this.currentSessionId) return;
+    await Promise.all(this.tabs.map((tab) => this._recoverTabAfterReconnect(tab)));
+  }
 
+  async _recoverTabAfterReconnect(tab) {
+    if (!tab?.isStreaming || tab.sessionId == null) return;
+    const capturedSessionId = tab.sessionId;
     try {
-      const response = await fetch(`/api/chat/session/${this.currentSessionId}/messages`);
+      const response = await fetch(`/api/chat/session/${tab.sessionId}/messages`);
+      if (!this.tabs.includes(tab) || tab.sessionId !== capturedSessionId) return;
       if (!response.ok) return;
-
       const result = await response.json();
+      if (!this.tabs.includes(tab) || tab.sessionId !== capturedSessionId) return;
       const messages = result.data?.messages || [];
-
-      // Find the last assistant message — this is the one being streamed
       let lastAssistant = null;
       for (let i = messages.length - 1; i >= 0; i--) {
         if (messages[i].type === 'message' && messages[i].role === 'assistant') {
@@ -2299,17 +3361,15 @@ class ChatPanel {
           break;
         }
       }
-
-      if (lastAssistant && lastAssistant.content) {
-        this._streamingContent = lastAssistant.content;
-        // The message is already persisted in the DB, so the stream is
-        // definitively complete. Finalize rather than continuing the
-        // streaming UI (which would leave the Stop button visible, etc.).
-        if (this.isOpen) {
-          this.finalizeStreamingMessage(lastAssistant.id);
+      if (lastAssistant?.content) {
+        tab.streamingContent = lastAssistant.content;
+        this._finalizeTabStream(tab, lastAssistant.id);
+        tab.streamingContent = '';
+        if (this.isOpen && this._getActiveTab() === tab) {
+          this._finalizeStreaming(tab);
         } else {
-          this.messages.push({ role: 'assistant', content: lastAssistant.content, id: lastAssistant.id });
-          this._finalizeStreaming();
+          tab.isStreaming = false;
+          this._updateTabStatus(tab, 'idle');
         }
       }
     } catch (err) {
@@ -2318,80 +3378,80 @@ class ChatPanel {
   }
 
   /**
-   * Unsubscribe from the current chat topic and re-subscribe to the new one.
-   * Called whenever `this.currentSessionId` changes.
+   * Handle a WebSocket event for a specific tab. Foreground tabs render
+   * directly to the DOM; background tabs accumulate state silently so it
+   * is visible when the user clicks back.
+   * @param {ChatTab} tab
+   * @param {Object} data - Parsed WS message
    */
-  _resubscribeChat() {
-    if (this._chatUnsub) { this._chatUnsub(); this._chatUnsub = null; }
-    if (this.currentSessionId) {
-      this._chatUnsub = window.wsClient.subscribe('chat:' + this.currentSessionId, (msg) => {
-        this._handleChatMessage(msg);
-      });
-    }
-  }
-
-  /**
-   * Handles incoming WebSocket messages for the active chat session.
-   * @param {Object} data - Parsed message object
-   */
-  _handleChatMessage(data) {
+  _handleChatMessageForTab(tab, data) {
     try {
-      // Assertion: WebSocket topic scoping guarantees sessionId match.
-      // This warn is a safety net — if it fires, something is wrong upstream.
-      if (data.sessionId !== this.currentSessionId) {
-        console.warn(`[ChatPanel] Unexpected sessionId mismatch: got ${data.sessionId}, expected ${this.currentSessionId}`);
+      if (data.sessionId !== tab.sessionId) {
+        console.warn(`[ChatPanel] sessionId mismatch on tab ${tab.sessionId}: got ${data.sessionId}`);
         return;
       }
 
       if (data.type !== 'delta') {
-        console.debug('[ChatPanel] WS event:', data.type, 'session:', data.sessionId);
+        console.debug('[ChatPanel] WS event:', data.type, 'tab:', tab.sessionId);
       }
 
-      // When the panel is closed, still accumulate internal state
-      // so messages are available when the panel reopens.
-      if (!this.isOpen) {
+      const isActive = this.isOpen && this._getActiveTab() === tab;
+
+      // Background tab (or panel closed): drive the per-tab DOM via tab-aware
+      // helpers so a tab switch reveals the same content the user would have
+      // seen had it been in the foreground all along.
+      if (!isActive) {
         switch (data.type) {
           case 'delta':
-            this._streamingContent += data.text;
+            if (!tab.streamingMsgEl) this._addStreamingPlaceholder(tab);
+            tab.streamingContent += data.text;
+            this.updateStreamingMessage(tab.streamingContent, tab);
+            this._markStreaming(tab);
+            break;
+          case 'status':
+            if (data.status === 'working') this._markStreaming(tab);
             break;
           case 'complete':
-            if (this._streamingContent) {
-              this.messages.push({ role: 'assistant', content: this._streamingContent, id: data.messageId });
-            }
-            this._streamingContent = '';
-            this.isStreaming = false;
+            this._finalizeTabStream(tab, data.messageId);
+            tab.streamingContent = '';
+            tab.isStreaming = false;
+            tab.errorMessage = null;
+            this._updateTabStatus(tab, 'idle');
             break;
           case 'error':
-            this._streamingContent = '';
-            this.isStreaming = false;
+            // Render the error inline so the user sees what happened when
+            // they switch back to this tab.
+            this._showError(data.message || 'An error occurred', tab);
+            this._finalizeTabStream(tab, null);
+            tab.streamingContent = '';
+            tab.isStreaming = false;
             break;
-          // tool_use, status: purely visual, skip when closed
         }
         return;
       }
 
+      // Foreground path — drive the DOM directly
       switch (data.type) {
         case 'delta':
-          this._hideThinkingIndicator();
-          this._streamingContent += data.text;
-          this.updateStreamingMessage(this._streamingContent);
+          this._hideThinkingIndicator(tab);
+          tab.streamingContent += data.text;
+          this.updateStreamingMessage(tab.streamingContent, tab);
           break;
-
         case 'tool_use':
-          this._showToolUse(data.toolName, data.status, data.toolInput);
+          this._showToolUse(data.toolName, data.status, data.toolInput, tab);
           break;
-
         case 'status':
-          this._handleAgentStatus(data.status);
+          this._handleAgentStatus(data.status, tab);
           break;
-
         case 'complete':
-          this.finalizeStreamingMessage(data.messageId);
+          tab.errorMessage = null;
+          this.finalizeStreamingMessage(data.messageId, tab);
           break;
-
         case 'error':
-          this._showError(data.message || 'An error occurred');
-          this._finalizeStreaming();
+          tab.errorMessage = data.message || 'An error occurred';
+          this._updateTabStatus(tab, 'error');
+          this._showError(tab.errorMessage, tab);
+          this._finalizeStreaming(tab);
           break;
       }
     } catch (e) {
@@ -2400,10 +3460,12 @@ class ChatPanel {
   }
 
   /**
-   * Close all WebSocket subscriptions (chat and review).
+   * Close the review-scope subscription and every tab's chat subscription.
    */
   _closeSubscriptions() {
-    if (this._chatUnsub) { this._chatUnsub(); this._chatUnsub = null; }
+    for (const tab of this.tabs) {
+      if (tab.wsUnsub) { try { tab.wsUnsub(); } catch { /* noop */ } tab.wsUnsub = null; }
+    }
     if (this._reviewUnsub) { this._reviewUnsub(); this._reviewUnsub = null; }
     if (this._onReconnect) {
       window.removeEventListener('wsReconnected', this._onReconnect);
@@ -2412,15 +3474,19 @@ class ChatPanel {
   }
 
   /**
-   * Add a message to the display
+   * Add a message to the display.
    * @param {string} role - 'user' or 'assistant'
    * @param {string} content - Message text
-   * @param {number} id - Optional message ID
+   * @param {number} [id] - Optional message ID
+   * @param {ChatTab} [targetTab] - Explicit tab; defaults to active tab
    * @returns {HTMLElement} The message element that was appended
    */
-  addMessage(role, content, id) {
+  addMessage(role, content, id, targetTab) {
+    const tab = targetTab || this._getActiveTab();
+    if (!tab || !tab.messagesEl) return null;
+
     const msg = { role, content, id };
-    this.messages.push(msg);
+    tab.messages.push(msg);
 
     const msgEl = document.createElement('div');
     msgEl.className = `chat-panel__message chat-panel__message--${role}`;
@@ -2438,8 +3504,19 @@ class ChatPanel {
     }
 
     msgEl.appendChild(bubble);
-    this.messagesEl.appendChild(msgEl);
-    this.scrollToBottom({ force: true });
+    tab.messagesEl.appendChild(msgEl);
+
+    // Update the tab title from the first user message if the user hasn't
+    // explicitly named it. Only do this when no prior user message exists.
+    if (role === 'user' && !tab.titleFromUser) {
+      const preview = this._truncate(content, 28);
+      if (preview) {
+        tab.titleFromUser = true;
+        this._setTabTitle(tab, preview);
+      }
+    }
+
+    if (this._getActiveTab() === tab) this.scrollToBottom({ force: true });
     return msgEl;
   }
 
@@ -2482,31 +3559,35 @@ class ChatPanel {
   }
 
   /**
-   * Add a streaming placeholder for the assistant's response
+   * Add a streaming placeholder for the assistant's response on a tab.
+   * @param {ChatTab} [targetTab] - Defaults to active tab
    */
-  _addStreamingPlaceholder() {
+  _addStreamingPlaceholder(targetTab) {
+    const tab = targetTab || this._getActiveTab();
+    if (!tab || !tab.messagesEl) return;
     const msgEl = document.createElement('div');
     msgEl.className = 'chat-panel__message chat-panel__message--assistant chat-panel__message--streaming';
-    msgEl.id = 'chat-streaming-msg';
 
     const bubble = document.createElement('div');
     bubble.className = 'chat-panel__bubble';
     bubble.innerHTML = getChatSpinnerHTML();
 
     msgEl.appendChild(bubble);
-    this.messagesEl.appendChild(msgEl);
-    this.scrollToBottom({ force: true });
+    tab.messagesEl.appendChild(msgEl);
+    tab.streamingMsgEl = msgEl;
+    if (this._getActiveTab() === tab) this.scrollToBottom({ force: true });
   }
 
   /**
-   * Update the currently streaming message
+   * Update the streaming message on a tab.
    * @param {string} text - Full accumulated text so far
+   * @param {ChatTab} [targetTab] - Defaults to active tab
    */
-  updateStreamingMessage(text) {
-    const streamingMsg = document.getElementById('chat-streaming-msg');
+  updateStreamingMessage(text, targetTab) {
+    const tab = targetTab || this._getActiveTab();
+    const streamingMsg = tab?.streamingMsgEl;
     if (!streamingMsg) return;
 
-    // Remove transient tool badge when real text arrives
     const transient = streamingMsg.querySelector('.chat-panel__tool-badge--transient');
     if (transient) transient.remove();
 
@@ -2515,96 +3596,116 @@ class ChatPanel {
       bubble.innerHTML = this.renderMarkdown(text) + '<span class="chat-panel__cursor"></span>';
       this._linkifyFileReferences(bubble);
     }
-    this.scrollToBottom();
+    if (this._getActiveTab() === tab) this.scrollToBottom();
   }
 
   /**
-   * Finalize the streaming message with final ID
+   * Finalize the streaming message on a tab. Idempotent — a second call when
+   * streamingMsgEl is already null is a no-op.
    * @param {number} messageId - Database message ID
+   * @param {ChatTab} [targetTab] - Defaults to active tab
    */
-  finalizeStreamingMessage(messageId) {
-    const streamingMsg = document.getElementById('chat-streaming-msg');
+  finalizeStreamingMessage(messageId, targetTab) {
+    const tab = targetTab || this._getActiveTab();
+    if (!tab) return;
+    this._finalizeTabStream(tab, messageId);
+    this._finalizeStreaming(tab);
+  }
+
+  /**
+   * Tab-aware DOM finalization helper. Writes the final streamed content into
+   * `tab.streamingMsgEl`, strips streaming/cursor classes, pushes the message
+   * into `tab.messages`, and nulls `tab.streamingMsgEl`. Safe to call twice.
+   * @param {ChatTab} tab
+   * @param {number} [messageId]
+   */
+  _finalizeTabStream(tab, messageId) {
+    if (!tab) return;
+    const streamingMsg = tab.streamingMsgEl;
     if (streamingMsg) {
       streamingMsg.classList.remove('chat-panel__message--streaming');
-      streamingMsg.id = '';
       if (messageId) streamingMsg.dataset.messageId = messageId;
 
-      // Remove cursor and thinking indicator
       const cursor = streamingMsg.querySelector('.chat-panel__cursor');
       if (cursor) cursor.remove();
       const thinking = streamingMsg.querySelector('.chat-panel__thinking');
       if (thinking) thinking.remove();
 
-      // Remove transient tool badge
       const transientBadge = streamingMsg.querySelector('.chat-panel__tool-badge--transient');
       if (transientBadge) transientBadge.remove();
 
-      // Remove any active tool spinners (e.g. abort mid-tool-execution)
       const spinners = streamingMsg.querySelectorAll('.chat-panel__tool-spinner');
       spinners.forEach(s => s.remove());
 
-      // Final render
       const bubble = streamingMsg.querySelector('.chat-panel__bubble');
       if (bubble) {
-        if (this._streamingContent) {
-          bubble.innerHTML = this.renderMarkdown(this._streamingContent);
+        if (tab.streamingContent) {
+          bubble.innerHTML = this.renderMarkdown(tab.streamingContent);
           this._linkifyFileReferences(bubble);
-          bubble.appendChild(this._createCopyButton(this._streamingContent));
+          bubble.appendChild(this._createCopyButton(tab.streamingContent));
         } else {
-          // Empty response - show a subtle message
           bubble.innerHTML = '<em class="chat-panel__empty-response">No response generated.</em>';
         }
       }
     }
 
-    // Store in messages array
-    if (this._streamingContent) {
-      this.messages.push({ role: 'assistant', content: this._streamingContent, id: messageId });
+    if (tab.streamingContent) {
+      tab.messages.push({ role: 'assistant', content: tab.streamingContent, id: messageId });
     }
-
-    this._finalizeStreaming();
+    tab.streamingMsgEl = null;
   }
 
   /**
-   * Abort the current agent turn
+   * Abort the current agent turn on the originating tab. Captures the tab
+   * at entry so a focus change between the user clicking Stop and the abort
+   * round-trip resolving can't finalize the wrong tab's stream.
    */
   async _stopAgent() {
-    if (!this.isStreaming || !this.currentSessionId) return;
-
+    const tab = this._getActiveTab();
+    if (!tab || !tab.isStreaming || tab.sessionId == null) return;
     try {
-      await fetch(`/api/chat/session/${this.currentSessionId}/abort`, {
-        method: 'POST'
-      });
+      await fetch(`/api/chat/session/${tab.sessionId}/abort`, { method: 'POST' });
     } catch (error) {
       console.error('[ChatPanel] Error aborting:', error);
     }
-
-    // Finalize the streaming message with whatever content we have so far
-    this.finalizeStreamingMessage(null);
+    if (!this.tabs.includes(tab)) return;
+    // Finalize the streaming message with whatever content we have so far.
+    this.finalizeStreamingMessage(null, tab);
   }
 
   /**
-   * Clean up streaming state
+   * Clean up streaming state on a tab. UI controls are only touched when the
+   * tab is currently active.
+   * @param {ChatTab} [targetTab] - Defaults to active tab
    */
-  _finalizeStreaming() {
-    this.isStreaming = false;
-    this._streamingContent = '';
-    this.sendBtn.style.display = '';
-    this.stopBtn.style.display = 'none';
-    this.sendBtn.disabled = !this.inputEl?.value?.trim();
-    this._updateActionButtons();
-    this.inputEl?.focus();
+  _finalizeStreaming(targetTab) {
+    const tab = targetTab || this._getActiveTab();
+    if (tab) {
+      tab.isStreaming = false;
+      tab.streamingContent = '';
+      tab.streamingMsgEl = null;
+      this._updateTabStatus(tab, tab.errorMessage ? 'error' : 'idle');
+    }
+    if (!tab || this._getActiveTab() === tab) {
+      this.sendBtn.style.display = '';
+      this.stopBtn.style.display = 'none';
+      this.sendBtn.disabled = !this.inputEl?.value?.trim();
+      this._updateActionButtons();
+      this.inputEl?.focus();
+    }
   }
 
   /**
-   * Show a tool use indicator in the streaming message
+   * Show a tool use indicator in a tab's streaming message.
    * @param {string} toolName - Name of the tool being used
    * @param {string} status - 'start' or 'end'
    * @param {Object} [toolInput] - Tool input/arguments (optional)
+   * @param {ChatTab} [targetTab] - Defaults to active tab
    */
-  _showToolUse(toolName, status, toolInput) {
+  _showToolUse(toolName, status, toolInput, targetTab) {
     if (!toolName) return;
-    const streamingMsg = document.getElementById('chat-streaming-msg');
+    const tab = targetTab || this._getActiveTab();
+    const streamingMsg = tab?.streamingMsgEl;
     if (!streamingMsg) return;
 
     const isTask = toolName.toLowerCase() === 'task' || toolName.toLowerCase() === 'agent';
@@ -2657,7 +3758,7 @@ class ChatPanel {
           if (spinner) spinner.remove();
         }
       }
-      this._showThinkingIndicator();
+      this._showThinkingIndicator(tab);
     }
   }
 
@@ -2704,32 +3805,46 @@ class ChatPanel {
   /**
    * Handle agent status events from the backend.
    * @param {string} status - 'working' or 'turn_complete'
+   * @param {ChatTab} [targetTab] - Defaults to active tab
    */
-  _handleAgentStatus(status) {
+  _handleAgentStatus(status, targetTab) {
+    const tab = targetTab || this._getActiveTab();
     if (status === 'working') {
-      this._showThinkingIndicator();
+      this._showThinkingIndicator(tab);
+      this._markStreaming(tab);
     }
     // 'turn_complete' is informational; the agent may start another turn
   }
 
   /**
-   * Show the pulsing thinking indicator in/below the streaming message.
-   * If there's already content, append it after the content. If no content, it's the typing dots.
+   * Mark a tab as streaming if it is not already. Used by foreground and
+   * background status arms to set the per-tab flag + status dot in one place.
+   * Short-circuits if already streaming — preserves errorMessage from being
+   * cleared mid-stream.
+   * @param {ChatTab} tab
    */
-  _showThinkingIndicator() {
-    const streamingMsg = document.getElementById('chat-streaming-msg');
+  _markStreaming(tab) {
+    if (!tab || tab.isStreaming) return;
+    tab.isStreaming = true;
+    this._updateTabStatus(tab, 'streaming');
+  }
+
+  /**
+   * Show the pulsing thinking indicator on a tab's streaming message.
+   * @param {ChatTab} [targetTab] - Defaults to active tab
+   */
+  _showThinkingIndicator(targetTab) {
+    const tab = targetTab || this._getActiveTab();
+    const streamingMsg = tab?.streamingMsgEl;
     if (!streamingMsg) return;
 
     // Don't add duplicate
     if (streamingMsg.querySelector('.chat-panel__thinking')) return;
 
     // Don't add if the bubble still has its initial spinner (no content yet).
-    // The bubble's own indicator is sufficient — adding a second would show two.
     const bubble = streamingMsg.querySelector('.chat-panel__bubble');
     if (bubble && (bubble.querySelector('.chat-panel__typing-indicator') || bubble.querySelector('.chat-panel__loop-spinner'))) return;
 
-    // Remove the cursor — the thinking indicator replaces it as the "working" signal.
-    // When new text arrives, updateStreamingMessage() will re-add the cursor naturally.
     const cursor = bubble?.querySelector('.chat-panel__cursor');
     if (cursor) cursor.remove();
 
@@ -2737,24 +3852,34 @@ class ChatPanel {
     indicator.className = 'chat-panel__thinking';
     indicator.innerHTML = getChatSpinnerHTML();
     streamingMsg.appendChild(indicator);
-    this.scrollToBottom();
+    if (this._getActiveTab() === tab) this.scrollToBottom();
   }
 
   /**
-   * Hide the thinking indicator from the streaming message.
+   * Hide the thinking indicator on a tab's streaming message.
+   * @param {ChatTab} [targetTab] - Defaults to active tab
    */
-  _hideThinkingIndicator() {
-    const streamingMsg = document.getElementById('chat-streaming-msg');
+  _hideThinkingIndicator(targetTab) {
+    const tab = targetTab || this._getActiveTab();
+    const streamingMsg = tab?.streamingMsgEl;
     if (!streamingMsg) return;
     const thinking = streamingMsg.querySelector('.chat-panel__thinking');
     if (thinking) thinking.remove();
   }
 
   /**
-   * Show an error message in the chat
+   * Show an error message in a tab.
    * @param {string} message - Error text
+   * @param {ChatTab} [targetTab] - Defaults to active tab
    */
-  _showError(message) {
+  _showError(message, targetTab) {
+    const tab = targetTab || this._getActiveTab();
+    if (tab) {
+      tab.errorMessage = message;
+      this._updateTabStatus(tab, 'error');
+    }
+    const messagesEl = tab?.messagesEl;
+    if (!messagesEl) return;
     const errorEl = document.createElement('div');
     errorEl.className = 'chat-panel__message chat-panel__message--error';
     errorEl.innerHTML = `
@@ -2765,8 +3890,8 @@ class ChatPanel {
         ${this._escapeHtml(message)}
       </div>
     `;
-    this.messagesEl.appendChild(errorEl);
-    this.scrollToBottom({ force: true });
+    messagesEl.appendChild(errorEl);
+    if (this._getActiveTab() === tab) this.scrollToBottom({ force: true });
   }
 
   /**
@@ -3172,7 +4297,9 @@ class ChatPanel {
    */
   _handleAdoptClick() {
     if (this.isStreaming || !this._contextItemId) return;
-    this._pendingActionContext = { type: 'adopt', itemId: this._contextItemId };
+    const tab = this._getActiveTab();
+    if (!tab) return;
+    tab.pendingActionContext = { type: 'adopt', itemId: tab.contextItemId };
     this.inputEl.value = 'Based on our conversation, please refine and adopt this AI suggestion.';
     this.sendMessage();
   }
@@ -3183,7 +4310,9 @@ class ChatPanel {
    */
   _handleUpdateClick() {
     if (this.isStreaming || !this._contextItemId) return;
-    this._pendingActionContext = { type: 'update', itemId: this._contextItemId };
+    const tab = this._getActiveTab();
+    if (!tab) return;
+    tab.pendingActionContext = { type: 'update', itemId: tab.contextItemId };
     this.inputEl.value = 'Based on our conversation, please update my comment.';
     this.sendMessage();
   }
@@ -3194,7 +4323,9 @@ class ChatPanel {
    */
   _handleDismissSuggestionClick() {
     if (this.isStreaming || !this._contextItemId) return;
-    this._pendingActionContext = { type: 'dismiss-suggestion', itemId: this._contextItemId };
+    const tab = this._getActiveTab();
+    if (!tab) return;
+    tab.pendingActionContext = { type: 'dismiss-suggestion', itemId: tab.contextItemId };
     this.inputEl.value = 'Please dismiss this AI suggestion.';
     this.sendMessage();
   }
@@ -3205,7 +4336,9 @@ class ChatPanel {
    */
   _handleDismissCommentClick() {
     if (this.isStreaming || !this._contextItemId) return;
-    this._pendingActionContext = { type: 'dismiss-comment', itemId: this._contextItemId };
+    const tab = this._getActiveTab();
+    if (!tab) return;
+    tab.pendingActionContext = { type: 'dismiss-comment', itemId: tab.contextItemId };
     this.inputEl.value = 'Please dismiss this comment.';
     this.sendMessage();
   }
@@ -3227,11 +4360,13 @@ class ChatPanel {
    */
   _handleCreateCommentClick() {
     if (this.isStreaming) return;
-    this._pendingActionContext = {
+    const tab = this._getActiveTab();
+    if (!tab) return;
+    tab.pendingActionContext = {
       type: 'create-comment',
-      file: this._contextLineMeta?.file,
-      line_start: this._contextLineMeta?.line_start,
-      line_end: this._contextLineMeta?.line_end,
+      file: tab.contextLineMeta?.file,
+      line_start: tab.contextLineMeta?.line_start,
+      line_end: tab.contextLineMeta?.line_end,
     };
     this.inputEl.value = 'Based on our conversation, please create a review comment for this code.';
     this.sendMessage();
@@ -3248,7 +4383,13 @@ class ChatPanel {
     document.body.appendChild(this._ctxTooltipEl);
     this._ctxTooltipTimer = null;
 
-    if (!this.messagesEl) return;
+    // Delegate hover events from the persistent stack element so the tooltip
+    // works for every per-tab messagesEl (which are created lazily by
+    // _createTabMessagesEl as tabs are opened/restored). Reading
+    // `this.messagesEl` here would always be null at construction time —
+    // there's no active tab yet — so the listeners would never bind.
+    const host = this.messagesStackEl;
+    if (!host) return;
 
     this._onCtxCardEnter = (e) => {
       const card = e.target.closest('.chat-panel__context-card[data-tooltip-body]');
@@ -3264,8 +4405,8 @@ class ChatPanel {
       this._ctxTooltipEl.style.display = 'none';
     };
 
-    this.messagesEl.addEventListener('mouseenter', this._onCtxCardEnter, true);
-    this.messagesEl.addEventListener('mouseleave', this._onCtxCardLeave, true);
+    host.addEventListener('mouseenter', this._onCtxCardEnter, true);
+    host.addEventListener('mouseleave', this._onCtxCardLeave, true);
   }
 
   /**
@@ -3311,7 +4452,8 @@ class ChatPanel {
     document.removeEventListener('keydown', this._onKeydown);
     window.removeEventListener('chat-state-changed', this._onChatStateChanged);
     this._closeSubscriptions();
-    this.messages = [];
+    this.tabs = [];
+    this.activeTabKey = null;
 
     // Clean up context tooltip
     clearTimeout(this._ctxTooltipTimer);

--- a/tests/e2e/chat-tabs.spec.js
+++ b/tests/e2e/chat-tabs.spec.js
@@ -1,0 +1,288 @@
+// Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+/**
+ * E2E Tests: Chat multi-tab support
+ *
+ * Phase 1/2 introduced multi-tab chat sessions. Three flows we want to lock
+ * down end-to-end (UI-level — message streaming uses a real bridge, which is
+ * mocked out in E2E):
+ *
+ *   1. Open multiple tabs from the "+" button; close them with "x".
+ *   2. Persistence across page reload — open tabs are restored, focus is
+ *      restored, and the persisted localStorage entry uses the documented
+ *      shape.
+ *   3. History dropdown marks open sessions with --open and clicking an
+ *      open-elsewhere entry focuses the existing tab rather than swapping.
+ */
+
+import { test, expect } from './fixtures.js';
+import { waitForDiffToRender } from './helpers.js';
+
+/**
+ * Force chat into "available" state so the toggle button is interactive.
+ * Pi isn't installed in the E2E environment, so we need to bypass the
+ * data-chat availability gate.
+ */
+async function enableChat(page) {
+  await page.evaluate(() => {
+    document.documentElement.setAttribute('data-chat', 'available');
+    window.__pairReview = window.__pairReview || {};
+    // Provide a single available provider so the "+" / new-tab path can
+    // POST to /api/chat/session without 400'ing on missing provider.
+    window.__pairReview.chatProvider = 'pi';
+    window.__pairReview.chatProviders = [
+      { id: 'pi', name: 'Pi', type: 'pi', available: true },
+    ];
+    window.dispatchEvent(new CustomEvent('chat-state-changed', { detail: { state: 'available' } }));
+  });
+}
+
+test.describe('Chat multi-tab UI', () => {
+  test.beforeEach(async ({ page }) => {
+    // Wipe persisted chat tab state BEFORE booting the chat panel. We use a
+    // bounce-through-the-origin-root pattern: index.html doesn't include
+    // ChatPanel, so we can safely touch localStorage there without racing the
+    // panel's restore logic. Wiping after the real /pr goto would race with
+    // the panel boot reading localStorage on DOMContentLoaded.
+    await page.goto('/');
+    await page.evaluate(() => {
+      try {
+        Object.keys(localStorage)
+          .filter((k) => k.startsWith('pair-review:chat-tabs:'))
+          .forEach((k) => localStorage.removeItem(k));
+      } catch { /* noop */ }
+    });
+    await page.goto('/pr/test-owner/test-repo/1');
+    await waitForDiffToRender(page);
+    await enableChat(page);
+  });
+
+  test('opens a new tab via the + button and closes it via x', async ({ page }) => {
+    // Open the chat panel — restores existing session 1 as the first tab.
+    await page.locator('#chat-toggle-btn').click();
+    await expect(page.locator('.chat-panel')).toBeVisible();
+
+    // Wait for the initial tab (loaded from the seeded session 1) to render.
+    const tabs = page.locator('.chat-panel__tab');
+    await expect(tabs).toHaveCount(1, { timeout: 5000 });
+
+    // Click "+" to open a second tab.
+    await page.locator('.chat-panel__tab-new-btn').click();
+    await expect(tabs).toHaveCount(2, { timeout: 5000 });
+
+    // The newest tab is focused (rightmost active).
+    await expect(tabs.last()).toHaveClass(/chat-panel__tab--active/);
+
+    // Close the focused tab. The previously-active tab becomes active.
+    await tabs.last().locator('.chat-panel__tab-close').click();
+    await expect(tabs).toHaveCount(1, { timeout: 5000 });
+
+    // Close the remaining tab. Empty state should appear.
+    await tabs.first().locator('.chat-panel__tab-close').click();
+    await expect(tabs).toHaveCount(0);
+    await expect(page.locator('.chat-panel__empty--no-tabs')).toBeVisible();
+  });
+
+  test('persists open tabs and focus across a page reload', async ({ page }) => {
+    await page.locator('#chat-toggle-btn').click();
+    await expect(page.locator('.chat-panel')).toBeVisible();
+
+    const tabs = page.locator('.chat-panel__tab');
+    await expect(tabs).toHaveCount(1, { timeout: 5000 });
+
+    // Open a second tab so there are at least two distinct sessions to persist.
+    await page.locator('.chat-panel__tab-new-btn').click();
+    await expect(tabs).toHaveCount(2, { timeout: 5000 });
+
+    // Sessions are lazily created on first message — send one in the active
+    // (second) tab so its sessionId materializes and persistence kicks in.
+    await page.locator('.chat-panel__input').fill('hello from tab 2');
+    await page.locator('.chat-panel__send-btn').click();
+    await expect.poll(async () => {
+      return page.evaluate(() => {
+        if (!window.chatPanel) return null;
+        return window.chatPanel.tabs.every(t => t.sessionId != null);
+      });
+    }, { timeout: 5000 }).toBe(true);
+
+    // Poll for the persisted entry to materialise with the expected shape
+    // rather than sleeping. The persistence write is debounced 100ms.
+    await expect.poll(async () => {
+      return page.evaluate(() => {
+        const raw = localStorage.getItem('pair-review:chat-tabs:1');
+        if (!raw) return null;
+        try { return JSON.parse(raw); } catch { return null; }
+      });
+    }, { timeout: 5000 }).toMatchObject({
+      version: 1,
+      tabs: expect.any(Array),
+      activeSessionId: expect.any(Number),
+    });
+
+    const persisted = await page.evaluate(() => {
+      const raw = localStorage.getItem('pair-review:chat-tabs:1');
+      return raw ? JSON.parse(raw) : null;
+    });
+    expect(persisted.tabs.length).toBe(2);
+    expect(typeof persisted.activeSessionId).toBe('number');
+
+    // The active (right-most) tab should be the second session.
+    const activeBefore = persisted.activeSessionId;
+
+    // Reload — the chat panel should restore the persisted tabs/focus.
+    await page.reload();
+    await waitForDiffToRender(page);
+    await enableChat(page);
+    // The panel may already be open via PanelGroup restoration. If not, click
+    // the toggle. Either way, .chat-panel should be visible afterward.
+    const panel = page.locator('.chat-panel');
+    if (!(await panel.isVisible())) {
+      const toggle = page.locator('#chat-toggle-btn');
+      // Wait until the toggle is interactive.
+      await toggle.waitFor({ state: 'visible', timeout: 5000 });
+      await toggle.click();
+    }
+    await expect(panel).toBeVisible();
+
+    const tabsAfter = page.locator('.chat-panel__tab');
+    await expect(tabsAfter).toHaveCount(2, { timeout: 5000 });
+
+    // Verify the same activeSessionId is still in localStorage (the restore
+    // path rewrites the entry to prune stale ids — confirm shape is preserved).
+    const persistedAfter = await page.evaluate(() => {
+      const raw = localStorage.getItem('pair-review:chat-tabs:1');
+      return raw ? JSON.parse(raw) : null;
+    });
+    expect(persistedAfter).not.toBeNull();
+    expect(persistedAfter.tabs).toEqual(persisted.tabs);
+    expect(persistedAfter.activeSessionId).toBe(activeBefore);
+  });
+
+  test('history dropdown marks open sessions and clicking one focuses the existing tab', async ({ page }) => {
+    await page.locator('#chat-toggle-btn').click();
+    await expect(page.locator('.chat-panel')).toBeVisible();
+
+    const tabs = page.locator('.chat-panel__tab');
+    await expect(tabs).toHaveCount(1, { timeout: 5000 });
+
+    // Open a second tab so two sessions show up as "open" in the history.
+    await page.locator('.chat-panel__tab-new-btn').click();
+    await expect(tabs).toHaveCount(2, { timeout: 5000 });
+
+    // Sessions are lazy now — send a message so the new tab gets its sessionId
+    // and history dropdown can mark it as "open". The first tab inherits its
+    // sessionId from the seeded MRU session.
+    await page.locator('.chat-panel__input').fill('seed second session');
+    await page.locator('.chat-panel__send-btn').click();
+    await expect.poll(async () => {
+      return page.evaluate(() => {
+        if (!window.chatPanel) return null;
+        return window.chatPanel.tabs.every(t => t.sessionId != null);
+      });
+    }, { timeout: 5000 }).toBe(true);
+
+    // Open the history dropdown.
+    await page.locator('.chat-panel__history-btn').click();
+    const dropdown = page.locator('.chat-panel__session-dropdown');
+    await expect(dropdown).toBeVisible();
+
+    // Both rows show the "open" tag.
+    const openTags = dropdown.locator('.chat-panel__session-open-tag');
+    await expect(openTags).toHaveCount(2);
+
+    // Capture the session id of the row we're about to click so we can assert
+    // that the matching tab becomes active (rather than asserting on a count).
+    const openElsewhere = dropdown.locator('.chat-panel__session-item--open').first();
+    const targetSessionId = await openElsewhere.getAttribute('data-session-id');
+    expect(targetSessionId).toBeTruthy();
+
+    await openElsewhere.click();
+
+    // Tab count is unchanged — focus simply swapped.
+    await expect(tabs).toHaveCount(2);
+    // The tab with the clicked session id is now active.
+    await expect(
+      page.locator(`.chat-panel__tab[data-session-id="${targetSessionId}"]`)
+    ).toHaveClass(/chat-panel__tab--active/);
+  });
+
+  test('messages sent in one tab do not appear in another', async ({ page }) => {
+    await page.locator('#chat-toggle-btn').click();
+    await expect(page.locator('.chat-panel')).toBeVisible();
+
+    const tabs = page.locator('.chat-panel__tab');
+    await expect(tabs).toHaveCount(1, { timeout: 5000 });
+
+    // Tab 1 is the restored MRU session — its sessionId is already populated.
+    // Focus tab A (index 0) and send its message first.
+    await tabs.first().click();
+    await expect(tabs.first()).toHaveClass(/chat-panel__tab--active/);
+
+    await page.locator('.chat-panel__input').fill('message for tab A');
+    await page.locator('.chat-panel__send-btn').click();
+
+    // Open the second tab AFTER tab A has its content — that way both tabs
+    // get their sessionId before we cross-check.
+    await page.locator('.chat-panel__tab-new-btn').click();
+    await expect(tabs).toHaveCount(2, { timeout: 5000 });
+
+    // Wait for tab A (index 0) to contain its user message.
+    await expect.poll(async () => {
+      return page.evaluate(() => {
+        const tab = window.chatPanel.tabs[0];
+        return tab ? tab.messages.map(m => m.content) : [];
+      });
+    }, { timeout: 5000 }).toContain('message for tab A');
+
+    // Switch to tab B (index 1) and send a different message. Tab B has no
+    // sessionId until it sends its first message, so click by position.
+    await tabs.nth(1).click();
+    await expect(tabs.nth(1)).toHaveClass(/chat-panel__tab--active/);
+
+    await page.locator('.chat-panel__input').fill('message for tab B');
+    await page.locator('.chat-panel__send-btn').click();
+
+    await expect.poll(async () => {
+      return page.evaluate(() => {
+        const tab = window.chatPanel.tabs[1];
+        return tab ? tab.messages.map(m => m.content) : [];
+      });
+    }, { timeout: 5000 }).toContain('message for tab B');
+
+    // Both tabs now have sessionIds — wait for the second one to materialize.
+    await expect.poll(async () => {
+      return page.evaluate(() => window.chatPanel.tabs.every(t => t.sessionId != null));
+    }, { timeout: 5000 }).toBe(true);
+
+    // Tab A still has only its own message — no cross-tab bleed (in-memory).
+    const aContents = await page.evaluate(() => {
+      const tab = window.chatPanel.tabs[0];
+      return tab ? tab.messages.map(m => m.content) : [];
+    });
+    expect(aContents).toContain('message for tab A');
+    expect(aContents).not.toContain('message for tab B');
+
+    // DOM assertion: the per-tab messages container for tab A contains its
+    // own message, not tab B's. Each per-tab container carries data-tab-key
+    // matching the tab's sessionId once a session is bound.
+    const tabAKey = await page.evaluate(() => window.chatPanel.tabs[0].sessionId);
+    const tabBKey = await page.evaluate(() => window.chatPanel.tabs[1].sessionId);
+    const tabAMessagesEl = page.locator(`.chat-panel__messages[data-tab-key="${tabAKey}"]`);
+    const tabBMessagesEl = page.locator(`.chat-panel__messages[data-tab-key="${tabBKey}"]`);
+    await expect(tabAMessagesEl).toContainText('message for tab A');
+    // Tab A's container must NOT contain tab B's message text.
+    await expect(tabAMessagesEl).not.toContainText('message for tab B');
+    // Tab B's container must contain tab B's message text.
+    await expect(tabBMessagesEl).toContainText('message for tab B');
+
+    // Switch back to tab A and verify the active container contains tab A's
+    // message text. We don't constrain to "first" because tests share a DB
+    // across the worker and tab A's session may already have older messages
+    // from prior tests in the suite.
+    await page.locator(`.chat-panel__tab[data-session-id="${tabAKey}"]`).click();
+    await expect(tabs.first()).toHaveClass(/chat-panel__tab--active/);
+    const activeContainer = page.locator('.chat-panel__messages:not([style*="display: none"])');
+    await expect(activeContainer).toContainText('message for tab A');
+    // And the active container must NOT contain tab B's content.
+    await expect(activeContainer).not.toContainText('message for tab B');
+  });
+});

--- a/tests/e2e/test-server.js
+++ b/tests/e2e/test-server.js
@@ -628,11 +628,49 @@ async function startTestServer(port) {
   const localRoutes = require('../../src/routes/local');
   const contextFilesRoutes = require('../../src/routes/context-files');
 
-  // Mock chat session manager for E2E (reads from DB, no real bridge)
+  // Mock chat session manager for E2E (reads from DB, no real bridge).
+  // createSession/sendMessage write to the DB so multi-tab tests that open
+  // additional sessions can observe distinct ids via /api/review/.../chat/sessions.
   app.chatSessionManager = {
-    createSession: async () => ({ id: Date.now(), status: 'active' }),
-    sendMessage: async () => ({ id: Date.now() }),
-    closeSession: async () => {},
+    createSession: async ({ reviewId, provider = 'pi', model = 'claude-sonnet-4' }) => {
+      const now = new Date().toISOString();
+      // Stamp a fake agent_session_id so the chat route treats this as a
+      // resumable session (without it, the /message route bails with 410
+      // and tests can never exercise sendMessage).
+      const info = db.prepare(`
+        INSERT INTO chat_sessions (review_id, provider, model, status, agent_session_id, created_at, updated_at)
+        VALUES (?, ?, ?, 'active', ?, ?, ?)
+      `).run(reviewId, provider, model, `mock-agent-session-${Date.now()}`, now, now);
+      return { id: info.lastInsertRowid, status: 'active' };
+    },
+    // Match production sendMessage signature: (sessionId, content, options).
+    // Persist contextData rows FIRST (mirrors production) so message history
+    // round-trips show context cards in the right order, then the user
+    // message row. Real WS bridge isn't running in E2E so no broadcast.
+    sendMessage: async (sessionId, content, options = {}) => {
+      const { contextData } = options;
+      const insertAll = db.transaction(() => {
+        if (contextData) {
+          const ctxStmt = db.prepare(`
+            INSERT INTO chat_messages (session_id, role, type, content)
+            VALUES (?, 'user', 'context', ?)
+          `);
+          const items = Array.isArray(contextData) ? contextData : [contextData];
+          for (const item of items) {
+            ctxStmt.run(sessionId, typeof item === 'string' ? item : JSON.stringify(item));
+          }
+        }
+        return db.prepare(`
+          INSERT INTO chat_messages (session_id, role, type, content)
+          VALUES (?, 'user', 'message', ?)
+        `).run(sessionId, content);
+      });
+      const info = insertAll();
+      return { id: Number(info.lastInsertRowid) };
+    },
+    closeSession: async (sessionId) => {
+      db.prepare("UPDATE chat_sessions SET status='closed', updated_at=CURRENT_TIMESTAMP WHERE id = ?").run(sessionId);
+    },
     getSession: (id) => db.prepare('SELECT * FROM chat_sessions WHERE id = ?').get(id) || null,
     getSessionsWithMessageCount: (reviewId) =>
       db.prepare(`
@@ -649,14 +687,20 @@ async function startTestServer(port) {
       `).all(reviewId),
     getSessionsForReview: (reviewId) =>
       db.prepare('SELECT * FROM chat_sessions WHERE review_id = ? ORDER BY created_at DESC').all(reviewId),
+    // Mirror production: order by id ASC. Using created_at ASC would let two
+    // rows inserted in the same millisecond return out of order.
     getMessages: (sessionId) =>
-      db.prepare('SELECT * FROM chat_messages WHERE session_id = ? ORDER BY created_at ASC').all(sessionId),
+      db.prepare('SELECT * FROM chat_messages WHERE session_id = ? ORDER BY id ASC').all(sessionId),
+    resumeSession: async () => {},
+    saveContextMessage: () => ({ id: 0 }),
     onDelta: () => () => {},
     onComplete: () => () => {},
     onToolUse: () => () => {},
     onStatus: () => () => {},
     onError: () => () => {},
-    isSessionActive: () => false,
+    // Mark the seeded session as active so the chat route forwards messages
+    // straight to sendMessage instead of trying the resume branch.
+    isSessionActive: () => true,
     abortSession: () => {}
   };
 

--- a/tests/unit/chat-panel.test.js
+++ b/tests/unit/chat-panel.test.js
@@ -159,6 +159,12 @@ function buildElementRegistry() {
     'chat-history-btn': createMockElement('button'),
     'chat-title-text': createMockElement('span'),
     'chat-new-content-pill': createMockElement('button'),
+    'chat-tab-strip': createMockElement('div'),
+    'chat-tab-strip-items': createMockElement('div'),
+    'chat-tab-new-btn': createMockElement('button'),
+    'chat-empty-new-btn': createMockElement('button'),
+    'chat-messages-stack': createMockElement('div'),
+    'chat-status-flash': createMockElement('div'),
   };
 
   // Give the textarea a value property
@@ -199,6 +205,8 @@ global.localStorage = {
   setItem: vi.fn((key, val) => { global.localStorage._store[key] = String(val); }),
   removeItem: vi.fn((key) => { delete global.localStorage._store[key]; }),
 };
+// Production code reads `window.localStorage` for persisted tabs.
+global.window.localStorage = global.localStorage;
 
 global.wsClient = global.window.wsClient = {
   connect: vi.fn(),
@@ -296,6 +304,12 @@ function createChatPanel() {
       '.chat-panel__history-btn': reg['chat-history-btn'],
       '.chat-panel__title-text': reg['chat-title-text'],
       '.chat-panel__new-content-pill': reg['chat-new-content-pill'],
+      '.chat-panel__tab-strip': reg['chat-tab-strip'],
+      '.chat-panel__tab-strip-items': reg['chat-tab-strip-items'],
+      '.chat-panel__tab-new-btn': reg['chat-tab-new-btn'],
+      '.chat-panel__empty-new-btn': reg['chat-empty-new-btn'],
+      '#chat-messages-stack': reg['chat-messages-stack'],
+      '.chat-panel__status-flash': reg['chat-status-flash'],
     };
     return map[selector] || null;
   });
@@ -309,9 +323,76 @@ function createChatPanel() {
     return null;
   });
 
+  // The messages stack needs a querySelector that returns the per-tab empty
+  // state element used by _updateNoTabsEmptyState.
+  const noTabsEmpty = createMockElement('div');
+  reg['chat-messages-stack'].querySelector = vi.fn((sel) => {
+    if (sel === '.chat-panel__empty--no-tabs') return noTabsEmpty;
+    return null;
+  });
+  reg['chat-messages-stack']._noTabsEmpty = noTabsEmpty;
+
   // Construct the panel — triggers _render and _bindEvents
   const panel = new ChatPanel('chat-container');
+
+  // Auto-create an active tab so the legacy single-conversation tests still
+  // exercise the getter/setter delegation path. Tests that need a no-tab
+  // panel can call `clearActiveTab(panel)` to remove it.
+  attachActiveTab(panel);
   return panel;
+}
+
+/**
+ * Create a per-tab messagesEl mock that supports the same querySelector /
+ * appendChild / addEventListener surface that the original single-cached
+ * messagesEl had in this test file.
+ */
+function createMockMessagesEl() {
+  const el = createMockElement('div');
+  el.dataset = {};
+  el.style = { display: '' };
+  // Track scroll listener registrations (used by scroll listener tests)
+  el.addEventListener = vi.fn();
+  el.appendChild = vi.fn((child) => { el.children.push(child); return child; });
+  // isConnected is consulted by the race-guard checks in _loadMessageHistory
+  Object.defineProperty(el, 'isConnected', { value: true, writable: true, configurable: true });
+  // _renderInTab toggles parent.style.display via the stack so we make sure
+  // the element claims a parent.
+  el.parentNode = null;
+  return el;
+}
+
+/**
+ * Push a freshly-built tab onto the panel and make it the active one. Returns
+ * the tab descriptor. Useful for tests that want to start from a clean
+ * single-tab state or to add additional background tabs.
+ *
+ * Uses the production _createTabMessagesEl path so the scroll event listener
+ * is registered on the per-tab messagesEl — tests can then introspect that
+ * listener via chatPanel.messagesEl.addEventListener.mock.calls.
+ */
+function attachActiveTab(panel, init = {}) {
+  const tab = panel._createTab(init);
+  // Use the production helper to allocate the messagesEl so scroll listeners
+  // are wired up. The helper expects the panel's mock messagesStackEl, which
+  // we already wired up in createChatPanel.
+  panel._createTabMessagesEl(tab);
+  // Ensure isConnected is true so the race-guard checks in _loadMessageHistory
+  // do not bail.
+  Object.defineProperty(tab.messagesEl, 'isConnected', { value: true, writable: true, configurable: true });
+  panel.tabs.push(tab);
+  panel.activeTabKey = panel._tabKey(tab);
+  return tab;
+}
+
+/**
+ * Remove every tab from the panel and reset activeTabKey. Used by tests that
+ * specifically exercise the no-active-tab branch (e.g. delegation getter
+ * fallbacks, _closeTab last-tab semantics).
+ */
+function clearActiveTab(panel) {
+  panel.tabs = [];
+  panel.activeTabKey = null;
 }
 
 // ---------------------------------------------------------------------------
@@ -323,6 +404,9 @@ describe('ChatPanel', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    // Reset mockResolvedValueOnce/mockImplementation queues that leak across
+    // tests (clearAllMocks only clears CALL history, not implementations).
+    global.fetch.mockReset();
     documentListeners = {};
     windowListeners = {};
     global.localStorage._store = {};
@@ -454,7 +538,7 @@ describe('ChatPanel', () => {
 
       expect(chatPanel.inputEl.value).toContain('adopt');
       expect(chatPanel.inputEl.value).not.toContain('55');
-      expect(chatPanel._pendingActionContext).toEqual({ type: 'adopt', itemId: 55 });
+      expect(chatPanel._getActiveTab().pendingActionContext).toEqual({ type: 'adopt', itemId: 55 });
       expect(sendSpy).toHaveBeenCalled();
     });
 
@@ -489,7 +573,7 @@ describe('ChatPanel', () => {
 
       expect(chatPanel.inputEl.value).toContain('update');
       expect(chatPanel.inputEl.value).not.toContain('88');
-      expect(chatPanel._pendingActionContext).toEqual({ type: 'update', itemId: 88 });
+      expect(chatPanel._getActiveTab().pendingActionContext).toEqual({ type: 'update', itemId: 88 });
       expect(sendSpy).toHaveBeenCalled();
     });
 
@@ -524,7 +608,7 @@ describe('ChatPanel', () => {
 
       expect(chatPanel.inputEl.value).toContain('dismiss');
       expect(chatPanel.inputEl.value).not.toContain('42');
-      expect(chatPanel._pendingActionContext).toEqual({ type: 'dismiss-suggestion', itemId: 42 });
+      expect(chatPanel._getActiveTab().pendingActionContext).toEqual({ type: 'dismiss-suggestion', itemId: 42 });
       expect(sendSpy).toHaveBeenCalled();
     });
 
@@ -559,7 +643,7 @@ describe('ChatPanel', () => {
 
       expect(chatPanel.inputEl.value).toContain('dismiss');
       expect(chatPanel.inputEl.value).not.toContain('77');
-      expect(chatPanel._pendingActionContext).toEqual({ type: 'dismiss-comment', itemId: 77 });
+      expect(chatPanel._getActiveTab().pendingActionContext).toEqual({ type: 'dismiss-comment', itemId: 77 });
       expect(sendSpy).toHaveBeenCalled();
     });
 
@@ -592,7 +676,7 @@ describe('ChatPanel', () => {
 
       chatPanel._handleCreateCommentClick();
 
-      expect(chatPanel._pendingActionContext).toEqual({
+      expect(chatPanel._getActiveTab().pendingActionContext).toEqual({
         type: 'create-comment',
         file: 'src/foo.js',
         line_start: 10,
@@ -609,7 +693,7 @@ describe('ChatPanel', () => {
 
       chatPanel._handleCreateCommentClick();
 
-      expect(chatPanel._pendingActionContext).toBeNull();
+      expect(chatPanel._getActiveTab().pendingActionContext).toBeNull();
       expect(sendSpy).not.toHaveBeenCalled();
     });
   });
@@ -646,12 +730,12 @@ describe('ChatPanel', () => {
 
       chatPanel._sendCommentContextMessage(ctx);
 
-      expect(chatPanel._pendingContext).toHaveLength(1);
-      expect(chatPanel._pendingContextData).toHaveLength(1);
-      expect(chatPanel._pendingContext[0]).toContain('review comment');
-      expect(chatPanel._pendingContext[0]).toContain('src/app.js');
-      expect(chatPanel._pendingContext[0]).toContain('line 42');
-      expect(chatPanel._pendingContext[0]).toContain('Fix the typo here');
+      expect(chatPanel._getActiveTab().pendingContext).toHaveLength(1);
+      expect(chatPanel._getActiveTab().pendingContextData).toHaveLength(1);
+      expect(chatPanel._getActiveTab().pendingContext[0]).toContain('review comment');
+      expect(chatPanel._getActiveTab().pendingContext[0]).toContain('src/app.js');
+      expect(chatPanel._getActiveTab().pendingContext[0]).toContain('line 42');
+      expect(chatPanel._getActiveTab().pendingContext[0]).toContain('Fix the typo here');
     });
 
     it('should store context data for a file-level comment', () => {
@@ -667,8 +751,8 @@ describe('ChatPanel', () => {
 
       chatPanel._sendCommentContextMessage(ctx);
 
-      expect(chatPanel._pendingContext).toHaveLength(1);
-      expect(chatPanel._pendingContext[0]).toContain('File-level comment');
+      expect(chatPanel._getActiveTab().pendingContext).toHaveLength(1);
+      expect(chatPanel._getActiveTab().pendingContext[0]).toContain('File-level comment');
     });
 
     it('should store structured contextData with type "comment"', () => {
@@ -684,7 +768,7 @@ describe('ChatPanel', () => {
 
       chatPanel._sendCommentContextMessage(ctx);
 
-      const data = chatPanel._pendingContextData[0];
+      const data = chatPanel._getActiveTab().pendingContextData[0];
       expect(data.type).toBe('comment');
       expect(data.file).toBe('index.js');
       expect(data.line_start).toBe(10);
@@ -743,9 +827,9 @@ describe('ChatPanel', () => {
 
       chatPanel._sendCommentContextMessage(ctx);
 
-      expect(chatPanel._pendingContextData[0].file).toBeNull();
+      expect(chatPanel._getActiveTab().pendingContextData[0].file).toBeNull();
       // Should not contain "File:" line
-      expect(chatPanel._pendingContext[0]).not.toContain('File:');
+      expect(chatPanel._getActiveTab().pendingContext[0]).not.toContain('File:');
     });
 
     it('should show line range when line_end differs from line_start', () => {
@@ -761,7 +845,7 @@ describe('ChatPanel', () => {
 
       chatPanel._sendCommentContextMessage(ctx);
 
-      expect(chatPanel._pendingContext[0]).toContain('line 10-20');
+      expect(chatPanel._getActiveTab().pendingContext[0]).toContain('line 10-20');
     });
   });
 
@@ -855,7 +939,7 @@ describe('ChatPanel', () => {
     });
 
     it('should be removable when option set', () => {
-      chatPanel._pendingContextData = [{ type: 'file' }]; // pre-push data so _makeCardRemovable has an index
+      chatPanel._getActiveTab().pendingContextData = [{ type: 'file' }]; // pre-push data so _makeCardRemovable has an index
       const ctx = { file: 'src/app.js', type: 'file' };
       chatPanel._addFileContextCard(ctx, { removable: true });
 
@@ -873,7 +957,7 @@ describe('ChatPanel', () => {
   // -----------------------------------------------------------------------
   describe('_makeCardRemovable', () => {
     it('should set data-context-index from pending array length', () => {
-      chatPanel._pendingContextData = [{ id: 0 }, { id: 1 }];
+      chatPanel._getActiveTab().pendingContextData = [{ id: 0 }, { id: 1 }];
       const card = createMockElement('div');
       chatPanel._makeCardRemovable(card);
 
@@ -882,7 +966,7 @@ describe('ChatPanel', () => {
     });
 
     it('should create remove button with correct class and title', () => {
-      chatPanel._pendingContextData = [{ id: 0 }];
+      chatPanel._getActiveTab().pendingContextData = [{ id: 0 }];
       const card = createMockElement('div');
       chatPanel._makeCardRemovable(card);
 
@@ -892,7 +976,7 @@ describe('ChatPanel', () => {
     });
 
     it('should call _removeContextCard on click', () => {
-      chatPanel._pendingContextData = [{ id: 0 }];
+      chatPanel._getActiveTab().pendingContextData = [{ id: 0 }];
       const card = createMockElement('div');
       const removeCardSpy = vi.spyOn(chatPanel, '_removeContextCard').mockImplementation(() => {});
       chatPanel._makeCardRemovable(card);
@@ -937,13 +1021,13 @@ describe('ChatPanel', () => {
     });
 
     it('should clear pending context arrays', () => {
-      chatPanel._pendingContext = ['some context'];
-      chatPanel._pendingContextData = [{ type: 'comment' }];
+      chatPanel._getActiveTab().pendingContext = ['some context'];
+      chatPanel._getActiveTab().pendingContextData = [{ type: 'comment' }];
 
       chatPanel.close();
 
-      expect(chatPanel._pendingContext).toEqual([]);
-      expect(chatPanel._pendingContextData).toEqual([]);
+      expect(chatPanel._getActiveTab().pendingContext).toEqual([]);
+      expect(chatPanel._getActiveTab().pendingContextData).toEqual([]);
     });
 
     it('should clear context source and item ID', () => {
@@ -1011,19 +1095,19 @@ describe('ChatPanel', () => {
   // -----------------------------------------------------------------------
   describe('queueUserActionHint', () => {
     it('should initialize _pendingUserActionHints as empty array', () => {
-      expect(chatPanel._pendingUserActionHints).toEqual([]);
+      expect(chatPanel._getActiveTab().pendingUserActionHints).toEqual([]);
     });
 
     it('should push a hint onto the array', () => {
       chatPanel.queueUserActionHint('[User Action: adopted suggestion 42]');
-      expect(chatPanel._pendingUserActionHints).toEqual(['[User Action: adopted suggestion 42]']);
+      expect(chatPanel._getActiveTab().pendingUserActionHints).toEqual(['[User Action: adopted suggestion 42]']);
     });
 
     it('should accumulate multiple hints in order', () => {
       chatPanel.queueUserActionHint('[User Action: adopted suggestion 1]');
       chatPanel.queueUserActionHint('[User Action: dismissed suggestion 2]');
       chatPanel.queueUserActionHint('[User Action: created comment 3]');
-      expect(chatPanel._pendingUserActionHints).toEqual([
+      expect(chatPanel._getActiveTab().pendingUserActionHints).toEqual([
         '[User Action: adopted suggestion 1]',
         '[User Action: dismissed suggestion 2]',
         '[User Action: created comment 3]',
@@ -1031,15 +1115,32 @@ describe('ChatPanel', () => {
     });
 
     it('should survive close() — not cleared when panel is closed', () => {
-      chatPanel._pendingUserActionHints = ['[User Action: adopted suggestion 5]'];
+      chatPanel._getActiveTab().pendingUserActionHints = ['[User Action: adopted suggestion 5]'];
       chatPanel.close();
-      expect(chatPanel._pendingUserActionHints).toEqual(['[User Action: adopted suggestion 5]']);
+      expect(chatPanel._getActiveTab().pendingUserActionHints).toEqual(['[User Action: adopted suggestion 5]']);
     });
 
-    it('should be cleared on _startNewConversation()', async () => {
-      chatPanel._pendingUserActionHints = ['[User Action: adopted suggestion 5]'];
+    it('stays on the original tab when _startNewConversation opens a new tab', async () => {
+      // In the multi-tab impl, _startNewConversation calls _openNewTab which
+      // creates a tab and POSTs to /api/chat/session. The previously active
+      // tab's hints belong to that tab and must not bleed onto the new one.
+      chatPanel.reviewId = 1;
+      const original = chatPanel._getActiveTab();
+      original.pendingUserActionHints = ['[User Action: adopted suggestion 5]'];
+
+      global.fetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ data: { id: 999, status: 'active' } }),
+      });
+
       await chatPanel._startNewConversation();
-      expect(chatPanel._pendingUserActionHints).toEqual([]);
+
+      expect(chatPanel.tabs.length).toBeGreaterThanOrEqual(2);
+      // The original tab still owns its hints.
+      expect(chatPanel.tabs[0].pendingUserActionHints).toEqual(['[User Action: adopted suggestion 5]']);
+      // The freshly opened tab has none.
+      const newTab = chatPanel.tabs[chatPanel.tabs.length - 1];
+      expect(newTab.pendingUserActionHints).toEqual([]);
     });
   });
 
@@ -1069,7 +1170,7 @@ describe('ChatPanel', () => {
       expect(body.context).toContain('[User Action: adopted suggestion 42]');
 
       // Queue should be drained
-      expect(chatPanel._pendingUserActionHints).toEqual([]);
+      expect(chatPanel._getActiveTab().pendingUserActionHints).toEqual([]);
     });
 
     it('should combine user action hints with diff state notifications', async () => {
@@ -1106,7 +1207,7 @@ describe('ChatPanel', () => {
       await chatPanel.sendMessage();
 
       // Hints should be restored after the error
-      expect(chatPanel._pendingUserActionHints).toEqual([
+      expect(chatPanel._getActiveTab().pendingUserActionHints).toEqual([
         '[User Action: adopted suggestion 10]',
       ]);
     });
@@ -1114,225 +1215,45 @@ describe('ChatPanel', () => {
 
   // -----------------------------------------------------------------------
   // _startNewConversation()
+  //
+  // In the multi-tab refactor, "new conversation" no longer resets the active
+  // tab. It simply opens a new tab via _openNewTab. These tests verify that
+  // contract: the helper delegates to _openNewTab and closes any open
+  // dropdowns, but leaves the previously-active tab's state intact.
   // -----------------------------------------------------------------------
   describe('_startNewConversation()', () => {
-    it('should call _finalizeStreaming', async () => {
-      const finalizeSpy = vi.spyOn(chatPanel, '_finalizeStreaming');
+    it('should delegate to _openNewTab', async () => {
+      const spy = vi.spyOn(chatPanel, '_openNewTab').mockResolvedValue(undefined);
 
       await chatPanel._startNewConversation();
 
-      expect(finalizeSpy).toHaveBeenCalled();
+      expect(spy).toHaveBeenCalled();
     });
 
-    it('should reset currentSessionId', async () => {
-      chatPanel.currentSessionId = 'session-123';
+    it('should hide provider and session dropdowns', async () => {
+      vi.spyOn(chatPanel, '_openNewTab').mockResolvedValue(undefined);
+      const providerSpy = vi.spyOn(chatPanel, '_hideProviderDropdown');
+      const sessionSpy = vi.spyOn(chatPanel, '_hideSessionDropdown');
 
       await chatPanel._startNewConversation();
 
-      expect(chatPanel.currentSessionId).toBeNull();
+      expect(providerSpy).toHaveBeenCalled();
+      expect(sessionSpy).toHaveBeenCalled();
     });
 
-    it('should clear messages array', async () => {
-      chatPanel.messages = [{ role: 'user', content: 'hi' }];
+    it('should not mutate the previously active tab', async () => {
+      // Stub the new-tab path so we don't actually create a real session.
+      vi.spyOn(chatPanel, '_openNewTab').mockResolvedValue(undefined);
+      const tab = chatPanel._getActiveTab();
+      tab.sessionId = 'sess-existing';
+      tab.messages = [{ role: 'user', content: 'hi' }];
+      tab.streamingContent = 'partial';
 
       await chatPanel._startNewConversation();
 
-      expect(chatPanel.messages).toEqual([]);
-    });
-
-    it('should reset streaming content', async () => {
-      chatPanel._streamingContent = 'partial stuff';
-
-      await chatPanel._startNewConversation();
-
-      expect(chatPanel._streamingContent).toBe('');
-    });
-
-    it('should preserve pending context across new conversation', async () => {
-      chatPanel._pendingContext = ['ctx'];
-      chatPanel._pendingContextData = [{ type: 'suggestion', title: 'Test', file: 'a.js' }];
-
-      await chatPanel._startNewConversation();
-
-      expect(chatPanel._pendingContext).toEqual(['ctx']);
-      expect(chatPanel._pendingContextData).toEqual([{ type: 'suggestion', title: 'Test', file: 'a.js' }]);
-    });
-
-    it('should clear pending context arrays when they are empty', async () => {
-      chatPanel._pendingContext = [];
-      chatPanel._pendingContextData = [];
-
-      await chatPanel._startNewConversation();
-
-      expect(chatPanel._pendingContext).toEqual([]);
-      expect(chatPanel._pendingContextData).toEqual([]);
-    });
-
-    it('should preserve context source and item ID when pending context exists', async () => {
-      chatPanel._contextSource = 'user';
-      chatPanel._contextItemId = 77;
-      chatPanel._pendingContext = ['ctx'];
-      chatPanel._pendingContextData = [{ type: 'comment', source: 'user', body: 'Test' }];
-
-      await chatPanel._startNewConversation();
-
-      expect(chatPanel._contextSource).toBe('user');
-      expect(chatPanel._contextItemId).toBe(77);
-    });
-
-    it('should reset context source and item ID when no pending context', async () => {
-      chatPanel._contextSource = 'user';
-      chatPanel._contextItemId = 77;
-      chatPanel._pendingContext = [];
-      chatPanel._pendingContextData = [];
-
-      await chatPanel._startNewConversation();
-
-      expect(chatPanel._contextSource).toBeNull();
-      expect(chatPanel._contextItemId).toBeNull();
-    });
-
-    it('should reset _sessionAnalysisRunId', async () => {
-      chatPanel._sessionAnalysisRunId = 'run-456';
-
-      await chatPanel._startNewConversation();
-
-      expect(chatPanel._sessionAnalysisRunId).toBeNull();
-    });
-
-    it('should call _updateActionButtons after reset', async () => {
-      const updateSpy = vi.spyOn(chatPanel, '_updateActionButtons');
-
-      await chatPanel._startNewConversation();
-
-      expect(updateSpy).toHaveBeenCalled();
-    });
-
-    it('should call _clearMessages to restore empty state', async () => {
-      const clearSpy = vi.spyOn(chatPanel, '_clearMessages');
-
-      await chatPanel._startNewConversation();
-
-      expect(clearSpy).toHaveBeenCalled();
-    });
-
-    it('should call _ensureAnalysisContext to re-add analysis card', async () => {
-      const ensureSpy = vi.spyOn(chatPanel, '_ensureAnalysisContext');
-
-      await chatPanel._startNewConversation();
-
-      expect(ensureSpy).toHaveBeenCalled();
-    });
-
-    it('should re-add suggestion context cards as removable', async () => {
-      chatPanel._pendingContext = ['The user wants to discuss this specific suggestion:\n- Type: bug\n- Title: Fix null'];
-      chatPanel._pendingContextData = [{ type: 'bug', title: 'Fix null', file: 'app.js', line_start: 10, line_end: 10, body: 'Check for null' }];
-      chatPanel._contextSource = 'suggestion';
-      chatPanel._contextItemId = 42;
-
-      const addCardSpy = vi.spyOn(chatPanel, '_addContextCard');
-
-      await chatPanel._startNewConversation();
-
-      expect(addCardSpy).toHaveBeenCalledWith(
-        { type: 'bug', title: 'Fix null', file: 'app.js', line_start: 10, line_end: 10, body: 'Check for null' },
-        { removable: true }
-      );
-      expect(chatPanel._pendingContext).toHaveLength(1);
-      expect(chatPanel._pendingContextData).toHaveLength(1);
-      expect(chatPanel._contextSource).toBe('suggestion');
-      expect(chatPanel._contextItemId).toBe(42);
-    });
-
-    it('should re-add comment context cards as removable', async () => {
-      chatPanel._pendingContext = ['The user wants to discuss their own review comment:\n- File: b.js (line 5)'];
-      chatPanel._pendingContextData = [{ type: 'comment', source: 'user', title: 'Comment on line 5', file: 'b.js', line_start: 5, line_end: 5, body: 'Needs refactor' }];
-      chatPanel._contextSource = 'user';
-      chatPanel._contextItemId = 99;
-
-      const addCommentCardSpy = vi.spyOn(chatPanel, '_addCommentContextCard');
-
-      await chatPanel._startNewConversation();
-
-      expect(addCommentCardSpy).toHaveBeenCalledWith(
-        { type: 'comment', source: 'user', title: 'Comment on line 5', file: 'b.js', line_start: 5, line_end: 5, body: 'Needs refactor' },
-        { removable: true }
-      );
-      expect(chatPanel._contextSource).toBe('user');
-      expect(chatPanel._contextItemId).toBe(99);
-    });
-
-    it('should re-add file context cards as removable', async () => {
-      chatPanel._pendingContext = ['The user wants to discuss src/utils.js'];
-      chatPanel._pendingContextData = [{ type: 'file', title: 'src/utils.js', file: 'src/utils.js', line_start: null, line_end: null, body: null }];
-
-      const addFileCardSpy = vi.spyOn(chatPanel, '_addFileContextCard');
-
-      await chatPanel._startNewConversation();
-
-      expect(addFileCardSpy).toHaveBeenCalledWith(
-        { type: 'file', title: 'src/utils.js', file: 'src/utils.js', line_start: null, line_end: null, body: null },
-        { removable: true }
-      );
-    });
-
-    it('should re-add multiple context cards in order', async () => {
-      chatPanel._pendingContext = ['ctx1', 'ctx2'];
-      chatPanel._pendingContextData = [
-        { type: 'bug', title: 'Bug 1', file: 'a.js' },
-        { type: 'file', title: 'b.js', file: 'b.js', line_start: null, line_end: null, body: null }
-      ];
-
-      const addCardSpy = vi.spyOn(chatPanel, '_addContextCard');
-      const addFileCardSpy = vi.spyOn(chatPanel, '_addFileContextCard');
-
-      await chatPanel._startNewConversation();
-
-      expect(addCardSpy).toHaveBeenCalledTimes(1);
-      expect(addFileCardSpy).toHaveBeenCalledTimes(1);
-      expect(chatPanel._pendingContext).toHaveLength(2);
-      expect(chatPanel._pendingContextData).toHaveLength(2);
-    });
-
-    it('should not re-add cards when pending arrays were empty', async () => {
-      chatPanel._pendingContext = [];
-      chatPanel._pendingContextData = [];
-
-      const addCardSpy = vi.spyOn(chatPanel, '_addContextCard');
-      const addCommentCardSpy = vi.spyOn(chatPanel, '_addCommentContextCard');
-      const addFileCardSpy = vi.spyOn(chatPanel, '_addFileContextCard');
-
-      await chatPanel._startNewConversation();
-
-      expect(addCardSpy).not.toHaveBeenCalled();
-      expect(addCommentCardSpy).not.toHaveBeenCalled();
-      expect(addFileCardSpy).not.toHaveBeenCalled();
-    });
-
-    it('should remove empty state when re-adding saved context cards', async () => {
-      chatPanel._pendingContext = ['ctx'];
-      chatPanel._pendingContextData = [{ type: 'bug', title: 'Test' }];
-
-      const emptyEl = createMockElement('div');
-      chatPanel.messagesEl.querySelector = vi.fn((sel) => {
-        if (sel === '.chat-panel__empty') return emptyEl;
-        if (sel === '.chat-panel__context-card[data-analysis]') return null;
-        return null;
-      });
-
-      await chatPanel._startNewConversation();
-
-      expect(emptyEl.remove).toHaveBeenCalled();
-    });
-
-    it('should reset _analysisContextRemoved so analysis card reappears', async () => {
-      chatPanel._analysisContextRemoved = true;
-      chatPanel._pendingContext = [];
-      chatPanel._pendingContextData = [];
-
-      await chatPanel._startNewConversation();
-
-      expect(chatPanel._analysisContextRemoved).toBe(false);
+      expect(tab.sessionId).toBe('sess-existing');
+      expect(tab.messages).toEqual([{ role: 'user', content: 'hi' }]);
+      expect(tab.streamingContent).toBe('partial');
     });
   });
 
@@ -1501,33 +1422,40 @@ describe('ChatPanel', () => {
 
   // -----------------------------------------------------------------------
   // Background WS accumulation (isOpen === false)
+  //
+  // The single-tab _handleChatMessage was replaced by per-tab
+  // _handleChatMessageForTab(tab, data) in the multi-tab refactor. These
+  // tests now drive that helper directly with the active tab.
   // -----------------------------------------------------------------------
   describe('Background WS accumulation', () => {
+    let tab;
+
     beforeEach(() => {
       chatPanel.currentSessionId = 'sess-1';
+      tab = chatPanel._getActiveTab();
       chatPanel.isOpen = false;
-      chatPanel.isStreaming = true;
-      chatPanel._streamingContent = '';
+      tab.isStreaming = true;
+      tab.streamingContent = '';
     });
 
     function emitEvent(data) {
-      chatPanel._handleChatMessage(data);
+      chatPanel._handleChatMessageForTab(tab, data);
     }
 
     it('should accumulate delta events into _streamingContent when panel is closed', () => {
       emitEvent({ type: 'delta', text: 'Hello ', sessionId: 'sess-1' });
       emitEvent({ type: 'delta', text: 'World', sessionId: 'sess-1' });
 
-      expect(chatPanel._streamingContent).toBe('Hello World');
+      expect(tab.streamingContent).toBe('Hello World');
     });
 
     it('should push completed message to messages array on "complete" event', () => {
-      chatPanel._streamingContent = 'Full response';
+      tab.streamingContent = 'Full response';
 
       emitEvent({ type: 'complete', messageId: 101, sessionId: 'sess-1' });
 
-      expect(chatPanel.messages).toHaveLength(1);
-      expect(chatPanel.messages[0]).toEqual({
+      expect(tab.messages).toHaveLength(1);
+      expect(tab.messages[0]).toEqual({
         role: 'assistant',
         content: 'Full response',
         id: 101,
@@ -1535,32 +1463,32 @@ describe('ChatPanel', () => {
     });
 
     it('should clear streaming state on "complete" event', () => {
-      chatPanel._streamingContent = 'Some text';
-      chatPanel.isStreaming = true;
+      tab.streamingContent = 'Some text';
+      tab.isStreaming = true;
 
       emitEvent({ type: 'complete', messageId: 102, sessionId: 'sess-1' });
 
-      expect(chatPanel._streamingContent).toBe('');
-      expect(chatPanel.isStreaming).toBe(false);
+      expect(tab.streamingContent).toBe('');
+      expect(tab.isStreaming).toBe(false);
     });
 
     it('should not push empty content to messages on "complete"', () => {
-      chatPanel._streamingContent = '';
+      tab.streamingContent = '';
 
       emitEvent({ type: 'complete', messageId: 103, sessionId: 'sess-1' });
 
-      expect(chatPanel.messages).toHaveLength(0);
-      expect(chatPanel.isStreaming).toBe(false);
+      expect(tab.messages).toHaveLength(0);
+      expect(tab.isStreaming).toBe(false);
     });
 
     it('should clear streaming state on "error" event', () => {
-      chatPanel._streamingContent = 'partial';
-      chatPanel.isStreaming = true;
+      tab.streamingContent = 'partial';
+      tab.isStreaming = true;
 
       emitEvent({ type: 'error', message: 'Something broke', sessionId: 'sess-1' });
 
-      expect(chatPanel._streamingContent).toBe('');
-      expect(chatPanel.isStreaming).toBe(false);
+      expect(tab.streamingContent).toBe('');
+      expect(tab.isStreaming).toBe(false);
     });
 
     it('should warn and ignore events for mismatched sessions', () => {
@@ -1568,9 +1496,9 @@ describe('ChatPanel', () => {
 
       emitEvent({ type: 'delta', text: 'foreign', sessionId: 'other-session' });
 
-      expect(chatPanel._streamingContent).toBe('');
+      expect(tab.streamingContent).toBe('');
       expect(warnSpy).toHaveBeenCalledWith(
-        expect.stringContaining('Unexpected sessionId mismatch')
+        expect.stringContaining('sessionId mismatch')
       );
 
       warnSpy.mockRestore();
@@ -1581,8 +1509,8 @@ describe('ChatPanel', () => {
       emitEvent({ type: 'tool_use', toolName: 'Read', status: 'start', sessionId: 'sess-1' });
       emitEvent({ type: 'status', status: 'working', sessionId: 'sess-1' });
 
-      // No error and no side effects beyond what switch/default handles (nothing)
-      expect(chatPanel._streamingContent).toBe('');
+      // tool_use was not a delta, so streamingContent should remain empty.
+      expect(tab.streamingContent).toBe('');
     });
   });
 
@@ -1608,23 +1536,24 @@ describe('ChatPanel', () => {
       expect(chatPanel._reviewUnsub).not.toBeNull();
     });
 
-    it('should subscribe to chat topic when currentSessionId is set', () => {
+    it('should subscribe to chat topic for any open tab missing a wsUnsub', () => {
       window.wsClient.subscribe.mockClear();
-      chatPanel.currentSessionId = 'sess-99';
-      chatPanel._chatUnsub = null;
+      const tab = chatPanel._getActiveTab();
+      tab.sessionId = 'sess-99';
+      tab.wsUnsub = null;
 
       chatPanel._ensureSubscriptions();
 
       expect(window.wsClient.subscribe).toHaveBeenCalledWith('chat:sess-99', expect.any(Function));
-      expect(chatPanel._chatUnsub).not.toBeNull();
+      expect(tab.wsUnsub).not.toBeNull();
     });
 
-    it('should not re-subscribe if already subscribed', () => {
+    it('should not re-subscribe a tab that already has wsUnsub', () => {
       window.wsClient.subscribe.mockClear();
-      const existingUnsub = vi.fn();
-      chatPanel._chatUnsub = existingUnsub;
+      const tab = chatPanel._getActiveTab();
+      tab.sessionId = 'sess-99';
+      tab.wsUnsub = vi.fn();
       chatPanel._reviewUnsub = vi.fn();
-      chatPanel.currentSessionId = 'sess-99';
       chatPanel.reviewId = 'review-42';
 
       chatPanel._ensureSubscriptions();
@@ -1653,17 +1582,18 @@ describe('ChatPanel', () => {
   });
 
   describe('_closeSubscriptions', () => {
-    it('should call chat and review unsubscribe functions', () => {
-      const chatUnsub = vi.fn();
+    it('should call review unsubscribe and each tab unsubscribe', () => {
+      const tabUnsub = vi.fn();
       const reviewUnsub = vi.fn();
-      chatPanel._chatUnsub = chatUnsub;
+      const tab = chatPanel._getActiveTab();
+      tab.wsUnsub = tabUnsub;
       chatPanel._reviewUnsub = reviewUnsub;
 
       chatPanel._closeSubscriptions();
 
-      expect(chatUnsub).toHaveBeenCalled();
+      expect(tabUnsub).toHaveBeenCalled();
       expect(reviewUnsub).toHaveBeenCalled();
-      expect(chatPanel._chatUnsub).toBeNull();
+      expect(tab.wsUnsub).toBeNull();
       expect(chatPanel._reviewUnsub).toBeNull();
     });
 
@@ -1678,7 +1608,8 @@ describe('ChatPanel', () => {
     });
 
     it('should be safe to call when no subscriptions exist', () => {
-      chatPanel._chatUnsub = null;
+      const tab = chatPanel._getActiveTab();
+      tab.wsUnsub = null;
       chatPanel._reviewUnsub = null;
       chatPanel._onReconnect = null;
 
@@ -1708,13 +1639,12 @@ describe('ChatPanel', () => {
       expect(global.fetch).not.toHaveBeenCalled();
     });
 
-    it('should fetch messages and finalize streaming when panel is closed', async () => {
-      chatPanel.isStreaming = true;
+    it('should fetch messages and clear streaming state per tab when panel is closed', async () => {
       chatPanel.isOpen = false;
       chatPanel.currentSessionId = 'sess-1';
-      chatPanel._streamingContent = 'partial respo';
-
-      const finalizeSpy = vi.spyOn(chatPanel, '_finalizeStreaming');
+      const tab = chatPanel._getActiveTab();
+      tab.isStreaming = true;
+      tab.streamingContent = 'partial respo';
 
       global.fetch.mockResolvedValueOnce({
         ok: true,
@@ -1730,20 +1660,19 @@ describe('ChatPanel', () => {
 
       await chatPanel._recoverAfterReconnect();
 
-      // Stream is finalized (isStreaming reset, content cleared)
-      expect(finalizeSpy).toHaveBeenCalled();
-      expect(chatPanel.isStreaming).toBe(false);
-      // Message pushed to history
-      expect(chatPanel.messages).toContainEqual({ role: 'assistant', content: 'Full response text here', id: 2 });
+      // Per-tab recovery: stream cleared on the tab directly (no _finalizeStreaming
+      // for background paths in the multi-tab impl).
+      expect(tab.isStreaming).toBe(false);
+      expect(tab.streamingContent).toBe('');
+      expect(tab.messages).toContainEqual({ role: 'assistant', content: 'Full response text here', id: 2 });
     });
 
-    it('should call finalizeStreamingMessage when panel is open', async () => {
+    it('should finalize the streamed message when panel is open', async () => {
       chatPanel.isStreaming = true;
       chatPanel.isOpen = true;
       chatPanel.currentSessionId = 'sess-1';
-      chatPanel._streamingContent = 'partial';
-
-      const finalizeMsgSpy = vi.spyOn(chatPanel, 'finalizeStreamingMessage');
+      const tab = chatPanel._getActiveTab();
+      tab.streamingContent = 'partial';
 
       global.fetch.mockResolvedValueOnce({
         ok: true,
@@ -1758,19 +1687,19 @@ describe('ChatPanel', () => {
 
       await chatPanel._recoverAfterReconnect();
 
-      // finalizeStreamingMessage clears _streamingContent via _finalizeStreaming
-      expect(finalizeMsgSpy).toHaveBeenCalledWith(5);
-      expect(chatPanel.isStreaming).toBe(false);
+      expect(tab.isStreaming).toBe(false);
+      expect(tab.messages).toContainEqual({ role: 'assistant', content: 'Recovered content', id: 5 });
+      expect(tab.streamingContent).toBe('');
     });
 
-    it('should call _finalizeStreaming (not finalizeStreamingMessage) when panel is closed', async () => {
-      chatPanel.isStreaming = true;
+    it('should not call finalizeStreamingMessage when panel is closed (background tab path)', async () => {
       chatPanel.isOpen = false;
       chatPanel.currentSessionId = 'sess-1';
-      chatPanel._streamingContent = 'partial';
+      const tab = chatPanel._getActiveTab();
+      tab.isStreaming = true;
+      tab.streamingContent = 'partial';
 
       const finalizeMsgSpy = vi.spyOn(chatPanel, 'finalizeStreamingMessage');
-      const finalizeSpy = vi.spyOn(chatPanel, '_finalizeStreaming');
 
       global.fetch.mockResolvedValueOnce({
         ok: true,
@@ -1786,9 +1715,8 @@ describe('ChatPanel', () => {
       await chatPanel._recoverAfterReconnect();
 
       expect(finalizeMsgSpy).not.toHaveBeenCalled();
-      expect(finalizeSpy).toHaveBeenCalled();
-      expect(chatPanel.isStreaming).toBe(false);
-      expect(chatPanel.messages).toContainEqual({ role: 'assistant', content: 'Recovered', id: 5 });
+      expect(tab.isStreaming).toBe(false);
+      expect(tab.messages).toContainEqual({ role: 'assistant', content: 'Recovered', id: 5 });
     });
 
     it('should handle empty message history gracefully', async () => {
@@ -1858,7 +1786,7 @@ describe('ChatPanel', () => {
 
       // Finalized — message pushed to history with correct content and id
       expect(chatPanel.isStreaming).toBe(false);
-      expect(chatPanel.messages).toContainEqual({ role: 'assistant', content: 'Latest answer', id: 4 });
+      expect(chatPanel._getActiveTab().messages).toContainEqual({ role: 'assistant', content: 'Latest answer', id: 4 });
     });
 
     it('should skip context messages when looking for last assistant message', async () => {
@@ -1883,7 +1811,7 @@ describe('ChatPanel', () => {
 
       // Finalized — message pushed to history
       expect(chatPanel.isStreaming).toBe(false);
-      expect(chatPanel.messages).toContainEqual({ role: 'assistant', content: 'Answer', id: 2 });
+      expect(chatPanel._getActiveTab().messages).toContainEqual({ role: 'assistant', content: 'Answer', id: 2 });
     });
 
     it('should not replace content when no assistant messages exist', async () => {
@@ -1947,14 +1875,14 @@ describe('ChatPanel', () => {
     it('should push to messages array', () => {
       chatPanel.addMessage('user', 'Hello');
 
-      expect(chatPanel.messages).toHaveLength(1);
-      expect(chatPanel.messages[0]).toEqual({ role: 'user', content: 'Hello', id: undefined });
+      expect(chatPanel._getActiveTab().messages).toHaveLength(1);
+      expect(chatPanel._getActiveTab().messages[0]).toEqual({ role: 'user', content: 'Hello', id: undefined });
     });
 
     it('should push assistant messages with id', () => {
       chatPanel.addMessage('assistant', 'Hi there', 42);
 
-      expect(chatPanel.messages[0]).toEqual({ role: 'assistant', content: 'Hi there', id: 42 });
+      expect(chatPanel._getActiveTab().messages[0]).toEqual({ role: 'assistant', content: 'Hi there', id: 42 });
     });
 
     it('should append a DOM element to messagesEl', () => {
@@ -2004,10 +1932,11 @@ describe('ChatPanel', () => {
       expect(spy).toHaveBeenCalled();
     });
 
-    it('should clear messages array', () => {
-      chatPanel.messages = [{ role: 'user', content: 'hi' }];
+    it('should clear all tabs on destroy', () => {
+      chatPanel._getActiveTab().messages = [{ role: 'user', content: 'hi' }];
       chatPanel.destroy();
-      expect(chatPanel.messages).toEqual([]);
+      expect(chatPanel.tabs).toEqual([]);
+      expect(chatPanel.activeTabKey).toBeNull();
     });
 
     it('should remove keydown listener from document', () => {
@@ -2350,7 +2279,7 @@ describe('ChatPanel', () => {
   // -----------------------------------------------------------------------
   describe('Removable context cards', () => {
     it('should add close button when removable is true', () => {
-      chatPanel._pendingContextData = [{ type: 'bug' }]; // simulate data already pushed
+      chatPanel._getActiveTab().pendingContextData = [{ type: 'bug' }]; // simulate data already pushed
       chatPanel._addContextCard({ title: 'Test', type: 'bug' }, { removable: true });
 
       const card = chatPanel.messagesEl.appendChild.mock.calls[0][0];
@@ -2371,7 +2300,7 @@ describe('ChatPanel', () => {
     });
 
     it('should add close button to comment context card when removable', () => {
-      chatPanel._pendingContextData = [{ type: 'comment' }];
+      chatPanel._getActiveTab().pendingContextData = [{ type: 'comment' }];
       chatPanel._addCommentContextCard(
         { commentId: '1', body: 'Test', file: 'a.js', line_start: 1, isFileLevel: false },
         { removable: true }
@@ -2409,8 +2338,8 @@ describe('ChatPanel', () => {
 
     it('should restore removability on cards after sendMessage failure', async () => {
       // Setup: add some pending context
-      chatPanel._pendingContext = ['ctx'];
-      chatPanel._pendingContextData = [{ type: 'bug' }];
+      chatPanel._getActiveTab().pendingContext = ['ctx'];
+      chatPanel._getActiveTab().pendingContextData = [{ type: 'bug' }];
       chatPanel.currentSessionId = 'sess-1';
       chatPanel.isStreaming = false;
       chatPanel.inputEl.value = 'hello';
@@ -2462,19 +2391,19 @@ describe('ChatPanel', () => {
 
       chatPanel._sendContextMessage(ctx);
 
-      expect(chatPanel._pendingContext).toHaveLength(1);
-      expect(chatPanel._pendingContext[0]).toContain('Null check');
-      expect(chatPanel._pendingContext[0]).toContain('bug');
-      expect(chatPanel._pendingContext[0]).toContain('src/app.js');
-      expect(chatPanel._pendingContext[0]).toContain('line 42');
-      expect(chatPanel._pendingContext[0]).toContain('Check for null');
+      expect(chatPanel._getActiveTab().pendingContext).toHaveLength(1);
+      expect(chatPanel._getActiveTab().pendingContext[0]).toContain('Null check');
+      expect(chatPanel._getActiveTab().pendingContext[0]).toContain('bug');
+      expect(chatPanel._getActiveTab().pendingContext[0]).toContain('src/app.js');
+      expect(chatPanel._getActiveTab().pendingContext[0]).toContain('line 42');
+      expect(chatPanel._getActiveTab().pendingContext[0]).toContain('Check for null');
 
-      expect(chatPanel._pendingContextData).toHaveLength(1);
-      expect(chatPanel._pendingContextData[0].type).toBe('bug');
-      expect(chatPanel._pendingContextData[0].title).toBe('Null check');
-      expect(chatPanel._pendingContextData[0].file).toBe('src/app.js');
-      expect(chatPanel._pendingContextData[0].line_start).toBe(42);
-      expect(chatPanel._pendingContextData[0].body).toBe('Check for null');
+      expect(chatPanel._getActiveTab().pendingContextData).toHaveLength(1);
+      expect(chatPanel._getActiveTab().pendingContextData[0].type).toBe('bug');
+      expect(chatPanel._getActiveTab().pendingContextData[0].title).toBe('Null check');
+      expect(chatPanel._getActiveTab().pendingContextData[0].file).toBe('src/app.js');
+      expect(chatPanel._getActiveTab().pendingContextData[0].line_start).toBe(42);
+      expect(chatPanel._getActiveTab().pendingContextData[0].body).toBe('Check for null');
     });
 
     it('should create a context card and append to messages', () => {
@@ -2492,9 +2421,9 @@ describe('ChatPanel', () => {
 
       chatPanel._sendContextMessage(ctx);
 
-      expect(chatPanel._pendingContext).toHaveLength(1);
-      expect(chatPanel._pendingContext[0]).not.toContain('File:');
-      expect(chatPanel._pendingContextData[0].file).toBeNull();
+      expect(chatPanel._getActiveTab().pendingContext).toHaveLength(1);
+      expect(chatPanel._getActiveTab().pendingContext[0]).not.toContain('File:');
+      expect(chatPanel._getActiveTab().pendingContextData[0].file).toBeNull();
     });
 
     it('should handle context with empty title and type', () => {
@@ -2502,8 +2431,8 @@ describe('ChatPanel', () => {
 
       chatPanel._sendContextMessage(ctx);
 
-      expect(chatPanel._pendingContextData[0].type).toBe('general');
-      expect(chatPanel._pendingContextData[0].title).toBe('Untitled');
+      expect(chatPanel._getActiveTab().pendingContextData[0].type).toBe('general');
+      expect(chatPanel._getActiveTab().pendingContextData[0].title).toBe('Untitled');
     });
 
     it('should remove empty state before adding card', () => {
@@ -2524,8 +2453,8 @@ describe('ChatPanel', () => {
   // -----------------------------------------------------------------------
   describe('_removeContextCard', () => {
     it('should splice pending arrays at the correct index', () => {
-      chatPanel._pendingContext = ['ctx0', 'ctx1', 'ctx2'];
-      chatPanel._pendingContextData = [{ id: 0 }, { id: 1 }, { id: 2 }];
+      chatPanel._getActiveTab().pendingContext = ['ctx0', 'ctx1', 'ctx2'];
+      chatPanel._getActiveTab().pendingContextData = [{ id: 0 }, { id: 1 }, { id: 2 }];
 
       const cardEl = createMockElement('div', { dataset: { contextIndex: '1' } });
       // Mock querySelectorAll to return remaining cards for re-indexing
@@ -2533,14 +2462,14 @@ describe('ChatPanel', () => {
 
       chatPanel._removeContextCard(cardEl);
 
-      expect(chatPanel._pendingContext).toEqual(['ctx0', 'ctx2']);
-      expect(chatPanel._pendingContextData).toEqual([{ id: 0 }, { id: 2 }]);
+      expect(chatPanel._getActiveTab().pendingContext).toEqual(['ctx0', 'ctx2']);
+      expect(chatPanel._getActiveTab().pendingContextData).toEqual([{ id: 0 }, { id: 2 }]);
       expect(cardEl.remove).toHaveBeenCalled();
     });
 
     it('should re-index remaining cards', () => {
-      chatPanel._pendingContext = ['ctx0', 'ctx1', 'ctx2'];
-      chatPanel._pendingContextData = [{ id: 0 }, { id: 1 }, { id: 2 }];
+      chatPanel._getActiveTab().pendingContext = ['ctx0', 'ctx1', 'ctx2'];
+      chatPanel._getActiveTab().pendingContextData = [{ id: 0 }, { id: 1 }, { id: 2 }];
 
       const card0 = createMockElement('div', { dataset: { contextIndex: '0' } });
       const card2 = createMockElement('div', { dataset: { contextIndex: '2' } });
@@ -2554,9 +2483,9 @@ describe('ChatPanel', () => {
     });
 
     it('should restore empty state when last context card is removed and no messages', () => {
-      chatPanel._pendingContext = ['ctx0'];
-      chatPanel._pendingContextData = [{ id: 0 }];
-      chatPanel.messages = [];
+      chatPanel._getActiveTab().pendingContext = ['ctx0'];
+      chatPanel._getActiveTab().pendingContextData = [{ id: 0 }];
+      chatPanel._getActiveTab().messages = [];
 
       const clearSpy = vi.spyOn(chatPanel, '_clearMessages');
       const cardEl = createMockElement('div', { dataset: { contextIndex: '0' } });
@@ -2564,14 +2493,14 @@ describe('ChatPanel', () => {
 
       chatPanel._removeContextCard(cardEl);
 
-      expect(chatPanel._pendingContext).toEqual([]);
+      expect(chatPanel._getActiveTab().pendingContext).toEqual([]);
       expect(clearSpy).toHaveBeenCalled();
     });
 
     it('should NOT restore empty state when messages exist', () => {
-      chatPanel._pendingContext = ['ctx0'];
-      chatPanel._pendingContextData = [{ id: 0 }];
-      chatPanel.messages = [{ role: 'user', content: 'hi' }];
+      chatPanel._getActiveTab().pendingContext = ['ctx0'];
+      chatPanel._getActiveTab().pendingContextData = [{ id: 0 }];
+      chatPanel._getActiveTab().messages = [{ role: 'user', content: 'hi' }];
 
       const clearSpy = vi.spyOn(chatPanel, '_clearMessages');
       const cardEl = createMockElement('div', { dataset: { contextIndex: '0' } });
@@ -2589,7 +2518,7 @@ describe('ChatPanel', () => {
   describe('_ensureAnalysisContext', () => {
     it('should skip when _sessionAnalysisRunId is already set and no new run', () => {
       chatPanel._sessionAnalysisRunId = 'run-abc';
-      chatPanel.messages = [{ role: 'user', content: 'hello' }];
+      chatPanel._getActiveTab().messages = [{ role: 'user', content: 'hello' }];
 
       // No new run: _getLatestCompletedRunId returns same ID
       vi.spyOn(chatPanel, '_getLatestCompletedRunId').mockReturnValue('run-abc');
@@ -2610,7 +2539,7 @@ describe('ChatPanel', () => {
 
     it('should append (prepend: false) when existing message bubbles are present', () => {
       chatPanel._sessionAnalysisRunId = null;
-      chatPanel.messages = [{ role: 'user', content: 'hello' }];
+      chatPanel._getActiveTab().messages = [{ role: 'user', content: 'hello' }];
 
       // Mock: no analysis card in DOM, suggestions exist, message bubbles present
       chatPanel.messagesEl.querySelector = vi.fn((sel) => {
@@ -2634,7 +2563,7 @@ describe('ChatPanel', () => {
 
     it('should prepend (prepend: true) when no message bubbles exist (fresh conversation)', () => {
       chatPanel._sessionAnalysisRunId = null;
-      chatPanel.messages = [];
+      chatPanel._getActiveTab().messages = [];
 
       // Mock: no analysis card, no messages, suggestions exist
       chatPanel.messagesEl.querySelector = vi.fn((sel) => {
@@ -2658,7 +2587,7 @@ describe('ChatPanel', () => {
 
     it('should set _sessionAnalysisRunId to current run ID after creating the card', () => {
       chatPanel._sessionAnalysisRunId = null;
-      chatPanel.messages = [];
+      chatPanel._getActiveTab().messages = [];
 
       vi.spyOn(chatPanel, '_getLatestCompletedRunId').mockReturnValue('run-42');
       chatPanel.messagesEl.querySelector = vi.fn((sel) => {
@@ -2676,7 +2605,7 @@ describe('ChatPanel', () => {
 
     it('should fall back to "dom" when _getLatestCompletedRunId returns null', () => {
       chatPanel._sessionAnalysisRunId = null;
-      chatPanel.messages = [];
+      chatPanel._getActiveTab().messages = [];
 
       vi.spyOn(chatPanel, '_getLatestCompletedRunId').mockReturnValue(null);
       chatPanel.messagesEl.querySelector = vi.fn((sel) => {
@@ -2738,7 +2667,7 @@ describe('ChatPanel', () => {
       // Previous run was 'run-1', now prManager has 'run-2'
       chatPanel._sessionAnalysisRunId = 'run-1';
       chatPanel._analysisContextRemoved = false;
-      chatPanel.messages = [];
+      chatPanel._getActiveTab().messages = [];
 
       vi.spyOn(chatPanel, '_getLatestCompletedRunId').mockReturnValue('run-2');
 
@@ -2799,7 +2728,7 @@ describe('ChatPanel', () => {
 
     it('should NOT detect new run when currentRunId matches _sessionAnalysisRunId', () => {
       chatPanel._sessionAnalysisRunId = 'run-same';
-      chatPanel.messages = [];
+      chatPanel._getActiveTab().messages = [];
 
       vi.spyOn(chatPanel, '_getLatestCompletedRunId').mockReturnValue('run-same');
 
@@ -2819,7 +2748,7 @@ describe('ChatPanel', () => {
 
     it('should not detect new run when _sessionAnalysisRunId is null (first time)', () => {
       chatPanel._sessionAnalysisRunId = null;
-      chatPanel.messages = [];
+      chatPanel._getActiveTab().messages = [];
 
       vi.spyOn(chatPanel, '_getLatestCompletedRunId').mockReturnValue('run-1');
 
@@ -2843,7 +2772,7 @@ describe('ChatPanel', () => {
 
     it('should not detect new run when _getLatestCompletedRunId returns null', () => {
       chatPanel._sessionAnalysisRunId = 'run-old';
-      chatPanel.messages = [];
+      chatPanel._getActiveTab().messages = [];
 
       vi.spyOn(chatPanel, '_getLatestCompletedRunId').mockReturnValue(null);
 
@@ -2865,7 +2794,7 @@ describe('ChatPanel', () => {
 
     it('should replace stale DOM card when _sessionAnalysisRunId is null and card has different run ID', () => {
       chatPanel._sessionAnalysisRunId = null;
-      chatPanel.messages = [];
+      chatPanel._getActiveTab().messages = [];
 
       vi.spyOn(chatPanel, '_getLatestCompletedRunId').mockReturnValue('run-new');
 
@@ -2901,7 +2830,7 @@ describe('ChatPanel', () => {
 
     it('should replace stale DOM card when _sessionAnalysisRunId is null and card has no run ID stamp', () => {
       chatPanel._sessionAnalysisRunId = null;
-      chatPanel.messages = [];
+      chatPanel._getActiveTab().messages = [];
 
       vi.spyOn(chatPanel, '_getLatestCompletedRunId').mockReturnValue('run-123');
 
@@ -2934,7 +2863,7 @@ describe('ChatPanel', () => {
 
     it('should adopt existing card run ID when it matches the latest run', () => {
       chatPanel._sessionAnalysisRunId = null;
-      chatPanel.messages = [];
+      chatPanel._getActiveTab().messages = [];
 
       vi.spyOn(chatPanel, '_getLatestCompletedRunId').mockReturnValue('run-42');
 
@@ -2958,7 +2887,7 @@ describe('ChatPanel', () => {
 
     it('should skip card replacement when currentRunId is null even if _sessionAnalysisRunId is null', () => {
       chatPanel._sessionAnalysisRunId = null;
-      chatPanel.messages = [];
+      chatPanel._getActiveTab().messages = [];
 
       vi.spyOn(chatPanel, '_getLatestCompletedRunId').mockReturnValue(null);
 
@@ -3502,13 +3431,15 @@ describe('ChatPanel', () => {
         context: { suggestionCount: 5, aiRunId: 'run-abc', provider: 'claude', model: 'sonnet' }
       });
 
+      // Tab-aware persist now passes an explicit sessionId so the write isn't
+      // routed to whichever tab is active when the network call lands.
       expect(persistSpy).toHaveBeenCalledWith({
         type: 'analysis',
         suggestionCount: 5,
         aiRunId: 'run-abc',
         provider: 'claude',
         model: 'sonnet'
-      });
+      }, 20);
     });
   });
 
@@ -3675,13 +3606,14 @@ describe('ChatPanel', () => {
   describe('open() concurrency guard', () => {
     it('should serialize concurrent open() calls', async () => {
       chatPanel.reviewId = 1;
+      // _openInner only triggers _loadMRUSession when there are no tabs yet.
+      clearActiveTab(chatPanel);
       const callOrder = [];
 
       // First open() triggers a slow MRU load
       let resolveMRU1;
       const mruPromise1 = new Promise((resolve) => { resolveMRU1 = resolve; });
 
-      const originalLoadMRU = chatPanel._loadMRUSession.bind(chatPanel);
       let loadMRUCallCount = 0;
 
       vi.spyOn(chatPanel, '_loadMRUSession').mockImplementation(async () => {
@@ -3751,6 +3683,7 @@ describe('ChatPanel', () => {
 
     it('should not call _loadMRUSession twice when second open() runs after first sets currentSessionId', async () => {
       chatPanel.reviewId = 1;
+      clearActiveTab(chatPanel);
       let loadMRUCallCount = 0;
 
       vi.spyOn(chatPanel, '_loadMRUSession').mockImplementation(async () => {
@@ -3826,7 +3759,7 @@ describe('ChatPanel', () => {
     it('should call _persistAnalysisContext with analysis context data', () => {
       chatPanel._sessionAnalysisRunId = null;
       chatPanel.currentSessionId = 10;
-      chatPanel.messages = [];
+      chatPanel._getActiveTab().messages = [];
 
       chatPanel.messagesEl.querySelector = vi.fn((sel) => {
         if (sel === '.chat-panel__context-card[data-analysis]') return null;
@@ -3843,7 +3776,8 @@ describe('ChatPanel', () => {
 
       chatPanel._ensureAnalysisContext();
 
-      expect(persistSpy).toHaveBeenCalledWith({ type: 'analysis', suggestionCount: 3 });
+      // Tab-aware persist passes an explicit sessionId arg now.
+      expect(persistSpy).toHaveBeenCalledWith({ type: 'analysis', suggestionCount: 3 }, 10);
     });
 
     it('should NOT call _persistAnalysisContext when skipping (card already in DOM)', () => {
@@ -3877,13 +3811,14 @@ describe('ChatPanel', () => {
         context: { suggestionCount: 5, aiRunId: 'run-abc', provider: 'claude', model: 'sonnet' }
       });
 
+      // Tab-aware persist passes an explicit sessionId.
       expect(persistSpy).toHaveBeenCalledWith({
         type: 'analysis',
         suggestionCount: 5,
         aiRunId: 'run-abc',
         provider: 'claude',
         model: 'sonnet'
-      });
+      }, 20);
     });
 
     it('should NOT call _persistAnalysisContext when suggestionCount is 0', () => {
@@ -4036,6 +3971,9 @@ describe('ChatPanel', () => {
       streamingMsg.querySelectorAll = vi.fn(() => []);
 
       elementRegistry['chat-streaming-msg'] = streamingMsg;
+      // _showToolUse reads streamingMsgEl off the active tab now.
+      const activeTab = chatPanel._getActiveTab();
+      if (activeTab) activeTab.streamingMsgEl = streamingMsg;
     });
 
     afterEach(() => {
@@ -4142,6 +4080,24 @@ describe('ChatPanel', () => {
 
       const card = chatPanel.messagesEl.appendChild.mock.calls[0][0];
       expect(card.dataset.tooltipBody).toBeUndefined();
+    });
+
+    it('should bind tooltip hover listeners to the messages stack (not the per-tab messagesEl)', () => {
+      // Regression: pre-refactor `_initContextTooltip` attached its
+      // mouseenter/mouseleave listeners to `this.messagesEl`, but multi-tab
+      // mode makes that a getter that's null at constructor time (no active
+      // tab yet). The listeners were silently skipped, breaking hover
+      // tooltips on context cards. The fix delegates from the persistent
+      // messages stack element.
+      const stackAdd = chatPanel.messagesStackEl.addEventListener;
+      const mouseenterCalls = stackAdd.mock.calls.filter((c) => c[0] === 'mouseenter');
+      const mouseleaveCalls = stackAdd.mock.calls.filter((c) => c[0] === 'mouseleave');
+      expect(mouseenterCalls.length).toBe(1);
+      expect(mouseleaveCalls.length).toBe(1);
+      // Capture-phase delegation is required so the listeners fire for nested
+      // elements inside the per-tab containers.
+      expect(mouseenterCalls[0][2]).toBe(true);
+      expect(mouseleaveCalls[0][2]).toBe(true);
     });
 
     it('should use _renderInlineMarkdown for context card type and title', () => {
@@ -4411,12 +4367,12 @@ describe('ChatPanel', () => {
       chatPanel.reviewId = null;
       chatPanel.isStreaming = false;
       chatPanel.inputEl.value = 'test message';
-      chatPanel.messages = [];
+      chatPanel._getActiveTab().messages = [];
 
       await chatPanel.sendMessage();
 
       // addMessage pushes, but error recovery should pop
-      expect(chatPanel.messages).toHaveLength(0);
+      expect(chatPanel._getActiveTab().messages).toHaveLength(0);
     });
 
     it('should show error message when createSession fails', async () => {
@@ -4429,7 +4385,8 @@ describe('ChatPanel', () => {
 
       await chatPanel.sendMessage();
 
-      expect(errorSpy).toHaveBeenCalledWith('Unable to start chat session. Please try again.');
+      expect(errorSpy).toHaveBeenCalled();
+      expect(errorSpy.mock.calls[0][0]).toBe('Unable to start chat session. Please try again.');
     });
 
     it('should re-enable send button when createSession fails', async () => {
@@ -4488,6 +4445,41 @@ describe('ChatPanel', () => {
       // The retry message should be sent to the new session
       const retryCall = global.fetch.mock.calls[2];
       expect(retryCall[0]).toBe('/api/chat/session/new-sess/message');
+    });
+
+    it('should re-bind the SAME tab on 410 (not orphan it and spawn a new one)', async () => {
+      // Regression: when 410 nulls the sessionId, activeTabKey must be
+      // re-anchored to the tab's _localKey before createSession() runs so the
+      // existing tab is reused. Otherwise createSession() sees no active tab
+      // and appends a brand new tab, leaving the old one orphaned.
+      const tabsBefore = chatPanel.tabs.length;
+      chatPanel.currentSessionId = 'stale-sess';
+      chatPanel.reviewId = 1;
+      chatPanel.isStreaming = false;
+      chatPanel.inputEl.value = 'hello';
+
+      global.fetch
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 410,
+          json: () => Promise.resolve({ error: 'Session is not resumable' }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({ data: { id: 'new-sess', status: 'active' } }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({}),
+        });
+
+      await chatPanel.sendMessage();
+
+      // No new tab should have been spawned; the existing tab is reused.
+      expect(chatPanel.tabs.length).toBe(tabsBefore);
+      // The (single) active tab now owns the fresh session id.
+      expect(chatPanel.tabs[0].sessionId).toBe('new-sess');
+      expect(chatPanel.activeTabKey).toBe('new-sess');
     });
 
     it('should show error when createSession fails during 410 retry', async () => {
@@ -4729,8 +4721,8 @@ describe('ChatPanel', () => {
 
       it('should reset state and load new session', async () => {
         chatPanel.currentSessionId = 1;
-        chatPanel.messages = [{ role: 'user', content: 'old' }];
-        chatPanel._pendingContext = ['some context'];
+        chatPanel._getActiveTab().messages = [{ role: 'user', content: 'old' }];
+        chatPanel._getActiveTab().pendingContext = ['some context'];
 
         // Mock _loadMessageHistory and _ensureAnalysisContext
         chatPanel._loadMessageHistory = vi.fn().mockResolvedValue(undefined);
@@ -4747,11 +4739,14 @@ describe('ChatPanel', () => {
         });
 
         expect(chatPanel.currentSessionId).toBe(2);
-        expect(chatPanel.messages).toEqual([]);
-        expect(chatPanel._pendingContext).toEqual([]);
+        expect(chatPanel._getActiveTab().messages).toEqual([]);
+        expect(chatPanel._getActiveTab().pendingContext).toEqual([]);
         expect(chatPanel._finalizeStreaming).toHaveBeenCalled();
         expect(chatPanel._clearMessages).toHaveBeenCalled();
-        expect(chatPanel._loadMessageHistory).toHaveBeenCalledWith(2);
+        // Phase 2 added an optional `targetTab` 2nd arg so the race guard can
+        // anchor renders to a specific tab. _switchToSession passes the active
+        // tab explicitly.
+        expect(chatPanel._loadMessageHistory).toHaveBeenCalledWith(2, expect.anything());
         expect(chatPanel._ensureAnalysisContext).toHaveBeenCalled();
       });
 
@@ -4846,27 +4841,49 @@ describe('ChatPanel', () => {
     });
 
     describe('_selectProvider', () => {
-      it('should update _activeProvider and call _startNewConversation when provider changes', () => {
+      it('updates _activeProvider and reuses a fresh active tab without spawning a new one', async () => {
         chatPanel._activeProvider = 'pi';
-        chatPanel._startNewConversation = vi.fn();
+        chatPanel._openNewTab = vi.fn();
         chatPanel._updateTitle = vi.fn();
+        const tab = chatPanel._getActiveTab();
+        // Fresh: no messages, not streaming, no user title.
+        tab.messages = [];
+        tab.isStreaming = false;
+        tab.streamingContent = '';
+        tab.titleFromUser = false;
+        tab.sessionId = null;
 
-        chatPanel._selectProvider('copilot-acp');
+        await chatPanel._selectProvider('copilot-acp');
 
         expect(chatPanel._activeProvider).toBe('copilot-acp');
         expect(chatPanel._updateTitle).toHaveBeenCalled();
-        expect(chatPanel._startNewConversation).toHaveBeenCalled();
+        expect(chatPanel._openNewTab).not.toHaveBeenCalled();
+        // Provider on the reused tab updated.
+        expect(tab.provider).toBe('copilot-acp');
       });
 
-      it('should be a no-op when the same provider is selected', () => {
+      it('opens a new tab when the active tab is NOT fresh (has messages)', async () => {
         chatPanel._activeProvider = 'pi';
-        chatPanel._startNewConversation = vi.fn();
+        chatPanel._openNewTab = vi.fn().mockResolvedValue(undefined);
+        chatPanel._updateTitle = vi.fn();
+        const tab = chatPanel._getActiveTab();
+        tab.messages = [{ role: 'user', content: 'hi' }];
+
+        await chatPanel._selectProvider('copilot-acp');
+
+        expect(chatPanel._activeProvider).toBe('copilot-acp');
+        expect(chatPanel._openNewTab).toHaveBeenCalled();
+      });
+
+      it('should be a no-op when the same provider is selected', async () => {
+        chatPanel._activeProvider = 'pi';
+        chatPanel._openNewTab = vi.fn();
         chatPanel._updateTitle = vi.fn();
 
-        chatPanel._selectProvider('pi');
+        await chatPanel._selectProvider('pi');
 
         expect(chatPanel._updateTitle).not.toHaveBeenCalled();
-        expect(chatPanel._startNewConversation).not.toHaveBeenCalled();
+        expect(chatPanel._openNewTab).not.toHaveBeenCalled();
       });
     });
 
@@ -5548,8 +5565,10 @@ describe('ChatPanel', () => {
     });
 
     describe('scrollToBottom with no messagesEl', () => {
-      it('should not throw when messagesEl is null', () => {
-        chatPanel.messagesEl = null;
+      it('should not throw when there is no active tab', () => {
+        // The new getter returns null when no tab is active; removing all
+        // tabs mirrors the previous "messagesEl = null" state for scroll.
+        clearActiveTab(chatPanel);
         expect(() => chatPanel.scrollToBottom()).not.toThrow();
         expect(() => chatPanel.scrollToBottom({ force: true })).not.toThrow();
       });
@@ -5702,6 +5721,1014 @@ describe('ChatPanel', () => {
         expect(chatPanel._hideAnimationTimeout).toBeNull();
         vi.useRealTimers();
       });
+    });
+  });
+
+  // ===========================================================================
+  // Multi-tab support (Phase 1/2)
+  //
+  // These tests exercise the multi-tab state machine end-to-end in unit space:
+  // tab creation, switching, closing, status-dot derivation, per-tab WS
+  // accumulation, getter/setter delegation, localStorage persistence /
+  // restore, history-dropdown open-tag handling, and the
+  // _loadMessageHistory race guard.
+  // ===========================================================================
+  describe('multi-tab: state machine', () => {
+    beforeEach(() => {
+      // Start every multi-tab test from a clean no-tab state so we can assert
+      // creation/append semantics explicitly.
+      clearActiveTab(chatPanel);
+    });
+
+    it('starts with an empty tab list and a null activeTabKey', () => {
+      expect(chatPanel.tabs).toEqual([]);
+      expect(chatPanel.activeTabKey).toBeNull();
+    });
+
+    it('_createTab produces a tab with sensible defaults', () => {
+      const tab = chatPanel._createTab();
+      expect(tab.sessionId).toBeNull();
+      expect(tab.status).toBe('idle');
+      expect(tab.messages).toEqual([]);
+      expect(tab.isStreaming).toBe(false);
+      expect(tab.streamingContent).toBe('');
+      expect(tab.errorMessage).toBeNull();
+      expect(tab.sessionWarm).toBe(false);
+      expect(tab.pendingContext).toEqual([]);
+      expect(tab.pendingContextData).toEqual([]);
+      expect(tab.titleFromUser).toBe(false);
+      expect(tab.wsUnsub).toBeNull();
+      expect(typeof tab._localKey).toBe('number');
+      expect(tab._localKey).toBeLessThan(0);
+    });
+
+    it('_appendTab(tab, {focus: true}) adds the tab and focuses it', () => {
+      const tab = chatPanel._createTab();
+      chatPanel._appendTab(tab, { focus: true });
+      expect(chatPanel.tabs).toContain(tab);
+      expect(chatPanel.activeTabKey).toBe(chatPanel._tabKey(tab));
+    });
+
+    it('_appendTab(tab, {focus: false}) adds the tab without changing focus', () => {
+      const tab1 = chatPanel._createTab();
+      chatPanel._appendTab(tab1, { focus: true });
+      const prevActive = chatPanel.activeTabKey;
+      const tab2 = chatPanel._createTab();
+      chatPanel._appendTab(tab2, { focus: false });
+      expect(chatPanel.tabs).toHaveLength(2);
+      expect(chatPanel.activeTabKey).toBe(prevActive);
+    });
+
+    it('_switchToTab updates activeTabKey and hides other tabs’ messagesEl', () => {
+      const tab1 = chatPanel._createTab();
+      chatPanel._appendTab(tab1, { focus: true });
+      const tab2 = chatPanel._createTab();
+      chatPanel._appendTab(tab2, { focus: false });
+
+      chatPanel._switchToTab(chatPanel._tabKey(tab2));
+
+      expect(chatPanel.activeTabKey).toBe(chatPanel._tabKey(tab2));
+      expect(tab1.messagesEl.style.display).toBe('none');
+      expect(tab2.messagesEl.style.display).toBe('');
+    });
+
+    it('_closeTab removes the tab and focuses the right neighbour when active', async () => {
+      const tab1 = chatPanel._createTab();
+      chatPanel._appendTab(tab1, { focus: true });
+      tab1.sessionId = 101;
+      chatPanel.activeTabKey = tab1.sessionId;
+
+      const tab2 = chatPanel._createTab();
+      chatPanel._appendTab(tab2, { focus: false });
+      tab2.sessionId = 102;
+
+      const tab3 = chatPanel._createTab();
+      chatPanel._appendTab(tab3, { focus: false });
+      tab3.sessionId = 103;
+
+      chatPanel._switchToTab(102);
+
+      // Mock fetch for the DELETE so _closeTab’s fire-and-forget doesn’t throw.
+      global.fetch.mockResolvedValue({ ok: true, json: () => Promise.resolve({}) });
+
+      await chatPanel._closeTab(102);
+      expect(chatPanel.tabs).not.toContain(tab2);
+      // Right neighbour (tab3) should be focused.
+      expect(chatPanel.activeTabKey).toBe(103);
+    });
+
+    it('_closeTab on the last tab sets activeTabKey to null and shows empty state', async () => {
+      const tab = chatPanel._createTab();
+      chatPanel._appendTab(tab, { focus: true });
+      tab.sessionId = 99;
+      chatPanel.activeTabKey = tab.sessionId;
+
+      const noTabsEmpty = chatPanel.messagesStackEl._noTabsEmpty;
+      noTabsEmpty.style.display = 'none';
+
+      global.fetch.mockResolvedValue({ ok: true, json: () => Promise.resolve({}) });
+
+      await chatPanel._closeTab(99);
+
+      expect(chatPanel.tabs).toEqual([]);
+      expect(chatPanel.activeTabKey).toBeNull();
+      expect(noTabsEmpty.style.display).toBe('');
+    });
+
+    it('_closeTab calls tab.wsUnsub() before issuing the DELETE', async () => {
+      const tab = chatPanel._createTab();
+      chatPanel._appendTab(tab, { focus: true });
+      tab.sessionId = 55;
+      chatPanel.activeTabKey = 55;
+      const callOrder = [];
+      const unsubFn = vi.fn(() => callOrder.push('unsub'));
+      tab.wsUnsub = unsubFn;
+      global.fetch.mockImplementation(() => {
+        callOrder.push('fetch');
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+      });
+
+      await chatPanel._closeTab(55);
+
+      // _closeTab nulls out wsUnsub after calling it; assert on the captured fn.
+      expect(unsubFn).toHaveBeenCalled();
+      expect(tab.wsUnsub).toBeNull();
+      expect(callOrder[0]).toBe('unsub');
+      expect(callOrder).toContain('fetch');
+      // unsub fires before the DELETE network call.
+      expect(callOrder.indexOf('unsub')).toBeLessThan(callOrder.indexOf('fetch'));
+    });
+
+    it('_closeTab issues DELETE /api/chat/session/:id for tabs with sessionId', async () => {
+      const tab = chatPanel._createTab();
+      chatPanel._appendTab(tab, { focus: true });
+      tab.sessionId = 77;
+      chatPanel.activeTabKey = 77;
+
+      global.fetch.mockResolvedValue({ ok: true, json: () => Promise.resolve({}) });
+
+      await chatPanel._closeTab(77);
+
+      expect(global.fetch).toHaveBeenCalledWith('/api/chat/session/77', expect.objectContaining({ method: 'DELETE' }));
+    });
+  });
+
+  describe('multi-tab: status dot derivation', () => {
+    it('starts a tab at status: idle', () => {
+      const tab = chatPanel._getActiveTab();
+      expect(tab.status).toBe('idle');
+    });
+
+    it('isStreaming setter pushes the active tab to status: streaming', () => {
+      chatPanel.isStreaming = true;
+      expect(chatPanel._getActiveTab().status).toBe('streaming');
+    });
+
+    it('isStreaming = false on an error-free tab returns to status: idle', () => {
+      const tab = chatPanel._getActiveTab();
+      tab.errorMessage = null;
+      chatPanel.isStreaming = true;
+      chatPanel.isStreaming = false;
+      expect(tab.status).toBe('idle');
+    });
+
+    it('isStreaming = false on a tab with errorMessage keeps status: error', () => {
+      const tab = chatPanel._getActiveTab();
+      tab.errorMessage = 'previous bad';
+      chatPanel.isStreaming = true;
+      chatPanel.isStreaming = false;
+      expect(tab.status).toBe('error');
+    });
+
+    it('delta event on a background tab appends streamingContent and sets streaming', () => {
+      const tab = chatPanel._getActiveTab();
+      tab.sessionId = 'bg-1';
+      chatPanel.isOpen = false;
+      tab.streamingContent = '';
+
+      chatPanel._handleChatMessageForTab(tab, { type: 'delta', text: 'hi', sessionId: 'bg-1' });
+
+      expect(tab.streamingContent).toBe('hi');
+      expect(tab.status).toBe('streaming');
+    });
+
+    it('status: working on a background tab flips status to streaming', () => {
+      const tab = chatPanel._getActiveTab();
+      tab.sessionId = 'bg-1';
+      chatPanel.isOpen = false;
+      tab.isStreaming = false;
+
+      chatPanel._handleChatMessageForTab(tab, { type: 'status', status: 'working', sessionId: 'bg-1' });
+
+      expect(tab.status).toBe('streaming');
+    });
+
+    it('complete event on background tab pushes message, clears stream, status idle, clears error', () => {
+      const tab = chatPanel._getActiveTab();
+      tab.sessionId = 'bg-1';
+      chatPanel.isOpen = false;
+      tab.streamingContent = 'final text';
+      tab.errorMessage = 'prior error';
+
+      chatPanel._handleChatMessageForTab(tab, { type: 'complete', messageId: 5, sessionId: 'bg-1' });
+
+      expect(tab.messages).toContainEqual({ role: 'assistant', content: 'final text', id: 5 });
+      expect(tab.streamingContent).toBe('');
+      expect(tab.isStreaming).toBe(false);
+      expect(tab.status).toBe('idle');
+      expect(tab.errorMessage).toBeNull();
+    });
+
+    it('error event on background tab sets status: error and stores errorMessage', () => {
+      const tab = chatPanel._getActiveTab();
+      tab.sessionId = 'bg-1';
+      chatPanel.isOpen = false;
+      tab.streamingContent = 'partial';
+      tab.isStreaming = true;
+
+      chatPanel._handleChatMessageForTab(tab, { type: 'error', message: 'bad', sessionId: 'bg-1' });
+
+      expect(tab.status).toBe('error');
+      expect(tab.errorMessage).toBe('bad');
+      expect(tab.isStreaming).toBe(false);
+    });
+  });
+
+  describe('multi-tab: getter/setter delegation', () => {
+    it('with an active tab, currentSessionId reads and writes the tab’s sessionId', () => {
+      const tab = chatPanel._getActiveTab();
+      tab.sessionId = 50;
+      // Need to re-key the active marker so the getter resolves to this tab.
+      chatPanel.activeTabKey = 50;
+      expect(chatPanel.currentSessionId).toBe(50);
+
+      chatPanel.currentSessionId = 60;
+      expect(chatPanel.currentSessionId).toBe(60);
+      expect(chatPanel._getActiveTab().sessionId).toBe(60);
+    });
+
+    it('per-tab messages array is independent of the panel-level shim', () => {
+      const tab = chatPanel._getActiveTab();
+      tab.messages = [{ role: 'user', content: 'hi' }];
+      expect(chatPanel._getActiveTab().messages).toEqual([{ role: 'user', content: 'hi' }]);
+    });
+
+    it('with no active tab, scalar getters fall back to default values', () => {
+      clearActiveTab(chatPanel);
+      expect(chatPanel.currentSessionId).toBeNull();
+      expect(chatPanel.isStreaming).toBe(false);
+      expect(chatPanel._streamingContent).toBe('');
+      expect(chatPanel._sessionWarm).toBe(false);
+      // Array-valued state lives on tabs only — no panel-level shim.
+      expect(chatPanel._getActiveTab()).toBeNull();
+    });
+
+    it('with no active tab, scalar setters are silent no-ops', () => {
+      clearActiveTab(chatPanel);
+      expect(() => { chatPanel.currentSessionId = 7; }).not.toThrow();
+      expect(() => { chatPanel.isStreaming = true; }).not.toThrow();
+      expect(() => { chatPanel._contextSource = 'suggestion'; }).not.toThrow();
+      // Setters did not silently create a tab.
+      expect(chatPanel.tabs).toEqual([]);
+    });
+  });
+
+  describe('multi-tab: localStorage persistence', () => {
+    beforeEach(() => {
+      // Use fake timers so we can assert on the 100ms debounce semantics.
+      vi.useFakeTimers();
+      chatPanel.reviewId = 1;
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('_persistOpenTabs writes the expected JSON shape under the per-review key', () => {
+      const tab = chatPanel._getActiveTab();
+      tab.sessionId = 200;
+      chatPanel.activeTabKey = 200;
+
+      chatPanel._persistOpenTabs();
+      vi.runAllTimers();
+
+      const raw = global.localStorage._store['pair-review:chat-tabs:1'];
+      expect(raw).toBeTruthy();
+      const parsed = JSON.parse(raw);
+      expect(parsed).toEqual({ version: 1, tabs: [200], activeSessionId: 200 });
+    });
+
+    it('skips tabs without a sessionId when writing', () => {
+      const saved = chatPanel._getActiveTab();
+      saved.sessionId = 300;
+      chatPanel.activeTabKey = 300;
+      // Append a second tab that has no sessionId yet.
+      const pending = chatPanel._createTab();
+      chatPanel._appendTab(pending, { focus: false });
+
+      chatPanel._persistOpenTabs();
+      vi.runAllTimers();
+
+      const parsed = JSON.parse(global.localStorage._store['pair-review:chat-tabs:1']);
+      expect(parsed.tabs).toEqual([300]);
+    });
+
+    it('removes the storage entry when no tabs with a sessionId remain', () => {
+      const tab = chatPanel._getActiveTab();
+      tab.sessionId = 400;
+      chatPanel.activeTabKey = 400;
+      chatPanel._persistOpenTabs();
+      vi.runAllTimers();
+      expect(global.localStorage._store['pair-review:chat-tabs:1']).toBeTruthy();
+
+      // Now drop the sessionId — should remove the entry on next persist.
+      tab.sessionId = null;
+      chatPanel._persistOpenTabs();
+      vi.runAllTimers();
+
+      expect(global.localStorage._store['pair-review:chat-tabs:1']).toBeUndefined();
+    });
+
+    it('debounces multiple rapid calls to a single write within 100ms', () => {
+      const tab = chatPanel._getActiveTab();
+      tab.sessionId = 500;
+      chatPanel.activeTabKey = 500;
+      global.localStorage.setItem.mockClear();
+
+      chatPanel._persistOpenTabs();
+      chatPanel._persistOpenTabs();
+      chatPanel._persistOpenTabs();
+      // Before the 100ms timer fires no write has happened.
+      expect(global.localStorage.setItem).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(100);
+
+      // Exactly one write went through after the debounce window.
+      expect(global.localStorage.setItem).toHaveBeenCalledTimes(1);
+    });
+
+    it('soft-fails when localStorage.setItem throws', () => {
+      const tab = chatPanel._getActiveTab();
+      tab.sessionId = 600;
+      chatPanel.activeTabKey = 600;
+      global.localStorage.setItem.mockImplementationOnce(() => { throw new Error('quota exceeded'); });
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      chatPanel._persistOpenTabs();
+      expect(() => vi.runAllTimers()).not.toThrow();
+
+      expect(warnSpy).toHaveBeenCalled();
+      warnSpy.mockRestore();
+    });
+  });
+
+  describe('multi-tab: restore from localStorage', () => {
+    beforeEach(() => {
+      // Install fake timers BEFORE _restoreTabs schedules its debounced
+      // _persistOpenTabs setTimeout. Installing after-the-fact is a no-op
+      // because the global setTimeout mock fires synchronously.
+      vi.useFakeTimers();
+      chatPanel.reviewId = 7;
+      // Start from a clean state so _restoreTabs gets to do work.
+      clearActiveTab(chatPanel);
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    function mockSessionsResponse(sessions) {
+      global.fetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ data: { sessions } }),
+      });
+    }
+
+    it('restores saved tabs and focuses the saved activeSessionId', async () => {
+      mockSessionsResponse([
+        { id: 123, provider: 'pi', model: null, message_count: 0, first_message: null },
+        { id: 124, provider: 'pi', model: null, message_count: 0, first_message: 'hello' },
+      ]);
+
+      const ok = await chatPanel._restoreTabs({ version: 1, tabs: [123, 124], activeSessionId: 124 });
+
+      expect(ok).toBe(true);
+      expect(chatPanel.tabs).toHaveLength(2);
+      const sids = chatPanel.tabs.map(t => t.sessionId);
+      expect(sids).toEqual([123, 124]);
+      expect(chatPanel.activeTabKey).toBe(124);
+    });
+
+    it('drops stale sessionIds and rewrites localStorage without them', async () => {
+      // Sessions list only knows about 124 — 99999 is stale.
+      mockSessionsResponse([
+        { id: 124, provider: 'pi', model: null, message_count: 0, first_message: null },
+      ]);
+
+      const ok = await chatPanel._restoreTabs({ version: 1, tabs: [99999, 124], activeSessionId: 124 });
+      // Flush the debounced persistence write that _restoreTabs scheduled.
+      vi.advanceTimersByTime(150);
+
+      expect(ok).toBe(true);
+      const sids = chatPanel.tabs.map(t => t.sessionId);
+      expect(sids).toEqual([124]);
+      // Persisted list no longer contains the stale id.
+      const raw = global.localStorage._store['pair-review:chat-tabs:7'];
+      expect(raw).toBeTruthy();
+      const parsed = JSON.parse(raw);
+      expect(parsed.tabs).toEqual([124]);
+    });
+
+    it('does not auto-resume restored tabs (no /resume fetch on restore)', async () => {
+      mockSessionsResponse([
+        { id: 200, provider: 'pi', model: null, message_count: 0, first_message: null },
+      ]);
+
+      await chatPanel._restoreTabs({ version: 1, tabs: [200], activeSessionId: 200 });
+
+      // Inspect all fetch calls; the only one expected is /api/review/.../chat/sessions.
+      const urls = global.fetch.mock.calls.map(c => c[0]);
+      expect(urls.some(u => typeof u === 'string' && u.includes('/resume'))).toBe(false);
+      // All restored tabs default to status idle.
+      for (const tab of chatPanel.tabs) {
+        expect(tab.status).toBe('idle');
+      }
+    });
+
+    it('falls back to MRU when every saved sessionId is stale', async () => {
+      // The sessions list does not include any of the saved ids.
+      mockSessionsResponse([]);
+
+      const ok = await chatPanel._restoreTabs({ version: 1, tabs: [9999], activeSessionId: 9999 });
+
+      expect(ok).toBe(false);
+      // Caller is responsible for invoking MRU fall-back when this returns false.
+    });
+  });
+
+  describe('multi-tab: history dropdown open-tag and click routing', () => {
+    beforeEach(() => {
+      // Make the session dropdown a queryable mock for handler binding.
+      chatPanel.sessionDropdown = createMockElement('div');
+      // querySelectorAll returns the bound items so we can fire their click handlers.
+      chatPanel.sessionDropdown._items = [];
+      chatPanel.sessionDropdown.querySelectorAll = vi.fn((sel) => {
+        if (sel === '.chat-panel__session-item') return chatPanel.sessionDropdown._items;
+        return [];
+      });
+    });
+
+    it('marks rows for open sessions with the --open class', () => {
+      const tab = chatPanel._getActiveTab();
+      tab.sessionId = 124;
+      chatPanel.activeTabKey = 124;
+
+      // Add a second open tab for session 200 so it appears as open-elsewhere.
+      const other = chatPanel._createTab({ sessionId: 200 });
+      chatPanel._appendTab(other, { focus: false });
+
+      const sessions = [
+        { id: 124, provider: 'pi', updated_at: new Date().toISOString(), first_message: 'a' },
+        { id: 200, provider: 'pi', updated_at: new Date().toISOString(), first_message: 'b' },
+        { id: 999, provider: 'pi', updated_at: new Date().toISOString(), first_message: 'c' },
+      ];
+
+      chatPanel._renderSessionDropdown(sessions);
+
+      const html = chatPanel.sessionDropdown.innerHTML;
+      // Both 124 and 200 are open; 999 is not.
+      expect(html).toContain('chat-panel__session-item--active');
+      expect(html).toContain('chat-panel__session-item--open');
+      // The "open" tag is rendered for both currently-open sessions.
+      const openTagOccurrences = (html.match(/chat-panel__session-open-tag/g) || []).length;
+      expect(openTagOccurrences).toBe(2);
+    });
+
+    it('clicking an open session row focuses the existing tab via _switchToTab', () => {
+      const tab1 = chatPanel._getActiveTab();
+      tab1.sessionId = 100;
+      chatPanel.activeTabKey = 100;
+      const tab2 = chatPanel._createTab({ sessionId: 200 });
+      chatPanel._appendTab(tab2, { focus: false });
+
+      const sessions = [
+        { id: 100, provider: 'pi', updated_at: new Date().toISOString(), first_message: 'a' },
+        { id: 200, provider: 'pi', updated_at: new Date().toISOString(), first_message: 'b' },
+      ];
+
+      const switchToTabSpy = vi.spyOn(chatPanel, '_switchToTab');
+      const switchToSessionSpy = vi.spyOn(chatPanel, '_switchToSession');
+
+      // Capture the click handler the production code binds to each item.
+      const bound = [];
+      chatPanel.sessionDropdown.querySelectorAll = vi.fn(() => bound);
+      const origAddEventListener = chatPanel.sessionDropdown.addEventListener;
+      // Each item element will have an addEventListener stub that records its handler.
+      const makeItem = (id) => {
+        const el = createMockElement('button');
+        el.dataset.sessionId = String(id);
+        el.addEventListener = vi.fn((_e, h) => { el._click = h; });
+        return el;
+      };
+      const item100 = makeItem(100);
+      const item200 = makeItem(200);
+      bound.push(item100, item200);
+
+      chatPanel._renderSessionDropdown(sessions);
+
+      // Invoke the click handler for the open-elsewhere row (200, the inactive open tab).
+      item200._click({ target: item200 });
+
+      expect(switchToTabSpy).toHaveBeenCalledWith(chatPanel._tabKey(tab2));
+      expect(switchToSessionSpy).not.toHaveBeenCalled();
+    });
+
+    it('clicking a closed-session row swaps the active tab via _switchToSession', () => {
+      const tab = chatPanel._getActiveTab();
+      tab.sessionId = 100;
+      chatPanel.activeTabKey = 100;
+
+      const sessions = [
+        { id: 100, provider: 'pi', updated_at: new Date().toISOString(), first_message: 'a' },
+        { id: 555, provider: 'pi', updated_at: new Date().toISOString(), first_message: 'closed' },
+      ];
+
+      vi.spyOn(chatPanel, '_switchToSession').mockResolvedValue(undefined);
+      const switchToTabSpy = vi.spyOn(chatPanel, '_switchToTab');
+
+      const bound = [];
+      chatPanel.sessionDropdown.querySelectorAll = vi.fn(() => bound);
+      const makeItem = (id) => {
+        const el = createMockElement('button');
+        el.dataset.sessionId = String(id);
+        el.addEventListener = vi.fn((_e, h) => { el._click = h; });
+        return el;
+      };
+      const item100 = makeItem(100);
+      const item555 = makeItem(555);
+      bound.push(item100, item555);
+
+      chatPanel._renderSessionDropdown(sessions);
+
+      // 555 is not open in any tab — should _switchToSession on the active tab.
+      item555._click({ target: item555 });
+
+      expect(chatPanel._switchToSession).toHaveBeenCalledWith(555, expect.objectContaining({ id: 555 }));
+      // _switchToTab was NOT called for the closed-session row.
+      expect(switchToTabSpy).not.toHaveBeenCalledWith(555);
+    });
+  });
+
+  describe('multi-tab: _loadMessageHistory race guard', () => {
+    it('renders into the captured tab even after the user switches away', async () => {
+      // Set up two tabs: A is active and we ask history for A; user switches to B mid-fetch.
+      const tabA = chatPanel._getActiveTab();
+      tabA.sessionId = 700;
+      chatPanel.activeTabKey = 700;
+
+      const tabB = chatPanel._createTab({ sessionId: 800 });
+      chatPanel._appendTab(tabB, { focus: false });
+
+      // Manually controllable fetch resolution.
+      let resolveFetch;
+      const fetchPromise = new Promise((r) => { resolveFetch = r; });
+      global.fetch.mockReturnValueOnce(fetchPromise);
+
+      const addSpyA = vi.fn();
+      // Spy on addMessage so we can verify the render target was tabA.
+      chatPanel.addMessage = vi.fn((role, content, id) => {
+        const target = chatPanel._getActiveTab();
+        addSpyA(target.sessionId, role, content, id);
+      });
+
+      const p = chatPanel._loadMessageHistory(700, tabA);
+
+      // While fetch is in flight, the user switches to tab B.
+      chatPanel._switchToTab(chatPanel._tabKey(tabB));
+
+      // Resolve the fetch.
+      resolveFetch({
+        ok: true,
+        json: () => Promise.resolve({
+          data: {
+            messages: [{ type: 'message', role: 'assistant', content: 'hello A', id: 1 }],
+          },
+        }),
+      });
+
+      await p;
+
+      // _renderInTab redirected the activeTabKey for the synchronous render block,
+      // so addMessage observed sessionId 700 (tab A) at write time.
+      expect(addSpyA).toHaveBeenCalledWith(700, 'assistant', 'hello A', 1);
+      // After the synchronous render, the visible focus snaps back to tab B.
+      expect(chatPanel.activeTabKey).toBe(chatPanel._tabKey(tabB));
+    });
+
+    it('silently skips when the target tab was closed before fetch resolved', async () => {
+      const tabA = chatPanel._getActiveTab();
+      tabA.sessionId = 900;
+      chatPanel.activeTabKey = 900;
+
+      let resolveFetch;
+      const fetchPromise = new Promise((r) => { resolveFetch = r; });
+      global.fetch.mockReturnValueOnce(fetchPromise);
+
+      const renderSpy = vi.spyOn(chatPanel, '_renderInTab');
+
+      const p = chatPanel._loadMessageHistory(900, tabA);
+
+      // Simulate the tab being closed: pull it out of this.tabs.
+      chatPanel.tabs = chatPanel.tabs.filter(t => t !== tabA);
+
+      resolveFetch({
+        ok: true,
+        json: () => Promise.resolve({
+          data: { messages: [{ type: 'message', role: 'assistant', content: 'lost', id: 1 }] },
+        }),
+      });
+
+      await expect(p).resolves.toBeUndefined();
+      // No render occurred because the tab was removed.
+      expect(renderSpy).not.toHaveBeenCalled();
+    });
+
+    it('silently skips when the target tab’s sessionId changed before fetch resolved', async () => {
+      const tabA = chatPanel._getActiveTab();
+      tabA.sessionId = 1000;
+      chatPanel.activeTabKey = 1000;
+
+      let resolveFetch;
+      const fetchPromise = new Promise((r) => { resolveFetch = r; });
+      global.fetch.mockReturnValueOnce(fetchPromise);
+
+      const renderSpy = vi.spyOn(chatPanel, '_renderInTab');
+
+      const p = chatPanel._loadMessageHistory(1000, tabA);
+
+      // History picker swap: the tab’s sessionId changed underneath us.
+      tabA.sessionId = 2000;
+
+      resolveFetch({
+        ok: true,
+        json: () => Promise.resolve({
+          data: { messages: [{ type: 'message', role: 'assistant', content: 'stale', id: 1 }] },
+        }),
+      });
+
+      await expect(p).resolves.toBeUndefined();
+      expect(renderSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // _openNewTab + multi-tab context-wiring + per-tab isolation invariants
+  //
+  // Mirrors the deleted _startNewConversation tests that exercised the
+  // single-tab reset behaviour. The new contract: opening a new tab leaves
+  // the previous tab untouched; pending context still wires up via the
+  // active-tab getter on the fresh tab.
+  // -----------------------------------------------------------------------
+  describe('multi-tab: _openNewTab + new-tab context wiring', () => {
+    beforeEach(() => {
+      chatPanel.reviewId = 1;
+      // Reset any leftover suggestion-querySelectorAll mock from prior tests.
+      // _openNewTab now calls _ensureAnalysisContext, which would otherwise
+      // see leaked suggestion elements and stamp sessionAnalysisRunId='dom'.
+      global.document.querySelectorAll = vi.fn(() => []);
+    });
+
+    it('starts the new tab with an empty messages array', async () => {
+      global.fetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ data: { id: 11, status: 'active' } }),
+      });
+      await chatPanel._openNewTab();
+      const newTab = chatPanel.tabs[chatPanel.tabs.length - 1];
+      expect(newTab.messages).toEqual([]);
+    });
+
+    it('resets streaming state on a new tab', async () => {
+      global.fetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ data: { id: 12, status: 'active' } }),
+      });
+      await chatPanel._openNewTab();
+      const newTab = chatPanel.tabs[chatPanel.tabs.length - 1];
+      expect(newTab.isStreaming).toBe(false);
+      expect(newTab.streamingContent).toBe('');
+      expect(newTab.streamingMsgEl).toBeNull();
+    });
+
+    it('does not carry pending context from the previous tab to the new tab', async () => {
+      const original = chatPanel._getActiveTab();
+      original.pendingContext = ['original ctx'];
+      original.pendingContextData = [{ type: 'comment' }];
+      global.fetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ data: { id: 13, status: 'active' } }),
+      });
+
+      await chatPanel._openNewTab();
+      const newTab = chatPanel.tabs[chatPanel.tabs.length - 1];
+      expect(newTab.pendingContext).toEqual([]);
+      expect(newTab.pendingContextData).toEqual([]);
+      // Original tab still owns its context.
+      expect(chatPanel.tabs[0].pendingContext).toEqual(['original ctx']);
+    });
+
+    it('resets contextSource / contextItemId on a new tab', async () => {
+      const original = chatPanel._getActiveTab();
+      original.contextSource = 'suggestion';
+      original.contextItemId = 42;
+      global.fetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ data: { id: 14, status: 'active' } }),
+      });
+
+      await chatPanel._openNewTab();
+      const newTab = chatPanel.tabs[chatPanel.tabs.length - 1];
+      expect(newTab.contextSource).toBeNull();
+      expect(newTab.contextItemId).toBeNull();
+    });
+
+    it('resets sessionAnalysisRunId on a new tab', async () => {
+      const original = chatPanel._getActiveTab();
+      original.sessionAnalysisRunId = 'run-456';
+      global.fetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ data: { id: 15, status: 'active' } }),
+      });
+
+      await chatPanel._openNewTab();
+      const newTab = chatPanel.tabs[chatPanel.tabs.length - 1];
+      expect(newTab.sessionAnalysisRunId).toBeNull();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Multi-tab WebSocket isolation — the regression these tests guard against
+  // is the original bug: WS events on tab A were rerouted to whatever was
+  // active by the time the await resolved.
+  // -----------------------------------------------------------------------
+  describe('multi-tab: WS event isolation across tabs', () => {
+    function makeTwoTabs() {
+      const tabA = chatPanel._getActiveTab();
+      tabA.sessionId = 100;
+      chatPanel.activeTabKey = 100;
+      const tabB = chatPanel._createTab({ sessionId: 200 });
+      chatPanel._appendTab(tabB, { focus: false });
+      return { tabA, tabB };
+    }
+
+    it('delta + complete on background tab A do not bleed into foreground tab B', () => {
+      const { tabA, tabB } = makeTwoTabs();
+      chatPanel.activeTabKey = 200; // B is foreground
+      chatPanel.isOpen = true;
+      const bMessagesBefore = tabB.messages.slice();
+      const bStreamBefore = tabB.streamingContent;
+
+      chatPanel._handleChatMessageForTab(tabA, { type: 'delta', text: 'hello', sessionId: 100 });
+      chatPanel._handleChatMessageForTab(tabA, { type: 'complete', messageId: 9, sessionId: 100 });
+
+      expect(tabA.messages).toContainEqual({ role: 'assistant', content: 'hello', id: 9 });
+      expect(tabA.isStreaming).toBe(false);
+      // Tab B untouched
+      expect(tabB.messages).toEqual(bMessagesBefore);
+      expect(tabB.streamingContent).toBe(bStreamBefore);
+      expect(tabB.isStreaming).toBe(false);
+    });
+
+    it('delta + complete on foreground tab A do not bleed into background tab B', () => {
+      const { tabA, tabB } = makeTwoTabs(); // A is foreground (activeTabKey=100)
+      chatPanel.isOpen = true;
+
+      chatPanel._handleChatMessageForTab(tabA, { type: 'delta', text: 'fg', sessionId: 100 });
+      chatPanel._handleChatMessageForTab(tabA, { type: 'complete', messageId: 7, sessionId: 100 });
+
+      expect(tabA.messages).toContainEqual({ role: 'assistant', content: 'fg', id: 7 });
+      expect(tabB.messages).toEqual([]);
+      expect(tabB.streamingContent).toBe('');
+      expect(tabB.isStreaming).toBe(false);
+    });
+
+    it('finalises tab A correctly when user switches to tab B mid-stream', () => {
+      const { tabA, tabB } = makeTwoTabs();
+      chatPanel.isOpen = true;
+
+      // Simulate a real send: addStreamingPlaceholder establishes streamingMsgEl
+      chatPanel._addStreamingPlaceholder(tabA);
+      expect(tabA.streamingMsgEl).not.toBeNull();
+
+      // Delta arrives while A is foreground
+      chatPanel._handleChatMessageForTab(tabA, { type: 'delta', text: 'partial', sessionId: 100 });
+
+      // User switches to tab B mid-stream
+      chatPanel._switchToTab(chatPanel._tabKey(tabB));
+
+      // Complete arrives for A in the background — must still finalise into A
+      chatPanel._handleChatMessageForTab(tabA, { type: 'complete', messageId: 11, sessionId: 100 });
+
+      expect(tabA.streamingMsgEl).toBeNull();
+      expect(tabA.messages).toContainEqual({ role: 'assistant', content: 'partial', id: 11 });
+      expect(tabA.isStreaming).toBe(false);
+      expect(tabB.messages).toEqual([]);
+    });
+
+    it('_recoverAfterReconnect finalises both tabs when both are streaming', async () => {
+      const { tabA, tabB } = makeTwoTabs();
+      tabA.isStreaming = true;
+      tabA.streamingContent = 'A partial';
+      tabB.isStreaming = true;
+      tabB.streamingContent = 'B partial';
+      chatPanel.isOpen = true;
+      chatPanel.activeTabKey = 100; // A foreground
+
+      global.fetch.mockImplementation((url) => {
+        if (url === '/api/chat/session/100/messages') {
+          return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve({
+              data: { messages: [{ type: 'message', role: 'assistant', content: 'A full', id: 21 }] },
+            }),
+          });
+        }
+        if (url === '/api/chat/session/200/messages') {
+          return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve({
+              data: { messages: [{ type: 'message', role: 'assistant', content: 'B full', id: 22 }] },
+            }),
+          });
+        }
+        return Promise.resolve({ ok: false });
+      });
+
+      await chatPanel._recoverAfterReconnect();
+
+      expect(tabA.isStreaming).toBe(false);
+      expect(tabB.isStreaming).toBe(false);
+      expect(tabA.messages).toContainEqual({ role: 'assistant', content: 'A full', id: 21 });
+      expect(tabB.messages).toContainEqual({ role: 'assistant', content: 'B full', id: 22 });
+      expect(tabB.streamingMsgEl).toBeNull();
+    });
+
+    it('status:working on a tab already streaming does not call _updateTabStatus again', () => {
+      const tab = chatPanel._getActiveTab();
+      tab.sessionId = 'sid-1';
+      chatPanel.activeTabKey = 'sid-1';
+      chatPanel.isOpen = false;
+      tab.isStreaming = true;
+      tab.errorMessage = 'prior';
+      const spy = vi.spyOn(chatPanel, '_updateTabStatus');
+
+      chatPanel._handleChatMessageForTab(tab, { type: 'status', status: 'working', sessionId: 'sid-1' });
+
+      // _markStreaming short-circuits when isStreaming is already true
+      expect(spy).not.toHaveBeenCalled();
+      // errorMessage preserved
+      expect(tab.errorMessage).toBe('prior');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // queueDiffStateNotification + queueUserActionHint — semantic split.
+  //
+  // Diff state is a snapshot (one value per tab, overwriting writes); hints
+  // are an ordered log scoped to the active tab.
+  // -----------------------------------------------------------------------
+  describe('multi-tab: diff state + user action hint semantics', () => {
+    it('queueDiffStateNotification writes the same latest value into every tab', () => {
+      const tabA = chatPanel._getActiveTab();
+      tabA.sessionId = 1;
+      chatPanel.activeTabKey = 1;
+      const tabB = chatPanel._createTab({ sessionId: 2 });
+      chatPanel._appendTab(tabB, { focus: false });
+
+      chatPanel.queueDiffStateNotification('diff v1');
+
+      expect(tabA.latestDiffState).toBe('diff v1');
+      expect(tabB.latestDiffState).toBe('diff v1');
+    });
+
+    it('a second queueDiffStateNotification overwrites the first on every tab', () => {
+      const tabA = chatPanel._getActiveTab();
+      tabA.sessionId = 1;
+      const tabB = chatPanel._createTab({ sessionId: 2 });
+      chatPanel._appendTab(tabB, { focus: false });
+
+      chatPanel.queueDiffStateNotification('diff v1');
+      chatPanel.queueDiffStateNotification('diff v2');
+
+      expect(tabA.latestDiffState).toBe('diff v2');
+      expect(tabB.latestDiffState).toBe('diff v2');
+    });
+
+    it('queueUserActionHint appends only to the active tab', () => {
+      const tabA = chatPanel._getActiveTab();
+      tabA.sessionId = 1;
+      chatPanel.activeTabKey = 1;
+      const tabB = chatPanel._createTab({ sessionId: 2 });
+      chatPanel._appendTab(tabB, { focus: false });
+      chatPanel.activeTabKey = 1; // Force A to remain active
+
+      chatPanel.queueUserActionHint('[hint]');
+
+      expect(tabA.pendingUserActionHints).toEqual(['[hint]']);
+      expect(tabB.pendingUserActionHints).toEqual([]);
+    });
+
+    it('queueUserActionHint is a silent no-op when there is no active tab', () => {
+      clearActiveTab(chatPanel);
+      expect(() => chatPanel.queueUserActionHint('[hint]')).not.toThrow();
+      // No tabs were created.
+      expect(chatPanel.tabs).toEqual([]);
+    });
+
+    it('sendMessage drains diff state and hints from tab A only', async () => {
+      const tabA = chatPanel._getActiveTab();
+      tabA.sessionId = 1;
+      chatPanel.activeTabKey = 1;
+      const tabB = chatPanel._createTab({ sessionId: 2 });
+      chatPanel._appendTab(tabB, { focus: false });
+      chatPanel.activeTabKey = 1; // A active
+
+      chatPanel.queueDiffStateNotification('diff snapshot');
+      chatPanel.queueUserActionHint('[hint]');
+
+      chatPanel.inputEl.value = 'hello';
+      global.fetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({}) });
+
+      await chatPanel.sendMessage();
+
+      // Tab A drained
+      expect(tabA.latestDiffState).toBeNull();
+      expect(tabA.pendingUserActionHints).toEqual([]);
+      // Tab B's diff state is still the latest snapshot (not drained by A's send)
+      expect(tabB.latestDiffState).toBe('diff snapshot');
+
+      // Wire-level check: the drained values must actually appear in the POST
+      // body, otherwise the agent never sees them.
+      const sendBody = JSON.parse(global.fetch.mock.calls[0][1].body);
+      expect(sendBody.context).toContain('diff snapshot');
+      expect(sendBody.context).toContain('[hint]');
+    });
+
+    it('queueDiffStateNotification keeps _initialDiffState fresh even when tabs exist', () => {
+      // Without this invariant, a tab opened mid-stream would inherit an
+      // outdated snapshot. The update-alongside design always overwrites
+      // _initialDiffState so the next tab opened sees the latest.
+      const tabA = chatPanel._getActiveTab();
+      tabA.sessionId = 1;
+      chatPanel.queueDiffStateNotification('v1');
+      chatPanel.queueDiffStateNotification('v2');
+      expect(chatPanel._initialDiffState).toBe('v2');
+      // A tab opened now sees v2, not v1.
+      const fresh = chatPanel._createTab({});
+      expect(fresh.latestDiffState).toBe('v2');
+    });
+
+    it('integration: delta+complete on a freshly-sent tab updates the tab DOM and tab strip dot', async () => {
+      // Open a new tab, lazily POST via sendMessage, then drive WS deltas
+      // through _handleChatMessageForTab and verify the per-tab messagesEl
+      // contains the assistant content and the strip dot returned to idle.
+      chatPanel.reviewId = 1;
+      clearActiveTab(chatPanel);
+
+      // _openNewTab no longer POSTs — just creates a tab with sessionId=null
+      await chatPanel._openNewTab();
+      const tab = chatPanel.tabs[chatPanel.tabs.length - 1];
+      expect(tab.sessionId).toBeNull();
+
+      // Fire sendMessage; the lazy-create path POSTs and the second fetch is
+      // the message send. Mock both.
+      chatPanel.inputEl.value = 'hi there';
+      global.fetch
+        .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ data: { id: 777, status: 'active' } }) })
+        .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({}) });
+
+      await chatPanel.sendMessage();
+
+      expect(tab.sessionId).toBe(777);
+      // Drive a streaming delta and complete event into the captured tab.
+      chatPanel.isOpen = true;
+      chatPanel.activeTabKey = tab.sessionId;
+      chatPanel._handleChatMessageForTab(tab, { type: 'delta', text: 'hello world', sessionId: 777 });
+      chatPanel._handleChatMessageForTab(tab, { type: 'complete', messageId: 42, sessionId: 777 });
+
+      // Tab now has the assistant message and idled out.
+      expect(tab.messages).toContainEqual({ role: 'assistant', content: 'hello world', id: 42 });
+      expect(tab.isStreaming).toBe(false);
+      expect(tab.status).toBe('idle');
+    });
+
+    it('queueDiffStateNotification stashes _initialDiffState when no tabs are open', () => {
+      clearActiveTab(chatPanel);
+      chatPanel.queueDiffStateNotification('pre-tab diff');
+      expect(chatPanel._initialDiffState).toBe('pre-tab diff');
+      // Next tab inherits the stashed value.
+      const tab = chatPanel._createTab({ sessionId: 50 });
+      expect(tab.latestDiffState).toBe('pre-tab diff');
     });
   });
 });

--- a/tests/unit/chat-panel.test.js
+++ b/tests/unit/chat-panel.test.js
@@ -5748,7 +5748,9 @@ describe('ChatPanel', () => {
     it('_createTab produces a tab with sensible defaults', () => {
       const tab = chatPanel._createTab();
       expect(tab.sessionId).toBeNull();
-      expect(tab.status).toBe('idle');
+      // Fresh tabs start in 'pending' (gray dot) until the first message
+      // is exchanged. See _updateTabStatus for the demote rule.
+      expect(tab.status).toBe('pending');
       expect(tab.messages).toEqual([]);
       expect(tab.isStreaming).toBe(false);
       expect(tab.streamingContent).toBe('');
@@ -5874,9 +5876,9 @@ describe('ChatPanel', () => {
   });
 
   describe('multi-tab: status dot derivation', () => {
-    it('starts a tab at status: idle', () => {
+    it('starts a fresh tab at status: pending', () => {
       const tab = chatPanel._getActiveTab();
-      expect(tab.status).toBe('idle');
+      expect(tab.status).toBe('pending');
     });
 
     it('isStreaming setter pushes the active tab to status: streaming', () => {
@@ -5884,12 +5886,22 @@ describe('ChatPanel', () => {
       expect(chatPanel._getActiveTab().status).toBe('streaming');
     });
 
-    it('isStreaming = false on an error-free tab returns to status: idle', () => {
+    it('isStreaming = false on an error-free tab with messages returns to status: idle', () => {
       const tab = chatPanel._getActiveTab();
       tab.errorMessage = null;
+      tab.messages = [{ role: 'user', content: 'hi' }];
       chatPanel.isStreaming = true;
       chatPanel.isStreaming = false;
       expect(tab.status).toBe('idle');
+    });
+
+    it('isStreaming = false on an empty tab returns to status: pending, not idle', () => {
+      const tab = chatPanel._getActiveTab();
+      tab.errorMessage = null;
+      tab.messages = [];
+      chatPanel.isStreaming = true;
+      chatPanel.isStreaming = false;
+      expect(tab.status).toBe('pending');
     });
 
     it('isStreaming = false on a tab with errorMessage keeps status: error', () => {
@@ -6149,9 +6161,11 @@ describe('ChatPanel', () => {
       // Inspect all fetch calls; the only one expected is /api/review/.../chat/sessions.
       const urls = global.fetch.mock.calls.map(c => c[0]);
       expect(urls.some(u => typeof u === 'string' && u.includes('/resume'))).toBe(false);
-      // All restored tabs default to status idle.
+      // Restored tabs start in 'pending' until their message history loads
+      // and the first message is observed. The fixture session has
+      // message_count: 0, so it remains pending throughout.
       for (const tab of chatPanel.tabs) {
-        expect(tab.status).toBe('idle');
+        expect(tab.status).toBe('pending');
       }
     });
 
@@ -6588,6 +6602,44 @@ describe('ChatPanel', () => {
       expect(spy).not.toHaveBeenCalled();
       // errorMessage preserved
       expect(tab.errorMessage).toBe('prior');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Tab status: 'pending' for fresh tabs (gray dot until first message)
+  // -----------------------------------------------------------------------
+  describe('tab status: pending → idle gating on first message', () => {
+    it('newly created tabs start in the "pending" status', () => {
+      const tab = chatPanel._createTab({});
+      expect(tab.status).toBe('pending');
+    });
+
+    it('_updateTabStatus(tab, "idle") on an empty tab demotes to "pending"', () => {
+      const tab = chatPanel._createTab({});
+      tab.messages = [];
+      chatPanel._updateTabStatus(tab, 'idle');
+      expect(tab.status).toBe('pending');
+    });
+
+    it('_updateTabStatus(tab, "idle") on a tab with messages stays "idle"', () => {
+      const tab = chatPanel._createTab({});
+      tab.messages = [{ role: 'user', content: 'hi' }];
+      chatPanel._updateTabStatus(tab, 'idle');
+      expect(tab.status).toBe('idle');
+    });
+
+    it('_updateTabStatus(tab, "streaming") always wins, even on empty tab', () => {
+      const tab = chatPanel._createTab({});
+      tab.messages = [];
+      chatPanel._updateTabStatus(tab, 'streaming');
+      expect(tab.status).toBe('streaming');
+    });
+
+    it('_updateTabStatus(tab, "error") always wins, even on empty tab', () => {
+      const tab = chatPanel._createTab({});
+      tab.messages = [];
+      chatPanel._updateTabStatus(tab, 'error');
+      expect(tab.status).toBe('error');
     });
   });
 


### PR DESCRIPTION
## Summary
- Adds a tab strip to the chat panel so multiple conversations can run side-by-side, each with an idle/streaming/error status dot.
- Persists open tabs and the focused conversation across reloads.
- Marks already-open sessions in the history dropdown so picking one focuses its tab instead of duplicating it.

## Test plan
- [ ] Open the chat panel, hit `+` to start a second conversation, send a message in each — both stream independently.
- [ ] Reload the page — open tabs and the focused tab restore.
- [ ] Open the session history dropdown — sessions already loaded in a tab show an "open" tag; selecting one focuses the existing tab.
- [ ] Close a tab via `x` — the tab disappears but the session record remains.
- [ ] Trigger a 404 (delete a session out-of-band) while another tab swap is in flight — the stale 404 does not tear down a repointed tab.
- [ ] `pnpm test` and `pnpm run test:e2e` (includes new `tests/e2e/chat-tabs.spec.js`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)