### PR TITLE
Add Team Review Requests tab to home page

### DIFF
--- a/.changeset/filter-team-review-requests-by-team.md
+++ b/.changeset/filter-team-review-requests-by-team.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Add a team filter to the "Team Review Requests" tab. Enter a team in `org/team` form to narrow the tab to just that team's open review requests (GitHub `team-review-requested:org/team`); leave it blank to keep the default "all my teams" view. The entered team is remembered across sessions, and filtered results are cached separately so they never clobber the all-teams view.

--- a/.changeset/team-review-requests-tab.md
+++ b/.changeset/team-review-requests-tab.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Add a "Team Review Requests" tab to the home page. It lists open pull requests where a team you belong to has been asked to review, but you have not been requested directly (GitHub `review-requested:<you> -user-review-requested:<you>`). This complements the existing "My Review Requests" tab, which shows requests addressed to you directly.

--- a/plans/filter-team-review-requests-by-team.md
+++ b/plans/filter-team-review-requests-by-team.md
@@ -1,0 +1,157 @@
+# Plan: Filter Team Review Requests by a Specific Team
+
+## Goal
+Let the user narrow the **Team Review Requests** tab to a single team they care
+about, instead of always seeing the union of every team they belong to.
+
+The default stays unchanged ("all my teams" — the current behavior). When the
+user enters a team in `org/team` form, the tab re-queries GitHub for just that
+team's open review requests.
+
+## Key Insight (why this is small)
+GitHub's search API supports a `team-review-requested:ORG/TEAM` qualifier that
+runs over the **same search scope the tab already uses**. Filtering by a named
+team requires **no new token scope** — only *enumerating* a user's teams would
+need `read:org`. By having the user type the team name, we skip team
+enumeration entirely:
+
+- No `/user/teams` call, no `read:org`, no scope-degradation logic.
+- Works with whatever token the user already has configured.
+- The empty result for a typo'd or non-member team degrades gracefully on its
+  own (just shows the empty state).
+
+The current tab query is:
+```
+is:pr is:open archived:false review-requested:${login} -user-review-requested:${login}
+```
+The filtered query becomes:
+```
+is:pr is:open archived:false team-review-requested:${team}
+```
+
+### Design decision (settled)
+When a specific team is selected we **drop** the `-user-review-requested:<you>`
+exclusion. Once the user explicitly picks a team, "show everything awaiting this
+team" is the least surprising behavior, even if they're also named individually.
+The exclusion only applies to the default all-teams view.
+
+## Scope Notes
+- **Home-page feature only** — not tied to a review session, so the
+  Local-mode/PR-mode parity requirement does **not** apply here.
+- **No DB migration** — we reuse the existing `github_pr_cache` table and
+  namespace the `collection` column value (see Caching below).
+- Auto-populated team dropdown (the `read:org` path) is explicitly **out of
+  scope** for this change; it can be layered on later as an optional
+  enhancement that pre-fills suggestions.
+
+## Implementation
+
+### 1. Backend — `src/routes/github-collections.js`
+- Generalize the collection definition from `buildQuery(login)` to
+  `buildQuery(login, params)`. Only `team-reviews` uses `params`; the other two
+  ignore it (keep their existing single-arg arrow, or accept and ignore the 2nd
+  arg).
+- `team-reviews` `buildQuery(login, { team })`:
+  - If `team` is a valid `org/team` string → `is:pr is:open archived:false team-review-requested:${team}`
+  - Else → current default query (`review-requested:${login} -user-review-requested:${login}`).
+- **Validate `team` server-side** before interpolating into the query. Accept
+  only `^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$`. On invalid non-empty input, return
+  `400` with a clear message rather than silently falling back (a silent
+  fallback to all-teams would mislead the user into thinking the filter
+  applied). Empty/absent `team` is valid and means "all teams".
+- Read the param from `req.query.team` on the GET route and from
+  `req.query.team` (or body) on the POST `/refresh` route. Apply the same
+  validation in both.
+- **Caching:** namespace the cache key so a filtered view never clobbers the
+  all-teams cache. Use the bare `team-reviews` collection key for all-teams, and
+  `team-reviews:<org>/<team>` for a filtered view. Both the
+  `DELETE ... WHERE collection = ?` in refresh and the
+  `SELECT ... WHERE collection = ?` in GET already key on this single value, so
+  namespacing requires no schema or index change (unique index is
+  `(collection, owner, repo, number)`).
+  - Derive the storage key in one helper, e.g.
+    `cacheKey(name, team) => team ? name + ':' + team : name`, and use it in
+    both GET and POST handlers so they never diverge.
+
+### 2. Frontend — `public/index.html`
+- Add a small text input + clear/apply affordance inside the existing
+  `#team-reviews-tab` `.tab-pane-header` (next to `#team-reviews-fetched-at`
+  and `#refresh-team-reviews`). Placeholder: `org/team`. Include an inline
+  validation hint element (hidden by default).
+
+### 3. Frontend — `public/js/index.js`
+- Persist the entered team in `localStorage` (key e.g.
+  `github-collection-team:team-reviews`); restore it on load.
+- Thread the team value through `loadCollectionPrs` / `refreshCollectionPrs`:
+  append `?team=<encoded>` to both the GET and POST `/refresh` fetch URLs when a
+  team is set. (These two functions currently take
+  `(collection, containerId, state)` — add an optional `team` arg, or read it
+  from a small accessor so the tab-activation and refresh-button call sites stay
+  simple.)
+- Apply the same client-side format validation as the server before firing the
+  request; show the inline hint and skip the fetch on invalid input.
+- Wire an input/apply handler (debounced or on Enter / on blur / on a small
+  "Filter" button) that re-runs `refreshCollectionPrs('team-reviews', ...)`.
+- Update the `fetched-at` localStorage key handling so the timestamp reflects
+  the active view. Simplest: keep the existing single key; acceptable since the
+  label is informational. (Note this in code if we don't per-team it.)
+
+## Hazards
+- **`refreshCollectionPrs` / `loadCollectionPrs` are shared by all three
+  collections.** Call sites:
+  - Tab activation block (`public/js/index.js` ~1889–1906) — one per collection.
+  - Refresh-button delegation (`~1792–1809`) — `#refresh-review-requests`,
+    `#refresh-team-reviews`, `#refresh-my-prs`.
+  Any signature change (adding a `team` arg) must be applied/validated at
+  **all** these call sites, and must remain a no-op for `review-requests` and
+  `my-prs`.
+- **`buildQuery` shape change** ripples to the integration tests, which assert
+  the exact query string passed to `searchPullRequests`
+  (`tests/integration/github-collections.test.js` ~203, ~427, and the
+  team-reviews block ~563+). Update those expectations and add new cases.
+- **Cache-key namespacing touches two handlers that must agree.** GET reads
+  `WHERE collection = ?` and POST refresh writes/deletes `WHERE collection = ?`.
+  If one uses the namespaced key and the other doesn't, the GET will read stale
+  or empty data. Route both through the single `cacheKey` helper.
+- **Cache growth:** every distinct team string the user tries creates its own
+  cached rows that are never garbage-collected. Likely negligible (home-page,
+  local SQLite), but worth a one-line comment. If we want to avoid it, an
+  alternative is to **not persist** filtered views (fetch live, cache only the
+  all-teams view) — simpler storage story, loses offline cache for filtered
+  views. Decide before implementing; default recommendation: namespace + accept
+  the small growth.
+- **Query injection via the team field.** The value is interpolated into the
+  GitHub search query string. Validation (`^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$`)
+  must happen **server-side** (client validation is UX only). Without it a user
+  could inject extra qualifiers or break the query.
+- **`SelectionMode` for `team-reviews`** (`teamReviewsSelection`, keyed
+  `team-reviews` in `collectionSelections`) calls `sel.exit()` inside
+  `renderCollectionTable`. Re-rendering after a filter change must continue to
+  exit selection mode cleanly — verify a filter change while in selection mode
+  doesn't leave a stale action bar. The existing render path already calls
+  `exit()`, so this should hold, but test it.
+
+## Tests
+- **Integration** (`tests/integration/github-collections.test.js`):
+  - Default (no `team`) team-reviews refresh still issues the existing query
+    (regression).
+  - `?team=org/team` issues `team-review-requested:org/team` and **omits** the
+    `-user-review-requested` exclusion.
+  - Invalid `team` (e.g. `foo`, `a/b/c`, `org/team;extra`) → `400`, no GitHub
+    call.
+  - Filtered refresh caches under the namespaced key and GET with the same
+    `?team=` returns those rows without clobbering the all-teams cache.
+- **Frontend / E2E:** since this modifies `public/js/index.js` and
+  `public/index.html`, run E2E via a Task tool per project policy. Add/extend a
+  case that enters a team, verifies the request carries `?team=`, and that
+  invalid input shows the hint and fires no request.
+
+## Follow-ups / Docs
+- **Changeset:** `minor` (new user-facing capability on an existing tab).
+- **README:** the home-page tabs aren't currently documented in `README.md`
+  (grep found nothing), so likely no README change needed — verify at
+  implementation time.
+- **Optional future enhancement:** when a `read:org`-scoped token is present,
+  add a `GET /api/github/teams` endpoint (`octokit.rest.teams.listForAuthenticatedUser`)
+  to offer autocomplete/suggestions for the team field. Not required for this
+  change.

--- a/public/index.html
+++ b/public/index.html
@@ -960,6 +960,65 @@
             animation: spin 0.8s linear infinite;
         }
 
