### PR TITLE
Add Claude Fable 5 model options to the Claude provider

### DIFF
--- a/.changeset/add-fable-5-claude-models.md
+++ b/.changeset/add-fable-5-claude-models.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Add Claude Fable 5 (XHigh and High effort) as model options for the Claude provider

--- a/config.example.json
+++ b/config.example.json
@@ -95,7 +95,7 @@
     },
 
     "claude": {
-      "_comment": "Override Claude's built-in configuration. Useful for custom paths, wrapper scripts, or additional arguments. Built-in models include haiku, sonnet, opus-4.5, opus-4.6-low, opus-4.6-medium, opus, opus-4.6-1m, opus-4.7-high, and opus-4.7-xhigh. Use 'cli_model' to decouple the app-level model ID from the CLI --model argument. Use 'env' for model-specific environment variables.",
+      "_comment": "Override Claude's built-in configuration. Useful for custom paths, wrapper scripts, or additional arguments. Built-in models include fable, fable-5-high, opus, opus-4.7-high, opus-4.8-xhigh, opus-4.8-high, opus-4.6-high, sonnet-4.6, opus-4.6-1m, and haiku. Use 'cli_model' to decouple the app-level model ID from the CLI --model argument. Use 'env' for model-specific environment variables.",
       "command": "claude",
       "extra_args": [],
       "env": {},

--- a/src/ai/claude-provider.js
+++ b/src/ai/claude-provider.js
@@ -26,12 +26,40 @@ const BIN_DIR = path.join(__dirname, '..', '..', 'bin');
  * in the constructor's base args; individual models can override this via extra_args
  * (e.g., Haiku uses adaptive thinking for efficiency).
  *
- * Effort support by model (newest CLIs): Opus 4.8 / 4.7 support low|medium|high|
- * xhigh|max; Opus 4.6 & Sonnet 4.6 support low|medium|high|max (no xhigh); Haiku
- * has no effort levels.
+ * Effort support by model (newest CLIs): Fable 5 and Opus 4.8 / 4.7 support
+ * low|medium|high|xhigh|max; Opus 4.6 & Sonnet 4.6 support low|medium|high|max
+ * (no xhigh); Haiku has no effort levels.
  */
 const CLAUDE_MODELS = [
   // ── Thorough tier ───────────────────────────────────────────────────────
+  {
+    id: 'fable',
+    aliases: ['fable-5-xhigh'],
+    cli_model: 'claude-fable-5',
+    env: { CLAUDE_CODE_EFFORT_LEVEL: 'xhigh' },
+    name: 'Fable 5 XHigh',
+    tier: 'thorough',
+    tagline: 'New Model Tier',
+    description: 'Fable 5 (new tier above Opus) with extra-high effort',
+    badge: 'Extra-High Effort',
+    badgeClass: 'badge-power',
+    // Fable 5 is adaptive-thinking-only: an explicit "enabled"/"disabled"
+    // thinking mode is rejected by the API, so override the global
+    // `--thinking enabled` base arg (last occurrence wins in commander).
+    extra_args: ['--thinking', 'adaptive']
+  },
+  {
+    id: 'fable-5-high',
+    cli_model: 'claude-fable-5',
+    env: { CLAUDE_CODE_EFFORT_LEVEL: 'high' },
+    name: 'Fable 5 High',
+    tier: 'thorough',
+    tagline: 'New Model Tier',
+    description: 'Fable 5 with high effort — quicker than XHigh',
+    badge: 'High Effort',
+    badgeClass: 'badge-power',
+    extra_args: ['--thinking', 'adaptive']
+  },
   {
     id: 'opus',
     aliases: ['opus-4.7-xhigh'],

--- a/src/main.js
+++ b/src/main.js
@@ -159,8 +159,9 @@ OPTIONS:
                             The web UI also starts for the human reviewer.
     --model <name>          Override the AI model. Claude Code is the default provider.
                             Available models: opus, sonnet, haiku (Claude Code);
-                            also: opus-4.8-xhigh, opus-4.8-high, opus-4.7-xhigh,
-                                  opus-4.7-high, opus-4.6-high, opus-4.6-1m, sonnet-4.6
+                            also: fable-5-xhigh, fable-5-high, opus-4.8-xhigh,
+                                  opus-4.8-high, opus-4.7-xhigh, opus-4.7-high,
+                                  opus-4.6-high, opus-4.6-1m, sonnet-4.6
                             (opus is Opus 4.7 XHigh, the default)
                             or use provider-specific models with Gemini/Codex
     --use-checkout          Use current directory instead of creating worktree

--- a/tests/unit/claude-provider.test.js
+++ b/tests/unit/claude-provider.test.js
@@ -63,11 +63,13 @@ describe('ClaudeProvider', () => {
     it('should return array of models with expected structure', () => {
       const models = ClaudeProvider.getModels();
       expect(Array.isArray(models)).toBe(true);
-      expect(models.length).toBe(8);
+      expect(models.length).toBe(10);
 
-      // Check that we have haiku, sonnet, and opus variants
+      // Check that we have haiku, sonnet, opus, and fable variants
       const modelIds = models.map(m => m.id);
       expect(modelIds).toContain('haiku');
+      expect(modelIds).toContain('fable');
+      expect(modelIds).toContain('fable-5-high');
       expect(modelIds).toContain('sonnet-4.6');
       expect(modelIds).toContain('opus-4.8-xhigh');
       expect(modelIds).toContain('opus-4.8-high');
@@ -120,6 +122,38 @@ describe('ClaudeProvider', () => {
       expect(models.find(m => m.id === 'opus-4.7-high').env).toEqual({ CLAUDE_CODE_EFFORT_LEVEL: 'high' });
       expect(models.find(m => m.id === 'opus-4.8-xhigh').env).toEqual({ CLAUDE_CODE_EFFORT_LEVEL: 'xhigh' });
       expect(models.find(m => m.id === 'opus-4.8-high').env).toEqual({ CLAUDE_CODE_EFFORT_LEVEL: 'high' });
+
+      // Fable 5 variants are thorough, pinned to claude-fable-5, and adaptive-thinking-only
+      const fable = models.find(m => m.id === 'fable');
+      expect(fable).toMatchObject({
+        tier: 'thorough',
+        cli_model: 'claude-fable-5',
+        env: { CLAUDE_CODE_EFFORT_LEVEL: 'xhigh' },
+        extra_args: ['--thinking', 'adaptive']
+      });
+      expect(fable.aliases).toContain('fable-5-xhigh');
+      const fableHigh = models.find(m => m.id === 'fable-5-high');
+      expect(fableHigh).toMatchObject({
+        tier: 'thorough',
+        cli_model: 'claude-fable-5',
+        env: { CLAUDE_CODE_EFFORT_LEVEL: 'high' },
+        extra_args: ['--thinking', 'adaptive']
+      });
+    });
+
+    it('should override base --thinking enabled with adaptive for fable', () => {
+      const provider = new ClaudeProvider('fable');
+      expect(provider.args).toContain('claude-fable-5');
+      // Model extra_args come after base args so the adaptive override wins
+      const lastThinkingValue = provider.args[provider.args.lastIndexOf('--thinking') + 1];
+      expect(lastThinkingValue).toBe('adaptive');
+      expect(provider.extraEnv).toEqual({ CLAUDE_CODE_EFFORT_LEVEL: 'xhigh' });
+    });
+
+    it('should resolve fable-5-xhigh alias to the fable model', () => {
+      const provider = new ClaudeProvider('fable-5-xhigh');
+      expect(provider.args).toContain('claude-fable-5');
+      expect(provider.extraEnv).toEqual({ CLAUDE_CODE_EFFORT_LEVEL: 'xhigh' });
     });
 
     it('should return install instructions', () => {


### PR DESCRIPTION
## Summary
- Add **Fable 5** (`claude-fable-5`) to the Claude provider's thorough tier as two options: `fable` (alias `fable-5-xhigh`, effort `xhigh`) and `fable-5-high` (effort `high`)
- Fable 5 is adaptive-thinking-only — an explicit `enabled`/`disabled` thinking mode is rejected by the API — so both entries override the global `--thinking enabled` base arg with `--thinking adaptive` via `extra_args` (same pattern as Haiku)
- Default model is unchanged (`opus` / Opus 4.7 XHigh)
- Update the `--model` CLI help text in `src/main.js` with the new IDs
- Refresh the stale built-in Claude model list in the `config.example.json` `_comment`
- Changeset included (patch)

## Test plan
- Unit tests added: model structure assertions for both Fable entries, `--thinking adaptive` override wins over the base arg, and `fable-5-xhigh` alias resolution
- `pnpm vitest run tests/unit tests/integration` — 7789 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)