### PR TITLE
Fix scroll-to landing wrong on lazily rendered diff bodies

### DIFF
--- a/.changeset/fix-scroll-to-lazy-bodies.md
+++ b/.changeset/fix-scroll-to-lazy-bodies.md
@@ -1,0 +1,9 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Fix scroll-to landing at the wrong location on the first attempt for tour stops, AI suggestions, comments, and external threads. Lazily rendered file bodies (the large-PR perf change) shift the layout while the smooth scroll is in flight; scrolls now render the target's file body first and re-correct the position once lazy renders settle.
+
+Also hardens the stable scroll against rapid re-navigation: a newer scroll now supersedes any older in-flight one (latest-scroll-wins) instead of snapping the viewport back to a stale target, rapid Next/Prev suggestion navigation no longer highlights the wrong target across the lazy-render await, scroll-intent keys typed into form fields no longer cancel the correction loop, and file-level comment cards skip the unnecessary full diff-body render.
+
+Navigation now lands the target at the top of the diff panel (just below the sticky toolbar and file header) instead of the middle, for AI suggestions, findings, comments, external threads, and chat-line links.

--- a/public/css/pr.css
+++ b/public/css/pr.css
@@ -1661,6 +1661,23 @@
   scroll-margin-top: var(--toolbar-height, 0px);
 }
 
