### PR TITLE
Fix Codex CLI and chat integration

### DIFF
--- a/.changeset/fix-codex-full-auto.md
+++ b/.changeset/fix-codex-full-auto.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Remove the deprecated `--full-auto` flag from Codex CLI review invocations and allow Codex chat sessions to call the local pair-review API.

--- a/README.md
+++ b/README.md
@@ -493,7 +493,7 @@ Configure your preferred models in `providers.pi.models` — see [AI Provider Co
 }
 ```
 
-Available chat provider IDs: `pi`, `claude`, `codex`, `copilot-acp`, `gemini-acp`, `opencode-acp`, `cursor-acp`. Each supports `command`, `args` (replaces defaults), `extra_args` (appends), and `env` overrides.
+Available chat provider IDs: `pi`, `claude`, `codex`, `copilot-acp`, `gemini-acp`, `opencode-acp`, `cursor-acp`. Each supports `command`, `args` (replaces defaults), `extra_args` (appends), and `env` overrides. Codex chat also supports `sandbox`: use `workspace-write` by default, or `read-only` for discussion-only sessions.
 
 **Keyboard shortcut:** Press `p` then `c` to toggle the chat panel.
 

--- a/config.example.json
+++ b/config.example.json
@@ -236,15 +236,15 @@
   },
 
   "chat_providers": {
-    "_comment": "Chat provider command overrides. Separate from 'providers' (AI analysis). Chat providers are: pi, claude, codex, copilot-acp, gemini-acp, opencode-acp, cursor-acp. Supports 'command', 'args' (replaces defaults), 'extra_args' (appends), 'env', 'load_skills' (Pi: false suppresses skill auto-discovery), and 'app_extensions' (Pi: false omits pair-review task extension) overrides.",
+    "_comment": "Chat provider command overrides. Separate from 'providers' (AI analysis). Chat providers are: pi, claude, codex, copilot-acp, gemini-acp, opencode-acp, cursor-acp. Supports 'command', 'args' (replaces defaults), 'extra_args' (appends), 'env', 'load_skills' (Pi: false suppresses skill auto-discovery), and 'app_extensions' (Pi: false omits pair-review task extension) overrides. Codex also supports 'sandbox' ('workspace-write' or 'read-only').",
     "claude": {
       "_comment": "Example: use a wrapper script for Claude chat",
       "command": "claude"
     },
     "codex": {
-      "_comment": "Example: use a wrapper script for Codex chat",
+      "_comment": "Example: use a wrapper script for Codex chat. Use sandbox='read-only' for discussion-only sessions.",
       "command": "codex",
-      "args": ["app-server"]
+      "sandbox": "workspace-write"
     }
   },
 

--- a/src/ai/codex-provider.js
+++ b/src/ai/codex-provider.js
@@ -35,32 +35,6 @@ const BIN_DIR = path.join(__dirname, '..', '..', 'bin');
  */
 const CODEX_MODELS = [
   {
-    id: 'gpt-5.4-high',
-    // Alias keeps results/councils saved under the previous bare `gpt-5.4`
-    // model ID resolving to the now-explicit high-effort variant.
-    aliases: ['gpt-5.4'],
-    cli_model: 'gpt-5.4',
-    extra_args: ['-c', 'model_reasoning_effort="high"'],
-    name: 'GPT-5.4 High',
-    tier: 'thorough',
-    tagline: 'Deep Review',
-    description: 'GPT-5.4 with high reasoning effort for complex multi-file reviews, architectural consistency, and subtle behavioral regressions.',
-    badge: 'Recommended',
-    badgeClass: 'badge-recommended',
-    default: true
-  },
-  {
-    id: 'gpt-5.4-xhigh',
-    cli_model: 'gpt-5.4',
-    extra_args: ['-c', 'model_reasoning_effort="xhigh"'],
-    name: 'GPT-5.4 XHigh',
-    tier: 'thorough',
-    tagline: 'Max Depth',
-    description: 'GPT-5.4 with extra-high reasoning effort for difficult reviews that need broad context, careful tradeoff analysis, and deeper issue validation.',
-    badge: 'Extra High',
-    badgeClass: 'badge-power'
-  },
-  {
     id: 'gpt-5.5-high',
     cli_model: 'gpt-5.5',
     extra_args: ['-c', 'model_reasoning_effort="high"'],
@@ -68,8 +42,9 @@ const CODEX_MODELS = [
     tier: 'thorough',
     tagline: 'Latest Deep',
     description: 'Latest-generation GPT model with high reasoning effort for demanding PR reviews, strong code understanding, and careful cross-file analysis.',
-    badge: 'High Effort',
-    badgeClass: 'badge-power'
+    badge: 'Recommended',
+    badgeClass: 'badge-recommended',
+    default: true
   },
   {
     id: 'gpt-5.5-xhigh',
@@ -80,6 +55,31 @@ const CODEX_MODELS = [
     tagline: 'Frontier Depth',
     description: 'GPT-5.5 with extra-high reasoning effort for the hardest reviews: architecture, concurrency, security-sensitive changes, and large codebase context.',
     badge: 'Max Reasoning',
+    badgeClass: 'badge-power'
+  },
+  {
+    id: 'gpt-5.4-high',
+    // Alias keeps results/councils saved under the previous bare `gpt-5.4`
+    // model ID resolving to the now-explicit high-effort variant.
+    aliases: ['gpt-5.4'],
+    cli_model: 'gpt-5.4',
+    extra_args: ['-c', 'model_reasoning_effort="high"'],
+    name: 'GPT-5.4 High',
+    tier: 'thorough',
+    tagline: 'Deep Review',
+    description: 'GPT-5.4 with high reasoning effort for complex multi-file reviews, architectural consistency, and subtle behavioral regressions.',
+    badge: 'Previous Gen',
+    badgeClass: 'badge-power'
+  },
+  {
+    id: 'gpt-5.4-xhigh',
+    cli_model: 'gpt-5.4',
+    extra_args: ['-c', 'model_reasoning_effort="xhigh"'],
+    name: 'GPT-5.4 XHigh',
+    tier: 'thorough',
+    tagline: 'Max Depth',
+    description: 'GPT-5.4 with extra-high reasoning effort for difficult reviews that need broad context, careful tradeoff analysis, and deeper issue validation.',
+    badge: 'Extra High',
     badgeClass: 'badge-power'
   },
   {
@@ -121,7 +121,7 @@ class CodexProvider extends AIProvider {
    * @param {Object} configOverrides.env - Additional environment variables
    * @param {Object[]} configOverrides.models - Custom model definitions
    */
-  constructor(model = 'gpt-5.4-high', configOverrides = {}) {
+  constructor(model = 'gpt-5.5-high', configOverrides = {}) {
     super(model);
 
     // Command precedence: ENV > config > default
@@ -149,9 +149,9 @@ class CodexProvider extends AIProvider {
     // 2. "read-only" prevents ALL shell commands including git-diff-lines
     // 3. The AI is instructed to only analyze code, not modify it
     //
-    // --full-auto: Non-interactive mode that auto-approves within sandbox bounds.
-    // Combined with workspace-write sandbox, this limits damage to the worktree only.
-    // Note: The -a flag is for interactive mode only; exec subcommand uses --full-auto.
+    // Newer Codex CLI versions deprecate --full-auto; `codex exec` is already
+    // non-interactive, and `--sandbox workspace-write` selects the required
+    // sandbox policy.
     //
     // Shell environment config:
     // - allow_login_shell=false: Prevents zsh from using -l flag, which would
@@ -164,7 +164,7 @@ class CodexProvider extends AIProvider {
     // (--dangerously-bypass-approvals-and-sandbox is the Codex CLI equivalent of Claude's --dangerously-skip-permissions)
     const sandboxArgs = configOverrides.yolo
       ? ['--dangerously-bypass-approvals-and-sandbox']
-      : ['--sandbox', 'workspace-write', '--full-auto'];
+      : ['--sandbox', 'workspace-write'];
     // Shell env args prevent login shell from reconstructing PATH (orthogonal to
     // sandbox permissions). Overridable via configOverrides.args following the
     // same two-tier pattern as chat-providers.js: args replaces, extra_args appends.
@@ -352,7 +352,7 @@ class CodexProvider extends AIProvider {
 
         if (code !== 0) {
           logger.error(`${levelPrefix} Codex CLI exited with code ${code}`);
-          settle(reject, new Error(`${levelPrefix} Codex CLI exited with code ${code}: ${stderr}`));
+          settle(reject, this.createExitError(code, stderr, levelPrefix));
           return;
         }
 
@@ -431,6 +431,37 @@ class CodexProvider extends AIProvider {
       });
       codex.stdin.end();
     });
+  }
+
+  /**
+   * Build an actionable error for Codex CLI process failures.
+   *
+   * @param {number} code - Process exit code
+   * @param {string} stderr - Captured stderr
+   * @param {string} levelPrefix - Logging prefix
+   * @returns {Error}
+   */
+  createExitError(code, stderr, levelPrefix) {
+    const stderrText = stderr.trim();
+
+    if (this.isAuthError(stderrText)) {
+      return new Error(
+        `${levelPrefix} Codex CLI authentication failed. Check Codex CLI authentication and try again. ` +
+        `Original stderr: ${stderrText}`
+      );
+    }
+
+    return new Error(`${levelPrefix} Codex CLI exited with code ${code}: ${stderr}`);
+  }
+
+  /**
+   * Detect authentication failures reported by the Codex CLI.
+   *
+   * @param {string} stderr - Captured stderr
+   * @returns {boolean}
+   */
+  isAuthError(stderr) {
+    return /(?:401\s+Unauthorized|HTTP error:\s*401|Unauthorized)/i.test(stderr);
   }
 
   /**
@@ -664,7 +695,7 @@ class CodexProvider extends AIProvider {
 
     // Base args for extraction (read-only sandbox, no shell access needed)
     // Note: '-' (stdin marker) must come LAST, after any extra_args
-    const baseArgs = ['exec', '-m', cliModel, '--json', '--sandbox', 'read-only', '--full-auto'];
+    const baseArgs = ['exec', '-m', cliModel, '--json', '--sandbox', 'read-only'];
 
     // Append stdin marker '-' at the end after all other args
     return [...baseArgs, ...extraArgs, '-'];
@@ -790,7 +821,7 @@ class CodexProvider extends AIProvider {
   }
 
   static getDefaultModel() {
-    return 'gpt-5.4-high';
+    return 'gpt-5.5-high';
   }
 
   static getInstallInstructions() {

--- a/src/chat/chat-providers.js
+++ b/src/chat/chat-providers.js
@@ -12,6 +12,7 @@ const logger = require('../utils/logger');
 
 // Default dependencies (overridable for testing)
 const defaults = { spawn };
+const CODEX_SANDBOX_MODES = new Set(['workspace-write', 'read-only']);
 
 /**
  * Built-in chat provider definitions.
@@ -68,6 +69,7 @@ const CHAT_PROVIDERS = {
     name: 'Codex (JSON-RPC)',
     type: 'codex',
     command: 'codex',
+    sandbox: 'workspace-write',
     // Shell environment config prevents zsh -l from reconstructing PATH,
     // ensuring git-diff-lines and other bin/ scripts remain findable.
     args: [
@@ -126,6 +128,9 @@ function getChatProvider(id) {
     }
     if (overrides.load_skills !== undefined) provider.load_skills = overrides.load_skills;
     if (overrides.app_extensions !== undefined) provider.app_extensions = overrides.app_extensions;
+    if (provider.type === 'codex' && overrides.sandbox !== undefined) {
+      provider.sandbox = normalizeCodexSandbox(overrides.sandbox, id);
+    }
     if (provider.command.includes(' ')) {
       provider.useShell = true;
     }
@@ -152,11 +157,32 @@ function getChatProvider(id) {
   }
   if (overrides.load_skills !== undefined) merged.load_skills = overrides.load_skills;
   if (overrides.app_extensions !== undefined) merged.app_extensions = overrides.app_extensions;
+  if (base.type === 'codex' && overrides.sandbox !== undefined) {
+    merged.sandbox = normalizeCodexSandbox(overrides.sandbox, id);
+  }
   // For multi-word commands (e.g. "devx claude"), use shell mode
   if (merged.command && merged.command.includes(' ')) {
     merged.useShell = true;
   }
   return merged;
+}
+
+/**
+ * Validate the small user-facing Codex sandbox config surface.
+ * @param {string} sandbox
+ * @param {string} providerId
+ * @returns {string}
+ */
+function normalizeCodexSandbox(sandbox, providerId = 'codex') {
+  if (CODEX_SANDBOX_MODES.has(sandbox)) {
+    return sandbox;
+  }
+
+  logger.warn(
+    `[ChatProviders] Invalid sandbox "${sandbox}" for ${providerId}; ` +
+    'falling back to workspace-write. Supported values: workspace-write, read-only.'
+  );
+  return 'workspace-write';
 }
 
 /**

--- a/src/chat/codex-bridge.js
+++ b/src/chat/codex-bridge.js
@@ -13,6 +13,7 @@
 const { EventEmitter } = require('events');
 const { spawn } = require('child_process');
 const { createInterface } = require('readline');
+const { quoteShellArgs } = require('../ai/provider');
 const logger = require('../utils/logger');
 const { version: pkgVersion } = require('../../package.json');
 
@@ -21,6 +22,34 @@ const defaults = {
   spawn,
   createInterface,
 };
+
+const DEFAULT_APPROVAL_POLICY = 'never';
+const DEFAULT_SANDBOX_MODE = 'workspace-write';
+const ACTIVE_TURN_STATUSES = new Set(['inProgress', 'running', 'working']);
+const TERMINAL_TURN_STATUSES = new Set(['completed', 'failed', 'interrupted', 'cancelled', 'canceled']);
+
+function buildSandboxPolicy(sandbox = DEFAULT_SANDBOX_MODE) {
+  if (sandbox === 'read-only') {
+    return {
+      type: 'readOnly',
+      networkAccess: true,
+    };
+  }
+
+  return {
+    type: 'workspaceWrite',
+    writableRoots: [],
+    networkAccess: true,
+    excludeTmpdirEnvVar: false,
+    excludeSlashTmp: false,
+  };
+}
+
+function compactParams(params) {
+  return Object.fromEntries(
+    Object.entries(params).filter(([, value]) => value !== undefined && value !== null)
+  );
+}
 
 class CodexBridge extends EventEmitter {
   /**
@@ -33,6 +62,8 @@ class CodexBridge extends EventEmitter {
    * @param {Object} [options.env] - Extra env vars for subprocess
    * @param {boolean} [options.useShell] - Use shell mode for multi-word commands
    * @param {string} [options.resumeThreadId] - Thread ID to resume
+   * @param {string|null} [options.sandbox] - Thread sandbox mode (default: 'workspace-write')
+   * @param {Object|null} [options.sandboxPolicy] - Turn sandbox policy override for tests
    * @param {Object} [options._deps] - Dependency injection for testing
    */
   constructor(options = {}) {
@@ -43,6 +74,11 @@ class CodexBridge extends EventEmitter {
     this.env = options.env || {};
     this.useShell = options.useShell || false;
     this.resumeThreadId = options.resumeThreadId || null;
+    this.approvalPolicy = DEFAULT_APPROVAL_POLICY;
+    this.sandbox = options.sandbox !== undefined ? options.sandbox : DEFAULT_SANDBOX_MODE;
+    this.sandboxPolicy = options.sandboxPolicy !== undefined
+      ? options.sandboxPolicy
+      : buildSandboxPolicy(this.sandbox);
 
     // Command resolution: constructor option → env var → default
     this.codexCommand = options.codexCommand
@@ -81,13 +117,9 @@ class CodexBridge extends EventEmitter {
     const args = [...this.codexArgs];
     const useShell = this.useShell;
 
-    // Append model flag if configured
-    if (this.model) {
-      args.push('--model', this.model);
-    }
-
-    // For multi-word commands (e.g. "devx codex"), use shell mode
-    const spawnCmd = useShell ? `${command} ${args.join(' ')}` : command;
+    // For multi-word commands (e.g. "devx codex"), use shell mode. Quote args
+    // so TOML config values like include_only=["PATH","HOME"] survive the shell.
+    const spawnCmd = useShell ? `${command} ${quoteShellArgs(args).join(' ')}` : command;
     const spawnArgs = useShell ? [] : args;
 
     logger.info(`[CodexBridge] Starting Codex agent: ${command} ${args.join(' ')}`);
@@ -188,13 +220,13 @@ class CodexBridge extends EventEmitter {
 
     // 3. Start or resume thread
     if (this.resumeThreadId) {
-      const result = await this._sendRequest('thread/resume', {
+      const result = await this._sendRequest('thread/resume', this._buildThreadParams({
         threadId: this.resumeThreadId,
-      });
+      }));
       this._threadId = result.thread?.id || result.threadId || this.resumeThreadId;
       logger.info(`[CodexBridge] Thread resumed: ${this._threadId}`);
     } else {
-      const result = await this._sendRequest('thread/start', {});
+      const result = await this._sendRequest('thread/start', this._buildThreadParams());
       this._threadId = result.thread?.id || result.threadId;
       if (!this._threadId) {
         throw new Error('thread/start response missing thread ID');
@@ -204,6 +236,41 @@ class CodexBridge extends EventEmitter {
 
     // Emit session info so session-manager can store the threadId
     this.emit('session', { threadId: this._threadId });
+  }
+
+  /**
+   * Build thread start/resume settings that keep Codex chat able to call the
+   * pair-review API from the review worktree.
+   * @param {Object} [extra] - Additional params, e.g. threadId for resume.
+   * @returns {Object}
+   */
+  _buildThreadParams(extra = {}) {
+    return compactParams({
+      ...extra,
+      cwd: this.cwd,
+      model: this.model,
+      approvalPolicy: this.approvalPolicy,
+      // thread/start uses the same sandbox enum as the Codex CLI, while
+      // turn/start.sandboxPolicy uses the v2 camelCase policy object.
+      sandbox: this.sandbox,
+    });
+  }
+
+  /**
+   * Build turn/start params. App-server uses the v2 camelCase SandboxPolicy
+   * shape here, not the `codex exec --sandbox workspace-write` CLI flag.
+   * @param {Array<Object>} input
+   * @returns {Object}
+   */
+  _buildTurnStartParams(input) {
+    return compactParams({
+      threadId: this._threadId,
+      input,
+      cwd: this.cwd,
+      model: this.model,
+      approvalPolicy: this.approvalPolicy,
+      sandboxPolicy: this.sandboxPolicy,
+    });
   }
 
   /**
@@ -232,14 +299,11 @@ class CodexBridge extends EventEmitter {
     // not by this response. Store turnId for abort support.
     // Codex app-server expects `input` as an array of typed objects, not a
     // plain string.  See https://developers.openai.com/codex/app-server/
-    this._sendRequest('turn/start', {
-      threadId: this._threadId,
-      input: [{ type: 'text', text: messageContent }],
-      approvalPolicy: 'never',
-    })
+    this._sendRequest('turn/start', this._buildTurnStartParams([{ type: 'text', text: messageContent }]))
       .then((result) => {
-        if (result && result.turnId) {
-          this._turnId = result.turnId;
+        const turnId = this._extractTurnId(result);
+        if (turnId) {
+          this._turnId = turnId;
         }
       })
       .catch((err) => {
@@ -468,7 +532,14 @@ class CodexBridge extends EventEmitter {
         break;
 
       case 'turn/started':
-        this.emit('status', { status: 'working' });
+        this._handleTurnStarted(params);
+        break;
+
+      case 'turn/statusChanged':
+        this._handleTurnStatusChanged(params);
+        break;
+
+      case 'remoteControl/status/changed':
         break;
 
       case 'item/started':
@@ -490,10 +561,61 @@ class CodexBridge extends EventEmitter {
    */
   _handleDelta(params) {
     if (!params) return;
-    const text = params.delta || params.text;
+    let text = params.delta || params.text;
     if (text) {
+      text = this._normalizeDeltaBoundary(text);
       this._accumulatedText += text;
       this.emit('delta', { text });
+    }
+  }
+
+  /**
+   * Preserve readable boundaries when app-server splits prose deltas without
+   * carrying the whitespace between adjacent chunks.
+   * @param {string} text
+   * @returns {string}
+   */
+  _normalizeDeltaBoundary(text) {
+    const previous = this._accumulatedText;
+    if (
+      previous &&
+      /[.!?]$/.test(previous) &&
+      /^[A-Z]/.test(text)
+    ) {
+      return ` ${text}`;
+    }
+    return text;
+  }
+
+  /**
+   * Handle turn started notifications and capture the active turn id.
+   * @param {Object} params
+   */
+  _handleTurnStarted(params) {
+    const turnId = this._extractTurnId(params);
+    if (turnId) {
+      this._turnId = turnId;
+    }
+    this.emit('status', { status: 'working' });
+  }
+
+  /**
+   * Handle turn status changes without reviving a completed turn.
+   * @param {Object} params
+   */
+  _handleTurnStatusChanged(params) {
+    const status = params?.status || params?.turn?.status;
+
+    if (ACTIVE_TURN_STATUSES.has(status)) {
+      this._handleTurnStarted(params);
+      return;
+    }
+
+    if (TERMINAL_TURN_STATUSES.has(status)) {
+      this._turnId = null;
+      if (status === 'failed') {
+        this._inMessage = false;
+      }
     }
   }
 
@@ -530,12 +652,38 @@ class CodexBridge extends EventEmitter {
     if (!params) return;
     const type = params.type || params.itemType;
     if (type === 'command' || type === 'tool_call' || type === 'function_call') {
-      this.emit('tool_use', {
-        toolCallId: params.itemId || params.id,
-        toolName: params.name || params.title || params.command || type,
-        status: 'start',
-      });
+      this.emit('tool_use', this._buildToolUseEvent(params, 'start'));
     }
+  }
+
+  /**
+   * Build the normalized tool event shape consumed by the chat broadcaster.
+   * Command items are represented as bash calls so internal pair-review API
+   * curls can be suppressed consistently across providers.
+   * @param {Object} params
+   * @param {'start'|'end'} status
+   * @returns {Object}
+   */
+  _buildToolUseEvent(params, status) {
+    const type = params.type || params.itemType;
+    const toolCallId = params.itemId || params.id;
+    if (type === 'command') {
+      const event = {
+        toolCallId,
+        toolName: 'bash',
+        status,
+      };
+      if (params.command) {
+        event.args = { command: params.command };
+      }
+      return event;
+    }
+
+    return {
+      toolCallId,
+      toolName: params.name || params.title || params.command || type,
+      status,
+    };
   }
 
   /**
@@ -546,11 +694,7 @@ class CodexBridge extends EventEmitter {
     if (!params) return;
     const type = params.type || params.itemType;
     if (type === 'command' || type === 'tool_call' || type === 'function_call') {
-      this.emit('tool_use', {
-        toolCallId: params.itemId || params.id,
-        toolName: params.name || params.title || params.command || type,
-        status: 'end',
-      });
+      this.emit('tool_use', this._buildToolUseEvent(params, 'end'));
     }
   }
 
@@ -573,9 +717,74 @@ class CodexBridge extends EventEmitter {
       return;
     }
 
+    if (method === 'item/commandExecution/requestApproval') {
+      logger.debug(`[CodexBridge] Auto-approving command execution request (id=${id})`);
+      this._sendResponse(id, { decision: 'accept' });
+      return;
+    }
+
+    if (method === 'execCommandApproval') {
+      logger.debug(`[CodexBridge] Auto-approving execCommandApproval request (id=${id})`);
+      this._sendResponse(id, { decision: 'approved' });
+      return;
+    }
+
+    if (method === 'item/permissions/requestApproval') {
+      logger.debug(`[CodexBridge] Granting requested network permissions (id=${id})`);
+      this._sendResponse(id, this._buildPermissionsApproval(params));
+      return;
+    }
+
+    if (method === 'item/fileChange/requestApproval') {
+      logger.debug(`[CodexBridge] Declining file change approval request (id=${id})`);
+      this._sendResponse(id, { decision: 'decline' });
+      return;
+    }
+
+    if (method === 'applyPatchApproval') {
+      logger.debug(`[CodexBridge] Denying applyPatchApproval request (id=${id})`);
+      this._sendResponse(id, { decision: 'denied' });
+      return;
+    }
+
     // Unknown server request — respond with error to avoid hangs
     logger.warn(`[CodexBridge] Unknown server request: ${method} (id=${id})`);
     this._sendErrorResponse(id, -32601, `Method not found: ${method}`);
+  }
+
+  /**
+   * Build a response for Codex v2 permission requests. For pair-review chat we
+   * grant network permission so localhost API `curl` calls can proceed, while
+   * avoiding broad file-system permission grants beyond the configured sandbox.
+   * @param {Object} params
+   * @returns {Object}
+   */
+  _buildPermissionsApproval(params = {}) {
+    const requested = params.permissions || {};
+    const permissions = {};
+
+    if (requested.network) {
+      permissions.network = requested.network;
+    } else {
+      // Codex chat needs localhost network access to call pair-review's API.
+      // Grant it even if app-server requests permissions without a network body.
+      permissions.network = { enabled: true };
+    }
+
+    return {
+      permissions,
+      scope: 'session',
+      strictAutoReview: false,
+    };
+  }
+
+  /**
+   * Extract a turn id from legacy and current app-server shapes.
+   * @param {Object} value
+   * @returns {string|null}
+   */
+  _extractTurnId(value) {
+    return value?.turn?.id || value?.turnId || value?.id || null;
   }
 
   /**

--- a/src/chat/session-manager.js
+++ b/src/chat/session-manager.js
@@ -571,6 +571,7 @@ class ChatSessionManager {
         codexArgs: def?.args,
         env: def?.env,
         useShell: def?.useShell,
+        sandbox: def?.sandbox,
       });
     }
     // Pi provider — resolve config overrides (command, model, env) from provider def.

--- a/tests/unit/chat/chat-providers.test.js
+++ b/tests/unit/chat/chat-providers.test.js
@@ -105,6 +105,18 @@ describe('chat-providers', () => {
       expect(getChatProvider('unknown')).toBeNull();
     });
 
+    it('should return codex provider with chat-safe sandbox defaults', () => {
+      const codex = getChatProvider('codex');
+      expect(codex).toMatchObject({
+        id: 'codex',
+        name: 'Codex (JSON-RPC)',
+        type: 'codex',
+        command: 'codex',
+        sandbox: 'workspace-write',
+      });
+      expect(codex.args).toContain('app-server');
+    });
+
     it('should merge config overrides for command', () => {
       applyConfigOverrides({
         'copilot-acp': { command: '/usr/local/bin/copilot' },
@@ -128,6 +140,24 @@ describe('chat-providers', () => {
       });
       const provider = getChatProvider('copilot-acp');
       expect(provider.args).toEqual(['--acp', '--stdio', '--verbose']);
+    });
+
+    it('should merge codex sandbox override', () => {
+      applyConfigOverrides({
+        codex: {
+          sandbox: 'read-only',
+        },
+      });
+      const provider = getChatProvider('codex');
+      expect(provider.sandbox).toBe('read-only');
+    });
+
+    it('should fall back to workspace-write for invalid codex sandbox override', () => {
+      applyConfigOverrides({
+        codex: { sandbox: 'danger-full-access' },
+      });
+      const provider = getChatProvider('codex');
+      expect(provider.sandbox).toBe('workspace-write');
     });
 
     it('should merge config overrides for env', () => {

--- a/tests/unit/chat/codex-bridge.test.js
+++ b/tests/unit/chat/codex-bridge.test.js
@@ -62,6 +62,7 @@ function createMockDeps(overrides = {}) {
  */
 function setupHandshake(fakeProc, options = {}) {
   const threadId = options.threadId || 'test-thread-123';
+  const turnStartResult = options.turnStartResult || { turnId: 'turn-001' };
   const rl = createInterface({ input: fakeProc.stdin });
 
   rl.on('line', (line) => {
@@ -82,8 +83,8 @@ function setupHandshake(fakeProc, options = {}) {
       // thread/resume returns flat { threadId } per Codex protocol (unlike thread/start's nested shape)
       sendResponse(fakeProc, msg.id, { threadId: msg.params?.threadId || threadId });
     } else if (msg.method === 'turn/start') {
-      // Return turnId so the bridge can track the active turn
-      sendResponse(fakeProc, msg.id, { turnId: 'turn-001' });
+      // Return turn id so the bridge can track the active turn
+      sendResponse(fakeProc, msg.id, turnStartResult);
     } else if (msg.method === 'turn/interrupt') {
       sendResponse(fakeProc, msg.id, {});
     }
@@ -171,6 +172,15 @@ describe('CodexBridge', () => {
       expect(bridge.cwd).toBe(process.cwd());
       expect(bridge.systemPrompt).toBeNull();
       expect(bridge.codexCommand).toBe('codex');
+      expect(bridge.approvalPolicy).toBe('never');
+      expect(bridge.sandbox).toBe('workspace-write');
+      expect(bridge.sandboxPolicy).toEqual({
+        type: 'workspaceWrite',
+        writableRoots: [],
+        networkAccess: true,
+        excludeTmpdirEnvVar: false,
+        excludeSlashTmp: false,
+      });
     });
 
     it('should accept custom options', () => {
@@ -180,11 +190,15 @@ describe('CodexBridge', () => {
         systemPrompt: 'Be helpful',
         codexCommand: '/usr/local/bin/codex',
         env: { CUSTOM_VAR: '1' },
+        sandbox: 'read-only',
       });
       expect(bridge.model).toBe('o4-mini');
       expect(bridge.cwd).toBe('/tmp/work');
       expect(bridge.systemPrompt).toBe('Be helpful');
       expect(bridge.codexCommand).toBe('/usr/local/bin/codex');
+      expect(bridge.approvalPolicy).toBe('never');
+      expect(bridge.sandbox).toBe('read-only');
+      expect(bridge.sandboxPolicy).toEqual({ type: 'readOnly', networkAccess: true });
     });
 
     it('should use PAIR_REVIEW_CODEX_CMD env var when set', () => {
@@ -328,8 +342,9 @@ describe('CodexBridge', () => {
       );
     });
 
-    it('should include --model argument when model is set', async () => {
+    it('should pass configured model through thread params, not app-server CLI args', async () => {
       const { mockDeps, mockSpawn, fakeProc } = createMockDeps();
+      const { messages, rl } = collectStdinMessages(fakeProc);
       handshakeRl = setupHandshake(fakeProc);
 
       const bridge = new CodexBridge({
@@ -340,9 +355,13 @@ describe('CodexBridge', () => {
 
       expect(mockSpawn).toHaveBeenCalledWith(
         'codex',
-        expect.arrayContaining(['app-server', '--model', 'o4-mini']),
+        expect.not.arrayContaining(['--model', 'o4-mini']),
         expect.any(Object)
       );
+
+      rl.close();
+      const threadStart = messages.find((m) => m.method === 'thread/start');
+      expect(threadStart.params.model).toBe('o4-mini');
     });
 
     it('should not include --model argument when model is not set', async () => {
@@ -360,7 +379,7 @@ describe('CodexBridge', () => {
       expect(spawnCall[1]).not.toContain('--model');
     });
 
-    it('should include --model in shell command when useShell and model are set', async () => {
+    it('should not include --model in shell command when useShell and model are set', async () => {
       const { mockDeps, mockSpawn, fakeProc } = createMockDeps();
       handshakeRl = setupHandshake(fakeProc);
 
@@ -374,7 +393,30 @@ describe('CodexBridge', () => {
       await bridge.start();
 
       expect(mockSpawn).toHaveBeenCalledWith(
-        'devx codex app-server --model o4-mini',
+        'devx codex app-server',
+        [],
+        expect.objectContaining({ shell: true })
+      );
+    });
+
+    it('should quote Codex config args in shell mode', async () => {
+      const { mockDeps, mockSpawn, fakeProc } = createMockDeps();
+      handshakeRl = setupHandshake(fakeProc);
+
+      const bridge = new CodexBridge({
+        codexCommand: 'devx codex',
+        codexArgs: [
+          'app-server',
+          '-c', 'allow_login_shell=false',
+          '-c', 'shell_environment_policy.include_only=["PATH","HOME","USER"]',
+        ],
+        useShell: true,
+        _deps: mockDeps,
+      });
+      await bridge.start();
+
+      expect(mockSpawn).toHaveBeenCalledWith(
+        'devx codex app-server -c allow_login_shell=false -c \'shell_environment_policy.include_only=["PATH","HOME","USER"]\'',
         [],
         expect.objectContaining({ shell: true })
       );
@@ -436,6 +478,12 @@ describe('CodexBridge', () => {
       const threadStart = messages.find((m) => m.method === 'thread/start');
       expect(threadStart).toBeDefined();
       expect(threadStart.id).toBeDefined();
+      expect(threadStart.params).toEqual(expect.objectContaining({
+        cwd: process.cwd(),
+        approvalPolicy: 'never',
+        sandbox: 'workspace-write',
+      }));
+      expect(threadStart.params).not.toHaveProperty('model');
     });
 
     it('should emit session event with threadId', async () => {
@@ -505,6 +553,12 @@ describe('CodexBridge', () => {
       const threadResume = messages.find((m) => m.method === 'thread/resume');
       expect(threadResume).toBeDefined();
       expect(threadResume.params.threadId).toBe('existing-thread-456');
+      expect(threadResume.params).toEqual(expect.objectContaining({
+        cwd: process.cwd(),
+        approvalPolicy: 'never',
+        sandbox: 'workspace-write',
+      }));
+      expect(threadResume.params).not.toHaveProperty('model');
 
       const threadStart = messages.find((m) => m.method === 'thread/start');
       expect(threadStart).toBeUndefined();
@@ -605,6 +659,49 @@ describe('CodexBridge', () => {
       expect(turnReq.params.threadId).toBe('test-thread-123');
       expect(turnReq.params.input).toEqual([{ type: 'text', text: 'Review this code' }]);
       expect(turnReq.params.approvalPolicy).toBe('never');
+      expect(turnReq.params.cwd).toBe(process.cwd());
+      expect(turnReq.params).not.toHaveProperty('model');
+      expect(turnReq.params.sandboxPolicy).toEqual({
+        type: 'workspaceWrite',
+        writableRoots: [],
+        networkAccess: true,
+        excludeTmpdirEnvVar: false,
+        excludeSlashTmp: false,
+      });
+    });
+
+    it('should send CLI-style sandbox to thread params and policy object to turn params', async () => {
+      const { mockDeps, fakeProc } = createMockDeps();
+      const { messages, rl } = collectStdinMessages(fakeProc);
+      handshakeRl = setupHandshake(fakeProc);
+
+      const bridge = new CodexBridge({ sandbox: 'read-only', _deps: mockDeps });
+      await bridge.start();
+
+      bridge.sendMessage('Review this code');
+      await tick();
+
+      rl.close();
+      const threadReq = messages.find((m) => m.method === 'thread/start');
+      const turnReq = messages.find((m) => m.method === 'turn/start');
+      expect(threadReq.params.sandbox).toBe('read-only');
+      expect(turnReq.params.sandboxPolicy).toEqual({ type: 'readOnly', networkAccess: true });
+    });
+
+    it('should pass configured model through turn params', async () => {
+      const { mockDeps, fakeProc } = createMockDeps();
+      const { messages, rl } = collectStdinMessages(fakeProc);
+      handshakeRl = setupHandshake(fakeProc);
+
+      const bridge = new CodexBridge({ model: 'o4-mini', _deps: mockDeps });
+      await bridge.start();
+
+      bridge.sendMessage('Review this code');
+      await tick();
+
+      rl.close();
+      const turnReq = messages.find((m) => m.method === 'turn/start');
+      expect(turnReq.params.model).toBe('o4-mini');
     });
 
     it('should reset accumulated text on new message', async () => {
@@ -671,6 +768,20 @@ describe('CodexBridge', () => {
       expect(bridge._accumulatedText).toBe('Hello world');
     });
 
+    it('should preserve sentence spacing across adjacent deltas', async () => {
+      const { bridge, fakeProc } = await startedBridge();
+      const handler = vi.fn();
+      bridge.on('delta', handler);
+
+      sendNotification(fakeProc, 'item/agentMessage/delta', { delta: 'bad.' });
+      sendNotification(fakeProc, 'item/agentMessage/delta', { delta: 'First' });
+      await tick();
+
+      expect(handler).toHaveBeenNthCalledWith(1, { text: 'bad.' });
+      expect(handler).toHaveBeenNthCalledWith(2, { text: ' First' });
+      expect(bridge._accumulatedText).toBe('bad. First');
+    });
+
     it('should emit complete on turn/completed with status=completed', async () => {
       const { bridge, fakeProc } = await startedBridge();
       const handler = vi.fn();
@@ -716,6 +827,66 @@ describe('CodexBridge', () => {
       expect(handler).toHaveBeenCalledWith({ status: 'working' });
     });
 
+    it('should capture nested turn id from turn/started notification', async () => {
+      const { bridge, fakeProc } = await startedBridge();
+
+      sendNotification(fakeProc, 'turn/started', {
+        threadId: 'test-thread-123',
+        turn: { id: 'turn-nested-001', items: [], status: 'running' },
+      });
+      await tick();
+
+      expect(bridge._turnId).toBe('turn-nested-001');
+    });
+
+    it('should not revive turn id from terminal turn/statusChanged after completion', async () => {
+      const { bridge, fakeProc } = await startedBridge();
+
+      bridge._turnId = 'turn-active';
+      bridge._inMessage = true;
+      sendNotification(fakeProc, 'turn/completed', { status: 'completed' });
+      await tick();
+
+      sendNotification(fakeProc, 'turn/statusChanged', {
+        turn: { id: 'turn-late', status: 'completed' },
+      });
+      await tick();
+
+      expect(bridge._turnId).toBeNull();
+      expect(bridge._inMessage).toBe(false);
+    });
+
+    it('should capture turn id from active turn/statusChanged notification', async () => {
+      const { bridge, fakeProc } = await startedBridge();
+      const handler = vi.fn();
+      bridge.on('status', handler);
+
+      sendNotification(fakeProc, 'turn/statusChanged', {
+        turn: { id: 'turn-active-status', status: 'inProgress' },
+      });
+      await tick();
+
+      expect(bridge._turnId).toBe('turn-active-status');
+      expect(handler).toHaveBeenCalledWith({ status: 'working' });
+    });
+
+    it('should capture nested turn id from turn/start response', async () => {
+      const { mockDeps, fakeProc } = createMockDeps();
+      handshakeRl = setupHandshake(fakeProc, {
+        turnStartResult: {
+          turn: { id: 'turn-response-nested', items: [], status: 'running' },
+        },
+      });
+
+      const bridge = new CodexBridge({ _deps: mockDeps });
+      await bridge.start();
+
+      bridge.sendMessage('some task');
+      await tick();
+
+      expect(bridge._turnId).toBe('turn-response-nested');
+    });
+
     it('should emit tool_use with start on item/started (command type)', async () => {
       const { bridge, fakeProc } = await startedBridge();
       const handler = vi.fn();
@@ -730,7 +901,8 @@ describe('CodexBridge', () => {
 
       expect(handler).toHaveBeenCalledWith({
         toolCallId: 'item-1',
-        toolName: 'cat src/main.js',
+        toolName: 'bash',
+        args: { command: 'cat src/main.js' },
         status: 'start',
       });
     });
@@ -749,7 +921,8 @@ describe('CodexBridge', () => {
 
       expect(handler).toHaveBeenCalledWith({
         toolCallId: 'item-1',
-        toolName: 'cat src/main.js',
+        toolName: 'bash',
+        args: { command: 'cat src/main.js' },
         status: 'end',
       });
     });
@@ -849,20 +1022,11 @@ describe('CodexBridge', () => {
   describe('approval handling', () => {
     it('should auto-respond to requestApproval with accept', async () => {
       const { mockDeps, fakeProc } = createMockDeps();
+      const { messages, rl } = collectStdinMessages(fakeProc);
       handshakeRl = setupHandshake(fakeProc);
-      // Collect responses written back to stdin
-      const responses = [];
-      const origWrite = fakeProc.stdout.write.bind(fakeProc.stdout);
 
       const bridge = new CodexBridge({ _deps: mockDeps });
       await bridge.start();
-
-      // Intercept what bridge writes to the process stdin
-      const stdinRl = createInterface({ input: fakeProc.stdin });
-      const stdinMessages = [];
-      stdinRl.on('line', (line) => {
-        try { stdinMessages.push(JSON.parse(line)); } catch { /* ignore */ }
-      });
 
       // Server sends a requestApproval request
       sendServerRequest(fakeProc, 'requestApproval', {
@@ -871,12 +1035,134 @@ describe('CodexBridge', () => {
       }, 'server-req-1');
       await tick();
 
-      stdinRl.close();
-      const approvalResponse = stdinMessages.find(
+      rl.close();
+      const approvalResponse = messages.find(
         (m) => m.id === 'server-req-1' && m.result
       );
       expect(approvalResponse).toBeDefined();
       expect(approvalResponse.result.decision).toBe('accept');
+    });
+
+    it('should auto-respond to commandExecution approval with accept', async () => {
+      const { mockDeps, fakeProc } = createMockDeps();
+      const { messages, rl } = collectStdinMessages(fakeProc);
+      handshakeRl = setupHandshake(fakeProc);
+
+      const bridge = new CodexBridge({ _deps: mockDeps });
+      await bridge.start();
+
+      sendServerRequest(fakeProc, 'item/commandExecution/requestApproval', {
+        command: 'curl -s http://localhost:7247/api/reviews/1/comments',
+      }, 'server-req-command');
+      await tick();
+
+      rl.close();
+      const response = messages.find((m) => m.id === 'server-req-command' && m.result);
+      expect(response).toBeDefined();
+      expect(response.result.decision).toBe('accept');
+    });
+
+    it('should auto-respond to legacy execCommandApproval with approved', async () => {
+      const { mockDeps, fakeProc } = createMockDeps();
+      const { messages, rl } = collectStdinMessages(fakeProc);
+      handshakeRl = setupHandshake(fakeProc);
+
+      const bridge = new CodexBridge({ _deps: mockDeps });
+      await bridge.start();
+
+      sendServerRequest(fakeProc, 'execCommandApproval', {
+        command: 'curl -s http://localhost:7247/api/reviews/1/comments',
+      }, 'server-req-exec');
+      await tick();
+
+      rl.close();
+      const response = messages.find((m) => m.id === 'server-req-exec' && m.result);
+      expect(response).toBeDefined();
+      expect(response.result.decision).toBe('approved');
+    });
+
+    it('should grant requested network permissions', async () => {
+      const { mockDeps, fakeProc } = createMockDeps();
+      const { messages, rl } = collectStdinMessages(fakeProc);
+      handshakeRl = setupHandshake(fakeProc);
+
+      const bridge = new CodexBridge({ _deps: mockDeps });
+      await bridge.start();
+
+      sendServerRequest(fakeProc, 'item/permissions/requestApproval', {
+        permissions: { network: { enabled: true }, fileSystem: null },
+      }, 'server-req-permissions');
+      await tick();
+
+      rl.close();
+      const response = messages.find((m) => m.id === 'server-req-permissions' && m.result);
+      expect(response).toBeDefined();
+      expect(response.result).toEqual({
+        permissions: { network: { enabled: true } },
+        scope: 'session',
+        strictAutoReview: false,
+      });
+    });
+
+    it('should grant network permissions when request omits network payload', async () => {
+      const { mockDeps, fakeProc } = createMockDeps();
+      const { messages, rl } = collectStdinMessages(fakeProc);
+      handshakeRl = setupHandshake(fakeProc);
+
+      const bridge = new CodexBridge({ _deps: mockDeps });
+      await bridge.start();
+
+      sendServerRequest(fakeProc, 'item/permissions/requestApproval', {
+        permissions: { fileSystem: null },
+      }, 'server-req-permissions-no-network');
+      await tick();
+
+      rl.close();
+      const response = messages.find((m) => m.id === 'server-req-permissions-no-network' && m.result);
+      expect(response).toBeDefined();
+      expect(response.result).toEqual({
+        permissions: { network: { enabled: true } },
+        scope: 'session',
+        strictAutoReview: false,
+      });
+    });
+
+    it('should decline file change approval requests', async () => {
+      const { mockDeps, fakeProc } = createMockDeps();
+      const { messages, rl } = collectStdinMessages(fakeProc);
+      handshakeRl = setupHandshake(fakeProc);
+
+      const bridge = new CodexBridge({ _deps: mockDeps });
+      await bridge.start();
+
+      sendServerRequest(fakeProc, 'item/fileChange/requestApproval', {
+        reason: 'extra write access',
+      }, 'server-req-file');
+      await tick();
+
+      rl.close();
+      const response = messages.find((m) => m.id === 'server-req-file' && m.result);
+      expect(response).toBeDefined();
+      expect(response.result.decision).toBe('decline');
+    });
+
+    it('should deny applyPatchApproval requests', async () => {
+      const { mockDeps, fakeProc } = createMockDeps();
+      const { messages, rl } = collectStdinMessages(fakeProc);
+      handshakeRl = setupHandshake(fakeProc);
+
+      const bridge = new CodexBridge({ _deps: mockDeps });
+      await bridge.start();
+
+      sendServerRequest(fakeProc, 'applyPatchApproval', {
+        files: ['src/main.js'],
+      }, 'server-req-patch');
+      await tick();
+
+      rl.close();
+      const response = messages.find((m) => m.id === 'server-req-patch' && m.result);
+      expect(response).toBeDefined();
+      expect(response.result).toEqual({ decision: 'denied' });
     });
 
     it('should respond with JSON-RPC error for unknown server requests', async () => {
@@ -928,6 +1214,7 @@ describe('CodexBridge', () => {
       const interruptReq = messages.find((m) => m.method === 'turn/interrupt');
       expect(interruptReq).toBeDefined();
       expect(interruptReq.params.threadId).toBe('test-thread-123');
+      expect(interruptReq.params.turnId).toBe('turn-001');
     });
 
     it('should be a no-op when no active turn', async () => {

--- a/tests/unit/chat/session-manager.test.js
+++ b/tests/unit/chat/session-manager.test.js
@@ -1094,6 +1094,21 @@ describe('ChatSessionManager', () => {
       const bridge = _createdClaudeCodeBridges[0];
       expect(bridge._constructorOptions.model).toBe('claude-opus-4-6');
     });
+
+    it('should pass Codex sandbox setting from provider def to CodexBridge', async () => {
+      mockChatProviders.getChatProvider.mockImplementationOnce(
+        () => ({
+          id: 'codex',
+          type: 'codex',
+          command: 'codex',
+          args: ['app-server'],
+          sandbox: 'read-only',
+        })
+      );
+      await manager.createSession({ provider: 'codex', reviewId: 1 });
+      const bridge = _createdCodexBridges[0];
+      expect(bridge._constructorOptions.sandbox).toBe('read-only');
+    });
   });
 
   describe('constructor', () => {

--- a/tests/unit/codex-provider.test.js
+++ b/tests/unit/codex-provider.test.js
@@ -53,8 +53,8 @@ describe('CodexProvider', () => {
       expect(CodexProvider.getProviderId()).toBe('codex');
     });
 
-    it('should return gpt-5.4-high as default model', () => {
-      expect(CodexProvider.getDefaultModel()).toBe('gpt-5.4-high');
+    it('should return gpt-5.5-high as default model', () => {
+      expect(CodexProvider.getDefaultModel()).toBe('gpt-5.5-high');
     });
 
     it('should return array of models with expected structure', () => {
@@ -64,6 +64,12 @@ describe('CodexProvider', () => {
 
       // Check that we have the expected model IDs
       const modelIds = models.map(m => m.id);
+      expect(modelIds.slice(0, 4)).toEqual([
+        'gpt-5.5-high',
+        'gpt-5.5-xhigh',
+        'gpt-5.4-high',
+        'gpt-5.4-xhigh',
+      ]);
       expect(modelIds).toContain('gpt-5.4-nano');
       expect(modelIds).toContain('gpt-5.4-mini');
       expect(modelIds).toContain('gpt-5.3-codex');
@@ -80,12 +86,13 @@ describe('CodexProvider', () => {
 
       const high54 = models.find(m => m.id === 'gpt-5.4-high');
       expect(high54.aliases).toContain('gpt-5.4');
+      expect(high54.badge).toBe('Previous Gen');
 
-      // Check model structure — default is now gpt-5.4-high (explicit reasoning)
+      // Check model structure — default is now gpt-5.5-high (explicit reasoning)
       const defaultModel = models.find(m => m.default === true);
       expect(defaultModel).toMatchObject({
-        id: 'gpt-5.4-high',
-        name: 'GPT-5.4 High',
+        id: 'gpt-5.5-high',
+        name: 'GPT-5.5 High',
         tier: 'thorough',
         default: true
       });
@@ -120,7 +127,7 @@ describe('CodexProvider', () => {
   describe('constructor', () => {
     it('should create instance with default model', () => {
       const provider = new CodexProvider();
-      expect(provider.model).toBe('gpt-5.4-high');
+      expect(provider.model).toBe('gpt-5.5-high');
     });
 
     it('should create instance with specified model', () => {
@@ -165,7 +172,7 @@ describe('CodexProvider', () => {
       expect(provider.args).toContain('--json');
       expect(provider.args).toContain('--sandbox');
       expect(provider.args).toContain('workspace-write');
-      expect(provider.args).toContain('--full-auto');
+      expect(provider.args).not.toContain('--full-auto');
       expect(provider.args).toContain('-');
     });
 
@@ -307,7 +314,7 @@ describe('CodexProvider', () => {
         const provider = new CodexProvider('gpt-5.4-nano');
         expect(provider.args).toContain('--sandbox');
         expect(provider.args).toContain('workspace-write');
-        expect(provider.args).toContain('--full-auto');
+        expect(provider.args).not.toContain('--full-auto');
         expect(provider.args).not.toContain('--dangerously-bypass-approvals-and-sandbox');
       });
 
@@ -323,7 +330,7 @@ describe('CodexProvider', () => {
         const provider = new CodexProvider('gpt-5.4-nano', { yolo: false });
         expect(provider.args).toContain('--sandbox');
         expect(provider.args).toContain('workspace-write');
-        expect(provider.args).toContain('--full-auto');
+        expect(provider.args).not.toContain('--full-auto');
         expect(provider.args).not.toContain('--dangerously-bypass-approvals-and-sandbox');
       });
     });
@@ -549,6 +556,31 @@ describe('CodexProvider', () => {
     });
   });
 
+  describe('createExitError', () => {
+    it('should include Codex auth recovery steps for 401 Unauthorized failures', () => {
+      const provider = new CodexProvider('gpt-5.4-mini');
+      const stderr = [
+        'ERROR codex_api::endpoint::responses_websocket:',
+        'failed to connect to websocket: HTTP error: 401 Unauthorized, url: wss://api.openai.com/v1/responses'
+      ].join(' ');
+
+      const error = provider.createExitError(1, stderr, '[Level 2]');
+
+      expect(error.message).toContain('[Level 2] Codex CLI authentication failed');
+      expect(error.message).toContain('Check Codex CLI authentication and try again');
+      expect(error.message).toContain('Original stderr');
+      expect(error.message).toContain(stderr);
+      expect(error.message).not.toContain('CODEX_API_KEY');
+    });
+
+    it('should preserve the generic exit error for non-auth failures', () => {
+      const provider = new CodexProvider('gpt-5.4-mini');
+      const error = provider.createExitError(2, 'some other failure', '[Level 1]');
+
+      expect(error.message).toBe('[Level 1] Codex CLI exited with code 2: some other failure');
+    });
+  });
+
   describe('buildArgsForModel', () => {
     it('should resolve cli_model for gpt-5.4-high variant', () => {
       // Reasoning variants pass the base model to `-m` and add effort via
@@ -581,7 +613,7 @@ describe('CodexProvider', () => {
       const sandboxIdx = args.indexOf('--sandbox');
       expect(sandboxIdx).toBeGreaterThanOrEqual(0);
       expect(args[sandboxIdx + 1]).toBe('read-only');
-      expect(args).toContain('--full-auto');
+      expect(args).not.toContain('--full-auto');
       // Extraction must not inherit the constructor's workspace-write mode
       expect(args).not.toContain('workspace-write');
     });


### PR DESCRIPTION
## Summary
- remove deprecated Codex --full-auto usage and update Codex review defaults/model ordering
- simplify Codex chat config to sandbox, wire app-server thread/turn params correctly, and preserve local API access
- fix Codex chat event handling for turn IDs, status changes, command events, approvals, and text deltas

## Tests
- pnpm exec vitest run tests/unit/chat/codex-bridge.test.js tests/unit/chat/chat-providers.test.js tests/unit/chat/session-manager.test.js tests/unit/codex-provider.test.js tests/unit/provider-config.test.js
- pnpm exec vitest run tests/unit/codex-provider.test.js
- git -c core.fsmonitor=false diff --check