### PR TITLE
Fix stack analysis worktree config and sparse-checkout expansion

### DIFF
--- a/.changeset/fix-stack-analysis-worktree-template.md
+++ b/.changeset/fix-stack-analysis-worktree-template.md
@@ -1,0 +1,7 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Fix stack analysis ignoring a repo's configured worktree options. Per-PR worktrees created during a stack analysis now honor the repo's full worktree config instead of falling back to the defaults. This covers the `worktree_name_template` / `worktree_directory` naming and location (previously the default `{id}` naming and `~/.pair-review/worktrees`), and also threads through the repo's checkout script, checkout timeout, and sparse-checkout inheritance — matching the behavior of the non-stack PR setup path.
+
+Also fix stack analysis under-reviewing files in monorepo sparse-checkout repos. Per-PR stack worktrees inherit the trigger worktree's sparse-checkout layout, but the stack setup path never expanded that cone to include the PR's changed directories. The stored diff was unaffected (it is computed from commit objects, not the working tree), but the file-context and codebase-context analysis steps read files from disk and could silently analyze an incomplete checkout. Stack setup now expands the sparse cone for the PR's directories before analysis — except when a `checkout_script` is configured, in which case the script remains the sole owner of sparse-checkout setup (matching the non-stack path).

--- a/src/routes/stack-analysis.js
+++ b/src/routes/stack-analysis.js
@@ -19,7 +19,7 @@ const { normalizeRepository } = require('../utils/paths');
 const { mergeInstructions } = require('../utils/instructions');
 const { GitWorktreeManager } = require('../git/worktree');
 const { GitHubClient } = require('../github/client');
-const { getGitHubToken, resolveHostBinding, resolveBindingRepositoryFromPR, resolveLoadSkills, buildCouncilProviderOverrides } = require('../config');
+const { getGitHubToken, resolveHostBinding, resolveBindingRepositoryFromPR, resolveRepoOptions, resolveLoadSkills, buildCouncilProviderOverrides } = require('../config');
 const { setupStackPR } = require('../setup/stack-setup');
 const Analyzer = require('../ai/analyzer');
 const { getProviderClass, createProvider } = require('../ai/provider');
