### PR TITLE
Clarify guided-tour toolbar button label by state

### DIFF
--- a/.changeset/tour-button-generate-label.md
+++ b/.changeset/tour-button-generate-label.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Label the guided-tour toolbar button "Generate guided tour" (instead of "Start guided tour (none available yet)") when no tour exists yet and auto-generation is off, since clicking it kicks off generation.

--- a/public/js/pr.js
+++ b/public/js/pr.js
@@ -1690,8 +1690,12 @@ class PRManager {
       label = 'Exit guided tour';
     } else if (this._tourStops && this._tourStops.length > 0) {
       label = 'Start guided tour';
+    } else if (this._toursAutoGenerate === false) {
+      // No stops yet and auto-generation is off: a click kicks off manual
+      // generation (see startOrToggleTour), so the verb is "Generate".
+      label = 'Generate guided tour';
     } else {
-      label = 'Start guided tour (none available yet)';
+      label = 'Guided tour (none available yet)';
     }
     btn.title = label;
     btn.setAttribute('aria-label', label);

--- a/tests/unit/pr-manager-tour.test.js
+++ b/tests/unit/pr-manager-tour.test.js
@@ -1023,3 +1023,39 @@ describe('PRManager toggle-click handlers', () => {
     expect(m.startOrToggleTour).not.toHaveBeenCalled();
   });
 });
+
+describe('PRManager._syncTourToolbarButton label', () => {
+  let m;
+  let btn;
+
+  beforeEach(() => {
+    btn = buildToolbar();
+    m = makeBareManager();
+  });
+
+  it('reads "Generate guided tour" when no stops exist and auto-generate is off', () => {
+    // Auto-generation off: clicking kicks off manual generation, so the verb
+    // is "Generate" rather than "Start".
+    m._tourStops = null;
+    m._toursAutoGenerate = false;
+    m._syncTourToolbarButton();
+    expect(btn.title).toBe('Generate guided tour');
+    expect(btn.getAttribute('aria-label')).toBe('Generate guided tour');
+  });
+
+  it('reads "(none available yet)" when no stops exist and auto-generate is on', () => {
+    // Auto-generation on: the tour is produced for us, so the inert button
+    // keeps its passive label.
+    m._tourStops = null;
+    m._toursAutoGenerate = true;
+    m._syncTourToolbarButton();
+    expect(btn.title).toBe('Guided tour (none available yet)');
+  });
+
+  it('reads "Start guided tour" once stops exist regardless of auto-generate', () => {
+    m._tourStops = [{ title: 's0' }];
+    m._toursAutoGenerate = false;
+    m._syncTourToolbarButton();
+    expect(btn.title).toBe('Start guided tour');
+  });
+});


### PR DESCRIPTION
## What

The guided-tour toolbar button (`_syncTourToolbarButton` in `public/js/pr.js`) read **"Start guided tour (none available yet)"** in two different no-tour states. That single label was misleading, so it now reflects what a click actually does:

- **No tour + auto-generation off** → clicking triggers manual generation → label is now **"Generate guided tour"**.
- **No tour + auto-generation on** → button is inert (a tour is being produced automatically) → dropped the false "Start" verb; now reads **"Guided tour (none available yet)"**.
- **Tour stops exist** → **"Start guided tour"** as before.

## Why

"Start" implied an action that either didn't exist (nothing to start) or wasn't what the click did (it generates). The new wording matches the button's actual behavior in each state.

## Notes for reviewers

- `_syncTourToolbarButton` is a shared `PRManager` method — Local mode patches `PRManager` but does not override it, so PR and Local modes both pick up the fix (no parallel change needed).
- Added unit coverage for all three label states in `tests/unit/pr-manager-tour.test.js`. All 72 tour/manual-start tests pass.
- Changeset included (`patch`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)