### PR TITLE
Fix false "no-diff" for local manual tour/summary; persist scoped diffs

### DIFF
--- a/.changeset/local-tour-summary-no-diff-self-heal.md
+++ b/.changeset/local-tour-summary-no-diff-self-heal.md
@@ -1,0 +1,12 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Fix false "No tour to generate" / "No summary to generate" in local mode. The manual **Start guided tour** and **Generate summaries** buttons reported `no-diff` for local reviews that clearly had changes, because the manual job-start handler read the diff only from the `local_diffs` table — and several paths created/analyzed a local review without ever writing that table (the analysis-push, council, and MCP-analyze flows cached the diff in memory only or in `analysis_runs`).
+
+Two complementary fixes:
+
+- The local manual job-start handler now resolves the diff through the same chain the rest of local mode uses — in-memory cache → persisted `local_diffs` row → regenerate from the live working tree (scope-aware) — and persists the regenerated diff. It only reports `no-diff` when the working tree genuinely has no changes in scope, and self-heals reviews created before this fix. The working-tree regeneration is now gated by the same HEAD-snapshot guard as `refresh-diff`: for a non-branch review whose HEAD has moved off its recorded `local_head_sha`, regeneration is skipped and the user is funneled through the explicit `resolve-head-change` flow instead of silently re-snapshotting the moved HEAD onto a pinned review. Branch-scoped reviews (which persist across HEAD changes) keep regenerating as before.
+- The analysis-push (`POST /api/analyses/results`), local council, and MCP `start_analysis` (local) paths now durably persist the diff to `local_diffs`, so the diff survives a restart regardless of which path created the review. Each path persists using the review's recorded scope (`unstaged`/`staged`/`branch`) rather than the default-scope wrapper, so re-using a review that was moved to a different scope no longer overwrites its durable row with a narrower patch, and the MCP path also refreshes the in-memory diff cache alongside the database row.
+
+PR mode is unaffected: a PR's diff is always persisted in `pr_data` at load time, so its `no-diff` cannot be a false negative.

