### PR TITLE
Honor availability_command for chat providers

### DIFF
--- a/.changeset/honor-chat-availability-command.md
+++ b/.changeset/honor-chat-availability-command.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Honor `availability_command` for chat providers. Built-in providers and dynamic chat providers defined in config can now run a configured probe to determine availability instead of falling back to the generic `<command> --version` check (or, for Pi, the cached AI availability). Also hardens the underlying check: stdout/stderr are discarded to avoid pipe-buffer deadlock on verbose probes, signal-terminated processes are distinguished from non-zero exits, and error messages no longer leak the raw shell command.

--- a/src/chat/chat-providers.js
+++ b/src/chat/chat-providers.js
@@ -118,6 +118,9 @@ function getChatProvider(id) {
     };
     if (overrides.model) provider.model = overrides.model;
     if (overrides.provider) provider.provider = overrides.provider;
+    if (overrides.availability_command !== undefined) {
+      provider.availability_command = overrides.availability_command;
+    }
     if (overrides.extra_args && Array.isArray(overrides.extra_args)) {
       provider.args = [...provider.args, ...overrides.extra_args];
     }
@@ -136,6 +139,9 @@ function getChatProvider(id) {
   if (overrides.command) merged.command = overrides.command;
   if (overrides.model) merged.model = overrides.model;
   if (overrides.provider) merged.provider = overrides.provider;
+  if (overrides.availability_command !== undefined) {
+    merged.availability_command = overrides.availability_command;
+  }
   if (overrides.env) merged.env = { ...merged.env, ...overrides.env };
   if (overrides.args) {
     merged.args = overrides.args;
@@ -197,8 +203,10 @@ function isCodexProvider(id) {
 
 /**
  * Check availability of a single chat provider.
- * For Pi, delegates to the existing AI provider availability cache.
- * For ACP providers, spawns `<command> --version` to verify the binary exists.
+ * Providers with `availability_command` run that command first.
+ * Without an availability command, Pi delegates to the existing AI provider
+ * availability cache and other providers spawn `<command> --version` to verify
+ * the binary exists.
  * @param {string} id - Provider ID
  * @param {Object} [_deps] - Dependency overrides for testing
  * @returns {Promise<{available: boolean, error?: string}>}
@@ -207,6 +215,19 @@ async function checkChatProviderAvailability(id, _deps) {
   const provider = getChatProvider(id);
   if (!provider) {
     return { available: false, error: `Unknown provider: ${id}` };
+  }
+
+  const deps = { ...defaults, ..._deps };
+
+  if (provider.availability_command) {
+    return runCommandAvailabilityCheck({
+      deps,
+      command: provider.availability_command,
+      args: [],
+      displayCommand: 'availability command',
+      shell: true,
+      env: provider.env,
+    });
   }
 
   // Pi delegates to existing AI provider availability
@@ -218,30 +239,61 @@ async function checkChatProviderAvailability(id, _deps) {
   // Codex uses the same binary-check pattern as ACP providers
   // (falls through to the spawn check below)
 
-  const deps = { ...defaults, ..._deps };
   const command = provider.command;
   const useShell = provider.useShell || false;
 
+  // For multi-word commands, use shell mode
+  const spawnCmd = useShell ? `${command} --version` : command;
+  const spawnArgs = useShell ? [] : ['--version'];
+  return runCommandAvailabilityCheck({
+    deps,
+    command: spawnCmd,
+    args: spawnArgs,
+    displayCommand: `${command} --version`,
+    shell: useShell,
+    env: provider.env,
+  });
+}
+
+/**
+ * Spawn a command and resolve based on its exit status. Shared by the
+ * configured `availability_command` path and the legacy `<command> --version`
+ * fallback.
+ *
+ * Notes on the option choices:
+ * - `stdio: ['ignore', 'ignore', 'ignore']` discards output so a verbose probe
+ *   cannot fill an OS pipe buffer and block while waiting for a reader.
+ * - `shell: true` allows multi-word configured commands to run through the
+ *   user's shell.
+ * - `once()` avoids leaking listeners or resolving twice if multiple child
+ *   process events fire.
+ * - `displayCommand` is used in error messages so user-configured shell strings
+ *   do not need to be printed verbatim.
+ *
+ * @param {{deps: {spawn: Function}, command: string, args: string[], displayCommand: string, shell: boolean, env?: Record<string, string>}} opts
+ * @returns {Promise<{available: boolean, error?: string}>}
+ */
+function runCommandAvailabilityCheck({ deps, command, args, displayCommand, shell, env }) {
   return new Promise((resolve) => {
     try {
-      // For multi-word commands, use shell mode
-      const spawnCmd = useShell ? `${command} --version` : command;
-      const spawnArgs = useShell ? [] : ['--version'];
-      const proc = deps.spawn(spawnCmd, spawnArgs, {
-        stdio: ['ignore', 'pipe', 'pipe'],
+      const proc = deps.spawn(command, args, {
+        stdio: ['ignore', 'ignore', 'ignore'],
         timeout: 10000,
-        shell: useShell,
+        shell,
+        env: { ...process.env, ...(env || {}) },
       });
 
-      proc.on('error', (err) => {
+      proc.once('error', (err) => {
         resolve({ available: false, error: err.message });
       });
 
-      proc.on('close', (code) => {
+      proc.once('close', (code, signal) => {
         if (code === 0) {
           resolve({ available: true });
+        } else if (signal) {
+          resolve({ available: false, error: `${displayCommand} timed out or was terminated (${signal})` });
         } else {
-          resolve({ available: false, error: `${command} --version exited with code ${code}` });
+          resolve({ available: false, error: `${displayCommand} exited with code ${code}` });
         }
       });
     } catch (err) {

--- a/src/chat/chat-providers.js
+++ b/src/chat/chat-providers.js
@@ -270,7 +270,7 @@ async function checkChatProviderAvailability(id, _deps) {
  * - `displayCommand` is used in error messages so user-configured shell strings
  *   do not need to be printed verbatim.
  *
- * @param {{deps: {spawn: Function}, command: string, args: string[], displayCommand: string, shell: boolean, env?: Record<string, string>}} opts
+ * @param {{deps: {spawn: Function}, command: string, args: string[], displayCommand: string, shell: boolean, env?: Object}} opts
  * @returns {Promise<{available: boolean, error?: string}>}
  */
 function runCommandAvailabilityCheck({ deps, command, args, displayCommand, shell, env }) {

--- a/tests/unit/chat/chat-providers.test.js
+++ b/tests/unit/chat/chat-providers.test.js
@@ -205,6 +205,22 @@ describe('chat-providers', () => {
       expect(provider.command).toBe('my-pi');
     });
 
+    it('should pass through availability_command for dynamic providers', () => {
+      applyConfigOverrides({
+        'river': { type: 'pi', command: 'my-pi', availability_command: 'true' },
+      });
+      const provider = getChatProvider('river');
+      expect(provider.availability_command).toBe('true');
+    });
+
+    it('should pass through availability_command from config overrides for built-in providers', () => {
+      applyConfigOverrides({
+        'pi': { availability_command: 'devx pi --version' },
+      });
+      const provider = getChatProvider('pi');
+      expect(provider.availability_command).toBe('devx pi --version');
+    });
+
     it('should pass through load_skills from config overrides for built-in providers', () => {
       applyConfigOverrides({
         'pi': { load_skills: false },
@@ -439,6 +455,156 @@ describe('chat-providers', () => {
 
       // With shell mode, command is joined with args
       expect(mockSpawn).toHaveBeenCalledWith('devx claude --version', [], expect.objectContaining({ shell: true }));
+    });
+
+    it('should use availability_command for dynamic providers', async () => {
+      applyConfigOverrides({
+        'custom-chat': { command: 'custom-chat', availability_command: 'true' },
+      });
+
+      const { EventEmitter } = require('events');
+      const fakeProc = new EventEmitter();
+      const mockSpawn = vi.fn().mockReturnValue(fakeProc);
+
+      const promise = checkChatProviderAvailability('custom-chat', { spawn: mockSpawn });
+      fakeProc.emit('close', 0);
+
+      const result = await promise;
+      expect(result).toEqual({ available: true });
+      expect(mockSpawn).toHaveBeenCalledWith('true', [], expect.objectContaining({ shell: true, timeout: 10000 }));
+    });
+
+    it('should not consult cached generic pi availability for pi-typed dynamic providers with availability_command', async () => {
+      applyConfigOverrides({
+        'river-local': { type: 'pi', command: 'tec run //system/river/agent --', availability_command: 'true' },
+      });
+      mockGetCachedAvailability.mockReturnValue({ available: false, error: 'generic pi unavailable' });
+
+      const { EventEmitter } = require('events');
+      const fakeProc = new EventEmitter();
+      const mockSpawn = vi.fn().mockReturnValue(fakeProc);
+
+      const promise = checkChatProviderAvailability('river-local', { spawn: mockSpawn });
+      fakeProc.emit('close', 0);
+
+      const result = await promise;
+      expect(result).toEqual({ available: true });
+      expect(mockGetCachedAvailability).not.toHaveBeenCalled();
+      expect(mockSpawn).toHaveBeenCalledWith('true', [], expect.objectContaining({ shell: true }));
+    });
+
+    it('should use availability_command from built-in provider overrides', async () => {
+      applyConfigOverrides({
+        'claude': { availability_command: 'devx claude doctor' },
+      });
+
+      const { EventEmitter } = require('events');
+      const fakeProc = new EventEmitter();
+      const mockSpawn = vi.fn().mockReturnValue(fakeProc);
+
+      const promise = checkChatProviderAvailability('claude', { spawn: mockSpawn });
+      fakeProc.emit('close', 0);
+
+      const result = await promise;
+      expect(result).toEqual({ available: true });
+      expect(mockSpawn).toHaveBeenCalledWith('devx claude doctor', [], expect.objectContaining({ shell: true }));
+    });
+
+    it('should return unavailable when availability_command exits non-zero', async () => {
+      applyConfigOverrides({
+        'custom-chat': { command: 'custom-chat', availability_command: 'false' },
+      });
+
+      const { EventEmitter } = require('events');
+      const fakeProc = new EventEmitter();
+      const mockSpawn = vi.fn().mockReturnValue(fakeProc);
+
+      const promise = checkChatProviderAvailability('custom-chat', { spawn: mockSpawn });
+      fakeProc.emit('close', 1);
+
+      const result = await promise;
+      expect(result.available).toBe(false);
+      expect(result.error).toContain('availability command exited with code 1');
+      expect(result.error).not.toContain('false');
+    });
+
+    it('should return unavailable when availability_command spawn errors', async () => {
+      applyConfigOverrides({
+        'custom-chat': { command: 'custom-chat', availability_command: 'custom doctor' },
+      });
+
+      const { EventEmitter } = require('events');
+      const fakeProc = new EventEmitter();
+      const mockSpawn = vi.fn().mockReturnValue(fakeProc);
+
+      const promise = checkChatProviderAvailability('custom-chat', { spawn: mockSpawn });
+      fakeProc.emit('error', new Error('spawn failed'));
+
+      const result = await promise;
+      expect(result).toEqual({ available: false, error: 'spawn failed' });
+    });
+
+    it('should return unavailable when availability_command times out', async () => {
+      applyConfigOverrides({
+        'custom-chat': { command: 'custom-chat', availability_command: 'sleep 30' },
+      });
+
+      const { EventEmitter } = require('events');
+      const fakeProc = new EventEmitter();
+      const mockSpawn = vi.fn().mockReturnValue(fakeProc);
+
+      const promise = checkChatProviderAvailability('custom-chat', { spawn: mockSpawn });
+      fakeProc.emit('close', null, 'SIGTERM');
+
+      const result = await promise;
+      expect(result.available).toBe(false);
+      expect(result.error).toContain('availability command timed out or was terminated (SIGTERM)');
+      expect(result.error).not.toContain('sleep 30');
+      expect(mockSpawn).toHaveBeenCalledWith('sleep 30', [], expect.objectContaining({ timeout: 10000 }));
+    });
+
+    it('should merge provider.env over process.env when running availability_command', async () => {
+      applyConfigOverrides({
+        'custom-chat': {
+          command: 'custom-chat',
+          availability_command: 'true',
+          env: { CUSTOM_VAR: 'value' },
+        },
+      });
+
+      const { EventEmitter } = require('events');
+      const fakeProc = new EventEmitter();
+      const mockSpawn = vi.fn().mockReturnValue(fakeProc);
+
+      const promise = checkChatProviderAvailability('custom-chat', { spawn: mockSpawn });
+      fakeProc.emit('close', 0);
+      await promise;
+
+      const spawnOpts = mockSpawn.mock.calls[0][2];
+      expect(spawnOpts.env).toMatchObject({
+        ...process.env,
+        CUSTOM_VAR: 'value',
+      });
+    });
+
+    it('should merge provider.env over process.env when running --version probe', async () => {
+      applyConfigOverrides({
+        'copilot-acp': { env: { CUSTOM_VAR: 'value' } },
+      });
+
+      const { EventEmitter } = require('events');
+      const fakeProc = new EventEmitter();
+      const mockSpawn = vi.fn().mockReturnValue(fakeProc);
+
+      const promise = checkChatProviderAvailability('copilot-acp', { spawn: mockSpawn });
+      fakeProc.emit('close', 0);
+      await promise;
+
+      const spawnOpts = mockSpawn.mock.calls[0][2];
+      expect(spawnOpts.env).toMatchObject({
+        ...process.env,
+        CUSTOM_VAR: 'value',
+      });
     });
   });
 

--- a/tests/unit/chat/chat-providers.test.js
+++ b/tests/unit/chat/chat-providers.test.js
@@ -606,6 +606,30 @@ describe('chat-providers', () => {
         CUSTOM_VAR: 'value',
       });
     });
+
+    it('should pass merged env including parent process env and provider env override to availability_command spawn', async () => {
+      applyConfigOverrides({
+        'custom-chat': {
+          command: 'custom-chat',
+          availability_command: 'true',
+          env: { CUSTOM_API_KEY: 'secret' },
+        },
+      });
+
+      const { EventEmitter } = require('events');
+      const fakeProc = new EventEmitter();
+      const mockSpawn = vi.fn().mockReturnValue(fakeProc);
+
+      const promise = checkChatProviderAvailability('custom-chat', { spawn: mockSpawn });
+      fakeProc.emit('close', 0);
+      await promise;
+
+      const spawnOpts = mockSpawn.mock.calls[0][2];
+      expect(spawnOpts.env).toMatchObject({
+        ...process.env,
+        CUSTOM_API_KEY: 'secret',
+      });
+    });
   });
 
   describe('checkAllChatProviders', () => {


### PR DESCRIPTION
## Summary

- Adopts shop/world#731459 directly: chat providers now honor a configured `availability_command`, matching the existing behavior on the AI analysis side (`executable-provider.js`). Built-in providers and dynamic chat providers defined entirely in config can both supply a probe; absent one, the existing `<command> --version` (or, for Pi, cached AI availability) fallback is unchanged.
- Hardens the underlying availability check: stdout/stderr are discarded (avoids pipe-buffer deadlock on verbose probes), signal-terminated processes are distinguished from non-zero exits, and error messages no longer leak the raw shell command string into UI/logs.
- Threads `provider.env` through the probe so a user-configured `PATH` or API key is visible to the availability command, matching the env-merge pattern used by `claude-code-bridge`, `codex-bridge`, `acp-bridge`, and `pi-bridge`.

## Test plan

- [x] `pnpm test tests/unit/chat/chat-providers.test.js` — 66/66 pass, including new coverage for: `availability_command` happy path, non-zero exit, spawn error, timeout (SIGTERM), built-in vs dynamic provider overrides, env merge for both probe paths, and the "doesn't leak shell command in error" cases.
- [ ] Manual smoke: configure a dynamic chat provider with `availability_command` and verify it surfaces as available/unavailable in the chat picker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)