@@ -166,6 +166,7 @@ const defaults = {
   getGitHubToken,
   resolveHostBinding,
   resolveBindingRepositoryFromPR,
+  resolveRepoOptions,
   setupStackPR,
   Analyzer,
   getProviderClass,
@@ -205,8 +206,23 @@ async function executeStackAnalysis(params) {
   if (!state) return;
 
   try {
+    // 0. Resolve the config-binding key once. It drives both the per-repo
+    //    worktree config (just below) and the host binding (step 3). For
+    //    monorepo-style `url_pattern` configs this differs from the PR
+    //    identity `${owner}/${repo}`.
+    const bindingRepository = deps.resolveBindingRepositoryFromPR(owner, repo, config);
+    // Honor the repo's configured worktree options so stack worktrees match the
+    // non-stack path. This carries through:
+    //  - worktreeConfig (worktree_name_template / worktree_directory) so they
+    //    don't fall back to pair-review's default naming and location, and
+    //  - the checkout script + timeout and sparse-checkout inheritance used
+    //    during per-PR worktree creation (forwarded to createWorktreeForPR).
+    // These derive purely from file config, so DB repo_settings (pool config)
+    // are not needed here.
+    const { worktreeConfig, checkoutScript, checkoutTimeout } = deps.resolveRepoOptions(config, bindingRepository);
+
     // 1. Resolve repositoryPath from trigger worktree
-    const worktreeManager = new deps.GitWorktreeManager(db);
+    const worktreeManager = new deps.GitWorktreeManager(db, worktreeConfig || {});
     let repositoryPath;
     try {
       const owningRepoGit = await worktreeManager.resolveOwningRepo(triggerWorktreePath);
@@ -230,13 +246,13 @@ async function executeStackAnalysis(params) {
       logger.warn(`Bulk git fetch failed, will fetch per-PR: ${fetchError.message}`);
     }
 
-    // 3. Fetch all PR data from GitHub in parallel
-    // Use the per-repo binding so alt-host stack analyses target the right host.
-    // The PR identity (`${owner}/${repo}`) is used for DB rows and worktree
-    // identity. For host-binding lookups we MUST use the config-binding key,
-    // which differs from the PR identity for monorepo-style `url_pattern`
-    // configs (one `repos[...]` entry serves many captured owner/repo pairs).
-    const bindingRepository = deps.resolveBindingRepositoryFromPR(owner, repo, config);
+    // 3. Fetch all PR data from GitHub in parallel.
+    // `bindingRepository` (resolved in step 0) is the config-binding key. We use
+    // it — not the PR identity `${owner}/${repo}` — for host-binding lookups so
+    // alt-host stack analyses target the right host. The two differ for
+    // monorepo-style `url_pattern` configs (one `repos[...]` entry serves many
+    // captured owner/repo pairs). The PR identity is still used for DB rows and
+    // worktree identity.
     const stackBinding = deps.resolveHostBinding(bindingRepository, config);
     const githubToken = stackBinding.token;
     const prDataMap = new Map();
@@ -275,7 +291,16 @@ async function executeStackAnalysis(params) {
 
         const prInfo = { owner, repo, number: prNum };
         const { path: perPRWorktreePath } = await worktreeManager.createWorktreeForPR(
-          prInfo, prData, repositoryPath
+          prInfo, prData, repositoryPath,
+          {
+            checkoutScript,
+            checkoutTimeout,
+            // No checkout script → inherit the trigger worktree's sparse-checkout
+            // layout instead of a full checkout from the repo root. When a script is
+            // configured it sets up sparse-checkout itself, so worktreeSourcePath is
+            // unused (and omitted) in that case.
+            ...(checkoutScript ? {} : { worktreeSourcePath: triggerWorktreePath }),
+          }
         );
         worktreePathMap.set(prNum, perPRWorktreePath);
       } catch (wtError) {
@@ -307,6 +332,7 @@ async function executeStackAnalysis(params) {
           worktreePath: worktreePathMap.get(prNum),
           analysisConfig, stackAnalysisId, state,
           githubToken, binding: stackBinding, prData: prDataMap.get(prNum),
+          worktreeConfig, checkoutScript,
           onAnalysisIdReady
         }).then(result => {
           state.prStatuses.set(prNum, {
@@ -346,6 +372,7 @@ async function executeStackAnalysis(params) {
 async function analyzeStackPR(deps, db, config, {
   owner, repo, repository, bindingRepository, prNum, worktreePath,
   analysisConfig, stackAnalysisId, state, githubToken, binding, prData,
+  worktreeConfig, checkoutScript,
   onAnalysisIdReady
 }) {
   // Build a GitHubClient for analyzer-side dedup pre-fetch. The stack
@@ -357,12 +384,17 @@ async function analyzeStackPR(deps, db, config, {
   if (stackGithubClient) {
     logger.debug(`analyzer githubClient wired for ${owner}/${repo}#${prNum} (stack)`);
   }
-  // 1. Setup PR (generates diff, stores metadata)
-  const worktreeManager = new deps.GitWorktreeManager(db);
+  // 1. Setup PR (expands sparse-checkout, generates diff, stores metadata)
+  // Construct with the repo's resolved worktreeConfig for consistency with the
+  // creation manager. setupStackPR operates against the explicit worktreePath
+  // (diff generation + sparse-cone expansion), so the worktreeConfig naming /
+  // directory options are not exercised today — threading them through guards
+  // against silent latent regressions if that changes.
+  const worktreeManager = new deps.GitWorktreeManager(db, worktreeConfig || {});
   await deps.setupStackPR({
     db, owner, repo, prNumber: prNum,
     githubToken, binding, bindingRepository,
-    worktreePath, worktreeManager, prData
+    worktreePath, worktreeManager, prData, checkoutScript
   });
 
   // 2. Fetch prMetadata from DB

--- a/src/setup/stack-setup.js
+++ b/src/setup/stack-setup.js
@@ -32,9 +32,12 @@ const logger = require('../utils/logger');
  * @param {string} params.worktreePath - Path to the per-PR worktree
  * @param {import('../git/worktree').GitWorktreeManager} params.worktreeManager - Worktree manager instance
  * @param {Object} [params.prData] - Pre-fetched PR data from GitHub (skips API call when provided)
+ * @param {string|null} [params.checkoutScript] - Repo's configured checkout script, if any. When set,
+ *   the script owns all sparse-checkout setup, so built-in sparse-cone expansion is skipped (mirrors
+ *   the non-stack `pr-setup.js` contract).
  * @returns {Promise<{ reviewId: number, prMetadata: Object, prData: Object, isNew: boolean }>}
  */
-async function setupStackPR({ db, owner, repo, prNumber, githubToken, binding, bindingRepository, worktreePath, worktreeManager, prData: prefetchedPRData }) {
+async function setupStackPR({ db, owner, repo, prNumber, githubToken, binding, bindingRepository, worktreePath, worktreeManager, prData: prefetchedPRData, checkoutScript }) {
   // `bindingRepository` is accepted so callers (e.g. `executeStackAnalysis`)
   // can thread the resolved config-binding key through to any downstream
   // per-repo lookups added in this function. Currently unused inside this
@@ -56,13 +59,38 @@ async function setupStackPR({ db, owner, repo, prNumber, githubToken, binding, b
   const prFiles = await githubClient.fetchPullRequestFiles(owner, repo, prNumber);
   logger.info(`PR #${prNumber} has ${prFiles.length} changed files`);
 
-  // 3. Generate diff in the worktree (SHA-based, works after checkout)
+  // 3. Expand sparse-checkout for PR-changed directories (mirrors pr-setup.js).
+  // Stack worktrees inherit the trigger worktree's sparse-checkout layout, which
+  // may omit directories a sibling PR touches. The SHA-based diff below reads
+  // commit objects (not the working tree) so it is unaffected, but the later
+  // file-context and codebase-context analysis steps DO read files from disk —
+  // an unexpanded cone would silently under-review those files. Expanding here
+  // ensures every PR-changed directory is present on disk.
+  //
+  // IMPORTANT: when a checkout_script is configured the script owns all
+  // sparse-checkout setup, so we must NOT auto-expand — doing so would override
+  // the cone the script just configured. This matches the pr-setup.js contract.
+  if (!checkoutScript && prFiles.length > 0) {
+    const isSparse = await worktreeManager.isSparseCheckoutEnabled(worktreePath);
+    if (isSparse) {
+      try {
+        const addedDirs = await worktreeManager.ensurePRDirectoriesInSparseCheckout(worktreePath, prFiles);
+        if (addedDirs.length > 0) {
+          logger.info(`Stack PR #${prNumber}: expanded sparse-checkout for: ${addedDirs.join(', ')}`);
+        }
+      } catch (sparseError) {
+        logger.warn(`Stack PR #${prNumber}: sparse-checkout expansion failed (non-fatal): ${sparseError.message}`);
+      }
+    }
+  }
+
+  // 4. Generate diff in the worktree (SHA-based, works after checkout)
   const diff = await worktreeManager.generateUnifiedDiff(worktreePath, prData);
 
-  // 4. Get changed files with stats
+  // 5. Get changed files with stats
   const changedFiles = await worktreeManager.getChangedFiles(worktreePath, prData);
 
-  // 5. Store via storePRData (creates/updates pr_metadata, reviews, worktrees records)
+  // 6. Store via storePRData (creates/updates pr_metadata, reviews, worktrees records)
   const prInfo = { owner, repo, number: prNumber };
   const { isNewReview, reviewId } = await storePRData(db, prInfo, prData, diff, changedFiles, worktreePath);
 

--- a/tests/unit/stack-analysis-binding-repo.test.js
+++ b/tests/unit/stack-analysis-binding-repo.test.js
@@ -2,12 +2,20 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
 /**
- * Unit tests verifying that `executeStackAnalysis` resolves the
- * `repos[...]` config-binding key (via `resolveBindingRepositoryFromPR`)
- * before calling `resolveHostBinding`. This is required so monorepo
- * `url_pattern` configs route alt-host stack analyses through the
- * correct token / api_host instead of the bare `${owner}/${repo}` key
- * (which would miss a monorepo-style binding entirely).
+ * Unit tests for the config-derived setup wiring in `executeStackAnalysis`:
+ *
+ *  1. Binding resolution — `executeStackAnalysis` resolves the `repos[...]`
+ *     config-binding key (via `resolveBindingRepositoryFromPR`) before calling
+ *     `resolveHostBinding`, so monorepo `url_pattern` configs route alt-host
+ *     stack analyses through the correct token / api_host instead of the bare
+ *     `${owner}/${repo}` key (which would miss a monorepo-style binding).
+ *
+ *  2. Worktree config — `executeStackAnalysis` resolves the repo's worktree
+ *     options (via `resolveRepoOptions`, keyed off the binding repository) and
+ *     constructs the worktree-creating `GitWorktreeManager` with them. This
+ *     guards a regression where stack worktrees ignored the repo's configured
+ *     `worktree_name_template` / `worktree_directory` and fell back to
+ *     pair-review's default naming ('{id}') and location (~/.pair-review/worktrees).
  *
  * Mirrors the test patterns established in `stack-orchestrator.test.js`:
  * vi.spyOn on dependency modules loaded before the module under test,
@@ -82,20 +90,26 @@ const { executeStackAnalysis, activeStackAnalyses } =
 // ---------------------------------------------------------------------------
 
 function createMockDeps(overrides = {}) {
+  // Shared owning-repo handle returned by resolveOwningRepo on every instance.
+  // Its `.raw` resolves the repo toplevel used to derive repositoryPath.
   const mockOwningRepoGit = {
     raw: vi.fn().mockResolvedValue('/tmp/repos/test-repo\n'),
-  };
-  const mockWorktreeManagerInstance = {
-    resolveOwningRepo: vi.fn().mockResolvedValue(mockOwningRepoGit),
-    createWorktreeForPR: vi.fn().mockImplementation(async (prInfo) => ({
-      path: `/tmp/worktrees/pr-${prInfo.number}`, id: `wt-${prInfo.number}`
-    })),
   };
 
   return {
     execSync: vi.fn().mockReturnValue('abc123def\n'),
+    // Each construction yields a FRESH instance with its OWN spies. The
+    // production flow constructs TWO managers (the creation manager in
+    // executeStackAnalysis and a per-PR manager in analyzeStackPR); fresh
+    // instances let tests tie config + create-call assertions to the specific
+    // instance that actually created the worktree.
     GitWorktreeManager: vi.fn().mockImplementation(function () {
-      Object.assign(this, mockWorktreeManagerInstance);
+      this.resolveOwningRepo = vi.fn().mockResolvedValue(mockOwningRepoGit);
+      this.createWorktreeForPR = vi.fn().mockImplementation(async (prInfo) => ({
+        path: `/tmp/worktrees/pr-${prInfo.number}`, id: `wt-${prInfo.number}`,
+      }));
+      this.generateUnifiedDiff = vi.fn().mockResolvedValue('diff');
+      this.getChangedFiles = vi.fn().mockResolvedValue([]);
     }),
     GitHubClient: vi.fn().mockImplementation(function () {
       this.fetchPullRequest = vi.fn().mockImplementation(async (_owner, _repo, prNum) => ({
@@ -130,9 +144,24 @@ function createMockDeps(overrides = {}) {
     launchCouncilAnalysis: vi.fn(),
     runExecutableAnalysis: vi.fn(),
     waitForAnalysisCompletion: vi.fn().mockResolvedValue({ status: 'completed', suggestionsCount: 3 }),
-    _mockOwningRepoGit: mockOwningRepoGit,
-    _worktreeManagerInstance: mockWorktreeManagerInstance,
     ...overrides,
+  };
+}
+
+/**
+ * Locate the GitWorktreeManager construction whose instance actually called
+ * createWorktreeForPR, and return both its constructor options (2nd ctor arg)
+ * and the args of its create call. Maps instance→construction index via
+ * vitest's mock.results[i].value.
+ */
+function findCreationConstruction(GitWorktreeManagerMock) {
+  const idx = GitWorktreeManagerMock.mock.results.findIndex(
+    (r) => r && r.value && r.value.createWorktreeForPR && r.value.createWorktreeForPR.mock.calls.length > 0
+  );
+  expect(idx).toBeGreaterThanOrEqual(0);
+  return {
+    ctorOptions: GitWorktreeManagerMock.mock.calls[idx][1],
+    createArgs: GitWorktreeManagerMock.mock.results[idx].value.createWorktreeForPR.mock.calls[0],
   };
 }
 
@@ -332,5 +361,172 @@ describe('executeStackAnalysis — bindingRepository resolution', () => {
     const setupArgs = deps.setupStackPR.mock.calls[0][0];
     // Real resolver returns lowercased `${owner}/${repo}` fallback.
     expect(setupArgs.bindingRepository).toBe('acme/widget-a');
+  });
+
+  it('threads the repo checkout script into setupStackPR so it can skip built-in sparse expansion', async () => {
+    // setupStackPR owns the per-PR sparse-cone expansion. It must receive the
+    // repo's checkout script so it can honor the "script owns the cone" contract
+    // and skip auto-expansion when a script is configured.
+    const config = {
+      repos: {
+        'acme/widget-a': {
+          checkout_script: '/scripts/checkout.sh',
+          checkout_timeout_seconds: 120,
+        },
+      },
+    };
+
+    const deps = createMockDeps();
+    const params = createDefaultParams(deps, { config });
+    initActiveState(params.stackAnalysisId, params.prNumbers);
+
+    await executeStackAnalysis(params);
+
+    expect(deps.setupStackPR).toHaveBeenCalled();
+    const setupArgs = deps.setupStackPR.mock.calls[0][0];
+    expect(setupArgs.checkoutScript).toBe('/scripts/checkout.sh');
+  });
+
+  it('threads a null checkout script into setupStackPR when none is configured (expansion path enabled)', async () => {
+    const deps = createMockDeps();
+    const params = createDefaultParams(deps, { config: {} });
+    initActiveState(params.stackAnalysisId, params.prNumbers);
+
+    await executeStackAnalysis(params);
+
+    expect(deps.setupStackPR).toHaveBeenCalled();
+    const setupArgs = deps.setupStackPR.mock.calls[0][0];
+    // No script configured → null/undefined, so setupStackPR runs its built-in
+    // sparse-cone expansion for inherited worktrees.
+    expect(setupArgs.checkoutScript == null).toBe(true);
+  });
+
+  // -------------------------------------------------------------------------
+  // Worktree config wiring (regression: stack worktrees ignored the repo's
+  // configured worktree_name_template / worktree_directory).
+  // -------------------------------------------------------------------------
+
+  it('constructs the worktree manager with the repo\'s configured template + directory', async () => {
+    // Repo configures a custom worktree directory and name template. Stack
+    // analysis MUST honor them rather than falling back to the defaults.
+    const config = {
+      repos: {
+        'acme/widget-a': {
+          worktree_directory: '/custom/worktrees',
+          worktree_name_template: '{owner}-{repo}-{pr_number}',
+        },
+      },
+    };
+
+    const deps = createMockDeps();
+    const params = createDefaultParams(deps, { config });
+    initActiveState(params.stackAnalysisId, params.prNumbers);
+
+    await executeStackAnalysis(params);
+
+    // Tie the assertion to the instance that ACTUALLY created the worktree, not
+    // just "some construction". The creating manager must have been built with
+    // the resolved worktreeConfig, not the defaults.
+    const { ctorOptions } = findCreationConstruction(deps.GitWorktreeManager);
+    expect(ctorOptions).toEqual({
+      worktreeBaseDir: '/custom/worktrees',
+      nameTemplate: '{owner}-{repo}-{pr_number}',
+    });
+  });
+
+  it('resolves worktree options off the binding key for monorepo url_pattern configs', async () => {
+    // For a monorepo config, the worktree options live under the binding key
+    // ("acme-monorepo"), NOT the PR identity ("acme/widget-a"). The fix keys
+    // resolveRepoOptions off bindingRepository, so these must be applied.
+    const config = {
+      repos: {
+        'acme-monorepo': {
+          // api_host is required for resolveBindingRepositoryFromPR's
+          // url_pattern probe to fire (it builds a synthetic URL from it).
+          api_host: 'https://althost.example/api/v3',
+          token: 'monorepo-token',
+          url_pattern: '^https?://[^/]+/(?<owner>[^/]+)/(?<repo>[^/]+)/pull/\\d+',
+          worktree_directory: '/mono/worktrees',
+          worktree_name_template: 'stack-{pr_number}',
+        },
+      },
+    };
+
+    const deps = createMockDeps();
+    const params = createDefaultParams(deps, { config });
+    initActiveState(params.stackAnalysisId, params.prNumbers);
+
+    await executeStackAnalysis(params);
+
+    const { ctorOptions } = findCreationConstruction(deps.GitWorktreeManager);
+    expect(ctorOptions).toEqual({
+      worktreeBaseDir: '/mono/worktrees',
+      nameTemplate: 'stack-{pr_number}',
+    });
+  });
+
+  it('falls back to an empty worktree config when the repo configures none', async () => {
+    const deps = createMockDeps();
+    const params = createDefaultParams(deps, { config: {} });
+    initActiveState(params.stackAnalysisId, params.prNumbers);
+
+    await executeStackAnalysis(params);
+
+    // With no configured worktree options the creating manager receives `{}`,
+    // leaving the GitWorktreeManager constructor to apply its own defaults.
+    const { ctorOptions } = findCreationConstruction(deps.GitWorktreeManager);
+    expect(ctorOptions).toEqual({});
+  });
+
+  // -------------------------------------------------------------------------
+  // Checkout-option forwarding (regression: stack worktree creation dropped the
+  // repo's checkout script / timeout and sparse-checkout inheritance).
+  // -------------------------------------------------------------------------
+
+  it('forwards the repo checkout script + timeout (and omits worktreeSourcePath) when a script is configured', async () => {
+    // When a checkout script is configured, the worktree engine ignores
+    // worktreeSourcePath (the script sets up sparse-checkout itself), so the
+    // creation call must pass checkoutScript/checkoutTimeout but NOT
+    // worktreeSourcePath.
+    const config = {
+      repos: {
+        'acme/widget-a': {
+          checkout_script: '/scripts/checkout.sh',
+          checkout_timeout_seconds: 120,
+        },
+      },
+    };
+
+    const deps = createMockDeps();
+    const params = createDefaultParams(deps, { config });
+    initActiveState(params.stackAnalysisId, params.prNumbers);
+
+    await executeStackAnalysis(params);
+
+    const { createArgs } = findCreationConstruction(deps.GitWorktreeManager);
+    // createWorktreeForPR(prInfo, prData, repositoryPath, options) — options is 4th.
+    expect(createArgs[3]).toMatchObject({
+      checkoutScript: '/scripts/checkout.sh',
+      checkoutTimeout: 120000,
+    });
+    expect(createArgs[3]).not.toHaveProperty('worktreeSourcePath');
+  });
+
+  it('forwards default checkout options and the trigger worktree as the sparse-checkout source when no script is configured', async () => {
+    // No checkout script → checkoutScript is null and checkoutTimeout defaults
+    // to 300000 (5 min). worktreeSourcePath is the trigger worktree path so the
+    // per-PR worktree inherits its sparse-checkout layout.
+    const deps = createMockDeps();
+    const params = createDefaultParams(deps, { config: {} });
+    initActiveState(params.stackAnalysisId, params.prNumbers);
+
+    await executeStackAnalysis(params);
+
+    const { createArgs } = findCreationConstruction(deps.GitWorktreeManager);
+    expect(createArgs[3]).toMatchObject({
+      checkoutScript: null,
+      checkoutTimeout: 300000,
+      worktreeSourcePath: '/tmp/worktree/test-repo',
+    });
   });
 });

--- a/tests/unit/stack-setup.test.js
+++ b/tests/unit/stack-setup.test.js
@@ -80,6 +80,10 @@ describe('setupStackPR', () => {
         { filename: 'src/index.js', additions: 5, deletions: 2 },
         { filename: 'src/utils.js', additions: 20, deletions: 0 },
       ]),
+      // Default to non-sparse so the expansion path is a no-op for existing
+      // tests; sparse-specific tests override these per-case.
+      isSparseCheckoutEnabled: vi.fn().mockResolvedValue(false),
+      ensurePRDirectoriesInSparseCheckout: vi.fn().mockResolvedValue([]),
     };
   });
 
@@ -181,5 +185,84 @@ describe('setupStackPR', () => {
     mockStorePRData.mockRejectedValue(new Error('DB write failed'));
 
     await expect(setupStackPR(defaultParams())).rejects.toThrow('DB write failed');
+  });
+
+  // -------------------------------------------------------------------------
+  // Sparse-checkout expansion (regression: stack worktrees inherit the trigger
+  // worktree's sparse cone but never expanded it for the PR's directories, so
+  // downstream file-context / codebase-context analysis read an incomplete
+  // on-disk checkout and silently under-reviewed sibling-PR files).
+  // -------------------------------------------------------------------------
+
+  it('expands sparse-checkout for PR directories when sparse and no checkout script', async () => {
+    mockWorktreeManager.isSparseCheckoutEnabled.mockResolvedValue(true);
+    mockWorktreeManager.ensurePRDirectoriesInSparseCheckout.mockResolvedValue(['src']);
+
+    await setupStackPR(defaultParams());
+
+    expect(mockWorktreeManager.isSparseCheckoutEnabled)
+      .toHaveBeenCalledWith('/tmp/worktree/test-repo');
+    expect(mockWorktreeManager.ensurePRDirectoriesInSparseCheckout)
+      .toHaveBeenCalledWith('/tmp/worktree/test-repo', fakePRFiles);
+  });
+
+  it('expands the sparse cone BEFORE generating the diff (downstream disk reads)', async () => {
+    mockWorktreeManager.isSparseCheckoutEnabled.mockResolvedValue(true);
+    const callOrder = [];
+    mockWorktreeManager.ensurePRDirectoriesInSparseCheckout.mockImplementation(async () => {
+      callOrder.push('expand');
+      return ['src'];
+    });
+    mockWorktreeManager.generateUnifiedDiff.mockImplementation(async () => {
+      callOrder.push('diff');
+      return 'diff';
+    });
+
+    await setupStackPR(defaultParams());
+
+    expect(callOrder).toEqual(['expand', 'diff']);
+  });
+
+  it('does NOT expand sparse-checkout when a checkout script is configured (script owns the cone)', async () => {
+    mockWorktreeManager.isSparseCheckoutEnabled.mockResolvedValue(true);
+
+    await setupStackPR({ ...defaultParams(), checkoutScript: '/scripts/checkout.sh' });
+
+    // The script owns sparse-checkout setup — we must not touch it at all.
+    expect(mockWorktreeManager.isSparseCheckoutEnabled).not.toHaveBeenCalled();
+    expect(mockWorktreeManager.ensurePRDirectoriesInSparseCheckout).not.toHaveBeenCalled();
+  });
+
+  it('skips expansion when the worktree is not sparse', async () => {
+    mockWorktreeManager.isSparseCheckoutEnabled.mockResolvedValue(false);
+
+    await setupStackPR(defaultParams());
+
+    expect(mockWorktreeManager.isSparseCheckoutEnabled).toHaveBeenCalled();
+    expect(mockWorktreeManager.ensurePRDirectoriesInSparseCheckout).not.toHaveBeenCalled();
+  });
+
+  it('skips expansion when the PR has no changed files', async () => {
+    vi.spyOn(clientModule.GitHubClient.prototype, 'fetchPullRequestFiles')
+      .mockResolvedValue([]);
+    mockWorktreeManager.isSparseCheckoutEnabled.mockResolvedValue(true);
+
+    await setupStackPR(defaultParams());
+
+    expect(mockWorktreeManager.isSparseCheckoutEnabled).not.toHaveBeenCalled();
+    expect(mockWorktreeManager.ensurePRDirectoriesInSparseCheckout).not.toHaveBeenCalled();
+  });
+
+  it('treats a sparse-checkout expansion failure as non-fatal', async () => {
+    mockWorktreeManager.isSparseCheckoutEnabled.mockResolvedValue(true);
+    mockWorktreeManager.ensurePRDirectoriesInSparseCheckout
+      .mockRejectedValue(new Error('sparse-checkout add failed'));
+
+    // Setup must still complete and persist the PR despite the expansion error.
+    const result = await setupStackPR(defaultParams());
+
+    expect(result.reviewId).toBe(101);
+    expect(mockWorktreeManager.generateUnifiedDiff).toHaveBeenCalled();
+    expect(mockStorePRData).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

Brings stack analysis into parity with the non-stack PR setup path (`pr-setup.js`) in two related ways:

1. **Worktree config wiring** — per-PR worktrees created during a stack analysis now honor the repo's configured worktree options (`resolveRepoOptions`, keyed off the binding repository) instead of falling back to pair-review's defaults. Covers `worktree_name_template` / `worktree_directory` naming + location, and threads through the checkout script, checkout timeout, and sparse-checkout inheritance (`worktreeSourcePath`) used during worktree creation.

2. **Sparse-checkout expansion** — stack worktrees inherit the trigger worktree's sparse-checkout layout, but the stack setup path never expanded that cone to include the PR's changed directories.

## The sparse-checkout bug

`generateUnifiedDiff` / `getChangedFiles` diff `baseSha...headSha` against commit objects, so the **stored diff is unaffected**. The regression is subtler: the **Level 2 (file-context)** and **Level 3 (codebase-context)** analysis steps read files from disk. In a monorepo stack, a sibling PR that touches directories outside the trigger worktree's sparse patterns could be analyzed from an incomplete on-disk checkout — silently under-reviewing those files.

`setupStackPR` now expands the sparse cone for the PR's directories **before** any downstream disk read — **except** when a `checkout_script` is configured, in which case the script remains the sole owner of sparse-checkout setup (matching the `!checkoutScript` guard in `pr-setup.js`).

## Changes

- `src/routes/stack-analysis.js` — thread `checkoutScript` through `executeStackAnalysis` → `analyzeStackPR` → `setupStackPR`.
- `src/setup/stack-setup.js` — accept `checkoutScript`; expand the sparse cone (reusing the already-fetched `prFiles`) before diff generation, guarded by `!checkoutScript`, a sparse-enabled check, and treated as non-fatal on error.

## Tests

- `tests/unit/stack-setup.test.js` — sparse-cone expansion: expands before diff when sparse + no script, skips when a script is configured, skips when non-sparse, skips when no changed files, and non-fatal on expansion failure.
- `tests/unit/stack-analysis-binding-repo.test.js` — `checkoutScript` threading (script-configured and null cases).

All 69 stack-related unit tests pass (run under Node 24 to match the app's better-sqlite3 ABI).

## Mode parity

Stack analysis is PR-mode-only; the non-stack PR path (`pr-setup.js`) already had this behavior, so this brings the stack path up to parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)