### PR TITLE
Add copy button to AI review suggestions

### DIFF
--- a/.changeset/add-suggestion-copy-button.md
+++ b/.changeset/add-suggestion-copy-button.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Add a copy button for AI review suggestions that copies suggestion details as Markdown.

--- a/public/css/pr.css
+++ b/public/css/pr.css
@@ -2267,10 +2267,12 @@ tr.newly-expanded .d2h-code-line-ctn {
   position: relative;
   display: flex;
   align-items: center;
+  gap: 4px;
   flex-shrink: 0;
 }
 
-.btn-reasoning-toggle {
+.btn-reasoning-toggle,
+.btn-suggestion-copy {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -2285,10 +2287,22 @@ tr.newly-expanded .d2h-code-line-ctn {
   transition: all 0.15s ease;
 }
 
-.btn-reasoning-toggle:hover {
+.btn-reasoning-toggle:hover,
+.btn-suggestion-copy:hover {
   color: var(--color-reasoning-hover);
   background: var(--color-reasoning-hover-bg);
   border-color: var(--color-reasoning-hover-border);
+}
+
+.btn-suggestion-copy.copied {
+  color: var(--color-success, #1a7f37);
+  background: var(--color-success-subtle, rgba(46, 160, 67, 0.1));
+  border-color: var(--color-success, #1a7f37);
+}
+
+.btn-suggestion-copy.copy-failed {
+  color: var(--color-danger, #cf222e);
+  border-color: var(--color-danger, #cf222e);
 }
 
 .btn-reasoning-toggle.active {
@@ -2411,7 +2425,8 @@ tr.newly-expanded .d2h-code-line-ctn {
   gap: 4px;
 }
 
-.btn-reasoning-toggle.collapsed-reasoning {
+.btn-reasoning-toggle.collapsed-reasoning,
+.btn-suggestion-copy.collapsed-copy {
   width: 24px;
   height: 24px;
   border-radius: 4px;

--- a/public/js/modules/file-comment-manager.js
+++ b/public/js/modules/file-comment-manager.js
@@ -448,6 +448,10 @@ class FileCommentManager {
     // Use JSON.stringify to preserve newlines and special characters (matches line-level suggestions)
     card.dataset.originalBody = JSON.stringify(suggestion.body || '');
     card.dataset.formattedBody = JSON.stringify(suggestion.formattedBody || '');
+    card.dataset.title = suggestion.title || '';
+    card.dataset.type = suggestion.type || suggestion.category || '';
+    card.dataset.severity = suggestion.severity || '';
+    card.dataset.reasoning = JSON.stringify(suggestion.reasoning || []);
 
     // Store target info on the card for reliable retrieval in getFileAndLineInfo
     // File-level suggestions don't have line numbers, just the file name
@@ -494,6 +498,7 @@ class FileCommentManager {
           <span class="ai-title">${this.escapeHtml(suggestion.title || '')}</span>
         </div>
         <div class="ai-suggestion-header-right">
+          ${window.SuggestionUI?.renderSuggestionCopyButton ? window.SuggestionUI.renderSuggestionCopyButton() : ''}
           ${suggestion.reasoning && suggestion.reasoning.length > 0 ? `
           <button class="btn-reasoning-toggle" title="View reasoning" data-suggestion-id="${suggestion.id}" data-reasoning="${encodeURIComponent(JSON.stringify(suggestion.reasoning))}">
             <svg viewBox="0 0 24 24" width="14" height="14" fill="currentColor"><path d="M21.33 12.91c.09 1.55-.62 3.04-1.89 3.95l.77 1.49c.23.45.26.98.06 1.45c-.19.47-.58.84-1.06 1l-.79.25a1.69 1.69 0 0 1-1.86-.55L14.44 18c-.89-.15-1.73-.53-2.44-1.1c-.5.15-1 .23-1.5.23c-.88 0-1.76-.27-2.5-.79c-.53.16-1.07.23-1.62.22c-.79.01-1.57-.15-2.3-.45a4.1 4.1 0 0 1-2.43-3.61c-.08-.72.04-1.45.35-2.11c-.29-.75-.32-1.57-.07-2.33C2.3 7.11 3 6.32 3.87 5.82c.58-1.69 2.21-2.82 4-2.7c1.6-1.5 4.05-1.66 5.83-.37c.42-.11.86-.17 1.3-.17c1.36-.03 2.65.57 3.5 1.64c2.04.53 3.5 2.35 3.58 4.47c.05 1.11-.25 2.2-.86 3.13c.07.36.11.72.11 1.09m-5-1.41c.57.07 1.02.5 1.02 1.07a1 1 0 0 1-1 1h-.63c-.32.9-.88 1.69-1.62 2.29c.25.09.51.14.77.21c5.13-.07 4.53-3.2 4.53-3.25a2.59 2.59 0 0 0-2.69-2.49a1 1 0 0 1-1-1a1 1 0 0 1 1-1c1.23.03 2.41.49 3.33 1.3c.05-.29.08-.59.08-.89c-.06-1.24-.62-2.32-2.87-2.53c-1.25-2.96-4.4-1.32-4.4-.4c-.03.23.21.72.25.75a1 1 0 0 1 1 1c0 .55-.45 1-1 1c-.53-.02-1.03-.22-1.43-.56c-.48.31-1.03.5-1.6.56c-.57.05-1.04-.35-1.07-.9a.97.97 0 0 1 .88-1.1c.16-.02.94-.14.94-.77c0-.66.25-1.29.68-1.79c-.92-.25-1.91.08-2.91 1.29C6.75 5 6 5.25 5.45 7.2C4.5 7.67 4 8 3.78 9c1.08-.22 2.19-.13 3.22.25c.5.19.78.75.59 1.29c-.19.52-.77.78-1.29.59c-.73-.32-1.55-.34-2.3-.06c-.32.27-.32.83-.32 1.27c0 .74.37 1.43 1 1.83c.53.27 1.12.41 1.71.4q-.225-.39-.39-.81a1.038 1.038 0 0 1 1.96-.68c.4 1.14 1.42 1.92 2.62 2.05c1.37-.07 2.59-.88 3.19-2.13c.23-1.38 1.34-1.5 2.56-1.5m2 7.47l-.62-1.3l-.71.16l1 1.25zm-4.65-8.61a1 1 0 0 0-.91-1.03c-.71-.04-1.4.2-1.93.67c-.57.58-.87 1.38-.84 2.19a1 1 0 0 0 1 1c.57 0 1-.45 1-1c0-.27.07-.54.23-.76c.12-.1.27-.15.43-.15c.55.03 1.02-.38 1.02-.92"/></svg>
@@ -508,6 +513,7 @@ class FileCommentManager {
         <span class="collapsed-text">${isAdopted ? 'Suggestion adopted' : 'Hidden AI suggestion'}</span>
         <span class="collapsed-title">${this.escapeHtml(suggestion.title || '')}</span>
         <div class="ai-suggestion-header-right">
+          ${window.SuggestionUI?.renderSuggestionCopyButton ? window.SuggestionUI.renderSuggestionCopyButton({ collapsed: true }) : ''}
           ${suggestion.reasoning && suggestion.reasoning.length > 0 ? `
           <button class="btn-reasoning-toggle collapsed-reasoning" title="View reasoning" data-suggestion-id="${suggestion.id}" data-reasoning="${encodeURIComponent(JSON.stringify(suggestion.reasoning))}">
             <svg viewBox="0 0 24 24" width="12" height="12" fill="currentColor"><path d="M21.33 12.91c.09 1.55-.62 3.04-1.89 3.95l.77 1.49c.23.45.26.98.06 1.45c-.19.47-.58.84-1.06 1l-.79.25a1.69 1.69 0 0 1-1.86-.55L14.44 18c-.89-.15-1.73-.53-2.44-1.1c-.5.15-1 .23-1.5.23c-.88 0-1.76-.27-2.5-.79c-.53.16-1.07.23-1.62.22c-.79.01-1.57-.15-2.3-.45a4.1 4.1 0 0 1-2.43-3.61c-.08-.72.04-1.45.35-2.11c-.29-.75-.32-1.57-.07-2.33C2.3 7.11 3 6.32 3.87 5.82c.58-1.69 2.21-2.82 4-2.7c1.6-1.5 4.05-1.66 5.83-.37c.42-.11.86-.17 1.3-.17c1.36-.03 2.65.57 3.5 1.64c2.04.53 3.5 2.35 3.58 4.47c.05 1.11-.25 2.2-.86 3.13c.07.36.11.72.11 1.09m-5-1.41c.57.07 1.02.5 1.02 1.07a1 1 0 0 1-1 1h-.63c-.32.9-.88 1.69-1.62 2.29c.25.09.51.14.77.21c5.13-.07 4.53-3.2 4.53-3.25a2.59 2.59 0 0 0-2.69-2.49a1 1 0 0 1-1-1a1 1 0 0 1 1-1c1.23.03 2.41.49 3.33 1.3c.05-.29.08-.59.08-.89c-.06-1.24-.62-2.32-2.87-2.53c-1.25-2.96-4.4-1.32-4.4-.4c-.03.23.21.72.25.75a1 1 0 0 1 1 1c0 .55-.45 1-1 1c-.53-.02-1.03-.22-1.43-.56c-.48.31-1.03.5-1.6.56c-.57.05-1.04-.35-1.07-.9a.97.97 0 0 1 .88-1.1c.16-.02.94-.14.94-.77c0-.66.25-1.29.68-1.79c-.92-.25-1.91.08-2.91 1.29C6.75 5 6 5.25 5.45 7.2C4.5 7.67 4 8 3.78 9c1.08-.22 2.19-.13 3.22.25c.5.19.78.75.59 1.29c-.19.52-.77.78-1.29.59c-.73-.32-1.55-.34-2.3-.06c-.32.27-.32.83-.32 1.27c0 .74.37 1.43 1 1.83c.53.27 1.12.41 1.71.4q-.225-.39-.39-.81a1.038 1.038 0 0 1 1.96-.68c.4 1.14 1.42 1.92 2.62 2.05c1.37-.07 2.59-.88 3.19-2.13c.23-1.38 1.34-1.5 2.56-1.5m2 7.47l-.62-1.3-.71.16l1 1.25zm-4.65-8.61a1 1 0 0 0-.91-1.03c-.71-.04-1.4.2-1.93.67c-.57.58-.87 1.38-.84 2.19a1 1 0 0 0 1 1c.57 0 1-.45 1-1c0-.27.07-.54.23-.76c.12-.1.27-.15.43-.15c.55.03 1.02-.38 1.02-.92"/></svg>

--- a/public/js/modules/suggestion-manager.js
+++ b/public/js/modules/suggestion-manager.js
@@ -39,6 +39,15 @@ class SuggestionManager {
       }
     });
 
+    // Event delegation for copying suggestion cards as markdown
+    document.addEventListener('click', (e) => {
+      const copyBtn = e.target.closest('.btn-suggestion-copy');
+      if (copyBtn) {
+        e.stopPropagation();
+        this._handleSuggestionCopy(copyBtn);
+      }
+    });
+
     // Event delegation for reasoning brain icon popover (pinned to button)
     document.addEventListener('click', (e) => {
       const toggleBtn = e.target.closest('.btn-reasoning-toggle');
@@ -58,6 +67,8 @@ class SuggestionManager {
         this._openReasoningPopover(toggleBtn);
         return;
       }
+
+      if (e.target.closest('.btn-suggestion-copy')) return;
 
       // Close popover when clicking outside
       if (!e.target.closest('.reasoning-popover')) {
@@ -128,6 +139,78 @@ class SuggestionManager {
       existing._triggerBtn?.classList.remove('active');
       existing.remove();
     }
+  }
+
+  _parseDatasetJson(value, fallback = '') {
+    if (!value) return fallback;
+    try {
+      return JSON.parse(value);
+    } catch {
+      return fallback;
+    }
+  }
+
+  async _handleSuggestionCopy(copyBtn) {
+    const suggestionDiv = copyBtn.closest('.ai-suggestion');
+    if (!suggestionDiv || !window.SuggestionUI?.formatSuggestionMarkdown) return;
+
+    try {
+      const lineInfo = this.getFileAndLineInfo(suggestionDiv);
+      const markdown = window.SuggestionUI.formatSuggestionMarkdown({
+        title: suggestionDiv.dataset.title,
+        file: lineInfo.fileName || suggestionDiv.dataset.fileName,
+        location: lineInfo.isFileLevel ? 'file-level' : null,
+        lineStart: lineInfo.lineNumber,
+        lineEnd: lineInfo.lineEnd,
+        isFileLevel: lineInfo.isFileLevel,
+        type: suggestionDiv.dataset.type,
+        severity: suggestionDiv.dataset.severity,
+        body: this._parseDatasetJson(suggestionDiv.dataset.originalBody),
+        formattedBody: this._parseDatasetJson(suggestionDiv.dataset.formattedBody),
+        reasoning: this._parseDatasetJson(suggestionDiv.dataset.reasoning, [])
+      });
+
+      await navigator.clipboard.writeText(markdown);
+      this._setSuggestionCopyButtonState(copyBtn, true);
+      window.toast?.showSuccess('Suggestion copied');
+    } catch (error) {
+      console.error('Failed to copy suggestion:', error);
+      this._setSuggestionCopyButtonState(copyBtn, false);
+      window.toast?.showError('Failed to copy suggestion');
+    }
+  }
+
+  _setSuggestionCopyButtonState(copyBtn, copied) {
+    if (!copyBtn) return;
+
+    const resetTitle = 'Copy suggestion';
+    if (copied) {
+      copyBtn.classList.add('copied');
+      copyBtn.title = 'Copied';
+      copyBtn.setAttribute('aria-label', 'Copied');
+      if (window.SuggestionUI?.COPIED_ICON) {
+        copyBtn.innerHTML = window.SuggestionUI.COPIED_ICON;
+      }
+
+      setTimeout(() => {
+        copyBtn.classList.remove('copied');
+        copyBtn.title = resetTitle;
+        copyBtn.setAttribute('aria-label', resetTitle);
+        if (window.SuggestionUI?.COPY_ICON) {
+          copyBtn.innerHTML = window.SuggestionUI.COPY_ICON;
+        }
+      }, 1600);
+      return;
+    }
+
+    copyBtn.classList.add('copy-failed');
+    copyBtn.title = 'Copy failed';
+    copyBtn.setAttribute('aria-label', 'Copy failed');
+    setTimeout(() => {
+      copyBtn.classList.remove('copy-failed');
+      copyBtn.title = resetTitle;
+      copyBtn.setAttribute('aria-label', resetTitle);
+    }, 1600);
   }
 
   /**
@@ -475,6 +558,10 @@ class SuggestionManager {
       // Use JSON.stringify to preserve newlines and special characters
       suggestionDiv.dataset.originalBody = JSON.stringify(suggestion.body || '');
       suggestionDiv.dataset.formattedBody = JSON.stringify(suggestion.formattedBody || '');
+      suggestionDiv.dataset.title = suggestion.title || '';
+      suggestionDiv.dataset.type = suggestion.type || suggestion.category || '';
+      suggestionDiv.dataset.severity = suggestion.severity || '';
+      suggestionDiv.dataset.reasoning = JSON.stringify(suggestion.reasoning || []);
 
       // Store target info on the suggestion div for reliable retrieval in getFileAndLineInfo
       // This avoids fragile DOM traversal that fails when gap rows are between suggestion and target
@@ -528,6 +615,7 @@ class SuggestionManager {
             <span class="ai-title">${escapeHtml(suggestion.title || '')}</span>
           </div>
           <div class="ai-suggestion-header-right">
+            ${window.SuggestionUI?.renderSuggestionCopyButton ? window.SuggestionUI.renderSuggestionCopyButton() : ''}
             ${suggestion.reasoning && suggestion.reasoning.length > 0 ? `
             <button class="btn-reasoning-toggle" title="View reasoning" data-suggestion-id="${suggestion.id}" data-reasoning="${encodeURIComponent(JSON.stringify(suggestion.reasoning))}">
               <svg viewBox="0 0 24 24" width="14" height="14" fill="currentColor"><path d="M21.33 12.91c.09 1.55-.62 3.04-1.89 3.95l.77 1.49c.23.45.26.98.06 1.45c-.19.47-.58.84-1.06 1l-.79.25a1.69 1.69 0 0 1-1.86-.55L14.44 18c-.89-.15-1.73-.53-2.44-1.1c-.5.15-1 .23-1.5.23c-.88 0-1.76-.27-2.5-.79c-.53.16-1.07.23-1.62.22c-.79.01-1.57-.15-2.3-.45a4.1 4.1 0 0 1-2.43-3.61c-.08-.72.04-1.45.35-2.11c-.29-.75-.32-1.57-.07-2.33C2.3 7.11 3 6.32 3.87 5.82c.58-1.69 2.21-2.82 4-2.7c1.6-1.5 4.05-1.66 5.83-.37c.42-.11.86-.17 1.3-.17c1.36-.03 2.65.57 3.5 1.64c2.04.53 3.5 2.35 3.58 4.47c.05 1.11-.25 2.2-.86 3.13c.07.36.11.72.11 1.09m-5-1.41c.57.07 1.02.5 1.02 1.07a1 1 0 0 1-1 1h-.63c-.32.9-.88 1.69-1.62 2.29c.25.09.51.14.77.21c5.13-.07 4.53-3.2 4.53-3.25a2.59 2.59 0 0 0-2.69-2.49a1 1 0 0 1-1-1a1 1 0 0 1 1-1c1.23.03 2.41.49 3.33 1.3c.05-.29.08-.59.08-.89c-.06-1.24-.62-2.32-2.87-2.53c-1.25-2.96-4.4-1.32-4.4-.4c-.03.23.21.72.25.75a1 1 0 0 1 1 1c0 .55-.45 1-1 1c-.53-.02-1.03-.22-1.43-.56c-.48.31-1.03.5-1.6.56c-.57.05-1.04-.35-1.07-.9a.97.97 0 0 1 .88-1.1c.16-.02.94-.14.94-.77c0-.66.25-1.29.68-1.79c-.92-.25-1.91.08-2.91 1.29C6.75 5 6 5.25 5.45 7.2C4.5 7.67 4 8 3.78 9c1.08-.22 2.19-.13 3.22.25c.5.19.78.75.59 1.29c-.19.52-.77.78-1.29.59c-.73-.32-1.55-.34-2.3-.06c-.32.27-.32.83-.32 1.27c0 .74.37 1.43 1 1.83c.53.27 1.12.41 1.71.4q-.225-.39-.39-.81a1.038 1.038 0 0 1 1.96-.68c.4 1.14 1.42 1.92 2.62 2.05c1.37-.07 2.59-.88 3.19-2.13c.23-1.38 1.34-1.5 2.56-1.5m2 7.47l-.62-1.3l-.71.16l1 1.25zm-4.65-8.61a1 1 0 0 0-.91-1.03c-.71-.04-1.4.2-1.93.67c-.57.58-.87 1.38-.84 2.19a1 1 0 0 0 1 1c.57 0 1-.45 1-1c0-.27.07-.54.23-.76c.12-.1.27-.15.43-.15c.55.03 1.02-.38 1.02-.92"/></svg>
@@ -542,6 +630,7 @@ class SuggestionManager {
           ${suggestion.severity ? `<span class="severity-badge severity-${suggestion.severity}">${escapeHtml(suggestion.severity.toUpperCase())}</span>` : ''}
           <span class="collapsed-title">${escapeHtml(suggestion.title || '')}</span>
           <div class="ai-suggestion-header-right">
+            ${window.SuggestionUI?.renderSuggestionCopyButton ? window.SuggestionUI.renderSuggestionCopyButton({ collapsed: true }) : ''}
             ${suggestion.reasoning && suggestion.reasoning.length > 0 ? `
             <button class="btn-reasoning-toggle collapsed-reasoning" title="View reasoning" data-suggestion-id="${suggestion.id}" data-reasoning="${encodeURIComponent(JSON.stringify(suggestion.reasoning))}">
               <svg viewBox="0 0 24 24" width="12" height="12" fill="currentColor"><path d="M21.33 12.91c.09 1.55-.62 3.04-1.89 3.95l.77 1.49c.23.45.26.98.06 1.45c-.19.47-.58.84-1.06 1l-.79.25a1.69 1.69 0 0 1-1.86-.55L14.44 18c-.89-.15-1.73-.53-2.44-1.1c-.5.15-1 .23-1.5.23c-.88 0-1.76-.27-2.5-.79c-.53.16-1.07.23-1.62.22c-.79.01-1.57-.15-2.3-.45a4.1 4.1 0 0 1-2.43-3.61c-.08-.72.04-1.45.35-2.11c-.29-.75-.32-1.57-.07-2.33C2.3 7.11 3 6.32 3.87 5.82c.58-1.69 2.21-2.82 4-2.7c1.6-1.5 4.05-1.66 5.83-.37c.42-.11.86-.17 1.3-.17c1.36-.03 2.65.57 3.5 1.64c2.04.53 3.5 2.35 3.58 4.47c.05 1.11-.25 2.2-.86 3.13c.07.36.11.72.11 1.09m-5-1.41c.57.07 1.02.5 1.02 1.07a1 1 0 0 1-1 1h-.63c-.32.9-.88 1.69-1.62 2.29c.25.09.51.14.77.21c5.13-.07 4.53-3.2 4.53-3.25a2.59 2.59 0 0 0-2.69-2.49a1 1 0 0 1-1-1a1 1 0 0 1 1-1c1.23.03 2.41.49 3.33 1.3c.05-.29.08-.59.08-.89c-.06-1.24-.62-2.32-2.87-2.53c-1.25-2.96-4.4-1.32-4.4-.4c-.03.23.21.72.25.75a1 1 0 0 1 1 1c0 .55-.45 1-1 1c-.53-.02-1.03-.22-1.43-.56c-.48.31-1.03.5-1.6.56c-.57.05-1.04-.35-1.07-.9a.97.97 0 0 1 .88-1.1c.16-.02.94-.14.94-.77c0-.66.25-1.29.68-1.79c-.92-.25-1.91.08-2.91 1.29C6.75 5 6 5.25 5.45 7.2C4.5 7.67 4 8 3.78 9c1.08-.22 2.19-.13 3.22.25c.5.19.78.75.59 1.29c-.19.52-.77.78-1.29.59c-.73-.32-1.55-.34-2.3-.06c-.32.27-.32.83-.32 1.27c0 .74.37 1.43 1 1.83c.53.27 1.12.41 1.71.4q-.225-.39-.39-.81a1.038 1.038 0 0 1 1.96-.68c.4 1.14 1.42 1.92 2.62 2.05c1.37-.07 2.59-.88 3.19-2.13c.23-1.38 1.34-1.5 2.56-1.5m2 7.47l-.62-1.3-.71.16l1 1.25zm-4.65-8.61a1 1 0 0 0-.91-1.03c-.71-.04-1.4.2-1.93.67c-.57.58-.87 1.38-.84 2.19a1 1 0 0 0 1 1c.57 0 1-.45 1-1c0-.27.07-.54.23-.76c.12-.1.27-.15.43-.15c.55.03 1.02-.38 1.02-.92"/></svg>
@@ -608,8 +697,8 @@ class SuggestionManager {
     // Get type from ai-suggestion-badge data-type attribute or praise-badge
     const badgeElement = suggestionDiv.querySelector('.ai-suggestion-badge, .praise-badge');
     const titleElement = suggestionDiv.querySelector('.ai-title');
-    const suggestionType = badgeElement?.dataset?.type || (badgeElement?.classList?.contains('praise-badge') ? 'praise' : '');
-    const suggestionTitle = titleElement?.textContent?.trim() || '';
+    const suggestionType = suggestionDiv.dataset?.type || badgeElement?.dataset?.type || (badgeElement?.classList?.contains('praise-badge') ? 'praise' : '');
+    const suggestionTitle = suggestionDiv.dataset?.title || titleElement?.textContent?.trim() || '';
 
     return { suggestionText, formattedBody, suggestionType, suggestionTitle };
   }

--- a/public/js/utils/suggestion-ui.js
+++ b/public/js/utils/suggestion-ui.js
@@ -10,6 +10,103 @@
    * @constant {string}
    */
   const HIDDEN_SUGGESTION_TEXT = 'Hidden AI suggestion';
+  const COPY_ICON = `<svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+    <path d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 0 1 0 1.5h-1.5a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 0 0 .25-.25v-1.5a.75.75 0 0 1 1.5 0v1.5A1.75 1.75 0 0 1 9.25 16h-7.5A1.75 1.75 0 0 1 0 14.25Z"/>
+    <path d="M5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0 1 14.25 11h-7.5A1.75 1.75 0 0 1 5 9.25Zm1.75-.25a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 0 0 .25-.25v-7.5a.25.25 0 0 0-.25-.25Z"/>
+  </svg>`;
+  const COPIED_ICON = `<svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+    <path d="M13.78 4.22a.75.75 0 0 1 0 1.06l-7.25 7.25a.75.75 0 0 1-1.06 0L2.22 9.28a.751.751 0 0 1 .018-1.042.751.751 0 0 1 1.042-.018L6 10.94l6.72-6.72a.75.75 0 0 1 1.06 0Z"/>
+  </svg>`;
+
+  function normalizeText(value) {
+    return value === null || value === undefined ? '' : String(value).trim();
+  }
+
+  function humanizeLabel(value) {
+    return normalizeText(value)
+      .replace(/[-_]+/g, ' ')
+      .split(/\s+/)
+      .filter(Boolean)
+      .map(word => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+      .join(' ');
+  }
+
+  function normalizeReasoning(reasoning) {
+    if (Array.isArray(reasoning)) {
+      return reasoning.map(normalizeText).filter(Boolean);
+    }
+
+    const text = normalizeText(reasoning);
+    return text ? [text] : [];
+  }
+
+  function normalizeLocation(data) {
+    const explicitLocation = normalizeText(data.location);
+    if (explicitLocation) return explicitLocation;
+
+    if (data.isFileLevel) return 'file-level';
+
+    const lineStart = Number.parseInt(data.lineStart ?? data.line_start, 10);
+    const lineEnd = Number.parseInt(data.lineEnd ?? data.line_end, 10);
+
+    if (Number.isFinite(lineStart) && Number.isFinite(lineEnd) && lineEnd !== lineStart) {
+      return `lines ${lineStart}-${lineEnd}`;
+    }
+
+    if (Number.isFinite(lineStart)) {
+      return `line ${lineStart}`;
+    }
+
+    return 'file-level';
+  }
+
+  function formatInlineCode(value) {
+    const text = normalizeText(value) || 'unknown';
+    return text.includes('`') ? `\`\` ${text} \`\`` : `\`${text}\``;
+  }
+
+  /**
+   * Format an AI suggestion as copy-safe Markdown.
+   *
+   * @param {Object} data - Suggestion data
+   * @returns {string} Markdown representation
+   */
+  function formatSuggestionMarkdown(data = {}) {
+    const title = normalizeText(data.title) || 'AI Suggestion';
+    const file = normalizeText(data.file || data.fileName);
+    const type = humanizeLabel(data.type);
+    const severity = humanizeLabel(data.severity);
+    const body = normalizeText(data.formattedBody || data.body);
+    const reasoning = normalizeReasoning(data.reasoning);
+
+    const lines = [
+      `## ${title}`,
+      `- File: ${formatInlineCode(file)}`,
+      `- Location: ${normalizeLocation(data)}`
+    ];
+
+    if (type) lines.push(`- Type: ${type}`);
+    if (severity) lines.push(`- Severity: ${severity}`);
+
+    if (body) {
+      lines.push('', body);
+    }
+
+    if (reasoning.length > 0) {
+      lines.push('', '### Reasoning', ...reasoning.map(step => `- ${step}`));
+    }
+
+    return lines.join('\n');
+  }
+
+  function renderSuggestionCopyButton(options = {}) {
+    const collapsedClass = options.collapsed ? ' collapsed-copy' : '';
+    return `
+      <button type="button" class="btn-suggestion-copy${collapsedClass}" title="Copy suggestion" aria-label="Copy suggestion">
+        ${COPY_ICON}
+      </button>
+    `;
+  }
 
   /**
    * Update the UI for a dismissed AI suggestion.
@@ -47,6 +144,14 @@
   // Export to global scope
   window.SuggestionUI = {
     HIDDEN_SUGGESTION_TEXT,
+    COPY_ICON,
+    COPIED_ICON,
+    formatSuggestionMarkdown,
+    renderSuggestionCopyButton,
     updateDismissedSuggestionUI
   };
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = window.SuggestionUI;
+  }
 })();

--- a/tests/e2e/ai-analysis-actions.spec.js
+++ b/tests/e2e/ai-analysis-actions.spec.js
@@ -162,6 +162,34 @@ test.describe('Suggestion Actions', () => {
     await expect(dismissBtn).toBeVisible();
   });
 
+  test('should copy suggestion markdown to clipboard', async ({ page, context }) => {
+    await context.grantPermissions(['clipboard-read', 'clipboard-write']);
+
+    await page.goto('/pr/test-owner/test-repo/1');
+    await waitForDiffToRender(page);
+
+    await seedAISuggestions(page);
+
+    const suggestion = page.locator('.ai-suggestion:not(.collapsed)', {
+      has: page.locator('.ai-title', { hasText: 'Consider using const for immutable values' })
+    }).first();
+    await expect(suggestion).toBeVisible({ timeout: 5000 });
+    await suggestion.scrollIntoViewIfNeeded();
+
+    await suggestion.locator('.ai-suggestion-header .btn-suggestion-copy').click();
+
+    const clipboardText = await page.evaluate(() => navigator.clipboard.readText());
+
+    expect(clipboardText).toContain('## Consider using const for immutable values');
+    expect(clipboardText).toContain('- File: `src/utils.js`');
+    expect(clipboardText).toContain('- Location: line 3');
+    expect(clipboardText).toContain('- Type: Improvement');
+    expect(clipboardText).toContain('- Severity: Minor');
+    expect(clipboardText).toContain('The variable `result` could be declared with `const`');
+    expect(clipboardText).toContain('### Reasoning');
+    expect(clipboardText).toContain('- The variable `result` is assigned once and never reassigned.');
+  });
+
   test('should collapse suggestion when dismissed', async ({ page }) => {
     await page.goto('/pr/test-owner/test-repo/1');
     await waitForDiffToRender(page);

--- a/tests/e2e/test-server.js
+++ b/tests/e2e/test-server.js
@@ -50,6 +50,7 @@ const mockAISuggestions = [
       'Using `const` communicates immutability intent to other developers.',
       'This is a minor readability improvement with no behavioral change.'
     ],
+    severity: 'minor',
     status: 'active',
     created_at: new Date().toISOString(),
     updated_at: new Date().toISOString()
@@ -393,8 +394,8 @@ async function startTestServer(port) {
       const insertStmt = db.prepare(`
         INSERT INTO comments (
           review_id, source, ai_run_id, ai_level, file, line_start, line_end,
-          type, title, body, reasoning, status, created_at, updated_at
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+          type, title, body, reasoning, severity, status, created_at, updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       `);
       for (const suggestion of mockAISuggestions) {
         insertStmt.run(
@@ -409,6 +410,7 @@ async function startTestServer(port) {
           suggestion.title,
           suggestion.body,
           suggestion.reasoning ? JSON.stringify(suggestion.reasoning) : null,
+          suggestion.severity || null,
           suggestion.status,
           now,
           now
@@ -515,7 +517,7 @@ async function startTestServer(port) {
       const rows = db.prepare(`
         SELECT id, source, author, ai_run_id, ai_level, ai_confidence,
                file, line_start, line_end, side, type, title, body,
-               reasoning, status, is_file_level, created_at, updated_at
+               reasoning, severity, status, is_file_level, created_at, updated_at
         FROM comments
         WHERE review_id = ? AND source = 'ai'
           AND (ai_level IS NULL)

--- a/tests/unit/suggestion-manager.test.js
+++ b/tests/unit/suggestion-manager.test.js
@@ -12,10 +12,11 @@
  * to ensure tests verify real behavior, not a reimplementation.
  */
 
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
 // Setup global.window before importing production code that assigns to it
 global.window = global.window || {};
+global.window.SuggestionUI = require('../../public/js/utils/suggestion-ui.js');
 
 // Import the actual SuggestionManager class from production code
 const { SuggestionManager } = require('../../public/js/modules/suggestion-manager.js');
@@ -822,5 +823,160 @@ describe('SuggestionManager chat button event delegation', () => {
     // Should bail out — these clicks are handled by other managers
     expect(mockChatPanel.open).not.toHaveBeenCalled();
     expect(mockEvent.stopPropagation).not.toHaveBeenCalled();
+  });
+});
+
+describe('SuggestionManager suggestion copy event delegation', () => {
+  let clickHandlers;
+
+  beforeEach(() => {
+    clickHandlers = [];
+    vi.useFakeTimers();
+
+    global.document = {
+      addEventListener: vi.fn((event, handler) => {
+        if (event === 'click') clickHandlers.push(handler);
+      }),
+      querySelector: vi.fn(() => null),
+      querySelectorAll: vi.fn(() => []),
+      createElement: vi.fn(() => ({
+        className: '',
+        innerHTML: '',
+        textContent: '',
+        appendChild: vi.fn(),
+        remove: vi.fn(),
+        querySelector: vi.fn(() => null),
+      })),
+    };
+
+    vi.stubGlobal('navigator', {
+      clipboard: {
+        writeText: vi.fn().mockResolvedValue(undefined)
+      }
+    });
+
+    global.window.toast = {
+      showSuccess: vi.fn(),
+      showError: vi.fn()
+    };
+    global.window.SuggestionUI = require('../../public/js/utils/suggestion-ui.js');
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    delete global.document;
+    delete global.window.toast;
+  });
+
+  function createSuggestionCopyClick({ fileLevel = false } = {}) {
+    const suggestionDiv = {
+      dataset: {
+        title: fileLevel ? 'Document module ownership' : 'Reject oversized Vault user IDs before querying',
+        type: 'bug',
+        severity: 'critical',
+        originalBody: JSON.stringify('Raw body'),
+        formattedBody: JSON.stringify('Bug: `parse_vault_user_id` currently accepts any positive integer.'),
+        reasoning: JSON.stringify(['Checked the resolver input path.']),
+        fileName: fileLevel ? 'src/ownership.js' : 'app/graphql/resolvers/vault_user_resolver.rb',
+        lineNumber: fileLevel ? '' : '44',
+        lineEnd: fileLevel ? '' : '48',
+        side: fileLevel ? '' : 'RIGHT',
+        diffPosition: fileLevel ? '' : '12',
+        isFileLevel: fileLevel ? 'true' : 'false'
+      },
+      closest: vi.fn((selector) => {
+        if (selector === 'tr') return { previousElementSibling: null };
+        return null;
+      }),
+      querySelector: vi.fn(() => null)
+    };
+
+    const copyBtn = {
+      classList: { add: vi.fn(), remove: vi.fn() },
+      closest: vi.fn((selector) => {
+        if (selector === '.btn-suggestion-copy') return copyBtn;
+        if (selector === '.ai-suggestion') return suggestionDiv;
+        return null;
+      }),
+      setAttribute: vi.fn(),
+      title: 'Copy suggestion',
+      innerHTML: global.window.SuggestionUI.COPY_ICON
+    };
+
+    const event = {
+      target: {
+        closest: vi.fn((selector) => {
+          if (selector === '.ai-action-chat') return null;
+          if (selector === '.btn-suggestion-copy') return copyBtn;
+          if (selector === '.btn-reasoning-toggle') return null;
+          if (selector === '.reasoning-popover') return null;
+          return null;
+        })
+      },
+      stopPropagation: vi.fn()
+    };
+
+    return { copyBtn, event };
+  }
+
+  it('copies line-level suggestion markdown to the clipboard', async () => {
+    new SuggestionManager({
+      currentPR: { id: 'review-1' },
+      escapeHtml: (s) => s
+    });
+
+    expect(clickHandlers.length).toBeGreaterThanOrEqual(3);
+    const copyHandler = clickHandlers[1];
+    const { copyBtn, event } = createSuggestionCopyClick();
+
+    copyHandler(event);
+    await Promise.resolve();
+
+    expect(event.stopPropagation).toHaveBeenCalled();
+    expect(global.navigator.clipboard.writeText).toHaveBeenCalledWith(expect.stringContaining('## Reject oversized Vault user IDs before querying'));
+    expect(global.navigator.clipboard.writeText).toHaveBeenCalledWith(expect.stringContaining('- File: `app/graphql/resolvers/vault_user_resolver.rb`'));
+    expect(global.navigator.clipboard.writeText).toHaveBeenCalledWith(expect.stringContaining('- Location: lines 44-48'));
+    expect(global.navigator.clipboard.writeText).toHaveBeenCalledWith(expect.stringContaining('- Type: Bug'));
+    expect(global.navigator.clipboard.writeText).toHaveBeenCalledWith(expect.stringContaining('- Severity: Critical'));
+    expect(global.navigator.clipboard.writeText).toHaveBeenCalledWith(expect.stringContaining('Bug: `parse_vault_user_id` currently accepts any positive integer.'));
+    expect(global.window.toast.showSuccess).toHaveBeenCalledWith('Suggestion copied');
+    expect(copyBtn.classList.add).toHaveBeenCalledWith('copied');
+  });
+
+  it('copies file-level suggestion markdown with file-level location', async () => {
+    new SuggestionManager({
+      currentPR: { id: 'review-1' },
+      escapeHtml: (s) => s
+    });
+
+    const copyHandler = clickHandlers[1];
+    const { event } = createSuggestionCopyClick({ fileLevel: true });
+
+    copyHandler(event);
+    await Promise.resolve();
+
+    expect(global.navigator.clipboard.writeText).toHaveBeenCalledWith(expect.stringContaining('- Location: file-level'));
+  });
+
+  it('shows an error toast when clipboard writing fails', async () => {
+    global.navigator.clipboard.writeText.mockRejectedValueOnce(new Error('no clipboard'));
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    new SuggestionManager({
+      currentPR: { id: 'review-1' },
+      escapeHtml: (s) => s
+    });
+
+    const copyHandler = clickHandlers[1];
+    const { copyBtn, event } = createSuggestionCopyClick();
+
+    copyHandler(event);
+    await Promise.resolve();
+
+    expect(global.window.toast.showError).toHaveBeenCalledWith('Failed to copy suggestion');
+    expect(copyBtn.classList.add).toHaveBeenCalledWith('copy-failed');
+
+    consoleSpy.mockRestore();
   });
 });

--- a/tests/unit/suggestion-ui.test.js
+++ b/tests/unit/suggestion-ui.test.js
@@ -1,0 +1,54 @@
+// Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+import { describe, it, expect } from 'vitest';
+
+global.window = global.window || {};
+
+const SuggestionUI = require('../../public/js/utils/suggestion-ui.js');
+
+describe('SuggestionUI.formatSuggestionMarkdown()', () => {
+  it('formats a line-level suggestion with metadata, formatted body, and reasoning', () => {
+    const markdown = SuggestionUI.formatSuggestionMarkdown({
+      title: 'Reject oversized Vault user IDs before querying',
+      file: 'app/graphql/resolvers/vault_user_resolver.rb',
+      lineStart: 44,
+      lineEnd: 48,
+      type: 'bug',
+      severity: 'critical',
+      body: 'Raw body should not be used',
+      formattedBody: 'Bug: `parse_vault_user_id` currently accepts any positive integer.',
+      reasoning: [
+        'Checked the resolver input path.',
+        'Confirmed oversized IDs can reach ActiveRecord binding.'
+      ]
+    });
+
+    expect(markdown).toBe(`## Reject oversized Vault user IDs before querying
+- File: \`app/graphql/resolvers/vault_user_resolver.rb\`
+- Location: lines 44-48
+- Type: Bug
+- Severity: Critical
+
+Bug: \`parse_vault_user_id\` currently accepts any positive integer.
+
+### Reasoning
+- Checked the resolver input path.
+- Confirmed oversized IDs can reach ActiveRecord binding.`);
+  });
+
+  it('formats a file-level suggestion without optional severity or reasoning', () => {
+    const markdown = SuggestionUI.formatSuggestionMarkdown({
+      title: 'Document module ownership',
+      file: 'src/ownership.js',
+      isFileLevel: true,
+      type: 'suggestion',
+      body: 'Add ownership details near the top of the file.'
+    });
+
+    expect(markdown).toBe(`## Document module ownership
+- File: \`src/ownership.js\`
+- Location: file-level
+- Type: Suggestion
+
+Add ownership details near the top of the file.`);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a copy button to AI suggestion cards, including collapsed and file-level suggestions.
- Copies suggestion details as Markdown with file, location, type, severity, body, and reasoning.
- Adds a patch changeset for the user-facing copy action.

## Testing
- `pnpm test tests/unit/suggestion-ui.test.js tests/unit/suggestion-manager.test.js`
- `pnpm run test:e2e -- tests/e2e/ai-analysis-actions.spec.js`