+        /* Team Review Requests: filter-by-team control */
+        .team-filter-group {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            /* Push the filter to the left; fetched-at + refresh stay right. */
+            margin-right: auto;
+        }
+
+        .team-filter {
+            display: flex;
+            align-items: center;
+            gap: 4px;
+        }
+
+        .team-filter-input {
+            width: 160px;
+            height: 32px;
+            padding: 0 8px;
+            font-size: 13px;
+            background: var(--color-bg-primary);
+            border: 1px solid var(--color-border-primary);
+            border-radius: var(--radius-md);
+            color: var(--color-text-primary);
+        }
+
+        .team-filter-input:focus {
+            outline: none;
+            border-color: var(--ai-primary);
+        }
+
+        .team-filter-input.invalid {
+            border-color: var(--color-danger);
+        }
+
+        .team-filter-apply,
+        .team-filter-clear {
+            height: 32px;
+            padding: 0 10px;
+            font-size: 13px;
+            background: transparent;
+            border: 1px solid var(--color-border-primary);
+            border-radius: var(--radius-md);
+            color: var(--color-text-tertiary);
+            cursor: pointer;
+            transition: all var(--transition-fast);
+        }
+
+        .team-filter-apply:hover,
+        .team-filter-clear:hover {
+            background: var(--color-bg-secondary);
+            color: var(--color-text-primary);
+        }
+
+        .team-filter-hint {
+            font-size: 12px;
+            color: var(--color-danger);
+        }
+
         .collection-pr-row {
             cursor: pointer;
         }
@@ -1396,6 +1455,23 @@
                     <!-- Team Review Requests Tab -->
                     <div class="tab-pane" id="team-reviews-tab">
                         <div class="tab-pane-header">
+                            <div class="team-filter-group">
+                                <form class="team-filter" id="team-reviews-filter">
+                                    <input
+                                        type="text"
+                                        class="team-filter-input"
+                                        id="team-reviews-team-input"
+                                        placeholder="org/team"
+                                        autocomplete="off"
+                                        spellcheck="false"
+                                        aria-label="Filter by team (org/team)"
+                                        aria-describedby="team-reviews-filter-hint"
+                                    >
+                                    <button type="submit" class="team-filter-apply" id="team-reviews-filter-apply" title="Filter by this team">Filter</button>
+                                    <button type="button" class="team-filter-clear" id="team-reviews-filter-clear" title="Show all teams" hidden>Clear</button>
+                                </form>
+                                <span class="team-filter-hint" id="team-reviews-filter-hint" role="alert" hidden>Use the form org/team.</span>
+                            </div>
                             <span class="fetched-at-label" id="team-reviews-fetched-at"></span>
                             <button class="btn-refresh" id="refresh-team-reviews" title="Refresh from GitHub">
                                 <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor"><path d="M1.705 8.005a.75.75 0 0 1 .834.656 5.5 5.5 0 0 0 9.592 2.97l-1.204-1.204a.25.25 0 0 1 .177-.427h3.646a.25.25 0 0 1 .25.25v3.646a.25.25 0 0 1-.427.177l-1.38-1.38A7.002 7.002 0 0 1 1.05 8.84a.75.75 0 0 1 .656-.834ZM8 2.5a5.487 5.487 0 0 0-4.131 1.869l1.204 1.204A.25.25 0 0 1 4.896 6H1.25A.25.25 0 0 1 1 5.75V2.104a.25.25 0 0 1 .427-.177l1.38 1.38A7.002 7.002 0 0 1 14.95 7.16a.75.75 0 0 1-1.49.178A5.5 5.5 0 0 0 8 2.5Z"/></svg>

--- a/public/index.html
+++ b/public/index.html
@@ -1343,6 +1343,7 @@
                         <div class="tab-bar" id="unified-tab-bar">
                             <button class="tab-btn active" data-tab="pr-tab" type="button">Pull Requests</button>
                             <button class="tab-btn" data-tab="review-requests-tab" type="button">My Review Requests</button>
+                            <button class="tab-btn" data-tab="team-reviews-tab" type="button">Team Review Requests</button>
                             <button class="tab-btn" data-tab="my-prs-tab" type="button">My PRs</button>
                             <span class="tab-divider"></span>
                             <button class="tab-btn" data-tab="local-tab" type="button">Local Reviews</button>
@@ -1388,6 +1389,19 @@
                             </button>
                         </div>
                         <div id="review-requests-container" class="recent-reviews-loading">
+                            Loading...
+                        </div>
+                    </div>
+
+                    <!-- Team Review Requests Tab -->
+                    <div class="tab-pane" id="team-reviews-tab">
+                        <div class="tab-pane-header">
+                            <span class="fetched-at-label" id="team-reviews-fetched-at"></span>
+                            <button class="btn-refresh" id="refresh-team-reviews" title="Refresh from GitHub">
+                                <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor"><path d="M1.705 8.005a.75.75 0 0 1 .834.656 5.5 5.5 0 0 0 9.592 2.97l-1.204-1.204a.25.25 0 0 1 .177-.427h3.646a.25.25 0 0 1 .25.25v3.646a.25.25 0 0 1-.427.177l-1.38-1.38A7.002 7.002 0 0 1 1.05 8.84a.75.75 0 0 1 .656-.834ZM8 2.5a5.487 5.487 0 0 0-4.131 1.869l1.204 1.204A.25.25 0 0 1 4.896 6H1.25A.25.25 0 0 1 1 5.75V2.104a.25.25 0 0 1 .427-.177l1.38 1.38A7.002 7.002 0 0 1 14.95 7.16a.75.75 0 0 1-1.49.178A5.5 5.5 0 0 0 8 2.5Z"/></svg>
+                            </button>
+                        </div>
+                        <div id="team-reviews-container" class="recent-reviews-loading">
                             Loading...
                         </div>
                     </div>

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -303,9 +303,29 @@
     loaded: false
   };
 
