### PR TITLE
Honor chat availability commands

### DIFF
--- a/.changeset/honor-chat-availability-command.md
+++ b/.changeset/honor-chat-availability-command.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Honor `chat_providers.*.availability_command` when checking chat provider availability.

--- a/src/chat/chat-providers.js
+++ b/src/chat/chat-providers.js
@@ -118,6 +118,9 @@ function getChatProvider(id) {
     };
     if (overrides.model) provider.model = overrides.model;
     if (overrides.provider) provider.provider = overrides.provider;
+    if (overrides.availability_command !== undefined) {
+      provider.availability_command = overrides.availability_command;
+    }
     if (overrides.extra_args && Array.isArray(overrides.extra_args)) {
       provider.args = [...provider.args, ...overrides.extra_args];
     }
@@ -136,6 +139,9 @@ function getChatProvider(id) {
   if (overrides.command) merged.command = overrides.command;
   if (overrides.model) merged.model = overrides.model;
   if (overrides.provider) merged.provider = overrides.provider;
+  if (overrides.availability_command !== undefined) {
+    merged.availability_command = overrides.availability_command;
+  }
   if (overrides.env) merged.env = { ...merged.env, ...overrides.env };
   if (overrides.args) {
     merged.args = overrides.args;
@@ -197,8 +203,10 @@ function isCodexProvider(id) {
 
 /**
  * Check availability of a single chat provider.
- * For Pi, delegates to the existing AI provider availability cache.
- * For ACP providers, spawns `<command> --version` to verify the binary exists.
+ * Providers with `availability_command` run that command first.
+ * Without an availability command, Pi delegates to the existing AI provider
+ * availability cache and other providers spawn `<command> --version` to verify
+ * the binary exists.
  * @param {string} id - Provider ID
  * @param {Object} [_deps] - Dependency overrides for testing
  * @returns {Promise<{available: boolean, error?: string}>}
@@ -207,6 +215,18 @@ async function checkChatProviderAvailability(id, _deps) {
   const provider = getChatProvider(id);
   if (!provider) {
     return { available: false, error: `Unknown provider: ${id}` };
+  }
+
+  const deps = { ...defaults, ..._deps };
+
+  if (provider.availability_command) {
+    return runCommandAvailabilityCheck({
+      deps,
+      command: provider.availability_command,
+      args: [],
+      displayCommand: 'availability command',
+      shell: true,
+    });
   }
 
   // Pi delegates to existing AI provider availability
@@ -218,30 +238,41 @@ async function checkChatProviderAvailability(id, _deps) {
   // Codex uses the same binary-check pattern as ACP providers
   // (falls through to the spawn check below)
 
-  const deps = { ...defaults, ..._deps };
   const command = provider.command;
   const useShell = provider.useShell || false;
 
+  // For multi-word commands, use shell mode
+  const spawnCmd = useShell ? `${command} --version` : command;
+  const spawnArgs = useShell ? [] : ['--version'];
+  return runCommandAvailabilityCheck({
+    deps,
+    command: spawnCmd,
+    args: spawnArgs,
+    displayCommand: `${command} --version`,
+    shell: useShell,
+  });
+}
+
+function runCommandAvailabilityCheck({ deps, command, args, displayCommand, shell }) {
   return new Promise((resolve) => {
     try {
-      // For multi-word commands, use shell mode
-      const spawnCmd = useShell ? `${command} --version` : command;
-      const spawnArgs = useShell ? [] : ['--version'];
-      const proc = deps.spawn(spawnCmd, spawnArgs, {
-        stdio: ['ignore', 'pipe', 'pipe'],
+      const proc = deps.spawn(command, args, {
+        stdio: ['ignore', 'ignore', 'ignore'],
         timeout: 10000,
-        shell: useShell,
+        shell,
       });
 
-      proc.on('error', (err) => {
+      proc.once('error', (err) => {
         resolve({ available: false, error: err.message });
       });
 
-      proc.on('close', (code) => {
+      proc.once('close', (code, signal) => {
         if (code === 0) {
           resolve({ available: true });
+        } else if (signal) {
+          resolve({ available: false, error: `${displayCommand} timed out or was terminated (${signal})` });
         } else {
-          resolve({ available: false, error: `${command} --version exited with code ${code}` });
+          resolve({ available: false, error: `${displayCommand} exited with code ${code}` });
         }
       });
     } catch (err) {

--- a/tests/unit/chat/chat-providers.test.js
+++ b/tests/unit/chat/chat-providers.test.js
@@ -205,6 +205,22 @@ describe('chat-providers', () => {
       expect(provider.command).toBe('my-pi');
     });
 
+    it('should pass through availability_command for dynamic providers', () => {
+      applyConfigOverrides({
+        'river': { type: 'pi', command: 'my-pi', availability_command: 'true' },
+      });
+      const provider = getChatProvider('river');
+      expect(provider.availability_command).toBe('true');
+    });
+
+    it('should pass through availability_command from config overrides for built-in providers', () => {
+      applyConfigOverrides({
+        'pi': { availability_command: 'devx pi --version' },
+      });
+      const provider = getChatProvider('pi');
+      expect(provider.availability_command).toBe('devx pi --version');
+    });
+
     it('should pass through load_skills from config overrides for built-in providers', () => {
       applyConfigOverrides({
         'pi': { load_skills: false },
@@ -439,6 +455,112 @@ describe('chat-providers', () => {
 
       // With shell mode, command is joined with args
       expect(mockSpawn).toHaveBeenCalledWith('devx claude --version', [], expect.objectContaining({ shell: true }));
+    });
+
+    it('should use availability_command for dynamic providers', async () => {
+      applyConfigOverrides({
+        'custom-chat': { command: 'custom-chat', availability_command: 'true' },
+      });
+
+      const { EventEmitter } = require('events');
+      const fakeProc = new EventEmitter();
+      const mockSpawn = vi.fn().mockReturnValue(fakeProc);
+
+      const promise = checkChatProviderAvailability('custom-chat', { spawn: mockSpawn });
+      fakeProc.emit('close', 0);
+
+      const result = await promise;
+      expect(result).toEqual({ available: true });
+      expect(mockSpawn).toHaveBeenCalledWith('true', [], expect.objectContaining({ shell: true, timeout: 10000 }));
+    });
+
+    it('should not consult cached generic pi availability for pi-typed dynamic providers with availability_command', async () => {
+      applyConfigOverrides({
+        'river-local': { type: 'pi', command: 'tec run //system/river/agent --', availability_command: 'true' },
+      });
+      mockGetCachedAvailability.mockReturnValue({ available: false, error: 'generic pi unavailable' });
+
+      const { EventEmitter } = require('events');
+      const fakeProc = new EventEmitter();
+      const mockSpawn = vi.fn().mockReturnValue(fakeProc);
+
+      const promise = checkChatProviderAvailability('river-local', { spawn: mockSpawn });
+      fakeProc.emit('close', 0);
+
+      const result = await promise;
+      expect(result).toEqual({ available: true });
+      expect(mockGetCachedAvailability).not.toHaveBeenCalled();
+      expect(mockSpawn).toHaveBeenCalledWith('true', [], expect.objectContaining({ shell: true }));
+    });
+
+    it('should use availability_command from built-in provider overrides', async () => {
+      applyConfigOverrides({
+        'claude': { availability_command: 'devx claude doctor' },
+      });
+
+      const { EventEmitter } = require('events');
+      const fakeProc = new EventEmitter();
+      const mockSpawn = vi.fn().mockReturnValue(fakeProc);
+
+      const promise = checkChatProviderAvailability('claude', { spawn: mockSpawn });
+      fakeProc.emit('close', 0);
+
+      const result = await promise;
+      expect(result).toEqual({ available: true });
+      expect(mockSpawn).toHaveBeenCalledWith('devx claude doctor', [], expect.objectContaining({ shell: true }));
+    });
+
+    it('should return unavailable when availability_command exits non-zero', async () => {
+      applyConfigOverrides({
+        'custom-chat': { command: 'custom-chat', availability_command: 'false' },
+      });
+
+      const { EventEmitter } = require('events');
+      const fakeProc = new EventEmitter();
+      const mockSpawn = vi.fn().mockReturnValue(fakeProc);
+
+      const promise = checkChatProviderAvailability('custom-chat', { spawn: mockSpawn });
+      fakeProc.emit('close', 1);
+
+      const result = await promise;
+      expect(result.available).toBe(false);
+      expect(result.error).toContain('availability command exited with code 1');
+      expect(result.error).not.toContain('false');
+    });
+
+    it('should return unavailable when availability_command spawn errors', async () => {
+      applyConfigOverrides({
+        'custom-chat': { command: 'custom-chat', availability_command: 'custom doctor' },
+      });
+
+      const { EventEmitter } = require('events');
+      const fakeProc = new EventEmitter();
+      const mockSpawn = vi.fn().mockReturnValue(fakeProc);
+
+      const promise = checkChatProviderAvailability('custom-chat', { spawn: mockSpawn });
+      fakeProc.emit('error', new Error('spawn failed'));
+
+      const result = await promise;
+      expect(result).toEqual({ available: false, error: 'spawn failed' });
+    });
+
+    it('should return unavailable when availability_command times out', async () => {
+      applyConfigOverrides({
+        'custom-chat': { command: 'custom-chat', availability_command: 'sleep 30' },
+      });
+
+      const { EventEmitter } = require('events');
+      const fakeProc = new EventEmitter();
+      const mockSpawn = vi.fn().mockReturnValue(fakeProc);
+
+      const promise = checkChatProviderAvailability('custom-chat', { spawn: mockSpawn });
+      fakeProc.emit('close', null, 'SIGTERM');
+
+      const result = await promise;
+      expect(result.available).toBe(false);
+      expect(result.error).toContain('availability command timed out or was terminated (SIGTERM)');
+      expect(result.error).not.toContain('sleep 30');
+      expect(mockSpawn).toHaveBeenCalledWith('sleep 30', [], expect.objectContaining({ timeout: 10000 }));
     });
   });
 


### PR DESCRIPTION
## Summary

Chat provider config can define an `availability_command`, but the availability check ignored that field for chat providers. That meant custom providers could be marked unavailable by the generic fallback check even when they configured a dedicated probe.

## Approach

- Preserve `availability_command` on dynamic chat providers and built-in provider overrides.
- Run configured availability commands with the existing injected `spawn` dependency, shell mode, and the same timeout used by version checks.
- Avoid capturing child stdout/stderr for availability probes, since availability only depends on exit status.
- Keep the existing fallback path unchanged when no `availability_command` is configured: Pi providers use generic cached Pi availability and other providers run `<command> --version`.
- Add focused unit coverage for configured command success, fallback behavior, and failure modes.

## Verification

- `npm test -- tests/unit/chat/chat-providers.test.js`
- `npm test` (151 files / 6351 tests passed; `tests/integration/council-routes.test.js` had one `socket hang up` failure during the full run)
- `npm test -- tests/integration/council-routes.test.js` passed on retry

Co-authored-by: Claude <noreply@anthropic.com>
Orchestrated-by: ae <noreply@shopify.com>