--- a/plans/fix-local-manual-tour-summary-no-diff.md
+++ b/plans/fix-local-manual-tour-summary-no-diff.md
@@ -1,0 +1,158 @@
+# Fix: "No tour to generate" in local mode when changes clearly exist
+
+## Context
+
+A user testing **local mode** clicked the manual **Start guided tour** button and got a
+`No tour to generate.` toast even though the review had real changes. The same gap affects
+the manual **Generate summaries** button (same handler).
+
+### Root cause (confirmed against the live DB)
+
+The toast fires when the server returns `{ started: false, reason: 'no-diff' }`
+(`public/js/pr.js:1841-1842`). In local mode that response comes from the manual job-start
+handler, which resolves the diff from the **`local_diffs` table only**:
+
+```js
+// src/routes/local.js ~2400  (POST /api/local/:reviewId/jobs/:jobKey/start)
+const localDiff = await reviewRepo.getLocalDiff(reviewId);   // local_diffs table ONLY
+const diffText = localDiff ? (localDiff.diff || '') : '';
+const worktreePath = review.local_path || null;
+if (!diffText || !worktreePath) return res.json({ started: false, reason: 'no-diff' });
+```
+
+But several paths create/analyze a local review **without ever writing `local_diffs`**:
+
+| Path | Diff stored in | Writes `local_diffs`? |
+|------|----------------|-----------------------|
+| `POST /api/local/start` (`local.js:514`) | in-memory Map **+** DB | ✅ |
+| CLI `setupLocalReviewSession` (`local-review.js:834`) | in-memory Map **+** DB | ✅ |
+| Analysis push `analyses.js:236` | in-memory Map **only** | ❌ |
+| Council `local.js:2279` | in-memory Map **only** | ❌ |
+| MCP analyze `mcp.js` (local mode) | `analysis_runs.diff` only | ❌ |
+
+Verified: the most recent local review (#727, branch `github-alt`) had a real **89,936-char**
+diff (analyzed by a council + three `pi` runs) but **zero rows in `local_diffs`** → tour
+button reads empty → false "no-diff".
+
+The *auto-kickoff* path (`local.js:766`) does not hit this because it falls back through
+in-memory → DB — but it only runs when `auto_generate` is **on**, i.e. never when the manual
+button is in use.
+
+### Intended outcome
+
+The manual tour/summary buttons must never report "no-diff" when the working tree has changes,
+and a local review's diff must be durably persisted regardless of which path created it.
+
+---
+
+## Approach (two complementary fixes)
+
+### Fix A — Manual job-start handler self-heals (`src/routes/local.js`)
+
+In the local manual-start handler (`POST /api/local/:reviewId/jobs/:jobKey/start`, ~line 2400),
+replace the DB-only read with the same resolution chain the rest of the file already uses:
+
+1. **In-memory cache** — `getLocalReviewDiff(reviewId)?.diff` (module helper, `local.js:73`).
+2. **Persisted DB** — `reviewRepo.getLocalDiff(reviewId)`.
+3. **Regenerate from the working tree** (scope-aware) when both are empty and `local_path`
+   exists — using the already-imported `reviewScope(review)`, `generateScopedDiff(worktreePath,
+   scopeStart, scopeEnd, review.local_base_branch)` and `computeScopedDigest(...)` (same calls as
+   `local.js:1714`, `1980`, `2277`). On success, persist via `setLocalReviewDiff` **and**
+   `reviewRepo.saveLocalDiff` so the next read is fast and durable. Wrap regen in `try/catch`
+   (mirror the council block at `local.js:2276-2282`): on error, log via `logger.warn` and leave
+   the diff empty.
+
+Only return `{ started: false, reason: 'no-diff' }` when, after all three steps, the diff is
+still empty (genuinely no changes in scope) or `local_path` is missing. This makes the tour
+reflect the **current** working tree and self-heals reviews created before Fix B (incl. #727).
+
+> All helpers (`getLocalReviewDiff`/`setLocalReviewDiff`, `reviewScope`, `generateScopedDiff`,
+> `computeScopedDigest`) are already in scope in `local.js` — no new imports.
+
+### Fix B — Persist the diff at the source (root cause)
+
+Add a durable `saveLocalDiff` to the three paths that currently skip it:
+
+1. **`src/routes/analyses.js` (after line 236)** — `generateLocalDiff` + `computeLocalDiffDigest`
+   are already imported and `reviewRepo` exists (line 210). After
+   `localReviewDiffs.set(reviewId, {...})`, add
+   `await reviewRepo.saveLocalDiff(reviewId, { diff: diffResult.diff, stats: diffResult.stats, digest })`
+   inside the existing `try`.
+
+2. **`src/routes/local.js` council endpoint (~line 2276-2282)** — hoist `diff/stats/digest` into
+   variables declared before the `try`, then after `reviewRepo` is constructed (line 2286) call
+   `await reviewRepo.saveLocalDiff(reviewId, {...})` when a diff was produced. Keep the existing
+   `setLocalReviewDiff` call.
+
+3. **`src/routes/mcp.js` local-analysis branch (after the review is found/created, ~line 541)** —
+   add imports for `generateLocalDiff` and `computeLocalDiffDigest` from `../local-review`
+   (currently only `getCurrentBranch` is imported, line 14). Generate the diff and call
+   `await reviewRepo.saveLocalDiff(reviewId, {...})` so the MCP-driven web UI can display the diff
+   and the manual buttons work after a restart. Wrap in `try/catch` + `logger.warn` (non-fatal),
+   matching `analyses.js:237-239`.
+
+### PR mode — not affected (documented, not changed)
+
+PR mode's diff is always persisted in `pr_data` at PR-load time, so `pr.js:813`
+(`extendedData.diff`) cannot exhibit this bug — a PR `no-diff` correctly means `pr_data` has no
+diff (no in-memory/regeneration equivalent exists). Add a one-line clarifying comment in the PR
+handler; no behavioral change. (Noting this explicitly to satisfy the both-modes-parity rule:
+the asymmetry is intentional because PR mode has no unpersisted-diff path.)
+
+---
+
+## Files to change
+
+- `src/routes/local.js` — Fix A (manual-start handler) + Fix B #2 (council persistence).
+- `src/routes/analyses.js` — Fix B #1.
+- `src/routes/mcp.js` — Fix B #3 (+ 2 new imports).
+- `src/routes/pr.js` — clarifying comment only.
+- Tests (below).
+- `.changeset/*.md` — new `patch` changeset for `@in-the-loop-labs/pair-review`
+  ("Fix false 'No tour/summary to generate' in local mode when the diff was never persisted").
+
+## Tests (mandatory — both happy path and regression)
+
+- **`tests/integration/manual-start-jobs.test.js`**
+  - Add: local review with **no `local_diffs` row** but a **real temp git repo with changes** →
+    handler regenerates → `{ started: true }` and `kickOffTourJob` called (regression for the
+    reported bug). Reuse the temp-git-repo fixture pattern from
+    `tests/integration/review-file-content.test.js` / `tests/unit/local-review.test.js`.
+  - Add: local review with an **in-memory diff but no DB row** (seed via `setLocalReviewDiff`
+    through a route, or assert via the regen path) → `{ started: true }`.
+  - Keep/clarify the existing "no-diff" case (`line 234`) so it uses a worktree with **no
+    changes** (e.g. the non-existent `/mock/repo` still throws in regen → caught → `no-diff`),
+    confirming the toast still appears when there genuinely is nothing to review.
+- **`tests/integration/local-sessions.test.js`** (or `council-routes.test.js`) — after a council
+  analysis on a local path, assert `getLocalDiff(reviewId)` returns the diff (Fix B #2).
+- **`tests/integration/mcp-routes.test.js`** — after a local MCP analyze, assert a `local_diffs`
+  row is written (Fix B #3).
+- Locate the analyses-push test home (extend `local-sessions.test.js` if none) — assert a local
+  analysis push writes `local_diffs` (Fix B #1).
+
+## Verification
+
+1. `pnpm test tests/integration/manual-start-jobs.test.js tests/integration/local-sessions.test.js tests/integration/mcp-routes.test.js`
+2. Full `pnpm test` (Node 24 — do **not** rebuild better-sqlite3 under Node 22).
+3. Frontend touch is toast-only/none, but run E2E via a Task agent per project rules:
+   `pnpm run test:e2e` (headless).
+4. Manual sanity: in local mode with `tours.auto_generate=false`, on a review created via an
+   MCP/analysis flow (no `local_diffs` row), click **Start guided tour** → it should start
+   generation (pulsing button), not show "No tour to generate".
+
+## Hazards
+
+- **`getLocalDiff` has many callers** (`local.js:768,909,972,1089`, `manual-start` handler,
+  `local-sessions` tests). Fix A only changes the manual-start handler; other readers keep the
+  in-memory→DB pattern they already have.
+- **`saveLocalDiff` uses `INSERT OR REPLACE`** keyed by `review_id` — adding it to the
+  analyses/council/mcp paths is idempotent and cannot create duplicates.
+- **Council diff block ordering**: `reviewRepo` is constructed *after* the diff `try` block
+  (`local.js:2286`); Fix B #2 must hoist the diff vars or move the save below that line.
+- **Regen reflects the live working tree**, which may differ from the diff the user is viewing
+  if the cache is stale. This is the desired behavior for a freshly-triggered tour and matches
+  what `GET .../diff?w=1` / scope endpoints already do; the digest-based dedup in
+  `kickOffTourJob`/`kickOffSummaryJob` handles cancel-and-restart on diff change.
+- **Existing "no-diff" test** at `manual-start-jobs.test.js:234` asserts current behavior using
+  `/mock/repo`; regen will throw there and be caught, so it still yields `no-diff` — but the
+  test's intent should be re-documented as "no changes in scope".

--- a/src/routes/analyses.js
+++ b/src/routes/analyses.js
@@ -33,7 +33,8 @@ const {
   killProcesses,
   createProgressCallback
 } = require('./shared');
-const { generateLocalDiff, computeLocalDiffDigest, getCurrentBranch } = require('../local-review');
+const { generateScopedDiff, computeScopedDigest, getCurrentBranch } = require('../local-review');
+const { reviewScope } = require('../local-scope');
 const { validateCouncilConfig, normalizeCouncilConfig } = require('./councils');
 const { TIERS, TIER_ALIASES, VALID_TIERS, resolveTier } = require('../ai/prompts/config');
 
@@ -229,13 +230,34 @@ router.post('/api/analyses/results', async (req, res) => {
         });
       }
 
-      // Generate and store diff so the web UI can display it
+      // Generate and store diff so the web UI can display it. Persist to the
+      // `local_diffs` table as well as the in-memory cache so the diff survives
+      // a restart and the manual tour/summary buttons never falsely report
+      // "no-diff" for a review created via this analysis-push path.
+      //
+      // Use the review's recorded scope (mirroring the council path) — NOT the
+      // default-scope `generateLocalDiff` wrapper — so that re-using an existing
+      // review whose scope is `staged` or `branch` does not clobber its durable
+      // `local_diffs` row with a narrower default-scope patch. For brand-new
+      // reviews the upsert above created a default-scope row, so either lookup
+      // yields the correct scope; reviewScope() falls back to the default scope
+      // when the columns are unset.
+      const reviewForScope = existingReview || await reviewRepo.getLocalReviewById(reviewId);
+      const { start: scopeStart, end: scopeEnd } = reviewScope(reviewForScope);
       try {
-        const diffResult = await generateLocalDiff(localPath);
-        const digest = await computeLocalDiffDigest(localPath);
+        const diffResult = await generateScopedDiff(
+          localPath,
+          scopeStart,
+          scopeEnd,
+          reviewForScope.local_base_branch || null
+        );
+        const digest = await computeScopedDigest(localPath, scopeStart, scopeEnd);
         localReviewDiffs.set(reviewId, { diff: diffResult.diff, stats: diffResult.stats, digest });
+        await reviewRepo.saveLocalDiff(reviewId, { diff: diffResult.diff, stats: diffResult.stats, digest });
       } catch (diffError) {
-        logger.warn(`Could not generate diff for local review ${reviewId}: ${diffError.message}`);
+        // Covers both diff generation AND the durable saveLocalDiff write, so the
+        // message names both failure modes rather than only generation.
+        logger.warn(`Could not generate or persist diff for local review ${reviewId}: ${diffError.message}`);
       }
     } else {
       const repoParts = repo.split('/');

--- a/src/routes/local.js
+++ b/src/routes/local.js
@@ -2272,11 +2272,19 @@ router.post('/api/local/:reviewId/analyses/council', async (req, res) => {
       baseBranch: review.local_base_branch || null,
     });
 
-    // Generate and cache diff
+    // Generate and cache diff. Hoist the result out of the try so we can also
+    // persist it to `local_diffs` below (after reviewRepo is constructed) — the
+    // council path previously cached the diff in-memory only, which left the
+    // manual tour/summary buttons reporting a false "no-diff" after a restart.
+    let councilDiff = null;
+    let councilStats = null;
+    let councilDigest = null;
     try {
       const diffResult = await generateScopedDiff(localPath, councilScopeStart, councilScopeEnd, review.local_base_branch);
-      const digest = await computeScopedDigest(localPath, councilScopeStart, councilScopeEnd);
-      setLocalReviewDiff(reviewId, { diff: diffResult.diff, stats: diffResult.stats, digest });
+      councilDigest = await computeScopedDigest(localPath, councilScopeStart, councilScopeEnd);
+      councilDiff = diffResult.diff;
+      councilStats = diffResult.stats;
+      setLocalReviewDiff(reviewId, { diff: councilDiff, stats: councilStats, digest: councilDigest });
     } catch (diffError) {
       logger.warn(`Could not generate diff for local council review ${reviewId}: ${diffError.message}`);
     }
@@ -2284,6 +2292,16 @@ router.post('/api/local/:reviewId/analyses/council', async (req, res) => {
     // Resolve instructions
     const repoSettingsRepo = new RepoSettingsRepository(db);
     const reviewRepo = new ReviewRepository(db);
+
+    // Durably persist the diff so it survives a restart and the manual
+    // tour/summary buttons can find it (parity with the analysis-push path).
+    if (councilDiff) {
+      try {
+        await reviewRepo.saveLocalDiff(reviewId, { diff: councilDiff, stats: councilStats, digest: councilDigest });
+      } catch (saveError) {
+        logger.warn(`Could not persist diff for local council review ${reviewId}: ${saveError.message}`);
+      }
+    }
     const repoSettings = await repoSettingsRepo.getRepoSettings(review.repository);
     const repoInstructions = repoSettings?.default_instructions || null;
     const requestInstructions = rawInstructions?.trim() || null;
@@ -2397,9 +2415,64 @@ router.post('/api/local/:reviewId/jobs/:jobKey/start', async (req, res) => {
       return res.status(404).json({ error: `Local review #${reviewId} not found` });
     }
 
-    const localDiff = await reviewRepo.getLocalDiff(reviewId);
-    const diffText = localDiff ? (localDiff.diff || '') : '';
     const worktreePath = review.local_path || null;
+
+    // Resolve the diff through the same chain the rest of this file uses, rather
+    // than a DB-only read. Reviews created via the analysis-push, council, or MCP
+    // paths may have a diff only in the in-memory cache (or nowhere yet), so a
+    // DB-only read would falsely report "no-diff" for a review that clearly has
+    // changes. Order: (1) in-memory cache, (2) persisted `local_diffs` row,
+    // (3) regenerate from the live working tree (scope-aware) and persist.
+    let diffText = getLocalReviewDiff(reviewId)?.diff || '';
+
+    if (!diffText) {
+      const persistedDiff = await reviewRepo.getLocalDiff(reviewId);
+      diffText = persistedDiff?.diff || '';
+    }
+
+    if (!diffText && worktreePath) {
+      // Regenerate from the current working tree and persist (in-memory + DB) so
+      // the next read is fast and durable, and so pre-Fix-B reviews self-heal.
+      // Mirrors the council diff block above: on error, log and leave it empty.
+      try {
+        const { start: scopeStart, end: scopeEnd } = reviewScope(review);
+        const hasBranch = includesBranch(scopeStart);
+
+        // Snapshot guard: mirror the HEAD invariant enforced by the refresh-diff
+        // handler (see ~line 1702). For a non-branch review, the persisted diff is
+        // pinned to `local_head_sha`. If HEAD has since moved, regenerating here
+        // would silently re-snapshot the CURRENT worktree onto a row that still
+        // claims the OLDER SHA — a data-consistency hole. So we only regenerate
+        // when HEAD still matches; otherwise we leave diffText empty and let the
+        // `{ started: false, reason: 'no-diff' }` response funnel the user through
+        // the established refresh-diff / resolve-head-change flow. Branch-scoped
+        // reviews persist across HEAD changes, so they always regenerate.
+        let headPinned = true;
+        if (!hasBranch && review.local_head_sha) {
+          // Lazy require keeps getHeadSha stubbable via vi.spyOn in tests.
+          const { getHeadSha } = require('../local-review');
+          const currentHeadSha = await getHeadSha(worktreePath);
+          if (currentHeadSha !== review.local_head_sha) {
+            headPinned = false;
+            logger.warn(`Skipping self-heal diff regen for local review ${reviewId} (${jobKey}): HEAD moved on non-branch review (recorded ${review.local_head_sha}, current ${currentHeadSha}) — funneling through resolve-head-change`);
+          }
+        }
+
+        if (headPinned) {
+          const diffResult = await generateScopedDiff(worktreePath, scopeStart, scopeEnd, review.local_base_branch);
+          diffText = diffResult.diff || '';
+          if (diffText) {
+            const digest = await computeScopedDigest(worktreePath, scopeStart, scopeEnd);
+            setLocalReviewDiff(reviewId, { diff: diffText, stats: diffResult.stats, digest });
+            await reviewRepo.saveLocalDiff(reviewId, { diff: diffText, stats: diffResult.stats, digest });
+          }
+        }
+      } catch (regenError) {
+        // A getHeadSha throw (e.g. missing worktree) lands here: leave diffText
+        // empty so the no-diff response fires, matching prior behavior.
+        logger.warn(`Could not regenerate diff for local review ${reviewId} manual ${jobKey} start: ${regenError.message}`);
+      }
+    }
 
     if (!diffText || !worktreePath) {
       return res.json({ started: false, reason: 'no-diff' });

--- a/src/routes/mcp.js
+++ b/src/routes/mcp.js
@@ -11,13 +11,15 @@ const { getTierForModel } = require('../ai/provider');
 const { TIERS, TIER_ALIASES, resolveTier } = require('../ai/prompts/config');
 const { GitWorktreeManager } = require('../git/worktree');
 const path = require('path');
-const { getCurrentBranch } = require('../local-review');
+const { getCurrentBranch, generateScopedDiff, computeScopedDigest } = require('../local-review');
+const { reviewScope } = require('../local-scope');
 const { normalizeRepository } = require('../utils/paths');
 const logger = require('../utils/logger');
 const { broadcastReviewEvent } = require('../events/review-events');
 const {
   activeAnalyses,
   reviewToAnalysisId,
+  localReviewDiffs,
   determineCompletionInfo,
   broadcastProgress,
   createProgressCallback
@@ -557,6 +559,32 @@ function createMCPServer(db, options = {}) {
           }
 
           const review = await reviewRepo.getLocalReviewById(reviewId);
+
+          // Persist the diff so the web UI can display it and the manual
+          // tour/summary buttons work (including after a restart). The MCP path
+          // previously stored the diff only in analysis_runs, leaving no
+          // `local_diffs` row.
+          //
+          // Use the review's recorded scope — not the default-scope wrapper — so
+          // re-using a review that was moved to `staged` or `branch` scope does
+          // not clobber its durable row with a narrower default-scope patch. Set
+          // the in-memory cache alongside the DB row so the cache-first readers
+          // in routes/local.js don't keep serving a stale entry. Non-fatal:
+          // matches the analysis-push path.
+          try {
+            const { start: scopeStart, end: scopeEnd } = reviewScope(review);
+            const diffResult = await generateScopedDiff(
+              localPath,
+              scopeStart,
+              scopeEnd,
+              review.local_base_branch || null
+            );
+            const digest = await computeScopedDigest(localPath, scopeStart, scopeEnd);
+            localReviewDiffs.set(reviewId, { diff: diffResult.diff, stats: diffResult.stats, digest });
+            await reviewRepo.saveLocalDiff(reviewId, { diff: diffResult.diff, stats: diffResult.stats, digest });
+          } catch (diffError) {
+            logger.warn(`Could not generate or persist diff for local review ${reviewId}: ${diffError.message}`);
+          }
 
           // Resolve provider and model
           const repoSettings = repository ? await repoSettingsRepo.getRepoSettings(repository) : null;

--- a/src/routes/pr.js
+++ b/src/routes/pr.js
@@ -813,6 +813,11 @@ router.post('/api/pr/:owner/:repo/:number/jobs/:jobKey/start', async (req, res) 
     const diffText = extendedData.diff || '';
     const worktreePath = extendedData.worktree_path || null;
 
+    // Unlike local mode, a PR's diff is always persisted in `pr_data` at PR-load
+    // time — there is no in-memory cache or working-tree regeneration to fall
+    // back on. So an empty diff here genuinely means `pr_data` has no diff, and
+    // this `no-diff` cannot be a false negative (no parity fix needed; see the
+    // local manual-start handler in local.js for the self-healing variant).
     if (!diffText || !worktreePath) {
       return res.json({ started: false, reason: 'no-diff' });
     }

--- a/tests/integration/analysis-results.test.js
+++ b/tests/integration/analysis-results.test.js
@@ -1,8 +1,31 @@
 // Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { execSync } from 'child_process';
 import express from 'express';
+import nodeFs from 'fs';
+import os from 'os';
+import path from 'path';
 import request from 'supertest';
 import { createTestDatabase, closeTestDatabase } from '../utils/schema';
+
+/**
+ * Create a throwaway git repo with an unstaged change so the real local-diff
+ * helpers (generateLocalDiff/computeLocalDiffDigest) produce a non-empty diff
+ * within the default 'unstaged'→'untracked' scope. Caller cleans up.
+ */
+function createTempRepoWithChanges() {
+  const tempRepo = nodeFs.mkdtempSync(path.join(os.tmpdir(), 'pair-review-analysis-results-'));
+  execSync('git init -b main', { cwd: tempRepo, stdio: 'pipe' });
+  execSync('git config user.email "test@test.com"', { cwd: tempRepo, stdio: 'pipe' });
+  execSync('git config user.name "Test User"', { cwd: tempRepo, stdio: 'pipe' });
+  const repoFile = path.join(tempRepo, 'file.js');
+  nodeFs.writeFileSync(repoFile, 'line 1\nline 2\nline 3\n');
+  execSync('git add file.js', { cwd: tempRepo, stdio: 'pipe' });
+  execSync('git commit -m "initial"', { cwd: tempRepo, stdio: 'pipe' });
+  // Unstaged modification — falls within the default 'unstaged'→'untracked' scope.
+  nodeFs.writeFileSync(repoFile, 'line 1 changed\nline 2\nline 3\nline 4 added\n');
+  return tempRepo;
+}
 
 // Mock modules that analysis routes depend on but we don't need
 vi.mock('../../src/ai/analyzer', () => ({
@@ -28,7 +51,7 @@ vi.spyOn(configModule, 'loadConfig').mockResolvedValue({
 });
 vi.spyOn(configModule, 'getConfigDir').mockReturnValue('/tmp/.pair-review-test');
 
-const { query, queryOne, run } = require('../../src/database');
+const { query, queryOne, run, ReviewRepository } = require('../../src/database');
 const ws = require('../../src/ws');
 
 const analysisRoutes = require('../../src/routes/analyses');
@@ -333,6 +356,50 @@ describe('POST /api/analyses/results', () => {
     expect(comments[1].file).toBe('src/utils.js');
     expect(comments[1].side).toBe('LEFT');
     expect(comments[1].type).toBe('improvement');
+  });
+
+  // --- Durable diff persistence (local mode) ---
+
+  it('should durably persist the local diff to the local_diffs table', async () => {
+    const tempRepo = createTempRepoWithChanges();
+    try {
+      const headSha = execSync('git rev-parse HEAD', { cwd: tempRepo, encoding: 'utf8' }).trim();
+
+      const response = await request(app)
+        .post('/api/analyses/results')
+        .send({
+          path: tempRepo,
+          headSha,
+          provider: 'claude',
+          model: 'sonnet',
+          summary: 'Found 1 issue',
+          suggestions: [
+            {
+              file: 'file.js',
+              line_start: 1,
+              line_end: 1,
+              old_or_new: 'NEW',
+              type: 'bug',
+              title: 'Example issue',
+              description: 'Something to look at.',
+              confidence: 0.8
+            }
+          ]
+        });
+
+      expect(response.status).toBe(201);
+      expect(response.body.reviewId).toBeDefined();
+
+      // The diff must be durably persisted to the local_diffs table so it
+      // survives a restart and the manual tour/summary buttons never falsely
+      // report "no-diff" for a review created via this analysis-push path.
+      const reviewRepo = new ReviewRepository(db);
+      const dbDiff = await reviewRepo.getLocalDiff(response.body.reviewId);
+      expect(dbDiff).not.toBeNull();
+      expect(dbDiff.diff).toContain('diff --git');
+    } finally {
+      nodeFs.rmSync(tempRepo, { recursive: true, force: true });
+    }
   });
 
   // --- PR mode happy path ---

--- a/tests/integration/local-sessions.test.js
+++ b/tests/integration/local-sessions.test.js
@@ -1,8 +1,31 @@
 // Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { execSync } from 'child_process';
 import express from 'express';
+import nodeFs from 'fs';
+import os from 'os';
+import path from 'path';
 import request from 'supertest';
 import { createTestDatabase, closeTestDatabase } from '../utils/schema';
+
+/**
+ * Create a throwaway git repo with an unstaged change. The council endpoint
+ * calls the real getChangedFiles (not mocked) in both the empty-scope guard
+ * and the main flow, so the review must point at a repo with real changes
+ * within the default 'unstaged'→'untracked' scope. Caller cleans up.
+ */
+function createTempRepoWithChanges() {
+  const tempRepo = nodeFs.mkdtempSync(path.join(os.tmpdir(), 'pair-review-council-diff-'));
+  execSync('git init -b main', { cwd: tempRepo, stdio: 'pipe' });
+  execSync('git config user.email "test@test.com"', { cwd: tempRepo, stdio: 'pipe' });
+  execSync('git config user.name "Test User"', { cwd: tempRepo, stdio: 'pipe' });
+  const repoFile = path.join(tempRepo, 'file.js');
+  nodeFs.writeFileSync(repoFile, 'line 1\nline 2\nline 3\n');
+  execSync('git add file.js', { cwd: tempRepo, stdio: 'pipe' });
+  execSync('git commit -m "initial"', { cwd: tempRepo, stdio: 'pipe' });
+  nodeFs.writeFileSync(repoFile, 'line 1 changed\nline 2\nline 3\nline 4 added\n');
+  return tempRepo;
+}
 
 /**
  * Local Sessions API Integration Tests
@@ -1792,6 +1815,64 @@ describe('Local Sessions API', () => {
       expect(res.status).toBe(200);
       expect(res.body.action).toBe('updated');
       expect(res.body.branchAvailable).toBe(false);
+    });
+  });
+
+  describe('POST /api/local/:reviewId/analyses/council (diff persistence)', () => {
+    it('should durably persist the local diff to the local_diffs table when starting a council analysis', async () => {
+      const tempRepo = createTempRepoWithChanges();
+
+      // The council endpoint imports launchCouncilAnalysis from analyses.js and
+      // calls it to spawn a real analyzer. Mock it so no provider/CLI runs.
+      const analysesRouter = require('../../src/routes/analyses');
+      const launchSpy = vi.spyOn(analysesRouter, 'launchCouncilAnalysis')
+        .mockResolvedValue({ analysisId: 'a1', runId: 'r1' });
+
+      try {
+        const reviewRepo = new ReviewRepository(db);
+        const reviewId = await reviewRepo.upsertLocalReview({
+          localPath: tempRepo,
+          localHeadSha: 'abc123',
+          repository: 'owner/repo',
+          localHeadBranch: 'main'
+        });
+
+        // Minimal valid advanced-format council config: one enabled level, one voice.
+        const councilConfig = {
+          levels: {
+            '1': {
+              enabled: true,
+              voices: [{ provider: 'claude', model: 'sonnet', tier: 'balanced' }]
+            },
+            '2': { enabled: false, voices: [] },
+            '3': { enabled: false, voices: [] }
+          }
+        };
+
+        const res = await request(app)
+          .post(`/api/local/${reviewId}/analyses/council`)
+          .send({ councilConfig, configType: 'advanced' });
+
+        expect(res.status).toBe(200);
+        expect(res.body.status).toBe('started');
+        expect(launchSpy).toHaveBeenCalledTimes(1);
+
+        // NOTE: the council route calls the destructured `generateScopedDiff`
+        // binding (see src/routes/local.js:30 and the explanatory note at
+        // lines 890-894), so the vi.spyOn on localReviewModule.generateScopedDiff
+        // from beforeEach does NOT intercept it here — the spy only replaces the
+        // property on the exports object, not the reference captured at require
+        // time. The REAL helper therefore runs against the temp repo's unstaged
+        // change. We assert that whatever diff it produced was persisted to
+        // local_diffs so it survives a restart and the manual tour/summary
+        // buttons can find it.
+        const dbDiff = await reviewRepo.getLocalDiff(reviewId);
+        expect(dbDiff).not.toBeNull();
+        expect(dbDiff.diff).toContain('diff --git');
+      } finally {
+        launchSpy.mockRestore();
+        nodeFs.rmSync(tempRepo, { recursive: true, force: true });
+      }
     });
   });
 });

--- a/tests/integration/manual-start-jobs.test.js
+++ b/tests/integration/manual-start-jobs.test.js
@@ -19,7 +19,11 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { execSync } from 'child_process';
 import express from 'express';
+import nodeFs from 'fs';
+import os from 'os';
+import path from 'path';
 import request from 'supertest';
 import { createTestDatabase, closeTestDatabase } from '../utils/schema';
 
@@ -29,6 +33,45 @@ const { ReviewRepository, run } = require('../../src/database');
 const summaryGenerator = require('../../src/ai/summary-generator');
 const tourGenerator = require('../../src/ai/tour-generator');
 const { backgroundQueue } = require('../../src/ai/background-queue');
+const { localReviewDiffs } = require('../../src/routes/shared');
+
+/**
+ * Create a throwaway git repo with an unstaged change so the manual-start
+ * handler's working-tree regeneration (scope-aware) produces a real diff.
+ * Returns the repo path; caller is responsible for cleanup.
+ */
+function createTempRepoWithChanges() {
+  const tempRepo = nodeFs.mkdtempSync(path.join(os.tmpdir(), 'pair-review-manual-start-'));
+  execSync('git init -b main', { cwd: tempRepo, stdio: 'pipe' });
+  execSync('git config user.email "test@test.com"', { cwd: tempRepo, stdio: 'pipe' });
+  execSync('git config user.name "Test User"', { cwd: tempRepo, stdio: 'pipe' });
+  const repoFile = path.join(tempRepo, 'file.js');
+  nodeFs.writeFileSync(repoFile, 'line 1\nline 2\nline 3\n');
+  execSync('git add file.js', { cwd: tempRepo, stdio: 'pipe' });
+  execSync('git commit -m "initial"', { cwd: tempRepo, stdio: 'pipe' });
+  // Unstaged modification — falls within the default 'unstaged'→'untracked' scope.
+  nodeFs.writeFileSync(repoFile, 'line 1 changed\nline 2\nline 3\nline 4 added\n');
+  return tempRepo;
+}
+
+/**
+ * Create a throwaway git repo with a clean working tree (a committed file and
+ * NO unstaged/untracked changes). Working-tree regeneration succeeds but
+ * produces an empty diff, exercising the genuine "no changes in scope" path
+ * (as opposed to the regeneration-throws path). Caller cleans up.
+ */
+function createTempRepoNoChanges() {
+  const tempRepo = nodeFs.mkdtempSync(path.join(os.tmpdir(), 'pair-review-manual-start-clean-'));
+  execSync('git init -b main', { cwd: tempRepo, stdio: 'pipe' });
+  execSync('git config user.email "test@test.com"', { cwd: tempRepo, stdio: 'pipe' });
+  execSync('git config user.name "Test User"', { cwd: tempRepo, stdio: 'pipe' });
+  const repoFile = path.join(tempRepo, 'file.js');
+  nodeFs.writeFileSync(repoFile, 'line 1\nline 2\nline 3\n');
+  execSync('git add file.js', { cwd: tempRepo, stdio: 'pipe' });
+  execSync('git commit -m "initial"', { cwd: tempRepo, stdio: 'pipe' });
+  // No further edits — the working tree is clean, so the default-scope diff is empty.
+  return tempRepo;
+}
 
 const SAMPLE_DIFF =
   'diff --git a/file.js b/file.js\n--- a/file.js\n+++ b/file.js\n@@ -1 +1 @@\n-old\n+new';
@@ -94,6 +137,10 @@ describe('Manual start endpoints', () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+    // The manual-start handler caches regenerated diffs in this module-level
+    // Map (keyed by reviewId). Clear it so an entry from one test cannot make a
+    // later test reusing the same reviewId see a diff it never seeded.
+    localReviewDiffs.clear();
     closeTestDatabase(db);
   });
 
@@ -231,7 +278,13 @@ describe('Manual start endpoints', () => {
       expect(tourSpy.mock.calls[0][0].trigger).toBe('manual');
     });
 
-    it('returns no-diff when the local review has no persisted diff', async () => {
+    it('returns no-diff when regeneration fails (worktree missing) and no diff is cached', async () => {
+      // The toast must still appear when the diff cannot be resolved at all.
+      // There is no local_diffs row, no in-memory cache entry, and the
+      // (non-existent) local_path makes working-tree regeneration throw, which
+      // the handler catches and treats as an empty diff → no-diff. This covers
+      // the regeneration-error fallthrough; the genuine clean-working-tree case
+      // is covered by the next test.
       const app = buildApp(db, { summaries: { enabled: true } });
       const reviewRepo = new ReviewRepository(db);
       const reviewId = await reviewRepo.upsertLocalReview({
@@ -245,6 +298,190 @@ describe('Manual start endpoints', () => {
       expect(res.status).toBe(200);
       expect(res.body).toEqual({ started: false, reason: 'no-diff' });
       expect(summarySpy).not.toHaveBeenCalled();
+    });
+
+    it('returns no-diff when the working tree is clean (genuinely no changes in scope)', async () => {
+      // The toast must appear when there is truly nothing to review: a real git
+      // repo with a committed file and no unstaged/untracked changes. There is
+      // no local_diffs row and no in-memory cache entry, so the handler
+      // regenerates from the working tree — regeneration SUCCEEDS but yields an
+      // empty diff (default 'unstaged'→'untracked' scope, clean tree) → no-diff.
+      // We seed the review's recorded HEAD to the repo's REAL HEAD so the
+      // snapshot guard passes and regen actually runs (rather than being
+      // blocked for a moved HEAD, which would be the wrong reason for no-diff).
+      const tempRepo = createTempRepoNoChanges();
+      try {
+        const app = buildApp(db, { summaries: { enabled: true } });
+        const reviewRepo = new ReviewRepository(db);
+        const realHead = execSync('git rev-parse HEAD', { cwd: tempRepo, encoding: 'utf8' }).trim();
+        const reviewId = await reviewRepo.upsertLocalReview({
+          localPath: tempRepo,
+          localHeadSha: realHead,
+          repository: 'owner/repo',
+          localHeadBranch: 'main',
+        });
+        expect(await reviewRepo.getLocalDiff(reviewId)).toBeNull();
+
+        const res = await request(app).post(`/api/local/${reviewId}/jobs/summary/start`);
+        expect(res.status).toBe(200);
+        expect(res.body).toEqual({ started: false, reason: 'no-diff' });
+        expect(summarySpy).not.toHaveBeenCalled();
+      } finally {
+        nodeFs.rmSync(tempRepo, { recursive: true, force: true });
+      }
+    });
+
+    it('regenerates the diff from the working tree when no local_diffs row exists', async () => {
+      // Regression for the reported bug: a local review created via an
+      // analysis/council/MCP path never wrote local_diffs, so the DB-only read
+      // falsely reported no-diff. The handler must now regenerate from the live
+      // working tree, kick the job, and persist the diff for next time.
+      const tempRepo = createTempRepoWithChanges();
+      try {
+        const app = buildApp(db, { tours: { enabled: true, auto_generate: false } });
+        const reviewRepo = new ReviewRepository(db);
+        // Seed the review's recorded HEAD to the repo's REAL HEAD so the
+        // snapshot guard (non-branch HEAD-pinning) passes and regeneration runs.
+        // A fake SHA would now be (correctly) blocked by the moved-HEAD guard.
+        const realHead = execSync('git rev-parse HEAD', { cwd: tempRepo, encoding: 'utf8' }).trim();
+        const reviewId = await reviewRepo.upsertLocalReview({
+          localPath: tempRepo,
+          localHeadSha: realHead,
+          repository: 'owner/repo',
+          localHeadBranch: 'main',
+        });
+        // Intentionally no saveLocalDiff and no in-memory cache entry.
+        expect(await reviewRepo.getLocalDiff(reviewId)).toBeNull();
+
+        const res = await request(app).post(`/api/local/${reviewId}/jobs/tour/start`);
+        expect(res.status).toBe(200);
+        expect(res.body).toEqual({ started: true, alreadyRunning: false });
+        expect(tourSpy).toHaveBeenCalledTimes(1);
+        const call = tourSpy.mock.calls[0][0];
+        expect(call.trigger).toBe('manual');
+        expect(call.diffText).toContain('diff --git');
+        expect(call.worktreePath).toBe(tempRepo);
+
+        // The regenerated diff is now durably persisted (self-heal).
+        const persisted = await reviewRepo.getLocalDiff(reviewId);
+        expect(persisted).not.toBeNull();
+        expect(persisted.diff).toContain('diff --git');
+      } finally {
+        nodeFs.rmSync(tempRepo, { recursive: true, force: true });
+      }
+    });
+
+    it('does NOT regenerate (no-diff) for a non-branch review whose HEAD has moved', async () => {
+      // Regression for the snapshot-invariant bug: the self-heal regen block used
+      // to persist a diff describing the CURRENT worktree onto a review row still
+      // pinned to the OLDER local_head_sha. For a non-branch review whose HEAD has
+      // since moved, regenerating + persisting here would silently re-snapshot the
+      // moved HEAD onto a pinned review — the same hole the refresh-diff handler
+      // closes by routing through resolve-head-change. The guard must now BLOCK
+      // regen: no generator call, no persisted local_diffs row, and a no-diff
+      // response so the user is funneled through the established flow.
+      //
+      // NOTE: without the guard this test FAILS — regen would succeed against the
+      // (changed) working tree and return { started: true }.
+      const tempRepo = createTempRepoWithChanges();
+      try {
+        const app = buildApp(db, { tours: { enabled: true, auto_generate: false } });
+        const reviewRepo = new ReviewRepository(db);
+        // Pin the review to the repo's INITIAL HEAD...
+        const initialHead = execSync('git rev-parse HEAD', { cwd: tempRepo, encoding: 'utf8' }).trim();
+        const reviewId = await reviewRepo.upsertLocalReview({
+          localPath: tempRepo,
+          localHeadSha: initialHead,
+          repository: 'owner/repo',
+          localHeadBranch: 'main',
+        });
+        // ...then move HEAD by committing a new change so current HEAD differs.
+        nodeFs.writeFileSync(path.join(tempRepo, 'file2.js'), 'new file\n');
+        execSync('git add file2.js', { cwd: tempRepo, stdio: 'pipe' });
+        execSync('git commit -m "second"', { cwd: tempRepo, stdio: 'pipe' });
+        const movedHead = execSync('git rev-parse HEAD', { cwd: tempRepo, encoding: 'utf8' }).trim();
+        expect(movedHead).not.toBe(initialHead);
+
+        // No cache entry, no local_diffs row.
+        expect(await reviewRepo.getLocalDiff(reviewId)).toBeNull();
+
+        const res = await request(app).post(`/api/local/${reviewId}/jobs/tour/start`);
+        expect(res.status).toBe(200);
+        expect(res.body).toEqual({ started: false, reason: 'no-diff' });
+        // Guard blocked regen: generator not called and nothing persisted.
+        expect(tourSpy).not.toHaveBeenCalled();
+        expect(await reviewRepo.getLocalDiff(reviewId)).toBeNull();
+      } finally {
+        nodeFs.rmSync(tempRepo, { recursive: true, force: true });
+      }
+    });
+
+    it('STILL regenerates for a branch-scoped review whose HEAD has moved', async () => {
+      // Branch-scoped reviews persist across HEAD changes (the diff is computed
+      // against the base branch, not a pinned HEAD snapshot), so the snapshot
+      // guard must NOT block them. Even with a moved HEAD, regen runs and the job
+      // starts. This complements the non-branch regression test above.
+      const tempRepo = createTempRepoWithChanges();
+      try {
+        const app = buildApp(db, { tours: { enabled: true, auto_generate: false } });
+        const reviewRepo = new ReviewRepository(db);
+        const initialHead = execSync('git rev-parse HEAD', { cwd: tempRepo, encoding: 'utf8' }).trim();
+        // Branch scope: start='branch', end='unstaged', with a base branch.
+        const reviewId = await reviewRepo.upsertLocalReview({
+          localPath: tempRepo,
+          localHeadSha: initialHead,
+          repository: 'owner/repo',
+          localHeadBranch: 'main',
+          scopeStart: 'branch',
+          scopeEnd: 'unstaged',
+          localBaseBranch: 'main',
+        });
+        // Move HEAD: create a feature branch with a new commit so there is a
+        // branch-ahead diff against the 'main' base branch.
+        execSync('git checkout -b feature', { cwd: tempRepo, stdio: 'pipe' });
+        nodeFs.writeFileSync(path.join(tempRepo, 'file3.js'), 'branch change\n');
+        execSync('git add file3.js', { cwd: tempRepo, stdio: 'pipe' });
+        execSync('git commit -m "feature commit"', { cwd: tempRepo, stdio: 'pipe' });
+        const movedHead = execSync('git rev-parse HEAD', { cwd: tempRepo, encoding: 'utf8' }).trim();
+        expect(movedHead).not.toBe(initialHead);
+
+        expect(await reviewRepo.getLocalDiff(reviewId)).toBeNull();
+
+        const res = await request(app).post(`/api/local/${reviewId}/jobs/tour/start`);
+        expect(res.status).toBe(200);
+        expect(res.body).toEqual({ started: true, alreadyRunning: false });
+        expect(tourSpy).toHaveBeenCalledTimes(1);
+        expect(tourSpy.mock.calls[0][0].diffText).toContain('diff --git');
+      } finally {
+        nodeFs.rmSync(tempRepo, { recursive: true, force: true });
+      }
+    });
+
+    it('starts the job from the in-memory diff cache when no DB row exists', async () => {
+      // The analysis/council paths populate the in-memory cache before any DB
+      // write. The handler must honor that cache without needing a local_diffs
+      // row and without touching the working tree.
+      const app = buildApp(db, { tours: { enabled: true, auto_generate: false } });
+      const reviewRepo = new ReviewRepository(db);
+      const reviewId = await reviewRepo.upsertLocalReview({
+        localPath: '/mock/repo',
+        localHeadSha: 'abc123',
+        repository: 'owner/repo',
+        localHeadBranch: 'main',
+      });
+      // Seed only the module-level in-memory cache (keyed by integer reviewId).
+      localReviewDiffs.set(reviewId, {
+        diff: SAMPLE_DIFF,
+        stats: { trackedChanges: 1 },
+        digest: 'mem-1',
+      });
+      expect(await reviewRepo.getLocalDiff(reviewId)).toBeNull();
+
+      const res = await request(app).post(`/api/local/${reviewId}/jobs/tour/start`);
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ started: true, alreadyRunning: false });
+      expect(tourSpy).toHaveBeenCalledTimes(1);
+      expect(tourSpy.mock.calls[0][0].diffText).toContain('diff --git');
     });
 
     it('is idempotent: returns alreadyRunning when a job is in flight', async () => {

--- a/tests/integration/mcp-routes.test.js
+++ b/tests/integration/mcp-routes.test.js
@@ -1,10 +1,32 @@
 // Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { execSync } from 'child_process';
 import express from 'express';
+import nodeFs from 'fs';
+import os from 'os';
+import path from 'path';
 import request from 'supertest';
 import { createTestDatabase, closeTestDatabase } from '../utils/schema';
 
 const { run, ReviewRepository, CommentRepository, AnalysisRunRepository } = require('../../src/database.js');
+
+/**
+ * Create a throwaway git repo with an unstaged change so the real local-diff
+ * helpers (generateLocalDiff/computeLocalDiffDigest) produce a non-empty diff
+ * within the default 'unstaged'→'untracked' scope. Caller cleans up.
+ */
+function createTempRepoWithChanges() {
+  const tempRepo = nodeFs.mkdtempSync(path.join(os.tmpdir(), 'pair-review-mcp-diff-'));
+  execSync('git init -b main', { cwd: tempRepo, stdio: 'pipe' });
+  execSync('git config user.email "test@test.com"', { cwd: tempRepo, stdio: 'pipe' });
+  execSync('git config user.name "Test User"', { cwd: tempRepo, stdio: 'pipe' });
+  const repoFile = path.join(tempRepo, 'file.js');
+  nodeFs.writeFileSync(repoFile, 'line 1\nline 2\nline 3\n');
+  execSync('git add file.js', { cwd: tempRepo, stdio: 'pipe' });
+  execSync('git commit -m "initial"', { cwd: tempRepo, stdio: 'pipe' });
+  nodeFs.writeFileSync(repoFile, 'line 1 changed\nline 2\nline 3\nline 4 added\n');
+  return tempRepo;
+}
 
 // We need a fresh MCP server per test to avoid state leakage
 // Import only the route creator, not the cached singleton
@@ -320,6 +342,51 @@ describe('MCP Routes Integration', () => {
       const result = extractResult(res);
       const content = JSON.parse(result.result.content[0].text);
       expect(content.comments).toEqual({});
+    });
+
+    it('start_analysis (local) durably persists the diff to the local_diffs table', async () => {
+      const tempRepo = createTempRepoWithChanges();
+      const headSha = execSync('git rev-parse HEAD', { cwd: tempRepo, encoding: 'utf8' }).trim();
+
+      // The local branch launches the analyzer fire-and-forget AND calls
+      // getLocalChangedFiles. Mock both on the prototype so no real provider
+      // calls occur. The diff persistence runs synchronously before the launch.
+      const Analyzer = require('../../src/ai/analyzer');
+      const changedFilesSpy = vi.spyOn(Analyzer.prototype, 'getLocalChangedFiles')
+        .mockResolvedValue([{ file: 'file.js' }]);
+      const level1Spy = vi.spyOn(Analyzer.prototype, 'analyzeLevel1')
+        .mockResolvedValue({ suggestions: [], summary: null });
+
+      try {
+        const res = await mcpRequest(app, {
+          jsonrpc: '2.0',
+          id: 20,
+          method: 'tools/call',
+          params: {
+            name: 'start_analysis',
+            arguments: { path: tempRepo, headSha }
+          }
+        });
+
+        expect(res.status).toBe(200);
+        const result = extractResult(res);
+        expect(result.result).toBeDefined();
+        const content = JSON.parse(result.result.content[0].text);
+        expect(content.status).toBe('started');
+        expect(content.reviewId).toBeDefined();
+
+        // The MCP local branch must persist the diff to the local_diffs table
+        // so the web UI can display it (including after a restart). Previously
+        // the diff lived only in analysis_runs, leaving no local_diffs row.
+        const reviewRepo = new ReviewRepository(db);
+        const dbDiff = await reviewRepo.getLocalDiff(content.reviewId);
+        expect(dbDiff).not.toBeNull();
+        expect(dbDiff.diff).toContain('diff --git');
+      } finally {
+        changedFilesSpy.mockRestore();
+        level1Spy.mockRestore();
+        nodeFs.rmSync(tempRepo, { recursive: true, force: true });
+      }
     });
   });
 


### PR DESCRIPTION
## Summary

Fixes a false **"No tour to generate" / "No summary to generate"** in local mode. The manual **Start guided tour** and **Generate summaries** buttons reported `no-diff` for local reviews that clearly had changes, because the manual job-start handler read the diff only from the `local_diffs` table — and several paths created/analyzed a local review without ever writing that table (the analysis-push, council, and MCP-analyze flows cached the diff in memory only, or in `analysis_runs`).

## Changes

- **Manual job-start handler** (`POST /api/local/:reviewId/jobs/:jobKey/start`) now resolves the diff through the same chain the rest of local mode uses — in-memory cache → persisted `local_diffs` row → **scope-aware regeneration** from the live working tree — and persists the regenerated diff so the next read is fast and durable. It only reports `no-diff` when there are genuinely no changes in scope, and self-heals reviews created before this fix.
- The regeneration fallback is gated by the **same HEAD-snapshot guard as `refresh-diff`**: for a non-branch review whose HEAD has moved off its recorded `local_head_sha`, regeneration is skipped and the user is funneled through the explicit `resolve-head-change` flow rather than silently re-snapshotting the moved HEAD onto a pinned review. Branch-scoped reviews (which persist across HEAD changes) keep regenerating as before.
- The **analysis-push** (`POST /api/analyses/results`), **local council**, and **MCP `start_analysis`** (local) paths now durably persist the diff to `local_diffs`, using the review's **recorded scope** (`unstaged`/`staged`/`branch`) rather than the default-scope wrapper — so re-using a review that was moved to a different scope no longer overwrites its durable row with a narrower patch. The MCP path also refreshes the in-memory diff cache alongside the database row (matching the other writers).
- **PR mode is unaffected**: a PR's diff is always persisted in `pr_data` at load time, so its `no-diff` cannot be a false negative. Added a clarifying comment in the PR handler noting why no parity fix is needed.

## Testing

All under Node 24:

- `tests/integration/manual-start-jobs.test.js` — **21 passed**. Adds regression tests for the moved-HEAD snapshot guard (non-branch → `no-diff`, nothing persisted; branch-scoped → still regenerates) and the clean-working-tree no-diff path. The moved-HEAD test was confirmed to fail without the guard.
- `tests/integration/local-sessions.test.js` — passing (council diff persistence).
- `tests/integration/mcp-routes.test.js` — passing (MCP local persists `local_diffs`).
- `tests/integration/analysis-results.test.js` — passing (analysis-push persists `local_diffs`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