+/* Suggestion / finding / comment / chat-line navigation lands the target at
+   the TOP of the diff panel (scrollIntoView block:'start'). Offset it below
+   the sticky toolbar AND the sticky file header so it isn't hidden behind
+   them. `--diff-file-header-height` is measured in JS (_measureFileHeaderHeight)
+   with a sane fallback. Suppressed during a tour, which scrolls to center and
+   manages its own sticky offsets. */
+:root {
+  --diff-scroll-offset: calc(var(--toolbar-height, 0px) + var(--diff-file-header-height, 38px));
+}
+body:not(.tour-active) .d2h-file-wrapper tr,
+body:not(.tour-active) .ai-suggestion,
+body:not(.tour-active) .file-comment-card,
+body:not(.tour-active) .user-comment-row,
+body:not(.tour-active) .external-comment-row {
+  scroll-margin-top: var(--diff-scroll-offset);
+}
+
 /* Hide diff content when collapsed */
 .d2h-file-wrapper.collapsed .d2h-file-body,
 .d2h-file-wrapper.collapsed .d2h-diff-table {

--- a/public/js/components/AIPanel.js
+++ b/public/js/components/AIPanel.js
@@ -44,6 +44,10 @@ class AIPanel {
         // Track selected item by stable identifier for restoration
         this.selectedItemKey = null; // Format: "file:lineNumber:itemType:identity"
 
+        // Monotonic token so a fast move between items that supersedes an
+        // in-flight scrollTo* can tell the older call to bail after its await.
+        this._navGen = 0;
+
         // Canonical file order for consistent sorting across components
         this.fileOrder = new Map(); // Map of file path -> index
 
@@ -1178,9 +1182,18 @@ class AIPanel {
     /**
      * Scroll to an AI finding/suggestion in the diff view
      */
-    scrollToFinding(findingId, file, line) {
+    async scrollToFinding(findingId, file, line) {
+        const myGen = ++this._navGen;
         // Expand the file first if it's collapsed
         const expansion = this.expandFileIfCollapsed(file);
+        if (expansion && typeof expansion.then === 'function') await expansion;
+        // Always render the target's lazy body — an expanded-but-offscreen
+        // body has no suggestion rows until rendered, so the lookup below
+        // would miss on the first attempt (expansion only covers the
+        // collapsed case).
+        if (file && window.prManager?.ensureFileBodyRendered) {
+            try { await window.prManager.ensureFileBodyRendered(file); } catch { /* best effort */ }
+        }
 
         const doScroll = () => {
             let targetSuggestion = null;
@@ -1216,36 +1229,54 @@ class AIPanel {
 
             if (targetSuggestion) {
                 const minimizer = window.prManager?.commentMinimizer;
+                let scrollTarget = targetSuggestion;
                 if (minimizer?.active) {
                     // Expand file-level comments so the target becomes visible
                     minimizer.expandForElement(targetSuggestion);
                     // Comments are minimized — scroll to the parent diff line instead
-                    const diffRow = minimizer.findDiffRowFor(targetSuggestion);
-                    (diffRow || targetSuggestion).scrollIntoView({ behavior: 'smooth', block: 'center' });
-                } else {
-                    targetSuggestion.scrollIntoView({ behavior: 'smooth', block: 'center' });
+                    scrollTarget = minimizer.findDiffRowFor(targetSuggestion) || targetSuggestion;
                 }
+                this._scrollDiffTarget(scrollTarget);
                 targetSuggestion.classList.add('current-suggestion');
                 setTimeout(() => targetSuggestion.classList.remove('current-suggestion'), 2000);
             }
         };
 
-        // When expansion routed through the async lazy-body render, wait for it
-        // to settle so the row lookup runs against a rendered, visible body.
-        // Otherwise scroll synchronously (fast path: file already expanded).
-        if (expansion && typeof expansion.then === 'function') {
-            expansion.then(doScroll);
+        // A newer navigation took over while we awaited — let it win.
+        if (myGen !== this._navGen) return;
+        doScroll();
+    }
+
+    /**
+     * Scroll a diff-panel element into view, preferring the stable helper
+     * (re-corrects after lazy file bodies render mid-scroll and shift
+     * layout). Fire-and-forget.
+     * @param {Element} target
+     */
+    _scrollDiffTarget(target) {
+        // Land the target at the top of the diff panel (scroll-margin-top in
+        // pr.css offsets it below the sticky toolbar + file header).
+        const options = { behavior: 'smooth', block: 'start' };
+        if (window.ScrollUtils?.scrollIntoViewStable) {
+            window.ScrollUtils.scrollIntoViewStable(target, options);
         } else {
-            doScroll();
+            target.scrollIntoView(options);
         }
     }
 
     /**
      * Scroll to a user comment in the diff view
      */
-    scrollToComment(commentId, file, line) {
+    async scrollToComment(commentId, file, line) {
+        const myGen = ++this._navGen;
         // Expand the file first if it's collapsed
         const expansion = this.expandFileIfCollapsed(file);
+        if (expansion && typeof expansion.then === 'function') await expansion;
+        // Always render the target's lazy body — comment rows don't exist
+        // inside an unrendered body, so the lookup below would miss.
+        if (file && window.prManager?.ensureFileBodyRendered) {
+            try { await window.prManager.ensureFileBodyRendered(file); } catch { /* best effort */ }
+        }
 
         const doScroll = () => {
             let targetElement = null;
@@ -1288,13 +1319,13 @@ class AIPanel {
 
             if (targetElement) {
                 const minimizer = window.prManager?.commentMinimizer;
+                let scrollTarget = targetElement;
                 if (minimizer?.active) {
                     minimizer.expandForElement(targetElement);
                     const diffRow = isFileLevel ? null : minimizer.findDiffRowFor(targetElement);
-                    (diffRow || targetElement).scrollIntoView({ behavior: 'smooth', block: 'center' });
-                } else {
-                    targetElement.scrollIntoView({ behavior: 'smooth', block: 'center' });
+                    scrollTarget = diffRow || targetElement;
                 }
+                this._scrollDiffTarget(scrollTarget);
                 // Add highlight effect
                 const commentDiv = isFileLevel ? targetElement : targetElement.querySelector('.user-comment');
                 if (commentDiv) {
@@ -1304,13 +1335,9 @@ class AIPanel {
             }
         };
 
-        // Await the async lazy-body render when expansion triggered one;
-        // scroll synchronously otherwise.
-        if (expansion && typeof expansion.then === 'function') {
-            expansion.then(doScroll);
-        } else {
-            doScroll();
-        }
+        // A newer navigation took over while we awaited — let it win.
+        if (myGen !== this._navGen) return;
+        doScroll();
     }
 
     /**
@@ -1325,9 +1352,16 @@ class AIPanel {
      * @param {string} file - File path for collapse-expand fallback
      * @param {string|number} line - Anchor line; used for file/line fallback
      */
-    scrollToExternalThread(threadId, source, file, line) {
+    async scrollToExternalThread(threadId, source, file, line) {
+        const myGen = ++this._navGen;
         // Expand the file first if it's collapsed
         const expansion = this.expandFileIfCollapsed(file);
+        if (expansion && typeof expansion.then === 'function') await expansion;
+        // Always render the target's lazy body — external thread rows don't
+        // exist inside an unrendered body, so the lookup below would miss.
+        if (file && window.prManager?.ensureFileBodyRendered) {
+            try { await window.prManager.ensureFileBodyRendered(file); } catch { /* best effort */ }
+        }
 
         const doScroll = () => {
             let target = null;
@@ -1368,13 +1402,12 @@ class AIPanel {
 
             if (target) {
                 const minimizer = window.prManager?.commentMinimizer;
+                let scrollTarget = target;
                 if (minimizer?.active) {
                     minimizer.expandForElement(target);
-                    const diffRow = minimizer.findDiffRowFor(target);
-                    (diffRow || target).scrollIntoView({ behavior: 'smooth', block: 'center' });
-                } else {
-                    target.scrollIntoView({ behavior: 'smooth', block: 'center' });
+                    scrollTarget = minimizer.findDiffRowFor(target) || target;
                 }
+                this._scrollDiffTarget(scrollTarget);
 
                 // Transient focus flash. The class is removed after 2s — if
                 // the row is rebuilt before then, the class is lost with it,
@@ -1384,13 +1417,9 @@ class AIPanel {
             }
         };
 
-        // Await the async lazy-body render when expansion triggered one;
-        // scroll synchronously otherwise.
-        if (expansion && typeof expansion.then === 'function') {
-            expansion.then(doScroll);
-        } else {
-            doScroll();
-        }
+        // A newer navigation took over while we awaited — let it win.
+        if (myGen !== this._navGen) return;
+        doScroll();
     }
 
     // ========================================

--- a/public/js/components/ChatPanel.js
+++ b/public/js/components/ChatPanel.js
@@ -4613,7 +4613,17 @@ class ChatPanel {
     const isVisible = rect.top >= 0 && rect.bottom <= window.innerHeight;
 
     if (!isVisible) {
-      primaryRow.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      // Stable variant re-corrects after lazy file bodies render mid-scroll
+      // and shift the layout (plain scrollIntoView lands off target the
+      // first time on large diffs). Fire-and-forget.
+      // Land the target at the top of the diff panel (scroll-margin-top in
+      // pr.css offsets it below the sticky toolbar + file header).
+      const scrollOptions = { behavior: 'smooth', block: 'start' };
+      if (window.ScrollUtils?.scrollIntoViewStable) {
+        window.ScrollUtils.scrollIntoViewStable(primaryRow, scrollOptions);
+      } else {
+        primaryRow.scrollIntoView(scrollOptions);
+      }
     }
 
     // Apply the highlight to all target rows

--- a/public/js/components/SuggestionNavigator.js
+++ b/public/js/components/SuggestionNavigator.js
@@ -10,7 +10,10 @@ class SuggestionNavigator {
     this.isCollapsed = this.loadCollapsedState();
     this.element = null;
     this.collapseToggle = null;
-    
+    // Monotonic token so a fast Next/Prev that supersedes an in-flight
+    // goToSuggestion can tell the older call to bail after its await.
+    this._navGen = 0;
+
     this.init();
     this.bindEvents();
   }
@@ -236,7 +239,7 @@ class SuggestionNavigator {
   /**
    * Navigate to specific suggestion by index
    */
-  goToSuggestion(index) {
+  async goToSuggestion(index) {
     if (index < 0 || index >= this.suggestions.length) {
       return;
     }
@@ -244,8 +247,40 @@ class SuggestionNavigator {
     this.currentSuggestionIndex = index;
     this.updateCounter();
     this.updateNavigationButtons();
+    // The suggestion's row only exists once its file body has rendered
+    // (lazy bodies start empty), so render it before the highlight/scroll
+    // lookups below — otherwise both silently miss on the first attempt.
+    // A collapsed file is expanded first so the row is actually visible.
+    const myGen = ++this._navGen;
+    await this.ensureSuggestionVisible(this.suggestions[index]);
+    // A newer goToSuggestion ran while we awaited and moved
+    // this.currentSuggestionIndex — let it own the highlight/scroll.
+    if (myGen !== this._navGen) return;
     this.highlightCurrentSuggestion();
     this.scrollToSuggestion();
+  }
+
+  /**
+   * Make sure a suggestion's file is expanded and its lazy diff body is
+   * rendered so the suggestion row exists in the DOM. Best effort: any
+   * failure falls through to the old lookup-miss behavior.
+   * @param {Object} suggestion
+   */
+  async ensureSuggestionVisible(suggestion) {
+    const file = suggestion?.file;
+    const pm = window.prManager;
+    if (!file || !pm) return;
+    try {
+      const wrapper = pm.findFileElement?.(file);
+      if (wrapper?.classList.contains('collapsed') && pm.toggleFileCollapse) {
+        // Renders the lazy body and removes `collapsed`.
+        await pm.toggleFileCollapse(wrapper.dataset.fileName || file);
+      } else if (pm.ensureFileBodyRendered) {
+        await pm.ensureFileBodyRendered(file);
+      }
+    } catch (err) {
+      console.warn('[SuggestionNavigator] could not prepare suggestion file', file, err);
+    }
   }
 
   /**
@@ -370,18 +405,22 @@ class SuggestionNavigator {
       
       if (suggestionEl) {
         const minimizer = window.prManager?.commentMinimizer;
+        let scrollTarget = suggestionEl;
         if (minimizer?.active) {
           // Expand file-level comments so the target becomes visible
           minimizer.expandForElement(suggestionEl);
           // Comments are minimized — scroll to the parent diff line instead
-          const diffRow = minimizer.findDiffRowFor(suggestionEl);
-          if (diffRow) {
-            diffRow.scrollIntoView({ behavior: 'smooth', block: 'center', inline: 'nearest' });
-          } else {
-            suggestionEl.scrollIntoView({ behavior: 'smooth', block: 'center', inline: 'nearest' });
-          }
+          scrollTarget = minimizer.findDiffRowFor(suggestionEl) || suggestionEl;
+        }
+        // Land the target at the top of the diff panel (scroll-margin-top in
+        // pr.css offsets it below the sticky toolbar + file header).
+        const options = { behavior: 'smooth', block: 'start', inline: 'nearest' };
+        // Stable variant re-corrects after lazy file bodies render
+        // mid-scroll and shift the layout. Fire-and-forget.
+        if (window.ScrollUtils?.scrollIntoViewStable) {
+          window.ScrollUtils.scrollIntoViewStable(scrollTarget, options);
         } else {
-          suggestionEl.scrollIntoView({ behavior: 'smooth', block: 'center', inline: 'nearest' });
+          scrollTarget.scrollIntoView(options);
         }
       }
     }
@@ -474,4 +513,10 @@ class SuggestionNavigator {
 }
 
 // Export for use
-window.SuggestionNavigator = SuggestionNavigator;
+if (typeof window !== 'undefined') {
+  window.SuggestionNavigator = SuggestionNavigator;
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = SuggestionNavigator;
+}

--- a/public/js/modules/tour-renderer.js
+++ b/public/js/modules/tour-renderer.js
@@ -488,10 +488,20 @@ class TourRenderer {
   scrollToStop(index) {
     const row = this._mounted.get(index);
     if (!row || !row.isConnected) return;
-    row.scrollIntoView({
+    const options = {
       behavior: this._reduceMotion ? 'auto' : 'smooth',
       block: 'center'
-    });
+    };
+    // Lazy bodies between the viewport and the stop render as the scroll
+    // passes them, shifting layout so a plain scrollIntoView lands off
+    // target. The stable variant re-corrects once the scroll settles.
+    // Fire-and-forget: it bails on its own if the row unmounts (tour exit)
+    // or the user scrolls.
+    if (window.ScrollUtils?.scrollIntoViewStable) {
+      window.ScrollUtils.scrollIntoViewStable(row, options);
+    } else {
+      row.scrollIntoView(options);
+    }
   }
 
   /**

--- a/public/js/pr.js
+++ b/public/js/pr.js
@@ -403,6 +403,22 @@ class PRManager {
   }
 
   /**
+   * Keep --diff-file-header-height in sync with the rendered sticky file
+   * header so navigation (block:'start' + scroll-margin-top in pr.css) lands
+   * targets just below the header rather than hidden behind it. Headers are
+   * single-line and uniform, so measuring the first one is representative.
+   * Call after renderDiff appends the headers.
+   */
+  _measureFileHeaderHeight() {
+    const header = document.querySelector('.d2h-file-wrapper .d2h-file-header');
+    if (header && header.offsetHeight) {
+      document.documentElement.style.setProperty(
+        '--diff-file-header-height', header.offsetHeight + 'px'
+      );
+    }
+  }
+
+  /**
    * Set up event handlers
    */
   setupEventHandlers() {
@@ -3323,6 +3339,10 @@ class PRManager {
 
       // NOTE: end-of-file gap validation runs per-file inside _renderFileBodyNow
       // now (bodies render lazily), not once globally here.
+
+      // Measure the now-rendered sticky file header so navigation can offset
+      // targets below it (scroll-margin-top in pr.css).
+      this._measureFileHeaderHeight();
     } else {
       diffContainer.innerHTML = '<div class="no-diff">No files changed</div>';
     }
@@ -6383,7 +6403,16 @@ class PRManager {
       if (!fileWrapper.classList.contains('collapsed')) {
         await this.ensureFileBodyRendered(filePath);
       }
-      fileWrapper.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      // Stable variant: lazy bodies between here and the target render as
+      // the smooth scroll passes them, shifting layout mid-flight. The
+      // helper re-corrects after the scroll settles so the first attempt
+      // lands where the second used to.
+      const scrollOptions = { behavior: 'smooth', block: 'start' };
+      if (window.ScrollUtils?.scrollIntoViewStable) {
+        await window.ScrollUtils.scrollIntoViewStable(fileWrapper, scrollOptions);
+      } else {
+        fileWrapper.scrollIntoView(scrollOptions);
+      }
     }
   }
 
@@ -7750,7 +7779,7 @@ class PRManager {
    * @param {string} file - File path
    * @param {number} [lineStart] - Optional line number to highlight
    */
-  scrollToContextFile(file, lineStart, contextId) {
+  async scrollToContextFile(file, lineStart, contextId) {
     // Use contextId to find a specific chunk tbody within a merged wrapper,
     // or fall back to a standalone wrapper or the file-level wrapper.
     let target;
@@ -7769,23 +7798,30 @@ class PRManager {
     }
     if (!target) return;
 
-    target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    // Stable variant ensures the target's lazy body is rendered and
+    // re-corrects after lazy renders along the scroll path shift layout.
+    const scrollOptions = { behavior: 'smooth', block: 'start' };
+    if (window.ScrollUtils?.scrollIntoViewStable) {
+      await window.ScrollUtils.scrollIntoViewStable(target, scrollOptions);
+    } else {
+      target.scrollIntoView(scrollOptions);
+    }
 
     if (lineStart) {
       // Search for the line row within the wrapper (not just the target chunk)
       const wrapper = target.closest('.d2h-file-wrapper') || target;
-      // Brief delay to let scroll settle, then highlight the target line
-      setTimeout(() => {
-        const row = wrapper.querySelector(`tr[data-line-number="${lineStart}"]`);
-        if (row) {
+      // The awaited stable scroll has already settled (and rendered the lazy
+      // body), so the row exists now — highlight it immediately rather than
+      // pulsing on a stale timer that would fire after the scroll completes.
+      const row = wrapper.querySelector(`tr[data-line-number="${lineStart}"]`);
+      if (row) {
+        row.classList.remove('chat-line-highlight');
+        void row.offsetWidth;
+        row.classList.add('chat-line-highlight');
+        row.addEventListener('animationend', () => {
           row.classList.remove('chat-line-highlight');
-          void row.offsetWidth;
-          row.classList.add('chat-line-highlight');
-          row.addEventListener('animationend', () => {
-            row.classList.remove('chat-line-highlight');
-          }, { once: true });
-        }
-      }, 400);
+        }, { once: true });
+      }
     }
   }
 

--- a/public/js/utils/scroll-into-view.js
+++ b/public/js/utils/scroll-into-view.js
@@ -1,0 +1,164 @@
+// Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+/**
+ * Stable scroll-into-view for the lazily rendered diff panel.
+ *
+ * Since the large-PR perf fix, expanded file bodies start as empty
+ * placeholders (`minHeight` ≈ patch lines × APPROX_DIFF_LINE_PX) and only
+ * render real rows when an IntersectionObserver sees them near the viewport.
+ * A plain `scrollIntoView()` therefore lands wrong on the first attempt:
+ * the browser computes the destination from placeholder heights, then the
+ * bodies passed during the scroll render and change height, shifting the
+ * target away from where the animation ends. A second attempt "works"
+ * because everything along the path has rendered by then.
+ *
+ * `scrollIntoViewStable()` fixes this by:
+ *   1. Rendering the target's own file body first (rows inside a lazy body
+ *      don't exist until rendered, and its placeholder height is wrong).
+ *   2. Issuing the caller's scroll (smooth behavior preserved).
+ *   3. Waiting for the viewport-relative position of the target to stop
+ *      moving (scroll animation done AND observer-triggered renders settled),
+ *      then re-issuing an instant scroll. If that correction moved the
+ *      target, newly revealed placeholders rendered and shifted layout
+ *      again — so settle and correct again, up to MAX_CORRECTIONS times.
+ *
+ * The settle loop aborts if the user starts scrolling themselves (wheel /
+ * touch / scroll-intent keys) so corrections never fight real input, and
+ * whenever the target leaves the DOM (file list re-render, tour unmount).
+ */
+
+/** Corrective re-scroll attempts after the initial scroll. */
+const MAX_CORRECTIONS = 4;
+/** Position delta (px) treated as "didn't move". */
+const STABLE_PX = 2;
+/** Consecutive same-position frames before the target counts as settled. */
+const SETTLE_FRAMES = 3;
+/** Hard cap on one settle wait — covers the longest smooth animation. */
+const SETTLE_TIMEOUT_MS = 2000;
+
+/** Keys that express scroll intent and should cancel pending corrections. */
+const SCROLL_KEYS = new Set([
+  'ArrowUp', 'ArrowDown', 'PageUp', 'PageDown', 'Home', 'End', ' '
+]);
+
+/**
+ * Latest-scroll-wins token. Every call captures `++activeGeneration`; any
+ * call whose captured value no longer matches has been superseded by a newer
+ * scroll and must bow out so stale settle loops don't fight or snap the
+ * viewport back to an old target.
+ */
+let activeGeneration = 0;
+
+/**
+ * Wait until `target`'s viewport-relative top is unchanged for
+ * SETTLE_FRAMES consecutive animation frames (or SETTLE_TIMEOUT_MS passes).
+ * Resolves early when the target is disconnected or `isCancelled()` trips.
+ * @param {Element} target
+ * @param {() => boolean} isCancelled
+ * @returns {Promise<void>}
+ */
+function waitForStablePosition(target, isCancelled) {
+  return new Promise((resolve) => {
+    const start = Date.now();
+    let lastTop = null;
+    let stableFrames = 0;
+    const tick = () => {
+      if (isCancelled() || !target.isConnected || Date.now() - start > SETTLE_TIMEOUT_MS) {
+        resolve();
+        return;
+      }
+      const top = target.getBoundingClientRect().top;
+      if (lastTop !== null && Math.abs(top - lastTop) <= STABLE_PX) {
+        stableFrames += 1;
+        if (stableFrames >= SETTLE_FRAMES) {
+          resolve();
+          return;
+        }
+      } else {
+        stableFrames = 0;
+      }
+      lastTop = top;
+      requestAnimationFrame(tick);
+    };
+    requestAnimationFrame(tick);
+  });
+}
+
+/**
+ * Scroll `target` into view and keep it there while lazy file bodies render.
+ * Safe to call on any element; outside a lazy diff it degrades to one
+ * `scrollIntoView` plus a settle wait. Fire-and-forget friendly.
+ * @param {Element} target - Element to bring into view
+ * @param {ScrollIntoViewOptions} [options] - Passed to the initial scroll;
+ *   corrective re-scrolls force `behavior: 'auto'`.
+ * @returns {Promise<void>} resolves once the position is stable (or aborted)
+ */
+async function scrollIntoViewStable(target, options = {}) {
+  if (!target || !target.isConnected || typeof target.scrollIntoView !== 'function') return;
+
+  // Claim the active-scroll slot. A later call bumps activeGeneration past
+  // ours, at which point isCancelled() trips and this call bows out.
+  const myGen = ++activeGeneration;
+
+  // Render the target's own lazy body first: until then its rows don't
+  // exist and the wrapper's height is the placeholder estimate. Skip
+  // collapsed wrappers — their body is display:none (zero height), so
+  // rendering would pay full renderPatch cost without changing the scroll.
+  // Skip file-level comment/suggestion cards too: they live in
+  // `.file-comments-zone`, which sits above the lazy body, so rendering the
+  // body can't move them — only burn the renderPatch cost we want to avoid.
+  const prManager = (typeof window !== 'undefined') ? window.prManager : null;
+  const wrapper = target.closest?.('.d2h-file-wrapper');
+  if (wrapper && !target.closest?.('.file-comments-zone')
+      && !wrapper.classList.contains('collapsed')
+      && typeof prManager?.ensureFileBodyRendered === 'function') {
+    try {
+      await prManager.ensureFileBodyRendered(wrapper);
+    } catch (err) {
+      console.warn('[ScrollUtils] ensureFileBodyRendered failed; scrolling anyway', err);
+    }
+    if (!target.isConnected || myGen !== activeGeneration) return;
+  }
+
+  // Cancel corrections when the user scrolls on their own OR when a newer
+  // scrollIntoViewStable call supersedes this one (latest-scroll-wins).
+  let cancelled = false;
+  const isCancelled = () => cancelled || myGen !== activeGeneration;
+  const cancel = () => { cancelled = true; };
+  const onKeyDown = (e) => {
+    // Scroll-intent keys are also everyday caret/typing keys inside form
+    // fields — there they mean "move the cursor", not "scroll the page", so
+    // they must not abort the correction loop.
+    if (e.target?.closest?.('input, textarea, select') || e.target?.isContentEditable) return;
+    if (SCROLL_KEYS.has(e.key)) cancelled = true;
+  };
+  window.addEventListener('wheel', cancel, { capture: true, passive: true });
+  window.addEventListener('touchstart', cancel, { capture: true, passive: true });
+  window.addEventListener('keydown', onKeyDown, { capture: true });
+
+  try {
+    target.scrollIntoView(options);
+    for (let i = 0; i < MAX_CORRECTIONS; i++) {
+      await waitForStablePosition(target, isCancelled);
+      if (isCancelled() || !target.isConnected) return;
+      // Re-issue instantly: a no-op when the smooth scroll landed true, a
+      // snap to the real position when lazy renders shifted the layout.
+      const before = target.getBoundingClientRect().top;
+      target.scrollIntoView({ ...options, behavior: 'auto' });
+      if (Math.abs(target.getBoundingClientRect().top - before) <= STABLE_PX) return;
+      // The correction moved us — newly revealed bodies may render and
+      // shift layout once more; loop to settle and verify again.
+    }
+  } finally {
+    window.removeEventListener('wheel', cancel, { capture: true });
+    window.removeEventListener('touchstart', cancel, { capture: true });
+    window.removeEventListener('keydown', onKeyDown, { capture: true });
+  }
+}
+
+if (typeof window !== 'undefined') {
+  window.ScrollUtils = { scrollIntoViewStable, waitForStablePosition };
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { scrollIntoViewStable, waitForStablePosition, MAX_CORRECTIONS, STABLE_PX, SETTLE_FRAMES, SETTLE_TIMEOUT_MS };
+}

--- a/public/local.html
+++ b/public/local.html
@@ -614,6 +614,9 @@
     <!-- Modal detection (shared by KeyboardShortcuts and PRManager) -->
     <script src="/js/utils/modal-detection.js"></script>
 
+    <!-- Stable scroll-into-view for lazily rendered diff bodies -->
+    <script src="/js/utils/scroll-into-view.js"></script>
+
     <!-- WebSocket client -->
     <script src="/js/ws-client.js"></script>
 

--- a/public/pr.html
+++ b/public/pr.html
@@ -417,6 +417,9 @@
     <!-- Modal detection (shared by KeyboardShortcuts and PRManager) -->
     <script src="/js/utils/modal-detection.js"></script>
 
+    <!-- Stable scroll-into-view for lazily rendered diff bodies -->
+    <script src="/js/utils/scroll-into-view.js"></script>
+
     <!-- WebSocket client -->
     <script src="/js/ws-client.js"></script>
 

--- a/tests/unit/SuggestionNavigator.test.js
+++ b/tests/unit/SuggestionNavigator.test.js
@@ -1,0 +1,154 @@
+// Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+// @vitest-environment jsdom
+
+/**
+ * Unit tests for SuggestionNavigator's async navigation path.
+ *
+ * The suggestion's diff row only exists once its (lazily rendered) file body
+ * is in the DOM, so `goToSuggestion` awaits `ensureSuggestionVisible` before
+ * highlighting/scrolling. These tests lock in:
+ *   - the render-before-lookup ordering (the bug being fixed),
+ *   - that a collapsed file is expanded vs. a rendered-but-collapsed body,
+ *   - the early returns when there's no file / no prManager,
+ *   - and the latest-call-wins guard against rapid Next/Prev racing on the
+ *     shared `this.currentSuggestionIndex` across the await.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+const SuggestionNavigator = require('../../public/js/components/SuggestionNavigator.js');
+
+/** Build a navigator with the list-rendering DOM stubbed out. */
+function makeNavigator() {
+  const nav = new SuggestionNavigator();
+  // Isolate goToSuggestion's await ordering from real DOM highlight/scroll.
+  vi.spyOn(nav, 'highlightCurrentSuggestion').mockImplementation(() => {});
+  vi.spyOn(nav, 'scrollToSuggestion').mockImplementation(() => {});
+  return nav;
+}
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+  localStorage.clear();
+  window.prManager = undefined;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  delete window.prManager;
+});
+
+describe('SuggestionNavigator.goToSuggestion', () => {
+  it('expands a collapsed file before highlight/scroll', async () => {
+    const wrapper = document.createElement('div');
+    wrapper.className = 'd2h-file-wrapper collapsed';
+    wrapper.dataset.fileName = 'a.js';
+    const order = [];
+    window.prManager = {
+      findFileElement: vi.fn(() => wrapper),
+      toggleFileCollapse: vi.fn(async () => order.push('toggle')),
+      ensureFileBodyRendered: vi.fn(async () => order.push('render'))
+    };
+    const nav = makeNavigator();
+    nav.highlightCurrentSuggestion.mockImplementation(() => order.push('highlight'));
+    nav.scrollToSuggestion.mockImplementation(() => order.push('scroll'));
+    nav.suggestions = [{ id: 's1', file: 'a.js' }];
+
+    await nav.goToSuggestion(0);
+
+    expect(window.prManager.toggleFileCollapse).toHaveBeenCalledWith('a.js');
+    expect(window.prManager.ensureFileBodyRendered).not.toHaveBeenCalled();
+    // Highlight/scroll run strictly after the expand await resolves.
+    expect(order).toEqual(['toggle', 'highlight', 'scroll']);
+  });
+
+  it('renders the lazy body for a non-collapsed file', async () => {
+    const wrapper = document.createElement('div');
+    wrapper.className = 'd2h-file-wrapper';
+    wrapper.dataset.fileName = 'a.js';
+    window.prManager = {
+      findFileElement: vi.fn(() => wrapper),
+      toggleFileCollapse: vi.fn(async () => {}),
+      ensureFileBodyRendered: vi.fn(async () => {})
+    };
+    const nav = makeNavigator();
+    nav.suggestions = [{ id: 's1', file: 'a.js' }];
+
+    await nav.goToSuggestion(0);
+
+    expect(window.prManager.ensureFileBodyRendered).toHaveBeenCalledWith('a.js');
+    expect(window.prManager.toggleFileCollapse).not.toHaveBeenCalled();
+    expect(nav.highlightCurrentSuggestion).toHaveBeenCalled();
+    expect(nav.scrollToSuggestion).toHaveBeenCalled();
+  });
+
+  it('does nothing for an out-of-range index', async () => {
+    window.prManager = { findFileElement: vi.fn(), ensureFileBodyRendered: vi.fn() };
+    const nav = makeNavigator();
+    nav.suggestions = [{ id: 's1', file: 'a.js' }];
+
+    await nav.goToSuggestion(5);
+
+    expect(window.prManager.findFileElement).not.toHaveBeenCalled();
+    expect(nav.highlightCurrentSuggestion).not.toHaveBeenCalled();
+  });
+
+  it('skips file prep when the suggestion has no file', async () => {
+    window.prManager = {
+      findFileElement: vi.fn(),
+      toggleFileCollapse: vi.fn(),
+      ensureFileBodyRendered: vi.fn()
+    };
+    const nav = makeNavigator();
+    nav.suggestions = [{ id: 's1' }]; // no file
+
+    await nav.goToSuggestion(0);
+
+    expect(window.prManager.findFileElement).not.toHaveBeenCalled();
+    expect(window.prManager.ensureFileBodyRendered).not.toHaveBeenCalled();
+    // Still navigates — best effort falls through to the lookup.
+    expect(nav.highlightCurrentSuggestion).toHaveBeenCalled();
+  });
+
+  it('still navigates when prManager is unavailable', async () => {
+    window.prManager = undefined;
+    const nav = makeNavigator();
+    nav.suggestions = [{ id: 's1', file: 'a.js' }];
+
+    await nav.goToSuggestion(0);
+
+    expect(nav.highlightCurrentSuggestion).toHaveBeenCalled();
+    expect(nav.scrollToSuggestion).toHaveBeenCalled();
+  });
+
+  it('lets a newer goToSuggestion supersede an older in-flight one', async () => {
+    // Each ensureFileBodyRendered call hands back a resolver we control, so we
+    // can interleave two goToSuggestion calls across their awaits.
+    const resolvers = [];
+    window.prManager = {
+      findFileElement: vi.fn(() => {
+        const w = document.createElement('div');
+        w.className = 'd2h-file-wrapper';
+        return w;
+      }),
+      toggleFileCollapse: vi.fn(),
+      ensureFileBodyRendered: vi.fn(() => new Promise((res) => resolvers.push(res)))
+    };
+    const nav = makeNavigator();
+    const highlighted = [];
+    nav.highlightCurrentSuggestion.mockImplementation(() => highlighted.push(nav.currentSuggestionIndex));
+    nav.suggestions = [{ id: 's1', file: 'a.js' }, { id: 's2', file: 'b.js' }];
+
+    const pA = nav.goToSuggestion(0); // _navGen = 1, awaits resolvers[0]
+    const pB = nav.goToSuggestion(1); // _navGen = 2, awaits resolvers[1]
+
+    // Resolve the OLDER call first; it must still bail because gen moved on.
+    resolvers[0]();
+    resolvers[1]();
+    await Promise.all([pA, pB]);
+
+    // Only the latest call highlights, and it sees its own (latest) index.
+    expect(highlighted).toEqual([1]);
+    expect(nav.currentSuggestionIndex).toBe(1);
+  });
+});

--- a/tests/unit/ai-panel-external-segment.test.js
+++ b/tests/unit/ai-panel-external-segment.test.js
@@ -86,6 +86,9 @@ function createTestPanel(overrides = {}) {
   panel.currentIndex = -1;
   panel.selectedItemKey = null;
   panel.fileOrder = new Map();
+  // Mirror the real constructor: latest-wins token for scrollTo* guards.
+  // Without this, ++undefined -> NaN and NaN !== NaN wrongly bails the scroll.
+  panel._navGen = 0;
 
   // DOM stubs — methods we don't care about in these tests are no-ops.
   panel.panel = {
@@ -642,7 +645,7 @@ describe('AIPanel.scrollToExternalThread', () => {
 
     panel.scrollToExternalThread('42', 'github', 'src/utils.js', 5);
 
-    expect(row.scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth', block: 'center' });
+    expect(row.scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth', block: 'start' });
   });
 
   it('adds a transient .external-comment-row--focused class', () => {

--- a/tests/unit/ai-panel-scroll-race.test.js
+++ b/tests/unit/ai-panel-scroll-race.test.js
@@ -1,0 +1,186 @@
+// Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+// @vitest-environment jsdom
+
+/**
+ * Regression test for the AIPanel scroll-to navigation race.
+ *
+ * The three scroll methods (scrollToFinding / scrollToComment /
+ * scrollToExternalThread) are async and await the target file's lazy body
+ * render before scrolling. handleItemClick fires them and-forgets, so two
+ * can be in flight at once. If the user moves to a NEWER item while an OLDER
+ * call is still awaiting a slow render, the older call must NOT scroll when
+ * its await finally resolves — otherwise it snaps the viewport back to the
+ * stale target. A monotonic `_navGen` token (bumped at the top of each
+ * method, re-checked before doScroll) enforces latest-wins at the consumer.
+ *
+ * We bypass AIPanel's heavy DOM constructor with Object.create and set
+ * `_navGen = 0` to mirror what the real constructor does.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+const { AIPanel } = require('../../public/js/components/AIPanel.js');
+
+/** Create a deferred promise we can resolve on demand. */
+function deferred() {
+  let resolve;
+  const promise = new Promise((res) => { resolve = res; });
+  return { promise, resolve };
+}
+
+function makeInstance() {
+  const inst = Object.create(AIPanel.prototype);
+  // Mirror the real constructor: latest-wins token starts at 0 so the first
+  // ++this._navGen yields 1 (not NaN from ++undefined).
+  inst._navGen = 0;
+  inst.expandFileIfCollapsed = vi.fn(() => undefined);
+  inst._scrollDiffTarget = vi.fn();
+  inst.comments = [];
+  return inst;
+}
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+  window.prManager = undefined;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  delete window.prManager;
+});
+
+describe('AIPanel scroll-to latest-wins race', () => {
+  it('scrollToFinding: an older call bails after a newer call supersedes it', async () => {
+    const oldGate = deferred();
+    const newGate = deferred();
+    let firstCall = true;
+    window.prManager = {
+      ensureFileBodyRendered: vi.fn(() => {
+        const gate = firstCall ? oldGate : newGate;
+        firstCall = false;
+        return gate.promise;
+      })
+    };
+
+    const inst = makeInstance();
+
+    const findingA = document.createElement('div');
+    findingA.className = 'ai-suggestion';
+    findingA.setAttribute('data-suggestion-id', 'A');
+    const findingB = document.createElement('div');
+    findingB.className = 'ai-suggestion';
+    findingB.setAttribute('data-suggestion-id', 'B');
+    document.body.append(findingA, findingB);
+
+    // Older call starts and parks on its pending render.
+    const olderP = inst.scrollToFinding('A', 'a.js', null);
+    // Newer call starts, bumps _navGen, parks on its own render.
+    const newerP = inst.scrollToFinding('B', 'b.js', null);
+
+    // Resolve the OLDER render LAST-ish: first let it through.
+    oldGate.resolve();
+    await olderP;
+    // Older call must have bailed — no scroll.
+    expect(inst._scrollDiffTarget).not.toHaveBeenCalled();
+
+    // Now let the newer call finish — it owns the scroll.
+    newGate.resolve();
+    await newerP;
+    expect(inst._scrollDiffTarget).toHaveBeenCalledTimes(1);
+    expect(inst._scrollDiffTarget).toHaveBeenCalledWith(findingB);
+  });
+
+  it('scrollToComment: an older call bails after a newer call supersedes it', async () => {
+    const oldGate = deferred();
+    const newGate = deferred();
+    let firstCall = true;
+    window.prManager = {
+      ensureFileBodyRendered: vi.fn(() => {
+        const gate = firstCall ? oldGate : newGate;
+        firstCall = false;
+        return gate.promise;
+      })
+    };
+
+    const inst = makeInstance();
+
+    const rowA = document.createElement('div');
+    rowA.className = 'user-comment-row';
+    rowA.setAttribute('data-comment-id', 'A');
+    rowA.appendChild(Object.assign(document.createElement('div'), { className: 'user-comment' }));
+    const rowB = document.createElement('div');
+    rowB.className = 'user-comment-row';
+    rowB.setAttribute('data-comment-id', 'B');
+    rowB.appendChild(Object.assign(document.createElement('div'), { className: 'user-comment' }));
+    document.body.append(rowA, rowB);
+
+    const olderP = inst.scrollToComment('A', 'a.js', null);
+    const newerP = inst.scrollToComment('B', 'b.js', null);
+
+    oldGate.resolve();
+    await olderP;
+    expect(inst._scrollDiffTarget).not.toHaveBeenCalled();
+
+    newGate.resolve();
+    await newerP;
+    expect(inst._scrollDiffTarget).toHaveBeenCalledTimes(1);
+    expect(inst._scrollDiffTarget).toHaveBeenCalledWith(rowB);
+  });
+
+  it('scrollToExternalThread: an older call bails after a newer call supersedes it', async () => {
+    const oldGate = deferred();
+    const newGate = deferred();
+    let firstCall = true;
+    window.prManager = {
+      ensureFileBodyRendered: vi.fn(() => {
+        const gate = firstCall ? oldGate : newGate;
+        firstCall = false;
+        return gate.promise;
+      })
+    };
+
+    const inst = makeInstance();
+
+    const rowA = document.createElement('div');
+    rowA.className = 'external-comment-row';
+    rowA.setAttribute('data-thread-id', 'A');
+    rowA.setAttribute('data-source', 'github');
+    const rowB = document.createElement('div');
+    rowB.className = 'external-comment-row';
+    rowB.setAttribute('data-thread-id', 'B');
+    rowB.setAttribute('data-source', 'github');
+    document.body.append(rowA, rowB);
+
+    const olderP = inst.scrollToExternalThread('A', 'github', 'a.js', null);
+    const newerP = inst.scrollToExternalThread('B', 'github', 'b.js', null);
+
+    oldGate.resolve();
+    await olderP;
+    expect(inst._scrollDiffTarget).not.toHaveBeenCalled();
+
+    newGate.resolve();
+    await newerP;
+    expect(inst._scrollDiffTarget).toHaveBeenCalledTimes(1);
+    expect(inst._scrollDiffTarget).toHaveBeenCalledWith(rowB);
+  });
+
+  it('single scrollToFinding call still scrolls (no false bail with _navGen = 0)', async () => {
+    // With _navGen initialized to 0 (as the constructor does), a lone call
+    // bumps it to 1 and 1 === 1, so it must NOT bail. This guards against the
+    // ++undefined -> NaN bug, where NaN !== NaN would wrongly skip the scroll.
+    window.prManager = {
+      ensureFileBodyRendered: vi.fn(() => Promise.resolve())
+    };
+    const inst = makeInstance();
+
+    const finding = document.createElement('div');
+    finding.className = 'ai-suggestion';
+    finding.setAttribute('data-suggestion-id', 'F1');
+    document.body.appendChild(finding);
+
+    await inst.scrollToFinding('F1', 'a.js', null);
+
+    expect(inst._scrollDiffTarget).toHaveBeenCalledTimes(1);
+    expect(inst._scrollDiffTarget).toHaveBeenCalledWith(finding);
+  });
+});

--- a/tests/unit/ai-panel-scroll-render.test.js
+++ b/tests/unit/ai-panel-scroll-render.test.js
@@ -1,0 +1,49 @@
+// Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+// @vitest-environment jsdom
+
+/**
+ * Regression test for AIPanel scroll-to navigation: the target's lazy file
+ * body must be rendered (awaited) BEFORE the row lookup inside doScroll —
+ * otherwise the suggestion/comment row doesn't exist yet and the scroll
+ * silently misses on the first attempt. We bypass AIPanel's heavy DOM
+ * constructor with Object.create and exercise scrollToFinding directly.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+const { AIPanel } = require('../../public/js/components/AIPanel.js');
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+  window.prManager = undefined;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  delete window.prManager;
+});
+
+describe('AIPanel.scrollToFinding', () => {
+  it('awaits ensureFileBodyRendered before scrolling to the finding row', async () => {
+    const order = [];
+    const inst = Object.create(AIPanel.prototype);
+    // Mirror the real constructor so the latest-wins guard doesn't NaN-bail.
+    inst._navGen = 0;
+    inst.expandFileIfCollapsed = vi.fn(() => undefined);
+    inst._scrollDiffTarget = vi.fn(() => order.push('scroll'));
+    window.prManager = {
+      ensureFileBodyRendered: vi.fn(() => { order.push('render'); return Promise.resolve(); })
+    };
+
+    const finding = document.createElement('div');
+    finding.className = 'ai-suggestion';
+    finding.setAttribute('data-suggestion-id', 'F1');
+    document.body.appendChild(finding);
+
+    await inst.scrollToFinding('F1', 'a.js', null);
+
+    expect(window.prManager.ensureFileBodyRendered).toHaveBeenCalledWith('a.js');
+    // Render strictly precedes the lookup-and-scroll.
+    expect(order).toEqual(['render', 'scroll']);
+  });
+});

--- a/tests/unit/measure-file-header-height.test.js
+++ b/tests/unit/measure-file-header-height.test.js
@@ -1,0 +1,65 @@
+// Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+// @vitest-environment jsdom
+
+/**
+ * Unit tests for PRManager._measureFileHeaderHeight().
+ *
+ * Navigation lands targets at the top of the diff panel (block:'start') and
+ * relies on a scroll-margin-top of `--toolbar-height + --diff-file-header-height`
+ * (pr.css) to clear the sticky toolbar and sticky file header. This method
+ * keeps `--diff-file-header-height` in sync with the rendered header so the
+ * offset is correct; if no header exists yet, the CSS fallback applies.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+const { PRManager } = require('../../public/js/pr.js');
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+  document.documentElement.style.removeProperty('--diff-file-header-height');
+});
+
+afterEach(() => {
+  document.documentElement.style.removeProperty('--diff-file-header-height');
+});
+
+describe('PRManager._measureFileHeaderHeight', () => {
+  it('publishes the rendered header height into --diff-file-header-height', () => {
+    const wrapper = document.createElement('div');
+    wrapper.className = 'd2h-file-wrapper';
+    const header = document.createElement('div');
+    header.className = 'd2h-file-header';
+    wrapper.appendChild(header);
+    document.body.appendChild(wrapper);
+    // jsdom has no layout, so stub the measured height.
+    Object.defineProperty(header, 'offsetHeight', { configurable: true, value: 41 });
+
+    const pm = Object.create(PRManager.prototype);
+    pm._measureFileHeaderHeight();
+
+    expect(document.documentElement.style.getPropertyValue('--diff-file-header-height')).toBe('41px');
+  });
+
+  it('leaves the variable unset when no header is present (CSS fallback applies)', () => {
+    const pm = Object.create(PRManager.prototype);
+    pm._measureFileHeaderHeight();
+
+    expect(document.documentElement.style.getPropertyValue('--diff-file-header-height')).toBe('');
+  });
+
+  it('does not set the variable for a zero-height header', () => {
+    const wrapper = document.createElement('div');
+    wrapper.className = 'd2h-file-wrapper';
+    const header = document.createElement('div');
+    header.className = 'd2h-file-header';
+    wrapper.appendChild(header);
+    document.body.appendChild(wrapper);
+    Object.defineProperty(header, 'offsetHeight', { configurable: true, value: 0 });
+
+    const pm = Object.create(PRManager.prototype);
+    pm._measureFileHeaderHeight();
+
+    expect(document.documentElement.style.getPropertyValue('--diff-file-header-height')).toBe('');
+  });
+});

--- a/tests/unit/scroll-into-view-stable.test.js
+++ b/tests/unit/scroll-into-view-stable.test.js
@@ -1,0 +1,271 @@
+// Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+// @vitest-environment jsdom
+
+/**
+ * Unit tests for ScrollUtils.scrollIntoViewStable — the stable scroll used by
+ * tour navigation, AI-panel/comment navigation, suggestion navigation, and
+ * scroll-to-file. It must:
+ *   - render the target's lazy file body before scrolling (skipping
+ *     collapsed wrappers, which contribute no height),
+ *   - issue the caller's scroll, wait for the position to settle, then
+ *     re-issue an instant corrective scroll,
+ *   - keep correcting while lazy renders shift the layout (bounded),
+ *   - bail when the target leaves the DOM or the user scrolls.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+const {
+  scrollIntoViewStable,
+  MAX_CORRECTIONS
+} = require('../../public/js/utils/scroll-into-view.js');
+
+/**
+ * Build a target element, optionally inside a .d2h-file-wrapper.
+ * jsdom has no layout, so getBoundingClientRect is mocked; `state.top`
+ * drives what the helper sees.
+ */
+function makeTarget({ wrapped = true, collapsed = false } = {}) {
+  const state = { top: 500 };
+  let parent = document.body;
+  let wrapper = null;
+  if (wrapped) {
+    wrapper = document.createElement('div');
+    wrapper.className = 'd2h-file-wrapper' + (collapsed ? ' collapsed' : '');
+    document.body.appendChild(wrapper);
+    parent = wrapper;
+  }
+  const target = document.createElement('tr');
+  parent.appendChild(target);
+  vi.spyOn(target, 'getBoundingClientRect').mockImplementation(() => ({
+    top: state.top, bottom: state.top + 20, left: 0, right: 100, width: 100, height: 20
+  }));
+  target.scrollIntoView = vi.fn();
+  return { target, wrapper, state };
+}
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+  // Make frames immediate so settle waits resolve without real delays.
+  window.requestAnimationFrame = (cb) => setTimeout(cb, 0);
+  window.prManager = undefined;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  delete window.prManager;
+});
+
+describe('scrollIntoViewStable', () => {
+  it('renders the lazy body of the target file before scrolling', async () => {
+    const { target, wrapper } = makeTarget();
+    const calls = [];
+    window.prManager = {
+      ensureFileBodyRendered: vi.fn(async (arg) => { calls.push(['render', arg]); })
+    };
+    target.scrollIntoView = vi.fn(() => calls.push(['scroll']));
+
+    await scrollIntoViewStable(target, { behavior: 'smooth', block: 'center' });
+
+    expect(window.prManager.ensureFileBodyRendered).toHaveBeenCalledWith(wrapper);
+    // Render must come before any scroll.
+    expect(calls[0]).toEqual(['render', wrapper]);
+    expect(calls.some((c) => c[0] === 'scroll')).toBe(true);
+  });
+
+  it('skips body rendering for collapsed wrappers', async () => {
+    const { target } = makeTarget({ collapsed: true });
+    window.prManager = { ensureFileBodyRendered: vi.fn(async () => {}) };
+
+    await scrollIntoViewStable(target, {});
+
+    expect(window.prManager.ensureFileBodyRendered).not.toHaveBeenCalled();
+    expect(target.scrollIntoView).toHaveBeenCalled();
+  });
+
+  it('scrolls with the caller options, then probes once instantly when stable', async () => {
+    const { target } = makeTarget();
+
+    await scrollIntoViewStable(target, { behavior: 'smooth', block: 'center' });
+
+    // Initial scroll + one corrective probe that found no movement.
+    expect(target.scrollIntoView).toHaveBeenCalledTimes(2);
+    expect(target.scrollIntoView.mock.calls[0][0]).toEqual({ behavior: 'smooth', block: 'center' });
+    expect(target.scrollIntoView.mock.calls[1][0]).toEqual({ behavior: 'auto', block: 'center' });
+  });
+
+  it('re-corrects when the corrective scroll moves the target (layout shifted)', async () => {
+    const { target, state } = makeTarget();
+    let scrollCount = 0;
+    target.scrollIntoView = vi.fn(() => {
+      scrollCount += 1;
+      // Simulate the first corrective probe (call #2) snapping the target
+      // to a new position because lazy renders shifted the layout.
+      if (scrollCount === 2) state.top = 100;
+    });
+
+    await scrollIntoViewStable(target, { behavior: 'smooth', block: 'center' });
+
+    // initial + moved probe + stable probe
+    expect(target.scrollIntoView).toHaveBeenCalledTimes(3);
+  });
+
+  it('gives up after MAX_CORRECTIONS when layout never stabilizes', async () => {
+    const { target, state } = makeTarget();
+    target.scrollIntoView = vi.fn(() => { state.top -= 50; });
+
+    await scrollIntoViewStable(target, {});
+
+    expect(target.scrollIntoView).toHaveBeenCalledTimes(1 + MAX_CORRECTIONS);
+  });
+
+  it('does nothing for a disconnected target', async () => {
+    const target = document.createElement('tr');
+    target.scrollIntoView = vi.fn();
+
+    await scrollIntoViewStable(target, {});
+
+    expect(target.scrollIntoView).not.toHaveBeenCalled();
+  });
+
+  it('bails out without probing after the target is removed mid-settle', async () => {
+    const { target } = makeTarget();
+    target.scrollIntoView = vi.fn(() => {
+      // Detach right after the initial scroll, as a tour exit / re-render would.
+      target.remove();
+    });
+
+    await scrollIntoViewStable(target, {});
+
+    expect(target.scrollIntoView).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops correcting when the user scrolls (wheel input)', async () => {
+    const { target } = makeTarget();
+    target.scrollIntoView = vi.fn(() => {
+      window.dispatchEvent(new Event('wheel'));
+    });
+
+    await scrollIntoViewStable(target, {});
+
+    // Initial scroll only — the user's wheel cancels all corrections.
+    expect(target.scrollIntoView).toHaveBeenCalledTimes(1);
+  });
+
+  it('still scrolls when ensureFileBodyRendered rejects', async () => {
+    const { target } = makeTarget();
+    window.prManager = {
+      ensureFileBodyRendered: vi.fn(async () => { throw new Error('boom'); })
+    };
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await scrollIntoViewStable(target, {});
+
+    expect(target.scrollIntoView).toHaveBeenCalled();
+    expect(warn).toHaveBeenCalled();
+  });
+
+  it('skips body rendering for targets inside the file comments zone', async () => {
+    // File-level comment cards live in .file-comments-zone, which sits above
+    // the lazy body — rendering the body can't move them, so skip the cost.
+    const wrapper = document.createElement('div');
+    wrapper.className = 'd2h-file-wrapper';
+    const zone = document.createElement('div');
+    zone.className = 'file-comments-zone';
+    const target = document.createElement('div');
+    zone.appendChild(target);
+    wrapper.appendChild(zone);
+    document.body.appendChild(wrapper);
+    vi.spyOn(target, 'getBoundingClientRect').mockImplementation(() => ({
+      top: 500, bottom: 520, left: 0, right: 100, width: 100, height: 20
+    }));
+    target.scrollIntoView = vi.fn();
+    window.prManager = { ensureFileBodyRendered: vi.fn(async () => {}) };
+
+    await scrollIntoViewStable(target, {});
+
+    expect(window.prManager.ensureFileBodyRendered).not.toHaveBeenCalled();
+    expect(target.scrollIntoView).toHaveBeenCalled();
+  });
+
+  it('stops correcting when a scroll-intent key is pressed', async () => {
+    const { target } = makeTarget();
+    target.scrollIntoView = vi.fn(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+    });
+
+    await scrollIntoViewStable(target, {});
+
+    // Initial scroll only — the keypress expresses scroll intent.
+    expect(target.scrollIntoView).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps correcting for non-scroll keys', async () => {
+    const { target } = makeTarget();
+    let n = 0;
+    target.scrollIntoView = vi.fn(() => {
+      if (++n === 1) window.dispatchEvent(new KeyboardEvent('keydown', { key: 'a' }));
+    });
+
+    await scrollIntoViewStable(target, {});
+
+    // 'a' is not scroll intent — the corrective probe still runs.
+    expect(target.scrollIntoView).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not cancel when a scroll key is typed into a form field', async () => {
+    const { target } = makeTarget();
+    const input = document.createElement('textarea');
+    document.body.appendChild(input);
+    target.scrollIntoView = vi.fn(() => {
+      // Space inside a textarea means "type a space", not "scroll the page".
+      input.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true }));
+    });
+
+    await scrollIntoViewStable(target, {});
+
+    expect(target.scrollIntoView).toHaveBeenCalledTimes(2);
+  });
+
+  it('stops correcting on touchstart', async () => {
+    const { target } = makeTarget();
+    target.scrollIntoView = vi.fn(() => {
+      window.dispatchEvent(new Event('touchstart'));
+    });
+
+    await scrollIntoViewStable(target, {});
+
+    expect(target.scrollIntoView).toHaveBeenCalledTimes(1);
+  });
+
+  it('lets a newer scroll supersede an older in-flight one (latest-scroll-wins)', async () => {
+    const a = makeTarget();
+    const b = makeTarget();
+
+    // Start A, then B before A settles. B bumps the active generation, so A
+    // must bail out of its corrective probe instead of snapping back.
+    const pA = scrollIntoViewStable(a.target, { behavior: 'smooth' });
+    const pB = scrollIntoViewStable(b.target, { behavior: 'smooth' });
+    await Promise.all([pA, pB]);
+
+    // A: initial scroll only — superseded before its corrective probe.
+    expect(a.target.scrollIntoView).toHaveBeenCalledTimes(1);
+    // B: initial + one stable corrective probe.
+    expect(b.target.scrollIntoView).toHaveBeenCalledTimes(2);
+  });
+
+  it('removes every cancel listener after it resolves', async () => {
+    const { target } = makeTarget();
+    const added = [];
+    const removed = [];
+    vi.spyOn(window, 'addEventListener').mockImplementation((type) => added.push(type));
+    vi.spyOn(window, 'removeEventListener').mockImplementation((type) => removed.push(type));
+
+    await scrollIntoViewStable(target, {});
+
+    for (const type of ['wheel', 'touchstart', 'keydown']) {
+      expect(added.filter((t) => t === type)).toHaveLength(1);
+      expect(removed.filter((t) => t === type)).toHaveLength(1);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Since the large-PR perf change, expanded diff file bodies start as empty placeholders and only render real rows when they near the viewport. A plain `scrollIntoView()` therefore lands wrong on the first attempt: the browser computes the destination from placeholder heights, then bodies along the path render mid-scroll and shift the target away. This PR makes scroll-to stable for tour stops, AI suggestions, comments, external threads, and chat-line links.

## What changed

- **New `public/js/utils/scroll-into-view.js` (`scrollIntoViewStable`)** — renders the target's own lazy body first, issues the caller's smooth scroll, then waits for the target's viewport position to settle and re-issues an instant corrective scroll, looping (bounded) while lazy renders keep shifting layout. Wired into `tour-renderer`, `SuggestionNavigator`, `AIPanel`, `ChatPanel`, and `pr.js` (`scrollToContextFile`). Loaded via `pr.html` / `local.html`.
- **Latest-scroll-wins** — a module-level generation token so a newer stable scroll supersedes an older in-flight one instead of fighting it or snapping the viewport back to a stale target.
- **Consumer-level race guards** — `SuggestionNavigator._navGen` and `AIPanel._navGen` (on `scrollToFinding` / `scrollToComment` / `scrollToExternalThread`): a token captured before the lazy-render `await` and checked before scrolling, so a late-resolving older navigation bows out. (The utility guard claims generations in call-order; only the consumer knows a late call is navigation-stale.)
- **Form-field keypresses** no longer cancel the correction loop (Space/arrows in a textarea move the caret, not the page).
- **File-level comment cards** skip the unnecessary full diff-body render (they live above the lazy body, so rendering it can't move them).
- **Top alignment** — navigation now lands targets at the top of the diff panel (`block: 'start'`) just below the sticky toolbar + file header, via a `scroll-margin-top` of `--toolbar-height + --diff-file-header-height` (header height measured in JS). Suppressed during tours, which keep center alignment.

## Test plan

- New unit tests: `scroll-into-view-stable`, `SuggestionNavigator`, `ai-panel-scroll-render`, `ai-panel-scroll-race`, `measure-file-header-height` — covering the settle/correct loop, cancel listeners (wheel/touch/keydown + form-field discrimination), latest-wins (utility and both consumers), comments-zone skip, and header measurement.
- Full unit suite: **6675 passed** (199 files).
- E2E navigation specs (`ai-analysis-sidebar`, `external-comments`, `pr-page`, `chat-lines`): green — scroll-into-view / flash assertions confirm single navigations still land correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)