-  // ─── GitHub PR Collections (My Review Requests / My PRs) ───────────────────
+  // ─── GitHub PR Collections (Review Requests / Team Reviews / My PRs) ───────
+
+  /** Empty-state message per collection (used when a fetch returned no PRs). */
+  var COLLECTION_EMPTY_MESSAGES = {
+    'review-requests': 'No pull requests awaiting your review.',
+    'team-reviews': 'No pull requests awaiting your team’s review.',
+    'my-prs': 'You have no open pull requests.'
+  };
+
+  /** Noun used in the "Configure a GitHub token to see …" message per collection. */
+  var COLLECTION_TOKEN_LABELS = {
+    'review-requests': 'review requests',
+    'team-reviews': 'team review requests',
+    'my-prs': 'your pull requests'
+  };
 
   var reviewRequestsState = {
+    loaded: false,
+    prs: [],
+    fetchedAt: null
+  };
+
+  var teamReviewsState = {
     loaded: false,
     prs: [],
     fetchedAt: null
@@ -320,7 +340,7 @@
   /**
    * Render a single row for a collection PR table.
    * @param {Object} pr - PR object from the API
-   * @param {string} collection - The collection name ('review-requests' or 'my-prs')
+   * @param {string} collection - The collection name ('review-requests', 'team-reviews', or 'my-prs')
    * @returns {string} HTML string for the table row
    */
   function renderCollectionPrRow(pr, collection) {
@@ -366,14 +386,13 @@
    * Render the collection table into a container element.
    * @param {HTMLElement} container - The container element
    * @param {Object} state - The collection state object
-   * @param {string} collection - The collection name ('review-requests' or 'my-prs')
+   * @param {string} collection - The collection name ('review-requests', 'team-reviews', or 'my-prs')
    */
   function renderCollectionTable(container, state, collection) {
-    var sel = collection === 'review-requests' ? reviewRequestsSelection : myPrsSelection;
-    sel.exit();
+    var sel = collectionSelections[collection];
+    if (sel) sel.exit();
 
-    var fetchedAtId = collection === 'review-requests' ? 'review-requests-fetched-at' : 'my-prs-fetched-at';
-    var fetchedAtEl = document.getElementById(fetchedAtId);
+    var fetchedAtEl = document.getElementById(collection + '-fetched-at');
     if (fetchedAtEl) {
       var lsKey = 'github-collection-fetched-at:' + collection;
       var displayTs = localStorage.getItem(lsKey) || state.fetchedAt;
@@ -383,13 +402,11 @@
     }
 
     if (state.prs.length === 0) {
-      var emptyMsg = collection === 'review-requests'
-        ? 'No pull requests awaiting your review.'
-        : 'You have no open pull requests.';
-
-      if (!state.fetchedAt) {
-        emptyMsg = 'Click refresh to fetch from GitHub.';
-      }
+      var emptyLsKey = 'github-collection-fetched-at:' + collection;
+      var hasFetched = state.fetchedAt || localStorage.getItem(emptyLsKey);
+      var emptyMsg = hasFetched
+        ? (COLLECTION_EMPTY_MESSAGES[collection] || 'No pull requests found.')
+        : 'Click refresh to fetch from GitHub.';
 
       container.innerHTML =
         '<div class="recent-reviews-empty">' +
@@ -401,7 +418,7 @@
 
     var authorTh = collection === 'my-prs' ? '' : '<th>Author</th>';
 
-    var tbodyId = collection === 'review-requests' ? 'review-requests-tbody' : 'my-prs-tbody';
+    var tbodyId = collection + '-tbody';
 
     container.innerHTML =
       '<table class="recent-reviews-table">' +
@@ -424,7 +441,7 @@
 
   /**
    * Load collection PRs from cached backend data.
-   * @param {string} collection - 'review-requests' or 'my-prs'
+   * @param {string} collection - 'review-requests', 'team-reviews', or 'my-prs'
    * @param {string} containerId - DOM id of the container element
    * @param {Object} state - The collection state object
    */
@@ -453,14 +470,13 @@
 
   /**
    * Refresh collection PRs by fetching fresh data from GitHub.
-   * @param {string} collection - 'review-requests' or 'my-prs'
+   * @param {string} collection - 'review-requests', 'team-reviews', or 'my-prs'
    * @param {string} containerId - DOM id of the container element
    * @param {Object} state - The collection state object
    */
   async function refreshCollectionPrs(collection, containerId, state) {
     var container = document.getElementById(containerId);
-    var btnId = collection === 'review-requests' ? 'refresh-review-requests' : 'refresh-my-prs';
-    var btn = document.getElementById(btnId);
+    var btn = document.getElementById('refresh-' + collection);
 
     if (btn) btn.classList.add('refreshing');
 
@@ -478,7 +494,7 @@
           container.innerHTML =
             '<div class="recent-reviews-empty">' +
               '<p>Configure a GitHub token to see ' +
-              (collection === 'review-requests' ? 'review requests' : 'your pull requests') +
+              (COLLECTION_TOKEN_LABELS[collection] || 'pull requests') +
               '.</p>' +
             '</div>';
           container.classList.remove('recent-reviews-loading');
@@ -1610,6 +1626,17 @@
     ]
   });
 
+  var teamReviewsSelection = new SelectionMode({
+    tabId: 'team-reviews-tab',
+    containerId: 'team-reviews-container',
+    tbodyId: 'team-reviews-tbody',
+    rowIdAttr: 'prUrl',
+    actions: [
+      { label: 'Open', className: 'btn-bulk-open', handler: handleBulkOpen },
+      { label: 'Analyze', className: 'btn-bulk-analyze', handler: handleBulkAnalyze }
+    ]
+  });
+
   var myPrsSelection = new SelectionMode({
     tabId: 'my-prs-tab',
     containerId: 'my-prs-container',
@@ -1620,6 +1647,13 @@
       { label: 'Analyze', className: 'btn-bulk-analyze', handler: handleBulkAnalyze }
     ]
   });
+
+  /** Map of collection name → its SelectionMode instance. */
+  var collectionSelections = {
+    'review-requests': reviewRequestsSelection,
+    'team-reviews': teamReviewsSelection,
+    'my-prs': myPrsSelection
+  };
 
   async function handleBulkDeletePR(selectedIds, selectionInstance) {
     var count = selectedIds.size;
@@ -1762,6 +1796,13 @@
       return;
     }
 
+    var refreshTeamReviewsBtn = event.target.closest('#refresh-team-reviews');
+    if (refreshTeamReviewsBtn) {
+      event.preventDefault();
+      refreshCollectionPrs('team-reviews', 'team-reviews-container', teamReviewsState);
+      return;
+    }
+
     var refreshMyPrsBtn = event.target.closest('#refresh-my-prs');
     if (refreshMyPrsBtn) {
       event.preventDefault();
@@ -1774,7 +1815,7 @@
     if (selectToggle) {
       event.preventDefault();
       var tabId = selectToggle.dataset.selectionTab;
-      var instances = { 'pr-tab': prSelection, 'local-tab': localSelection, 'review-requests-tab': reviewRequestsSelection, 'my-prs-tab': myPrsSelection };
+      var instances = { 'pr-tab': prSelection, 'local-tab': localSelection, 'review-requests-tab': reviewRequestsSelection, 'team-reviews-tab': teamReviewsSelection, 'my-prs-tab': myPrsSelection };
       var instance = instances[tabId];
       if (instance) instance.toggle();
       return;
@@ -1851,6 +1892,12 @@
           }
           refreshCollectionPrs('review-requests', 'review-requests-container', reviewRequestsState);
         }
+        if (tabId === 'team-reviews-tab') {
+          if (!teamReviewsState.loaded) {
+            await loadCollectionPrs('team-reviews', 'team-reviews-container', teamReviewsState);
+          }
+          refreshCollectionPrs('team-reviews', 'team-reviews-container', teamReviewsState);
+        }
         if (tabId === 'my-prs-tab') {
           if (!myPrsState.loaded) {
             await loadCollectionPrs('my-prs', 'my-prs-container', myPrsState);
@@ -1893,6 +1940,10 @@
     if (savedTab === 'review-requests-tab') {
       loadCollectionPrs('review-requests', 'review-requests-container', reviewRequestsState)
         .then(function () { refreshCollectionPrs('review-requests', 'review-requests-container', reviewRequestsState); });
+    }
+    if (savedTab === 'team-reviews-tab') {
+      loadCollectionPrs('team-reviews', 'team-reviews-container', teamReviewsState)
+        .then(function () { refreshCollectionPrs('team-reviews', 'team-reviews-container', teamReviewsState); });
     }
     if (savedTab === 'my-prs-tab') {
       loadCollectionPrs('my-prs', 'my-prs-container', myPrsState)
@@ -1983,6 +2034,14 @@
       var rrBtn = createSelectButton('review-requests-tab');
       reviewRequestsSelection._toggleBtn = rrBtn;
       rrHeader.insertBefore(rrBtn, rrHeader.firstChild);
+    }
+
+    // Team Reviews tab: add to existing header
+    var trHeader = document.querySelector('#team-reviews-tab .tab-pane-header');
+    if (trHeader) {
+      var trBtn = createSelectButton('team-reviews-tab');
+      teamReviewsSelection._toggleBtn = trBtn;
+      trHeader.insertBefore(trBtn, trHeader.firstChild);
     }
 
     // My PRs tab: add to existing header

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -328,7 +328,10 @@
   var teamReviewsState = {
     loaded: false,
     prs: [],
-    fetchedAt: null
+    fetchedAt: null,
+    // Monotonic token for the most recent team-reviews request (see
+    // beginTeamReviewsRequest). Stale responses compare against this and bail.
+    activeRequest: 0
   };
 
   var myPrsState = {
@@ -336,6 +339,71 @@
     prs: [],
     fetchedAt: null
   };
+
+  // Filter-by-team support for the Team Review Requests tab.
+  // Client-side validation is UX only; the server re-validates before
+  // interpolating the value into the GitHub search query (query-injection
+  // guard). Pattern must match the server's TEAM_SLUG_PATTERN.
+  var TEAM_SLUG_PATTERN = /^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/;
+  var TEAM_FILTER_LS_KEY = 'github-collection-team:team-reviews';
+
+  /**
+   * Read the persisted team filter, returning '' (all teams) for an absent or
+   * invalid stored value.
+   * @returns {string} A validated `org/team` slug, or ''.
+   */
+  function getStoredTeamFilter() {
+    try {
+      var v = (localStorage.getItem(TEAM_FILTER_LS_KEY) || '').trim();
+      return v && TEAM_SLUG_PATTERN.test(v) ? v : '';
+    } catch (e) {
+      return '';
+    }
+  }
+
+  /**
+   * Begin a new team-reviews request "epoch" and return its token. Every user
+   * action that (re)loads the team-reviews view — filter apply, tab switch,
+   * manual refresh, initial load — calls this once and threads the returned id
+   * through BOTH the cached GET and the live refresh. Because multiple in-flight
+   * fetches write into the shared `teamReviewsState` and render into the same
+   * container, completion order alone could otherwise let a slower earlier
+   * request (e.g. a previous team, or the all-teams view) repaint the table with
+   * PRs that no longer match the active selection. loadCollectionPrs /
+   * refreshCollectionPrs bail after `await fetch(...)` when their token is no
+   * longer `activeRequest`, discarding the stale response before it mutates
+   * state or the DOM.
+   * @returns {number} The token for this request epoch.
+   */
+  function beginTeamReviewsRequest() {
+    teamReviewsState.activeRequest += 1;
+    return teamReviewsState.activeRequest;
+  }
+
+  /**
+   * Resync the Team Review Requests filter controls to a known-applied value
+   * (typically getStoredTeamFilter()). Switching tabs only toggles `.active` —
+   * it does not rebuild the Team Reviews DOM — so unapplied draft text typed
+   * into the input survives a tab switch. Because every reload path keys its
+   * fetch off getStoredTeamFilter() (the persisted value) rather than the live
+   * input, the visible filter could otherwise advertise one team while the
+   * queue, row-click navigation, and bulk actions operate on another. Any path
+   * that re-consumes the stored filter must call this first so the displayed
+   * filter cannot diverge from the team actually being fetched and rendered.
+   * @param {string} value - The validated `org/team` slug to display, or '' for all teams.
+   */
+  function syncTeamFilterControls(value) {
+    var input = document.getElementById('team-reviews-team-input');
+    if (input) {
+      input.value = value || '';
+      input.classList.remove('invalid');
+      input.removeAttribute('aria-invalid');
+    }
+    var hint = document.getElementById('team-reviews-filter-hint');
+    if (hint) hint.hidden = true;
+    var clearBtn = document.getElementById('team-reviews-filter-clear');
+    if (clearBtn) clearBtn.hidden = !value;
+  }
 
   /**
    * Render a single row for a collection PR table.
@@ -394,6 +462,12 @@
 
     var fetchedAtEl = document.getElementById(collection + '-fetched-at');
     if (fetchedAtEl) {
+      // Note: this key is intentionally NOT per-team — unlike the DB cache key
+      // in src/routes/github-collections.js (which uses cacheKey()), the
+      // fetched-at timestamp is informational only. We accept a brief label
+      // mismatch when the user switches the team-reviews filter; the label
+      // updates once that view's next refresh completes. See the write site in
+      // refreshCollectionPrs.
       var lsKey = 'github-collection-fetched-at:' + collection;
       var displayTs = localStorage.getItem(lsKey) || state.fetchedAt;
       fetchedAtEl.textContent = displayTs
@@ -444,14 +518,24 @@
    * @param {string} collection - 'review-requests', 'team-reviews', or 'my-prs'
    * @param {string} containerId - DOM id of the container element
    * @param {Object} state - The collection state object
+   * @param {string} [team] - Optional validated `org/team` filter (team-reviews
+   *   only). When set, requests the namespaced cache for that team.
+   * @param {number} [requestId] - Optional team-reviews request token (see
+   *   beginTeamReviewsRequest). When provided, the response is discarded if a
+   *   newer request has superseded it before this fetch resolved.
    */
-  async function loadCollectionPrs(collection, containerId, state) {
+  async function loadCollectionPrs(collection, containerId, state, team, requestId) {
     var container = document.getElementById(containerId);
 
     try {
-      var response = await fetch('/api/github/' + collection);
+      var url = '/api/github/' + collection + (team ? '?team=' + encodeURIComponent(team) : '');
+      var response = await fetch(url);
       if (!response.ok) throw new Error('Failed to fetch');
       var data = await response.json();
+
+      // Discard a response a newer team-reviews request has superseded, so a
+      // slow earlier load can't repaint the table with a stale team's PRs.
+      if (requestId != null && requestId !== state.activeRequest) return;
 
       state.loaded = true;
       state.prs = data.prs || [];
@@ -460,6 +544,8 @@
       renderCollectionTable(container, state, collection);
     } catch (error) {
       console.error('Error loading ' + collection + ':', error);
+      // Don't paint the error over a view a newer request now owns.
+      if (requestId != null && requestId !== state.activeRequest) return;
       container.innerHTML =
         '<div class="recent-reviews-empty">' +
           '<p>Failed to load. Click refresh to try again.</p>' +
@@ -473,8 +559,13 @@
    * @param {string} collection - 'review-requests', 'team-reviews', or 'my-prs'
    * @param {string} containerId - DOM id of the container element
    * @param {Object} state - The collection state object
+   * @param {string} [team] - Optional validated `org/team` filter (team-reviews
+   *   only). When set, refreshes and caches under the namespaced key.
+   * @param {number} [requestId] - Optional team-reviews request token (see
+   *   beginTeamReviewsRequest). When provided, the response is discarded if a
+   *   newer request has superseded it before this fetch resolved.
    */
-  async function refreshCollectionPrs(collection, containerId, state) {
+  async function refreshCollectionPrs(collection, containerId, state, team, requestId) {
     var container = document.getElementById(containerId);
     var btn = document.getElementById('refresh-' + collection);
 
@@ -486,7 +577,12 @@
     }
 
     try {
-      var response = await fetch('/api/github/' + collection + '/refresh', { method: 'POST' });
+      var refreshUrl = '/api/github/' + collection + '/refresh' + (team ? '?team=' + encodeURIComponent(team) : '');
+      var response = await fetch(refreshUrl, { method: 'POST' });
+
+      // A newer team-reviews request has superseded this one; drop it before
+      // touching the 401 message, shared state, or the table.
+      if (requestId != null && requestId !== state.activeRequest) return;
 
       if (!response.ok) {
         var errData = await response.json().catch(function() { return {}; });
@@ -504,14 +600,26 @@
       }
 
       var data = await response.json();
+
+      // Re-check after the body parse: a newer request may have started while
+      // the response was streaming.
+      if (requestId != null && requestId !== state.activeRequest) return;
+
       state.prs = data.prs || [];
       state.fetchedAt = data.fetched_at;
       state.loaded = true;
+      // Note: this key is intentionally NOT per-team — unlike the DB cache key
+      // in src/routes/github-collections.js (which uses cacheKey()), the
+      // fetched-at timestamp is informational only. We accept a brief label
+      // mismatch when the user switches the team-reviews filter; the label
+      // updates once the next refresh completes (read site: renderCollectionTable).
       localStorage.setItem('github-collection-fetched-at:' + collection, new Date().toISOString());
 
       renderCollectionTable(container, state, collection);
     } catch (error) {
       console.error('Error refreshing ' + collection + ':', error);
+      // Don't repaint a view a newer request now owns.
+      if (requestId != null && requestId !== state.activeRequest) return;
       // If we had existing data, keep showing it
       if (state.prs.length > 0) {
         renderCollectionTable(container, state, collection);
@@ -525,6 +633,62 @@
     } finally {
       if (btn) btn.classList.remove('refreshing');
     }
+  }
+
+  /**
+   * Apply the Team Review Requests team filter from the input field.
+   * Validates client-side (UX only), persists the value, toggles the Clear
+   * affordance and inline hint, then reloads the team-reviews view for the
+   * selected team (empty input = all teams).
+   */
+  function applyTeamFilter() {
+    var input = document.getElementById('team-reviews-team-input');
+    if (!input) return;
+    var hint = document.getElementById('team-reviews-filter-hint');
+    var clearBtn = document.getElementById('team-reviews-filter-clear');
+    var value = input.value.trim();
+
+    // Non-empty input must match the org/team format; skip the fetch and show
+    // the inline hint on invalid input. Empty means "all teams" (valid).
+    if (value !== '' && !TEAM_SLUG_PATTERN.test(value)) {
+      input.classList.add('invalid');
+      input.setAttribute('aria-invalid', 'true');
+      if (hint) hint.hidden = false;
+      return;
+    }
+
+    input.classList.remove('invalid');
+    input.removeAttribute('aria-invalid');
+    if (hint) hint.hidden = true;
+
+    try {
+      if (value) {
+        localStorage.setItem(TEAM_FILTER_LS_KEY, value);
+      } else {
+        localStorage.removeItem(TEAM_FILTER_LS_KEY);
+      }
+    } catch (e) { /* localStorage unavailable; filter still applies for this view */ }
+
+    if (clearBtn) clearBtn.hidden = !value;
+
+    // Reset loaded state so we read the (namespaced) cache for the new view
+    // before refreshing live from GitHub.
+    teamReviewsState.loaded = false;
+    teamReviewsState.prs = [];
+    // Paint a placeholder so the previous team's rows don't linger while
+    // loadCollectionPrs / refreshCollectionPrs run asynchronously.
+    var container = document.getElementById('team-reviews-container');
+    if (container) {
+      container.innerHTML = '<div class="recent-reviews-loading">Loading...</div>';
+    }
+    var team = value || '';
+    // One token for this user action, threaded through both the cached GET and
+    // the live refresh, so a slower earlier request can't clobber this view.
+    var requestId = beginTeamReviewsRequest();
+    loadCollectionPrs('team-reviews', 'team-reviews-container', teamReviewsState, team, requestId)
+      .then(function () {
+        refreshCollectionPrs('team-reviews', 'team-reviews-container', teamReviewsState, team, requestId);
+      });
   }
 
   /**
@@ -1799,7 +1963,13 @@
     var refreshTeamReviewsBtn = event.target.closest('#refresh-team-reviews');
     if (refreshTeamReviewsBtn) {
       event.preventDefault();
-      refreshCollectionPrs('team-reviews', 'team-reviews-container', teamReviewsState);
+      // Resync the controls to the applied filter before refreshing: unapplied
+      // draft text in the input must not advertise a team different from the one
+      // we actually fetch (which keys off the persisted value).
+      var teamReviewsRefreshFilter = getStoredTeamFilter();
+      syncTeamFilterControls(teamReviewsRefreshFilter);
+      var teamReviewsRefreshId = beginTeamReviewsRequest();
+      refreshCollectionPrs('team-reviews', 'team-reviews-container', teamReviewsState, teamReviewsRefreshFilter, teamReviewsRefreshId);
       return;
     }
 
@@ -1893,10 +2063,16 @@
           refreshCollectionPrs('review-requests', 'review-requests-container', reviewRequestsState);
         }
         if (tabId === 'team-reviews-tab') {
+          var teamFilter = getStoredTeamFilter();
+          // Re-entering the tab preserves any unapplied draft text in the input
+          // (switchTab does not rebuild the DOM). Resync the controls to the
+          // applied filter so the visible team matches the one we reload.
+          syncTeamFilterControls(teamFilter);
+          var teamReviewsTabRequestId = beginTeamReviewsRequest();
           if (!teamReviewsState.loaded) {
-            await loadCollectionPrs('team-reviews', 'team-reviews-container', teamReviewsState);
+            await loadCollectionPrs('team-reviews', 'team-reviews-container', teamReviewsState, teamFilter, teamReviewsTabRequestId);
           }
-          refreshCollectionPrs('team-reviews', 'team-reviews-container', teamReviewsState);
+          refreshCollectionPrs('team-reviews', 'team-reviews-container', teamReviewsState, teamFilter, teamReviewsTabRequestId);
         }
         if (tabId === 'my-prs-tab') {
           if (!myPrsState.loaded) {
@@ -1942,8 +2118,10 @@
         .then(function () { refreshCollectionPrs('review-requests', 'review-requests-container', reviewRequestsState); });
     }
     if (savedTab === 'team-reviews-tab') {
-      loadCollectionPrs('team-reviews', 'team-reviews-container', teamReviewsState)
-        .then(function () { refreshCollectionPrs('team-reviews', 'team-reviews-container', teamReviewsState); });
+      var initialTeamFilter = getStoredTeamFilter();
+      var initialTeamRequestId = beginTeamReviewsRequest();
+      loadCollectionPrs('team-reviews', 'team-reviews-container', teamReviewsState, initialTeamFilter, initialTeamRequestId)
+        .then(function () { refreshCollectionPrs('team-reviews', 'team-reviews-container', teamReviewsState, initialTeamFilter, initialTeamRequestId); });
     }
     if (savedTab === 'my-prs-tab') {
       loadCollectionPrs('my-prs', 'my-prs-container', myPrsState)
@@ -1971,6 +2149,37 @@
     const browseBtn = document.getElementById('browse-local-btn');
     if (browseBtn) {
       browseBtn.addEventListener('click', handleBrowseLocal);
+    }
+
+    // Set up Team Review Requests team-filter handlers and restore the
+    // persisted value.
+    const teamFilterInput = document.getElementById('team-reviews-team-input');
+    const teamFilterForm = document.getElementById('team-reviews-filter');
+    const teamFilterClearBtn = document.getElementById('team-reviews-filter-clear');
+    if (teamFilterInput) {
+      // Restore the persisted filter into the controls on initial load (same
+      // resync the reload paths use, so the displayed team always matches the
+      // applied filter).
+      syncTeamFilterControls(getStoredTeamFilter());
+      // Clear the invalid state / inline hint as the user edits.
+      teamFilterInput.addEventListener('input', function () {
+        teamFilterInput.classList.remove('invalid');
+        teamFilterInput.removeAttribute('aria-invalid');
+        const hint = document.getElementById('team-reviews-filter-hint');
+        if (hint) hint.hidden = true;
+      });
+    }
+    if (teamFilterForm) {
+      teamFilterForm.addEventListener('submit', function (event) {
+        event.preventDefault();
+        applyTeamFilter();
+      });
+    }
+    if (teamFilterClearBtn) {
+      teamFilterClearBtn.addEventListener('click', function () {
+        if (teamFilterInput) teamFilterInput.value = '';
+        applyTeamFilter();
+      });
     }
 
     // Set up PR Analyze button handler
@@ -2036,12 +2245,17 @@
       rrHeader.insertBefore(rrBtn, rrHeader.firstChild);
     }
 
-    // Team Reviews tab: add to existing header
+    // Team Reviews tab: add to existing header. Insert before the fetched-at
+    // label rather than as firstChild — the leading `.team-filter-group` carries
+    // `margin-right: auto`, so a firstChild button would be shoved to the far
+    // left. Placing it here keeps Select grouped with fetched-at + refresh on
+    // the right, matching the other collection tabs.
     var trHeader = document.querySelector('#team-reviews-tab .tab-pane-header');
     if (trHeader) {
       var trBtn = createSelectButton('team-reviews-tab');
       teamReviewsSelection._toggleBtn = trBtn;
-      trHeader.insertBefore(trBtn, trHeader.firstChild);
+      var trFetchedAt = document.getElementById('team-reviews-fetched-at');
+      trHeader.insertBefore(trBtn, trFetchedAt || trHeader.firstChild);
     }
 
     // My PRs tab: add to existing header

--- a/src/routes/github-collections.js
+++ b/src/routes/github-collections.js
@@ -23,9 +23,22 @@ const router = express.Router();
 
 const SELECT_COLUMNS = 'owner, repo, number, title, author, updated_at, html_url, state, fetched_at';
 
+// Valid `org/team` slug: two non-empty segments of GitHub-allowed characters.
+// Used to guard against query injection when interpolating the team into the
+// GitHub search query string. Must be applied server-side; client validation
+// is UX only.
+const TEAM_SLUG_PATTERN = /^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/;
+
 /**
  * Collection definitions. `buildQuery` receives the authenticated user's login
- * and returns the GitHub search query for that collection.
+ * and an optional params object, and returns the GitHub search query for that
+ * collection. Only collections with `supportsTeamFilter: true` consume
+ * `params.team` (currently just `team-reviews`); the others accept and ignore
+ * it. The flag also gates the team plumbing in `registerCollection`: a stray
+ * `?team=` on a collection that doesn't support it is ignored rather than
+ * validated or folded into the cache key, so it can never create a misleading
+ * namespaced cache entry for a query whose results are identical to the
+ * unfiltered view.
  */
 const COLLECTIONS = [
   {
@@ -36,9 +49,21 @@ const COLLECTIONS = [
   {
     name: 'team-reviews',
     label: 'team review requests',
+    supportsTeamFilter: true,
     // Review requested from a team the user belongs to, excluding PRs where the
     // user is requested directly (those appear under review-requests).
-    buildQuery: (login) => `is:pr is:open archived:false review-requested:${login} -user-review-requested:${login}`
+    //
+    // When a specific `team` (org/team) is provided, narrow to that team's open
+    // review requests and drop the `-user-review-requested` exclusion: once the
+    // user explicitly picks a team, "show everything awaiting this team" is the
+    // least surprising behavior. The team value MUST already be validated.
+    buildQuery: (login, params) => {
+      const team = params && params.team;
+      if (team) {
+        return `is:pr is:open archived:false team-review-requested:${team}`;
+      }
+      return `is:pr is:open archived:false review-requested:${login} -user-review-requested:${login}`;
+    }
   },
   {
     name: 'my-prs',
@@ -46,6 +71,35 @@ const COLLECTIONS = [
     buildQuery: (login) => `is:pr is:open archived:false author:${login}`
   }
 ];
+
+/**
+ * Derive the cache storage key for a collection, namespacing by team so a
+ * filtered view never clobbers the all-teams cache. Both the GET (read) and
+ * POST refresh (write/delete) handlers must route through this single helper so
+ * they never diverge.
+ * @param {string} name - Collection name.
+ * @param {string} [team] - Validated `org/team` slug, or falsy for all-teams.
+ * @returns {string} The `collection` column value to use.
+ */
+function cacheKey(name, team) {
+  return team ? `${name}:${team}` : name;
+}
+
+/**
+ * Validate and normalize the `team` query param.
+ * @param {*} raw - The raw `team` value from the request.
+ * @returns {{ team: string|null, error: string|null }} `team` is the validated
+ *   slug (or null for all-teams); `error` is set when the input is invalid.
+ */
+function parseTeamParam(raw) {
+  if (raw === undefined || raw === null || raw === '') {
+    return { team: null, error: null };
+  }
+  if (typeof raw !== 'string' || !TEAM_SLUG_PATTERN.test(raw)) {
+    return { team: null, error: 'Invalid team. Use the form org/team.' };
+  }
+  return { team: raw, error: null };
+}
 
 /**
  * Fetch cached rows for a collection, newest first.
@@ -60,16 +114,28 @@ async function getCachedRows(db, collection) {
 
 /**
  * Register the GET (cached) and POST (refresh) routes for a single collection.
- * @param {Object} def - Collection definition ({ name, label, buildQuery }).
+ * @param {Object} def - Collection definition
+ *   ({ name, label, buildQuery, supportsTeamFilter }).
  */
 function registerCollection(def) {
-  const { name, label, buildQuery } = def;
+  const { name, label, buildQuery, supportsTeamFilter } = def;
 
   // GET cached PRs.
   router.get(`/api/github/${name}`, async (req, res) => {
     try {
+      // Only team-aware collections consume `team`; for the rest, ignore any
+      // stray `?team=` so it can't validate-error or skew the cache key.
+      let team = null;
+      if (supportsTeamFilter) {
+        const parsed = parseTeamParam(req.query.team);
+        if (parsed.error) {
+          return res.status(400).json({ success: false, error: parsed.error });
+        }
+        team = parsed.team;
+      }
+
       const db = req.app.get('db');
-      const rows = await getCachedRows(db, name);
+      const rows = await getCachedRows(db, cacheKey(name, team));
       const fetchedAt = rows.length > 0 ? rows[0].fetched_at : null;
       res.json({ success: true, prs: rows, fetched_at: fetchedAt });
     } catch (error) {
@@ -81,6 +147,19 @@ function registerCollection(def) {
   // POST refresh from GitHub.
   router.post(`/api/github/${name}/refresh`, async (req, res) => {
     try {
+      // Only team-aware collections consume `team` (from the query string or
+      // request body); for the rest, ignore any stray value so it can't
+      // validate-error or skew the cache key. Empty/absent means "all teams".
+      let team = null;
+      if (supportsTeamFilter) {
+        const rawTeam = req.query.team !== undefined ? req.query.team : (req.body && req.body.team);
+        const parsed = parseTeamParam(rawTeam);
+        if (parsed.error) {
+          return res.status(400).json({ success: false, error: parsed.error });
+        }
+        team = parsed.team;
+      }
+
       const config = req.app.get('config');
       const githubToken = getGitHubToken(config);
       if (!githubToken) {
@@ -90,19 +169,24 @@ function registerCollection(def) {
       const db = req.app.get('db');
       const client = new GitHubClient(githubToken);
       const user = await client.getAuthenticatedUser();
-      const prs = await client.searchPullRequests(buildQuery(user.login));
+      const prs = await client.searchPullRequests(buildQuery(user.login, { team }));
 
+      // Namespace the cache so a filtered view never clobbers the all-teams
+      // cache. Every distinct team string the user tries creates its own cached
+      // rows that are never garbage-collected; negligible for a local SQLite
+      // home-page feature.
+      const key = cacheKey(name, team);
       await withTransaction(db, async () => {
-        await run(db, 'DELETE FROM github_pr_cache WHERE collection = ?', [name]);
+        await run(db, 'DELETE FROM github_pr_cache WHERE collection = ?', [key]);
         for (const pr of prs) {
           await run(db,
             'INSERT INTO github_pr_cache (owner, repo, number, title, author, updated_at, html_url, state, collection) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)',
-            [pr.owner, pr.repo, pr.number, pr.title, pr.author, pr.updated_at, pr.html_url, pr.state, name]
+            [pr.owner, pr.repo, pr.number, pr.title, pr.author, pr.updated_at, pr.html_url, pr.state, key]
           );
         }
       });
 
-      const rows = await getCachedRows(db, name);
+      const rows = await getCachedRows(db, key);
       const fetchedAt = rows.length > 0 ? rows[0].fetched_at : null;
       res.json({ success: true, prs: rows, fetched_at: fetchedAt });
     } catch (error) {

--- a/src/routes/github-collections.js
+++ b/src/routes/github-collections.js
@@ -3,8 +3,14 @@
  * GitHub Collections Routes
  *
  * Handles endpoints for PR collections:
- * - Review Requests: PRs where the user's review is requested
+ * - Review Requests: PRs where the user's review is requested directly
+ * - Team Review Requests: PRs where a team the user belongs to is requested,
+ *   but the user is not requested directly
  * - My PRs: PRs authored by the user
+ *
+ * Each collection exposes two endpoints registered by `registerCollection`:
+ * - GET  /api/github/:collection          → cached rows from github_pr_cache
+ * - POST /api/github/:collection/refresh  → fetch from GitHub and re-cache
  */
 
 const express = require('express');
@@ -15,112 +21,100 @@ const logger = require('../utils/logger');
 
 const router = express.Router();
 
-/**
- * Get cached review request PRs.
- */
-router.get('/api/github/review-requests', async (req, res) => {
-  try {
-    const db = req.app.get('db');
-    const rows = await query(db, 'SELECT owner, repo, number, title, author, updated_at, html_url, state, fetched_at FROM github_pr_cache WHERE collection = ? ORDER BY updated_at DESC', ['review-requests']);
+const SELECT_COLUMNS = 'owner, repo, number, title, author, updated_at, html_url, state, fetched_at';
 
-    const fetchedAt = rows.length > 0 ? rows[0].fetched_at : null;
-    res.json({ success: true, prs: rows, fetched_at: fetchedAt });
-  } catch (error) {
-    logger.error('Failed to fetch review requests:', error);
-    res.status(500).json({ success: false, error: 'Failed to fetch review requests' });
+/**
+ * Collection definitions. `buildQuery` receives the authenticated user's login
+ * and returns the GitHub search query for that collection.
+ */
+const COLLECTIONS = [
+  {
+    name: 'review-requests',
+    label: 'review requests',
+    buildQuery: (login) => `is:pr is:open archived:false user-review-requested:${login}`
+  },
+  {
+    name: 'team-reviews',
+    label: 'team review requests',
+    // Review requested from a team the user belongs to, excluding PRs where the
+    // user is requested directly (those appear under review-requests).
+    buildQuery: (login) => `is:pr is:open archived:false review-requested:${login} -user-review-requested:${login}`
+  },
+  {
+    name: 'my-prs',
+    label: 'your pull requests',
+    buildQuery: (login) => `is:pr is:open archived:false author:${login}`
   }
-});
+];
 
 /**
- * Refresh review request PRs from GitHub.
+ * Fetch cached rows for a collection, newest first.
  */
-router.post('/api/github/review-requests/refresh', async (req, res) => {
-  try {
-    const config = req.app.get('config');
-    const githubToken = getGitHubToken(config);
-    if (!githubToken) {
-      return res.status(401).json({ success: false, error: 'GitHub token not configured' });
+async function getCachedRows(db, collection) {
+  return query(
+    db,
+    `SELECT ${SELECT_COLUMNS} FROM github_pr_cache WHERE collection = ? ORDER BY updated_at DESC`,
+    [collection]
+  );
+}
+
+/**
+ * Register the GET (cached) and POST (refresh) routes for a single collection.
+ * @param {Object} def - Collection definition ({ name, label, buildQuery }).
+ */
+function registerCollection(def) {
+  const { name, label, buildQuery } = def;
+
+  // GET cached PRs.
+  router.get(`/api/github/${name}`, async (req, res) => {
+    try {
+      const db = req.app.get('db');
+      const rows = await getCachedRows(db, name);
+      const fetchedAt = rows.length > 0 ? rows[0].fetched_at : null;
+      res.json({ success: true, prs: rows, fetched_at: fetchedAt });
+    } catch (error) {
+      logger.error(`Failed to fetch ${label}:`, error);
+      res.status(500).json({ success: false, error: `Failed to fetch ${label}` });
     }
+  });
 
-    const db = req.app.get('db');
-    const client = new GitHubClient(githubToken);
-    const user = await client.getAuthenticatedUser();
-    const prs = await client.searchPullRequests(`is:pr is:open archived:false user-review-requested:${user.login}`);
-
-    await withTransaction(db, async () => {
-      await run(db, 'DELETE FROM github_pr_cache WHERE collection = ?', ['review-requests']);
-      for (const pr of prs) {
-        await run(db,
-          'INSERT INTO github_pr_cache (owner, repo, number, title, author, updated_at, html_url, state, collection) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)',
-          [pr.owner, pr.repo, pr.number, pr.title, pr.author, pr.updated_at, pr.html_url, pr.state, 'review-requests']
-        );
+  // POST refresh from GitHub.
+  router.post(`/api/github/${name}/refresh`, async (req, res) => {
+    try {
+      const config = req.app.get('config');
+      const githubToken = getGitHubToken(config);
+      if (!githubToken) {
+        return res.status(401).json({ success: false, error: 'GitHub token not configured' });
       }
-    });
 
-    const rows = await query(db, 'SELECT owner, repo, number, title, author, updated_at, html_url, state, fetched_at FROM github_pr_cache WHERE collection = ? ORDER BY updated_at DESC', ['review-requests']);
-    const fetchedAt = rows.length > 0 ? rows[0].fetched_at : null;
-    res.json({ success: true, prs: rows, fetched_at: fetchedAt });
-  } catch (error) {
-    if (error.status === 401 || error.status === 403) {
-      return res.status(401).json({ success: false, error: 'GitHub token is invalid or expired' });
-    }
-    logger.error('Failed to refresh review requests:', error);
-    res.status(500).json({ success: false, error: 'Failed to refresh review requests' });
-  }
-});
+      const db = req.app.get('db');
+      const client = new GitHubClient(githubToken);
+      const user = await client.getAuthenticatedUser();
+      const prs = await client.searchPullRequests(buildQuery(user.login));
 
-/**
- * Get cached user's own PRs.
- */
-router.get('/api/github/my-prs', async (req, res) => {
-  try {
-    const db = req.app.get('db');
-    const rows = await query(db, 'SELECT owner, repo, number, title, author, updated_at, html_url, state, fetched_at FROM github_pr_cache WHERE collection = ? ORDER BY updated_at DESC', ['my-prs']);
+      await withTransaction(db, async () => {
+        await run(db, 'DELETE FROM github_pr_cache WHERE collection = ?', [name]);
+        for (const pr of prs) {
+          await run(db,
+            'INSERT INTO github_pr_cache (owner, repo, number, title, author, updated_at, html_url, state, collection) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)',
+            [pr.owner, pr.repo, pr.number, pr.title, pr.author, pr.updated_at, pr.html_url, pr.state, name]
+          );
+        }
+      });
 
-    const fetchedAt = rows.length > 0 ? rows[0].fetched_at : null;
-    res.json({ success: true, prs: rows, fetched_at: fetchedAt });
-  } catch (error) {
-    logger.error('Failed to fetch my PRs:', error);
-    res.status(500).json({ success: false, error: 'Failed to fetch my PRs' });
-  }
-});
-
-/**
- * Refresh user's own PRs from GitHub.
- */
-router.post('/api/github/my-prs/refresh', async (req, res) => {
-  try {
-    const config = req.app.get('config');
-    const githubToken = getGitHubToken(config);
-    if (!githubToken) {
-      return res.status(401).json({ success: false, error: 'GitHub token not configured' });
-    }
-
-    const db = req.app.get('db');
-    const client = new GitHubClient(githubToken);
-    const user = await client.getAuthenticatedUser();
-    const prs = await client.searchPullRequests(`is:pr is:open archived:false author:${user.login}`);
-
-    await withTransaction(db, async () => {
-      await run(db, 'DELETE FROM github_pr_cache WHERE collection = ?', ['my-prs']);
-      for (const pr of prs) {
-        await run(db,
-          'INSERT INTO github_pr_cache (owner, repo, number, title, author, updated_at, html_url, state, collection) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)',
-          [pr.owner, pr.repo, pr.number, pr.title, pr.author, pr.updated_at, pr.html_url, pr.state, 'my-prs']
-        );
+      const rows = await getCachedRows(db, name);
+      const fetchedAt = rows.length > 0 ? rows[0].fetched_at : null;
+      res.json({ success: true, prs: rows, fetched_at: fetchedAt });
+    } catch (error) {
+      if (error.status === 401 || error.status === 403) {
+        return res.status(401).json({ success: false, error: 'GitHub token is invalid or expired' });
       }
-    });
-
-    const rows = await query(db, 'SELECT owner, repo, number, title, author, updated_at, html_url, state, fetched_at FROM github_pr_cache WHERE collection = ? ORDER BY updated_at DESC', ['my-prs']);
-    const fetchedAt = rows.length > 0 ? rows[0].fetched_at : null;
-    res.json({ success: true, prs: rows, fetched_at: fetchedAt });
-  } catch (error) {
-    if (error.status === 401 || error.status === 403) {
-      return res.status(401).json({ success: false, error: 'GitHub token is invalid or expired' });
+      logger.error(`Failed to refresh ${label}:`, error);
+      res.status(500).json({ success: false, error: `Failed to refresh ${label}` });
     }
-    logger.error('Failed to refresh my PRs:', error);
-    res.status(500).json({ success: false, error: 'Failed to refresh my PRs' });
-  }
-});
+  });
+}
+
+COLLECTIONS.forEach(registerCollection);
 
 module.exports = router;

--- a/tests/e2e/team-reviews-filter.spec.js
+++ b/tests/e2e/team-reviews-filter.spec.js
@@ -1,0 +1,262 @@
+// Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+/**
+ * E2E Tests: Team Review Requests team filter
+ *
+ * Tests the team filter on the "Team Review Requests" tab of the home page.
+ * The home page makes real GitHub-backed calls to /api/github/team-reviews
+ * (GET) and /api/github/team-reviews/refresh (POST), which the test server
+ * does not stub. We intercept both with page.route() to (a) avoid real
+ * GitHub calls and (b) capture request URLs so we can assert whether the
+ * `?team=` query parameter is present.
+ */
+
+import { test, expect } from './fixtures.js';
+
+const MOCK_BODY = JSON.stringify({ success: true, prs: [], fetched_at: null });
+
+/**
+ * Register interception for the team-reviews GET + refresh endpoints, pushing
+ * each captured URL into `urls`. Must be called BEFORE navigation/tab-click.
+ * @param {import('@playwright/test').Page} page
+ * @param {string[]} urls - array to collect intercepted request URLs into
+ */
+async function interceptTeamReviews(page, urls) {
+  await page.route('**/api/github/team-reviews**', route => {
+    urls.push(route.request().url());
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: MOCK_BODY
+    });
+  });
+}
+
+test.describe('Team Review Requests team filter', () => {
+  test('valid team is applied to fetches and reveals the Clear button', async ({ page }) => {
+    const urls = [];
+    await interceptTeamReviews(page, urls);
+
+    await page.goto('/');
+    // Switching to the tab fires an initial GET + refresh (no team yet).
+    await page.click('#unified-tab-bar [data-tab="team-reviews-tab"]');
+
+    const input = page.locator('#team-reviews-team-input');
+    await expect(input).toBeVisible();
+
+    // The tab switch fires an initial GET + refresh (no team yet). Wait for
+    // both before clearing so they cannot leak into the post-submit assertion.
+    await expect.poll(() => urls.length).toBeGreaterThanOrEqual(2);
+    urls.length = 0;
+
+    await input.fill('org/platform');
+    await page.click('#team-reviews-filter-apply');
+
+    // Filtering fires both a cached GET and a refresh POST. Wait for both before
+    // asserting, so a regression that drops `team` from the refresh POST (the
+    // request that actually hits GitHub) can't slip through after only the GET
+    // has been captured.
+    await expect.poll(() => urls.length).toBeGreaterThanOrEqual(2);
+
+    // Every captured request after submit must carry the encoded team slug.
+    for (const url of urls) {
+      expect(url).toContain('team=org%2Fplatform');
+    }
+
+    // Clear button becomes visible once a team is applied.
+    await expect(page.locator('#team-reviews-filter-clear')).toBeVisible();
+  });
+
+  test('invalid value shows the hint and fires no team-reviews request', async ({ page }) => {
+    const urls = [];
+    await interceptTeamReviews(page, urls);
+
+    await page.goto('/');
+    await page.click('#unified-tab-bar [data-tab="team-reviews-tab"]');
+
+    const input = page.locator('#team-reviews-team-input');
+    await expect(input).toBeVisible();
+
+    // The tab switch fires an initial GET + refresh. Wait for both to be
+    // captured (they fire asynchronously) before clearing, so a late-arriving
+    // initial call cannot pollute the post-submit assertion below.
+    await expect.poll(() => urls.length).toBeGreaterThanOrEqual(2);
+    urls.length = 0;
+
+    await input.fill('foo');
+    await page.click('#team-reviews-filter-apply');
+
+    // The inline hint must become visible.
+    await expect(page.locator('#team-reviews-filter-hint')).toBeVisible();
+    // Input is flagged invalid.
+    await expect(input).toHaveClass(/invalid/);
+
+    // Give any (erroneous) fetch a chance to fire, then assert none did.
+    await page.waitForTimeout(500);
+    expect(urls).toHaveLength(0);
+
+    // Typing again clears the invalid state and re-hides the hint.
+    await input.fill('foob');
+    await expect(input).not.toHaveClass(/invalid/);
+    await expect(page.locator('#team-reviews-filter-hint')).toBeHidden();
+  });
+
+  test('valid team persists across reload and restores the input value', async ({ page }) => {
+    const urls = [];
+    await interceptTeamReviews(page, urls);
+
+    await page.goto('/');
+    await page.click('#unified-tab-bar [data-tab="team-reviews-tab"]');
+
+    const input = page.locator('#team-reviews-team-input');
+    await expect(input).toBeVisible();
+    await input.fill('org/platform');
+    await page.click('#team-reviews-filter-apply');
+
+    // Confirm it was persisted before reloading.
+    await expect.poll(() =>
+      page.evaluate(() => localStorage.getItem('github-collection-team:team-reviews'))
+    ).toBe('org/platform');
+
+    await page.reload();
+
+    // The team-reviews tab is restored (persisted tab choice), and the input
+    // is repopulated from localStorage with the Clear button visible.
+    const reloadedInput = page.locator('#team-reviews-team-input');
+    await expect(reloadedInput).toHaveValue('org/platform');
+    await expect(page.locator('#team-reviews-filter-clear')).toBeVisible();
+  });
+
+  test('a slow earlier team response does not overwrite a newer selection', async ({ page }) => {
+    // Regression test for the async race: multiple in-flight team-reviews
+    // requests write into the same state and render into the same container.
+    // Without a request token, completion order alone decides which dataset
+    // wins, so a slow earlier filter (org/alpha) could repaint the table after
+    // a newer one (org/beta). We delay every org/alpha response so it resolves
+    // last, then assert the newer org/beta selection still wins.
+    const bodyFor = (number, repo, title) => JSON.stringify({
+      success: true,
+      fetched_at: '2025-03-0' + number + 'T00:00:00Z',
+      prs: [{
+        owner: 'org', repo, number, title, author: 'octocat',
+        updated_at: '2025-03-0' + number + 'T00:00:00Z',
+        html_url: 'https://github.com/org/' + repo + '/pull/' + number,
+        state: 'open'
+      }]
+    });
+    const ALPHA = bodyFor(1, 'alpha-repo', 'Alpha team PR');
+    const BETA = bodyFor(2, 'beta-repo', 'Beta team PR');
+
+    // Count how many org/alpha responses have actually been fulfilled (the
+    // cached GET and the chained refresh POST = 2) so we can wait for the race
+    // window to close deterministically instead of guessing a timeout.
+    const alphaFulfilled = [];
+    await page.route('**/api/github/team-reviews**', async route => {
+      const url = route.request().url();
+      if (url.includes('team=org%2Falpha')) {
+        await new Promise(resolve => setTimeout(resolve, 500));
+        await route.fulfill({ status: 200, contentType: 'application/json', body: ALPHA });
+        alphaFulfilled.push(url);
+        return;
+      }
+      const body = url.includes('team=org%2Fbeta') ? BETA : MOCK_BODY;
+      await route.fulfill({ status: 200, contentType: 'application/json', body });
+    });
+
+    await page.goto('/');
+    await page.click('#unified-tab-bar [data-tab="team-reviews-tab"]');
+
+    const input = page.locator('#team-reviews-team-input');
+    await expect(input).toBeVisible();
+
+    // Apply the slow team first, then immediately switch to the fast team.
+    await input.fill('org/alpha');
+    await page.click('#team-reviews-filter-apply');
+    await input.fill('org/beta');
+    await page.click('#team-reviews-filter-apply');
+
+    // The newer selection (beta) renders.
+    const container = page.locator('#team-reviews-container');
+    await expect(container).toContainText('Beta team PR');
+
+    // Wait until both delayed org/alpha responses (GET + chained POST) have
+    // resolved, i.e. the race window has fully closed.
+    await expect.poll(() => alphaFulfilled.length).toBeGreaterThanOrEqual(2);
+
+    // The stale alpha responses must not have clobbered the beta view.
+    await expect(container).toContainText('Beta team PR');
+    await expect(container).not.toContainText('Alpha team PR');
+  });
+
+  test('unapplied draft text is discarded on tab re-entry; the applied team reloads', async ({ page }) => {
+    // Regression test: switchTab only toggles `.active` — it does not rebuild
+    // the Team Reviews DOM — so unapplied draft text typed into the input
+    // survives a tab switch. The reload path keys its fetch off the persisted
+    // filter, not the live input, so without a resync the input could advertise
+    // one team while the queue, row clicks, and bulk actions operate on another.
+    const urls = [];
+    await interceptTeamReviews(page, urls);
+
+    await page.goto('/');
+    await page.click('#unified-tab-bar [data-tab="team-reviews-tab"]');
+
+    const input = page.locator('#team-reviews-team-input');
+    await expect(input).toBeVisible();
+
+    // Apply a valid team so it becomes the persisted/active filter.
+    await input.fill('org/platform');
+    await page.click('#team-reviews-filter-apply');
+    // Wait for both apply fetches (cached GET + refresh POST) so none remain
+    // in flight to pollute the post-re-entry assertion.
+    await expect.poll(() => urls.filter(u => u.includes('team=org%2Fplatform')).length).toBeGreaterThanOrEqual(2);
+
+    // Type draft text the user never confirms via Apply, then tab away.
+    await input.fill('org/decoy');
+    await page.click('#unified-tab-bar [data-tab="pr-tab"]');
+
+    // Only inspect the re-entry fetches.
+    urls.length = 0;
+    await page.click('#unified-tab-bar [data-tab="team-reviews-tab"]');
+
+    // The input is resynced to the applied filter, NOT the abandoned draft.
+    await expect(input).toHaveValue('org/platform');
+    await expect(page.locator('#team-reviews-filter-clear')).toBeVisible();
+
+    // Re-entry fetches must carry the applied team and never the discarded draft.
+    await expect.poll(() => urls.length).toBeGreaterThanOrEqual(1);
+    for (const url of urls) {
+      expect(url).toContain('team=org%2Fplatform');
+      expect(url).not.toContain('decoy');
+    }
+  });
+
+  test('unapplied draft text is discarded on manual refresh; the applied team reloads', async ({ page }) => {
+    // Regression test for the input-vs-stored split on the manual Refresh path:
+    // refresh fetches the persisted filter, so the visible input must be
+    // resynced to it rather than left showing unapplied draft text.
+    const urls = [];
+    await interceptTeamReviews(page, urls);
+
+    await page.goto('/');
+    await page.click('#unified-tab-bar [data-tab="team-reviews-tab"]');
+
+    const input = page.locator('#team-reviews-team-input');
+    await expect(input).toBeVisible();
+
+    await input.fill('org/platform');
+    await page.click('#team-reviews-filter-apply');
+    await expect.poll(() => urls.filter(u => u.includes('team=org%2Fplatform')).length).toBeGreaterThanOrEqual(2);
+
+    // Type draft text, then hit the manual Refresh button without applying it.
+    await input.fill('org/decoy');
+    urls.length = 0;
+    await page.click('#refresh-team-reviews');
+
+    // Input resyncs to the applied filter; the refresh fetch uses it.
+    await expect(input).toHaveValue('org/platform');
+    await expect.poll(() => urls.length).toBeGreaterThanOrEqual(1);
+    for (const url of urls) {
+      expect(url).toContain('team=org%2Fplatform');
+      expect(url).not.toContain('decoy');
+    }
+  });
+});

--- a/tests/integration/github-collections.test.js
+++ b/tests/integration/github-collections.test.js
@@ -518,4 +518,130 @@ describe('GitHub Collections Routes', () => {
       expect(res.body.success).toBe(false);
     });
   });
+
+  // ==========================================================================
+  // GET /api/github/team-reviews
+  // ==========================================================================
+
+  describe('GET /api/github/team-reviews', () => {
+    it('should return empty array when no cached data', async () => {
+      const res = await request(app).get('/api/github/team-reviews');
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.prs).toEqual([]);
+      expect(res.body.fetched_at).toBeNull();
+    });
+
+    it('should return only team-reviews cached data', async () => {
+      await insertCachedPR(db, {
+        owner: 'org', repo: 'repo', number: 1,
+        title: 'Direct request', author: 'alice',
+        updated_at: '2025-01-01T00:00:00Z',
+        html_url: 'https://github.com/org/repo/pull/1',
+        state: 'open', collection: 'review-requests'
+      });
+      await insertCachedPR(db, {
+        owner: 'org', repo: 'repo', number: 2,
+        title: 'Team request', author: 'bob',
+        updated_at: '2025-01-02T00:00:00Z',
+        html_url: 'https://github.com/org/repo/pull/2',
+        state: 'open', collection: 'team-reviews'
+      });
+
+      const res = await request(app).get('/api/github/team-reviews');
+
+      expect(res.body.prs).toHaveLength(1);
+      expect(res.body.prs[0].number).toBe(2);
+    });
+  });
+
+  // ==========================================================================
+  // POST /api/github/team-reviews/refresh
+  // ==========================================================================
+
+  describe('POST /api/github/team-reviews/refresh', () => {
+    it('should return 401 when no GitHub token configured', async () => {
+      configModule.getGitHubToken.mockReturnValue(null);
+
+      const res = await request(app).post('/api/github/team-reviews/refresh');
+
+      expect(res.status).toBe(401);
+      expect(res.body.success).toBe(false);
+      expect(res.body.error).toContain('token not configured');
+    });
+
+    it('should query for team requests excluding direct requests', async () => {
+      configModule.getGitHubToken.mockReturnValue('test-token');
+      GitHubClient.prototype.getAuthenticatedUser.mockResolvedValue({
+        login: 'testuser', name: 'Test User', avatar_url: 'https://example.com/avatar.png'
+      });
+      GitHubClient.prototype.searchPullRequests.mockResolvedValue([
+        {
+          owner: 'org', repo: 'project', number: 20,
+          title: 'Team feature', author: 'carol',
+          updated_at: '2025-03-05T12:00:00Z',
+          html_url: 'https://github.com/org/project/pull/20',
+          state: 'open'
+        }
+      ]);
+
+      const res = await request(app).post('/api/github/team-reviews/refresh');
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.prs).toHaveLength(1);
+      expect(res.body.prs[0].number).toBe(20);
+
+      // Team reviews = requested via a team, excluding direct user requests
+      expect(GitHubClient.prototype.searchPullRequests).toHaveBeenCalledWith(
+        'is:pr is:open archived:false review-requested:testuser -user-review-requested:testuser'
+      );
+    });
+
+    it('should not clear data from other collections', async () => {
+      await insertCachedPR(db, {
+        owner: 'org', repo: 'repo', number: 50,
+        title: 'Direct request', author: 'me',
+        updated_at: '2025-01-01T00:00:00Z',
+        html_url: 'https://github.com/org/repo/pull/50',
+        state: 'open', collection: 'review-requests'
+      });
+
+      configModule.getGitHubToken.mockReturnValue('test-token');
+      GitHubClient.prototype.getAuthenticatedUser.mockResolvedValue({
+        login: 'testuser', name: 'Test User', avatar_url: 'https://example.com/avatar.png'
+      });
+      GitHubClient.prototype.searchPullRequests.mockResolvedValue([]);
+
+      await request(app).post('/api/github/team-reviews/refresh');
+
+      const reviewRequests = await query(db, "SELECT * FROM github_pr_cache WHERE collection = 'review-requests'", []);
+      expect(reviewRequests).toHaveLength(1);
+      expect(reviewRequests[0].number).toBe(50);
+    });
+
+    it('should return 401 when GitHub API returns 403 auth error', async () => {
+      configModule.getGitHubToken.mockReturnValue('bad-token');
+      const forbiddenError = new Error('Forbidden');
+      forbiddenError.status = 403;
+      GitHubClient.prototype.getAuthenticatedUser.mockRejectedValue(forbiddenError);
+
+      const res = await request(app).post('/api/github/team-reviews/refresh');
+
+      expect(res.status).toBe(401);
+      expect(res.body.success).toBe(false);
+      expect(res.body.error).toContain('invalid or expired');
+    });
+
+    it('should return 500 on unexpected errors', async () => {
+      configModule.getGitHubToken.mockReturnValue('test-token');
+      GitHubClient.prototype.getAuthenticatedUser.mockRejectedValue(new Error('Network timeout'));
+
+      const res = await request(app).post('/api/github/team-reviews/refresh');
+
+      expect(res.status).toBe(500);
+      expect(res.body.success).toBe(false);
+    });
+  });
 });

--- a/tests/integration/github-collections.test.js
+++ b/tests/integration/github-collections.test.js
@@ -599,6 +599,134 @@ describe('GitHub Collections Routes', () => {
       );
     });
 
+    it('should query a specific team and omit the user exclusion when ?team is given', async () => {
+      configModule.getGitHubToken.mockReturnValue('test-token');
+      GitHubClient.prototype.getAuthenticatedUser.mockResolvedValue({
+        login: 'testuser', name: 'Test User', avatar_url: 'https://example.com/avatar.png'
+      });
+      GitHubClient.prototype.searchPullRequests.mockResolvedValue([
+        {
+          owner: 'org', repo: 'project', number: 30,
+          title: 'Platform team PR', author: 'dave',
+          updated_at: '2025-03-06T12:00:00Z',
+          html_url: 'https://github.com/org/project/pull/30',
+          state: 'open'
+        }
+      ]);
+
+      const res = await request(app)
+        .post('/api/github/team-reviews/refresh')
+        .query({ team: 'org/platform' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.prs).toHaveLength(1);
+      expect(res.body.prs[0].number).toBe(30);
+
+      // Filtered view drops the -user-review-requested exclusion.
+      expect(GitHubClient.prototype.searchPullRequests).toHaveBeenCalledWith(
+        'is:pr is:open archived:false team-review-requested:org/platform'
+      );
+    });
+
+    it('should accept the team value from the request body', async () => {
+      configModule.getGitHubToken.mockReturnValue('test-token');
+      GitHubClient.prototype.getAuthenticatedUser.mockResolvedValue({
+        login: 'testuser', name: 'Test User', avatar_url: 'https://example.com/avatar.png'
+      });
+      GitHubClient.prototype.searchPullRequests.mockResolvedValue([]);
+
+      const res = await request(app)
+        .post('/api/github/team-reviews/refresh')
+        .send({ team: 'org/platform' });
+
+      expect(res.status).toBe(200);
+      expect(GitHubClient.prototype.searchPullRequests).toHaveBeenCalledWith(
+        'is:pr is:open archived:false team-review-requested:org/platform'
+      );
+    });
+
+    it.each(['foo', 'a/b/c', 'org/team;extra', 'org/te am', ''.padStart(3, ' ')])(
+      'should return 400 and make no GitHub call for invalid team %j',
+      async (team) => {
+        configModule.getGitHubToken.mockReturnValue('test-token');
+        GitHubClient.prototype.getAuthenticatedUser.mockResolvedValue({
+          login: 'testuser', name: 'Test User', avatar_url: 'https://example.com/avatar.png'
+        });
+
+        const res = await request(app)
+          .post('/api/github/team-reviews/refresh')
+          .query({ team });
+
+        expect(res.status).toBe(400);
+        expect(res.body.success).toBe(false);
+        expect(res.body.error).toMatch(/org\/team/);
+        expect(GitHubClient.prototype.searchPullRequests).not.toHaveBeenCalled();
+        expect(GitHubClient.prototype.getAuthenticatedUser).not.toHaveBeenCalled();
+      }
+    );
+
+    it('should cache filtered results under a namespaced key without clobbering all-teams', async () => {
+      // Seed the all-teams cache directly.
+      await insertCachedPR(db, {
+        owner: 'org', repo: 'repo', number: 1,
+        title: 'All-teams PR', author: 'alice',
+        updated_at: '2025-01-01T00:00:00Z',
+        html_url: 'https://github.com/org/repo/pull/1',
+        state: 'open', collection: 'team-reviews'
+      });
+
+      configModule.getGitHubToken.mockReturnValue('test-token');
+      GitHubClient.prototype.getAuthenticatedUser.mockResolvedValue({
+        login: 'testuser', name: 'Test User', avatar_url: 'https://example.com/avatar.png'
+      });
+      GitHubClient.prototype.searchPullRequests.mockResolvedValue([
+        {
+          owner: 'org', repo: 'project', number: 30,
+          title: 'Platform team PR', author: 'dave',
+          updated_at: '2025-03-06T12:00:00Z',
+          html_url: 'https://github.com/org/project/pull/30',
+          state: 'open'
+        }
+      ]);
+
+      // Refresh the filtered view.
+      await request(app)
+        .post('/api/github/team-reviews/refresh')
+        .query({ team: 'org/platform' });
+
+      // Filtered rows live under the namespaced collection key.
+      const namespaced = await query(db, "SELECT * FROM github_pr_cache WHERE collection = 'team-reviews:org/platform'", []);
+      expect(namespaced).toHaveLength(1);
+      expect(namespaced[0].number).toBe(30);
+
+      // The all-teams cache is untouched.
+      const allTeams = await query(db, "SELECT * FROM github_pr_cache WHERE collection = 'team-reviews'", []);
+      expect(allTeams).toHaveLength(1);
+      expect(allTeams[0].number).toBe(1);
+
+      // GET with the same ?team returns the namespaced rows.
+      const getRes = await request(app)
+        .get('/api/github/team-reviews')
+        .query({ team: 'org/platform' });
+      expect(getRes.status).toBe(200);
+      expect(getRes.body.prs).toHaveLength(1);
+      expect(getRes.body.prs[0].number).toBe(30);
+
+      // GET without ?team still returns the all-teams cache.
+      const getAll = await request(app).get('/api/github/team-reviews');
+      expect(getAll.body.prs).toHaveLength(1);
+      expect(getAll.body.prs[0].number).toBe(1);
+    });
+
+    it('should return 400 on GET with an invalid team', async () => {
+      const res = await request(app)
+        .get('/api/github/team-reviews')
+        .query({ team: 'not-a-slug' });
+
+      expect(res.status).toBe(400);
+      expect(res.body.success).toBe(false);
+    });
+
     it('should not clear data from other collections', async () => {
       await insertCachedPR(db, {
         owner: 'org', repo: 'repo', number: 50,


### PR DESCRIPTION
## Summary

Adds a **Team Review Requests** tab to the home page. It lists open pull requests where a team you belong to has been asked to review, but you have *not* been requested directly (`review-requested:<you> -user-review-requested:<you>`). This complements the existing **My Review Requests** tab, which shows requests addressed to you directly.

Also fixes two issues surfaced while reviewing the collection tabs:

- **Empty-state contradiction:** `renderCollectionTable` showed "Click refresh to fetch from GitHub" after a *successful* refresh that returned zero PRs, because the server returns a `null` `fetched_at` when there are no cached rows. The message is now gated on whether any fetch has occurred (a cached row **or** a local refresh timestamp). This also fixes the latent same bug for the `review-requests` and `my-prs` tabs, where it would surface for any user with zero open PRs.
- **Unreachable bulk actions:** the Team Review Requests tab never received its "Select" toggle button, so bulk Open/Analyze was dead code for that tab. Added the missing `DOMContentLoaded` insertion block mirroring the sibling tabs.

## Testing

- `tests/integration/github-collections.test.js` — 29/29 pass (run under Node 24 to match the better-sqlite3 ABI).
- Full E2E suite: 289 passed, 1 skipped (intentional). The single failure (`analysis-history.spec.js`) is pre-existing and unrelated — it exercises the PR/diff analysis-history dropdown, never touches the home page or changed code, and fails identically on the reverted baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)