### PR TITLE
Surface toast feedback for manual tour/summary start failures

### DIFF
--- a/.changeset/manual-start-job-feedback.md
+++ b/.changeset/manual-start-job-feedback.md
@@ -1,0 +1,8 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Surface user-visible toast feedback when the toolbar tour/summary generate button can't kick off a job. Previously, clicking the button when `auto_generate: false` and the review had no diff (or the request failed) silently did nothing — making the button appear broken. Now the user sees:
+
+- An info toast ("No tour to generate." / "No summaries to generate.") when the diff is empty.
+- An error toast when the HTTP request fails or the server declines for an unknown reason.

--- a/public/js/pr.js
+++ b/public/js/pr.js
@@ -1594,18 +1594,23 @@ class PRManager {
     const url = isLocal
       ? `/api/local/${encodeURIComponent(pr.id)}/jobs/${encodeURIComponent(jobKey)}/start`
       : `/api/pr/${encodeURIComponent(pr.owner)}/${encodeURIComponent(pr.repo)}/${encodeURIComponent(pr.number)}/jobs/${encodeURIComponent(jobKey)}/start`;
+    // Phrasing varies by job kind. `featureLabel` goes into the HTTP/decline
+    // error messages; `noDiffMessage` is the dedicated "nothing to do" line.
+    // NOTE: the toast singleton is lowercase `window.toast` (see
+    // cancel-background-job.js); `window.Toast` does not exist.
+    const featureLabel = jobKey === 'tour' ? 'tour' : 'summary';
+    const noDiffMessage = jobKey === 'tour' ? 'No tour to generate.' : 'No summaries to generate.';
     try {
       const resp = await fetch(url, { method: 'POST' });
       if (resp.status === 409) {
         // Feature disabled in config — shouldn't happen (the button is hidden
         // when disabled) but surface it rather than failing silently.
-        // NOTE: the toast singleton is lowercase `window.toast` (see
-        // cancel-background-job.js); `window.Toast` does not exist.
-        if (window.toast?.error) window.toast.error('This feature is disabled in config.');
+        window.toast?.showError?.('This feature is disabled in config.');
         return;
       }
       if (!resp.ok) {
         console.warn(`[StartJob] ${jobKey} start POST failed: ${resp.status}`);
+        window.toast?.showError?.(`Failed to start ${featureLabel} generation (HTTP ${resp.status}).`);
         return;
       }
       // Optimistic UI: there is no `review:background_job_started` broadcast,
@@ -1623,9 +1628,20 @@ class PRManager {
           this._tourGenerating = true;
           this._syncTourToolbarButton();
         }
+        return;
+      }
+      // Server accepted the request but declined to enqueue. The known
+      // reason today is `'no-diff'` — review has no changes to act on. Tell
+      // the user so the button doesn't appear inert. Unknown decline
+      // reasons fall through to a generic message rather than silence.
+      if (payload.reason === 'no-diff') {
+        window.toast?.showInfo?.(noDiffMessage);
+      } else {
+        window.toast?.showError?.(`Could not start ${featureLabel} generation.`);
       }
     } catch (err) {
       console.warn(`[StartJob] ${jobKey} start POST error:`, err.message);
+      window.toast?.showError?.(`Failed to start ${featureLabel} generation: ${err.message}`);
     }
   }
 

--- a/tests/unit/pr-manager-manual-start.test.js
+++ b/tests/unit/pr-manager-manual-start.test.js
@@ -94,33 +94,70 @@ describe('PRManager._startGenerationJob', () => {
     expect(mgr._syncTourToolbarButton).toHaveBeenCalledTimes(1);
   });
 
-  it('409 disabled: calls toast.error and sets no generating flag', async () => {
+  it('409 disabled: calls toast.showError and sets no generating flag', async () => {
     mgr.currentPR = { id: 7, owner: 'o', repo: 'r', number: 3, reviewType: 'pr' };
     sandbox.fetch = vi.fn().mockResolvedValue({
       ok: false,
       status: 409,
       json: async () => ({}),
     });
-    sandbox.toast = { error: vi.fn() };
+    sandbox.toast = { showError: vi.fn() };
 
     await mgr._startGenerationJob('summary');
 
-    expect(sandbox.toast.error).toHaveBeenCalledTimes(1);
-    expect(sandbox.toast.error).toHaveBeenCalledWith('This feature is disabled in config.');
+    expect(sandbox.toast.showError).toHaveBeenCalledTimes(1);
+    expect(sandbox.toast.showError).toHaveBeenCalledWith('This feature is disabled in config.');
     expect(mgr._summariesGenerating).toBe(false);
     expect(mgr._syncSummaryToolbarButton).not.toHaveBeenCalled();
   });
 
-  it('200 no-diff (started:false, no alreadyRunning): sets no flag and does not sync', async () => {
+  it('200 no-diff for summary: shows info toast and sets no flag', async () => {
     mgr.currentPR = { id: 7, owner: 'o', repo: 'r', number: 3, reviewType: 'pr' };
     sandbox.fetch = vi.fn().mockResolvedValue({
       ok: true,
       status: 200,
       json: async () => ({ started: false, reason: 'no-diff' }),
     });
+    sandbox.toast = { showInfo: vi.fn() };
 
     await mgr._startGenerationJob('summary');
 
+    expect(sandbox.toast.showInfo).toHaveBeenCalledTimes(1);
+    expect(sandbox.toast.showInfo).toHaveBeenCalledWith('No summaries to generate.');
+    expect(mgr._summariesGenerating).toBe(false);
+    expect(mgr._syncSummaryToolbarButton).not.toHaveBeenCalled();
+  });
+
+  it('200 no-diff for tour: shows info toast and sets no flag', async () => {
+    mgr.currentPR = { id: 7, owner: 'o', repo: 'r', number: 3, reviewType: 'local' };
+    sandbox.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ started: false, reason: 'no-diff' }),
+    });
+    sandbox.toast = { showInfo: vi.fn() };
+
+    await mgr._startGenerationJob('tour');
+
+    expect(sandbox.toast.showInfo).toHaveBeenCalledTimes(1);
+    expect(sandbox.toast.showInfo).toHaveBeenCalledWith('No tour to generate.');
+    expect(mgr._tourGenerating).toBe(false);
+    expect(mgr._syncTourToolbarButton).not.toHaveBeenCalled();
+  });
+
+  it('200 started:false with unknown reason: shows generic error toast', async () => {
+    mgr.currentPR = { id: 7, owner: 'o', repo: 'r', number: 3, reviewType: 'pr' };
+    sandbox.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ started: false }),
+    });
+    sandbox.toast = { showError: vi.fn() };
+
+    await mgr._startGenerationJob('summary');
+
+    expect(sandbox.toast.showError).toHaveBeenCalledTimes(1);
+    expect(sandbox.toast.showError).toHaveBeenCalledWith('Could not start summary generation.');
     expect(mgr._summariesGenerating).toBe(false);
     expect(mgr._syncSummaryToolbarButton).not.toHaveBeenCalled();
   });
@@ -139,17 +176,32 @@ describe('PRManager._startGenerationJob', () => {
     expect(mgr._syncSummaryToolbarButton).toHaveBeenCalledTimes(1);
   });
 
-  it('non-409 !ok (500): sets no flag and does not throw', async () => {
+  it('non-409 !ok (500): shows error toast, sets no flag, does not throw', async () => {
     mgr.currentPR = { id: 7, owner: 'o', repo: 'r', number: 3, reviewType: 'pr' };
     sandbox.fetch = vi.fn().mockResolvedValue({
       ok: false,
       status: 500,
       json: async () => ({}),
     });
+    sandbox.toast = { showError: vi.fn() };
 
     await expect(mgr._startGenerationJob('summary')).resolves.toBeUndefined();
+    expect(sandbox.toast.showError).toHaveBeenCalledTimes(1);
+    expect(sandbox.toast.showError).toHaveBeenCalledWith('Failed to start summary generation (HTTP 500).');
     expect(mgr._summariesGenerating).toBe(false);
     expect(mgr._syncSummaryToolbarButton).not.toHaveBeenCalled();
+  });
+
+  it('fetch rejects: shows error toast and swallows the error', async () => {
+    mgr.currentPR = { id: 7, owner: 'o', repo: 'r', number: 3, reviewType: 'local' };
+    sandbox.fetch = vi.fn().mockRejectedValue(new Error('network down'));
+    sandbox.toast = { showError: vi.fn() };
+
+    await expect(mgr._startGenerationJob('tour')).resolves.toBeUndefined();
+    expect(sandbox.toast.showError).toHaveBeenCalledTimes(1);
+    expect(sandbox.toast.showError).toHaveBeenCalledWith('Failed to start tour generation: network down');
+    expect(mgr._tourGenerating).toBe(false);
+    expect(mgr._syncTourToolbarButton).not.toHaveBeenCalled();
   });
 
   it('returns early without fetching when currentPR is null', async () => {


### PR DESCRIPTION
## Summary
- The toolbar tour/summary generate button silently swallowed every non-happy response from `/jobs/<kind>/start`, so a click on an empty-diff review (the canonical local-mode case) looked like a dead button.
- `_startGenerationJob` now surfaces user-visible toasts for: no-diff decline (info), non-OK HTTP (error), accepted-but-declined responses (error), and fetch failures (error). 409 already had a toast — kept.
- Wording is parallel per job kind: "No tour to generate." / "No summaries to generate." — no awkward verbing.

## Test plan
- [x] `pnpm vitest run tests/unit/pr-manager-manual-start.test.js` → 18/18 pass
- [x] `pnpm vitest run tests/unit/` → 6180/6180 pass
- [x] Reproduced live in local mode with `tours.enabled=true, tours.auto_generate=false`: no-diff click now shows `toast-info` "No tour to generate."; 500 click shows `toast-error` "Failed to start tour generation (HTTP 500)."
- [ ] Manual sanity check in PR mode (shares the same code path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)