### PR TITLE
Add --council and --list-councils CLI flags

### DIFF
--- a/.changeset/cli-council-selection.md
+++ b/.changeset/cli-council-selection.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": minor
+---
+
+Add `--council <handle>` to select a saved multi-voice council from the CLI (headless PR, interactive PR, and local modes), plus `--list-councils` to discover council handles. Handles resolve by council name, name-slug, id (prefix), or a partial name fragment (resolving when unique, otherwise listing the candidates).

--- a/README.md
+++ b/README.md
@@ -192,6 +192,8 @@ pair-review --local [path]
 | `<PR-URL>` | Full GitHub PR URL (e.g., `https://github.com/owner/repo/pull/123`) |
 | `--ai` | Automatically run AI analysis when the review loads |
 | `--ai-draft` | Run AI analysis and save suggestions as a draft review on GitHub |
+| `--council <handle>` | Run analysis with a saved multi-voice council. Implies analysis. The handle resolves by council name, name-slug, id (prefix), or a partial name fragment (resolving when it matches a single council, otherwise listing the candidates). When set, `--model` is ignored (council voices use their own per-voice models). Works in headless PR (`--ai-draft`/`--ai-review`), interactive PR (`--ai`), and local (`--local --ai`) modes. |
+| `--list-councils` | List saved councils with their handles, names, types, and last-used repo, then exit. Use a printed handle with `--council`. |
 | `--configure` | Show setup instructions and configuration options |
 | `-d`, `--debug` | Enable verbose debug logging for troubleshooting |
 | `-h`, `--help` | Show help message with full CLI documentation |
@@ -209,9 +211,19 @@ pair-review 123                        # Review PR #123 in current repo
 pair-review https://github.com/owner/repo/pull/456
 pair-review --local                    # Review uncommitted local changes
 pair-review 123 --ai                   # Auto-run AI analysis
+pair-review --list-councils            # List saved councils and their handles
+pair-review 123 --ai-draft --council security-review  # Headless draft with a council
+pair-review --local --ai --council security-review    # Local review with a council
 pair-review --register                 # Register pair-review:// URL scheme (macOS)
 pair-review --register --command "node bin/pair-review.js"  # Custom command
 ```
+
+> **Councils** are saved multi-voice review configurations created and managed
+> in the web UI (under Analysis settings). `--council <handle>` selects one from
+> the CLI; the handle can be the council's name, its name-slug, an id prefix, or
+> a partial name fragment (which resolves when it uniquely identifies a council,
+> otherwise lists the candidates). Run `pair-review --list-councils` to discover
+> available handles.
 
 ## Configuration
 

--- a/plans/cli-council-selection.md
+++ b/plans/cli-council-selection.md
@@ -1,0 +1,292 @@
+# CLI Council Selection (`--council` + `--list-councils`)
+
+> Rename this plan file to `plans/cli-council-selection.md` when implementation begins (per CLAUDE.md convention).
+
+## Context
+
+Today a "council" (a multi-voice / multi-provider AI review config) can only be
+selected in the web UI or via the HTTP API (`POST /api/.../analyses/council`).
+There is no way to choose a council from the command line — the existing
+`--model <name>` flag only sets a single global model and feeds the standard
+`analyzeAllLevels` path. Users running headless reviews (`--ai-draft`,
+`--ai-review`) or kicking off an interactive analysis (`--ai`, `--local --ai`)
+cannot use a council at all.
+
+This change adds a `--council <handle>` flag (works in PR headless, PR
+interactive, and local modes) plus a `--list-councils` discovery command.
+
+**Identifier decision (settled):** Use a **smart resolver, no schema change.**
+A council handle resolves by UUID → UUID-prefix (git-style) → exact name
+(case-insensitive) → normalized name (`"My Council"` ↔ `my-council`). Ambiguous
+matches fail loudly and list the candidates with their short ids;
+`--list-councils` prints the short id as the always-unique fallback. We are
+deliberately **not** adding a persistent `slug` column now (it would require a
+migration, backfill, create/rename sync, UI work, and test-schema updates). The
+resolver is a strict subset of a future hybrid, so slugs can be added later and
+integrated with the resolver with nothing wasted.
+
+## Approach
+
+### 1. New resolver module — `src/councils/resolve-council.js`
+
+Export `resolveCouncilHandle(db, handle)` returning the full council row
+(`{ id, name, type, config, ... }`) or throwing a clear `Error`.
+
+Algorithm (first unambiguous match wins):
+1. `const all = await new CouncilRepository(db).list()` (small N; one query).
+2. Exact id: `all.find(c => c.id === handle)`.
+3. UUID-prefix (only when `handle.length >= 4` and `/^[0-9a-f-]+$/i`): filter by
+   `c.id.startsWith(handle.toLowerCase())`. 1 → return; >1 → ambiguity error.
+4. Exact name (case-insensitive). 1 → return; >1 → ambiguity error (names are
+   non-unique).
+5. Normalized name: `normalizeForMatch(s) = s.toLowerCase().trim().replace(/[^a-z0-9]+/g,'-').replace(/^-+|-+$/g,'')` on both sides. 1 → return; >1 → ambiguity.
+6. No match → not-found error: `No council matches "<handle>". Run \`pair-review --list-councils\` to see available councils.`
+
+Also export `shortId(id) => id.slice(0, 8)` (reused by `--list-councils`).
+Ambiguity message lists `name (shortId)` per candidate and tells the user to
+disambiguate with the id.
+
+`CouncilRepository` already exists at `src/database.js:5374` with `list()` and
+`getById()` — reuse it; no new repo methods needed.
+
+### 2. `--list-councils` discovery command (`src/main.js`)
+
+Early-return handler, like `--configure`, runs **without a PR arg and without
+starting the server** — needs only a DB handle.
+- Guard `if (args.includes('--list-councils'))` placed **before** single-port
+  delegation, after `loadConfig()`. Initialize the DB (mirror existing init),
+  call `CouncilRepository.list()` (already MRU-ordered), enrich each council with
+  its last-used repo (query below), print a table, then `db.close()` and
+  `process.exit(0)` (mirror other early-exit handlers — do not leave a dangling
+  handle).
+- Columns: `HANDLE` (short id), `NAME`, `TYPE` (`council`/`advanced`),
+  `LAST USED` (date or `never`), `LAST USED WITH` (repo, or `—`). Footer shows an
+  example `--council` invocation.
+- **"Last Used With" derivation.** Council runs are recorded in `analysis_runs`
+  with `provider='council'` and `model=<councilId>` (inline configs use
+  `model='inline-config'` and are excluded), tied to a `review_id`. Join to
+  `reviews` for the repo. One grouped query covers all councils (SQLite's
+  bare-column-with-MAX semantics return the row at the latest run):
+  ```sql
+  SELECT ar.model AS council_id,
+         r.repository, r.review_type, r.pr_number,
+         MAX(ar.started_at) AS last_started
+  FROM analysis_runs ar
+  JOIN reviews r ON r.id = ar.review_id
+  WHERE ar.provider = 'council' AND ar.model != 'inline-config'
+  GROUP BY ar.model
+  ```
+  Build a `Map(council_id → { repository, review_type, pr_number, last_started })`.
+  Display: PR reviews → `repository` (append `#pr_number` when present); local
+  reviews (`review_type='local'`) → `repository`; no matching run → `—`. Add this
+  as a small read helper (e.g. `getCouncilLastUsedRepos(db)`) rather than inline
+  SQL in `main.js`, so it is unit-testable. Note: `analysis_runs.started_at` is a
+  more accurate "last used" than the touched `councils.last_used_at`; keep list
+  ordering on `CouncilRepository.list()` (MRU by `last_used_at`) but source both
+  the `LAST USED` date and the repo from this join when a run exists, falling back
+  to `last_used_at`/`never`/`—` otherwise.
+- Empty state: `No councils found. Create one in the web UI under Analysis settings.`
+
+### 3. `--council <handle>` flag wiring
+
+**parseArgs / flags (`src/main.js`):**
+- Add `'--council'` and `'--list-councils'` to `KNOWN_FLAGS` (`:271`).
+- Add a `--council` branch in `parseArgs` (`:323`) mirroring `--model` exactly
+  (consume next arg unless it starts with `-`, else throw
+  `--council flag requires a council handle (e.g., --council my-council)`).
+  Sets `flags.council`.
+- Add `--list-councils` to the skip-branch (`:341`, handled in `main()`).
+- `printHelp()` (`:129`): document both flags under OPTIONS and add an EXAMPLE.
+
+**Headless PR (`--ai-draft` / `--ai-review`):** Encapsulate the council run in a
+NEW server-free helper `src/councils/headless-council.js` →
+`runHeadlessCouncilAnalysis(db, { analyzer, reviewId, council, configType, councilConfig, worktreePath, prMetadata, instructions, githubClient })`,
+called from `performHeadlessReview` (~`src/main.js:976`–`1000`) when `flags.council`
+is set. This replicates the **server-free essence** of `launchCouncilAnalysis`
+(`src/routes/analyses.js:505`) — verified contract below — WITHOUT the SSE /
+pool / hooks / `activeAnalyses` coupling. Add a code comment in both functions
+cross-referencing each other so the two council invokers stay in parity.
+
+Resolve **early** in `performHeadlessReview` (right after `repoSettings`, before
+GitHub work) so a bad handle aborts fast:
+1. `const council = await resolveCouncilHandle(db, flags.council)`;
+   `const configType = council.type` (`'council'` | `'advanced'`).
+2. Reuse route helpers: `const { validateCouncilConfig, normalizeCouncilConfig } = require('./routes/councils')`;
+   `const councilConfig = normalizeCouncilConfig(council.config, configType)`; throw on `validateCouncilConfig`.
+3. Construct `const analyzer = new Analyzer(db, 'council', 'council', providerOverrides)` (per-voice provider/model come from the config).
+
+Inside `runHeadlessCouncilAnalysis` (mirrors `launchCouncilAnalysis:530`–`654`):
+1. `const runId = uuidv4()`.
+2. Compute `levelsConfig` exactly as the route (analyses.js:533–541): voice-centric → `councilConfig.levels`; advanced → map each level to `val?.enabled !== false`.
+3. **Pre-create the parent run with the council id** (this is the key — do NOT
+   omit runId): `await new AnalysisRunRepository(db).create({ id: runId, reviewId, provider: 'council', model: council.id, tier: null, globalInstructions, repoInstructions, requestInstructions: null, headSha: prMetadata?.head_sha || null, configType, levelsConfig })`.
+   (`runCouncilAnalysis`/advanced creates NO parent run itself;
+   `runReviewerCentricCouncil` would create one with `model:'voice-centric'` when
+   `runId` is omitted — both wrong for council attribution. Passing our `runId`
+   makes the analyzer reuse our record, keeping `model = council.id` so
+   `last_council_id` detection and the "Last Used With" join work.)
+4. `new CouncilRepository(db).touchLastUsedAt(council.id).catch(() => {})` (best-effort).
+5. `reviewContext = { reviewId, worktreePath, prMetadata, changedFiles: null, instructions: { globalInstructions, repoInstructions, requestInstructions: null } }`.
+6. `const result = await (configType === 'council' ? analyzer.runReviewerCentricCouncil(reviewContext, councilConfig, { runId, progressCallback: null, githubClient }) : analyzer.runCouncilAnalysis(reviewContext, councilConfig, { runId, progressCallback: null, githubClient }))`.
+7. On success: `await runRepo.update(runId, { status: 'completed', summary: result.summary, totalSuggestions: result.suggestions.length, ...(result.levelOutcomes ? { levelOutcomes: result.levelOutcomes } : {}) })`. Return `result`.
+8. On error: `await runRepo.update(runId, { status: 'failed' }).catch(() => {})`; rethrow.
+
+Back in `performHeadlessReview`: `analysisSummary = result.summary`, then fall
+through to the **existing** suggestions query/print path (`src/main.js:1000`) —
+council methods persist orchestrated suggestions with the same shape
+(`source='ai'`, `ai_level IS NULL`, `is_raw=0`, `status='active'`), so no
+print/submit change is needed (the integration test must confirm suggestions land).
+
+When `flags.council` is unset, the existing `analyzeAllLevels` path is unchanged.
+
+**Interactive PR (`--ai`) and Local (`--local`) — pass through the browser URL:**
+The browser already runs council analysis; we just need to hand it the id.
+- `src/main.js:665` (PR URL build): when `flags.council`, resolve to
+  `council.id` (reusing the already-initialized `db` in `handlePullRequest`) and
+  append `&council=${council.id}` after `?analyze=true`. Resolve **before**
+  building the URL so a bad handle errors at the CLI, not in the browser.
+- `src/local-review.js:921` (local URL build): same append.
+- **`--council` implies analysis** in interactive mode: if `--council` is set and
+  none of `--ai`/`--ai-draft`/`--ai-review` is present, treat it like `--ai`
+  (the browser only auto-analyzes on `?analyze=true`). Document this.
+
+**Frontend (small change — the `council` param is NOT honored today):**
+- `public/js/pr.js` `_buildDefaultAnalysisConfig` (~`:636`): read
+  `const urlCouncilId = new URLSearchParams(window.location.search).get('council')`
+  and use it as the highest-priority councilId:
+  `urlCouncilId || repoSettings?.default_council_id || reviewSettings?.last_council_id || null`.
+  When `urlCouncilId` is present, force the council branch and fetch
+  `/api/councils/${councilId}` to get `config` + `type`.
+- Clean the param: add `cleanUrl.searchParams.delete('council')` beside the
+  existing `delete('analyze')` in `_maybeAutoAnalyze` (`pr.js:714`) and the local
+  auto-analyze `finally` (`local.js:88`).
+- `_buildDefaultAnalysisConfig` is shared (local monkey-patches `PRManager`), so
+  the `pr.js` edit covers both routes; `local.js` only needs the cleanup line.
+
+**Precedence:** explicit `--council` > (browser only) `repoSettings.default_council_id`.
+Headless mode does **not** auto-apply `default_council_id` when `--council` is
+absent — this preserves current headless behavior (deliberate; a one-line
+opt-in fallback is a possible future follow-up).
+
+**`--model` interaction:** a council defines per-voice models, so `--model` is
+meaningless under `--council`. When both are set, print a stderr warning
+(`Warning: --model is ignored when --council is set; council voices use their own per-voice models.`)
+and **gate every `process.env.PAIR_REVIEW_MODEL = flags.model` assignment behind
+`!flags.council`** (`src/main.js:654`, `src/local-review.js:912`).
+
+### 4. Validation & errors
+- Unknown / ambiguous handle → resolver throws (see §1); headless aborts before
+  GitHub work, interactive errors before opening the browser.
+- Invalid config / provider not configured → reuse `normalizeCouncilConfig` +
+  `validateCouncilConfig` (same as `src/routes/local.js:2229`, `pr.js:2490`);
+  `validateCouncilFormat` already checks each voice has a valid
+  `provider`/`model`.
+
+## Tests (mandatory)
+- `tests/unit/resolve-council.test.js` (new): seed a temp DB via
+  `CouncilRepository.create`; cover exact id, unique prefix, ambiguous prefix,
+  exact name (case-insensitive), normalized name (`"My Council"` ↔ `my-council`),
+  duplicate-name ambiguity, not-found, and short-prefix-treated-as-name. Assert
+  error messages contain the short ids.
+- `tests/unit/main.test.js` (extend): parseArgs — `--council x` sets
+  `flags.council`; `--council` with no value throws; `--council --ai` (value
+  looks like a flag) throws; `--list-councils` recognized (no unknown-flag
+  error).
+- `getCouncilLastUsedRepos(db)` (new helper) unit test: seed councils +
+  `reviews` + `analysis_runs` rows (a PR review and a local review, plus an
+  `inline-config` run that must be excluded); assert the map returns the repo of
+  the **most recent** run per council and omits never-used councils.
+- `tests/integration` (extend/new, spawnSync with `PAIR_REVIEW_NO_OPEN: '1'`):
+  `--list-councils` against a seeded temp DB prints handle/name/type and the
+  `LAST USED WITH` repo for a council with a seeded run (and `—` for an unused
+  one), and exits 0; `--ai-draft --council <bad>` exits non-zero with
+  "No council matches".
+- No DB/migration/schema test changes (Option A adds no column).
+- E2E: if an existing spec exercises `?analyze=true`, add a minimal assertion
+  that `?analyze=true&council=<id>` selects the council config. Run frontend
+  E2E via a Task per CLAUDE.md after the `pr.js`/`local.js` edits.
+
+## Docs / changeset
+- README: document `--council <handle>` and `--list-councils`, with PR
+  (`--ai`/`--ai-draft`/`--ai-review`) and `--local --ai --council` examples; note
+  the `--model` interaction and that `--council` implies analysis interactively.
+- Changeset (`.changeset/*.md`, **minor**): "Add `--council <handle>` to select a
+  multi-voice council from the CLI (PR headless, PR interactive, and local) plus
+  `--list-councils` to discover handles. Handles resolve by id, id-prefix, or
+  name."
+
+## Hazards
+- **Do NOT call `launchCouncilAnalysis` headless.** It mutates module-level
+  server state (`activeAnalyses`, `reviewToAnalysisId`) and calls
+  `broadcastProgress` / `broadcastReviewEvent` / `poolLifecycle` — all undefined
+  or unsafe outside the running server. The analyzer council methods are
+  self-contained (create their own run record, persist suggestions, tolerate a
+  null `progressCallback`); call them directly, mirroring the existing
+  `analyzeAllLevels` call.
+- **Run-record creation (RESOLVED — pre-create with the council id, pass runId).**
+  Verified: `runCouncilAnalysis` (advanced, `analyzer.js:3482`) creates NO parent
+  `analysis_runs` row; `runReviewerCentricCouncil` (`:2943`) creates one with
+  `model:'voice-centric'` only when `options.runId` is absent. The route
+  (`launchCouncilAnalysis:543`–`556`) always pre-creates the row with
+  `model = councilId || 'inline-config'` and passes `runId`, which is what makes
+  `last_council_id` (`local.js:2125`, keyed on `model`) and the "Last Used With"
+  join work. The headless helper MUST do the same: pre-create with
+  `model = council.id` and pass `runId`. It also must replicate the route's
+  completion/failure `analysisRunRepo.update` (the route does this in its
+  `.then()/.catch()` at `analyses.js:648`/`731`), since the analyzer methods do
+  not mark the parent run completed themselves.
+- **Two council invokers must stay in parity.** `launchCouncilAnalysis` (web) and
+  `runHeadlessCouncilAnalysis` (CLI) both drive the council analyzer methods.
+  CLAUDE.md already documents three analyzer *paths*; this adds a second
+  *invoker*, not a new analyzer path. Cross-reference them in comments; if the
+  run-record fields or completion semantics change in one, change both.
+- **`process.env.PAIR_REVIEW_MODEL` is process-global**, set in two places
+  (`src/main.js:654`, `src/local-review.js:912`) and read at `src/main.js:977`.
+  The `!flags.council` gate must be applied at **both** assignment sites.
+- **`_buildDefaultAnalysisConfig` is shared by PR and local** via `PRManager`
+  monkey-patching. Editing it to read the `council` param affects both — intended
+  for parity, but verify the local path still cleans the param and that forcing
+  the council branch when `urlCouncilId` is set doesn't break the `default_tab`
+  UI assumptions in the progress modal.
+- **`changedFiles: null` in `reviewContext`**: the analyzer falls back to
+  `getChangedFilesList`. Confirm `storedPRData` carries `head_sha` so the diff
+  snapshot + path validation behave identically to `analyzeAllLevels`.
+- **`--list-councils` DB lifecycle**: `db.close()` before `process.exit(0)`, and
+  place the check before single-port delegation so it doesn't collide with it.
+
+## Verification (end-to-end)
+1. `pnpm test` — new resolver + parseArgs + integration tests pass.
+2. Manual discovery: `pair-review --list-councils` lists seeded councils with
+   short-id handles (and prints the empty-state when none exist).
+3. Headless PR: `pair-review <pr> --ai-draft --council <name-or-shortid>` runs the
+   council (multiple voices in logs), persists suggestions, prints the summary;
+   `--council <bad>` aborts with a clear error before any GitHub call.
+4. Interactive: `pair-review <pr> --council <handle>` opens the browser, the
+   council config tab is pre-selected, and analysis auto-runs; same for
+   `pair-review --local --ai --council <handle>`.
+5. `--model` + `--council` together prints the ignore warning and still uses the
+   council's per-voice models.
+6. Frontend E2E run (via Task) green after `pr.js`/`local.js` edits.
+
+## Critical files
+- `src/councils/resolve-council.js` — NEW resolver (`resolveCouncilHandle`,
+  `shortId`, `normalizeForMatch`) and `getCouncilLastUsedRepos(db)` helper (the
+  `analysis_runs`⋈`reviews` join for the "Last Used With" column).
+- `src/councils/headless-council.js` — NEW `runHeadlessCouncilAnalysis(...)`:
+  server-free council run (pre-create run with `model=council.id` + `runId`,
+  invoke analyzer council method, update status/summary). Mirrors
+  `launchCouncilAnalysis` minus SSE/pool/hooks.
+- `src/database.js` — reuse `AnalysisRunRepository.create`/`update` (`:4969`/`:4995`)
+  and `CouncilRepository` (`:5374`); no schema change.
+- `src/main.js` — `KNOWN_FLAGS` (`:271`), `parseArgs` (`:299`), `printHelp`
+  (`:129`), `--list-councils` early handler in `main()`, headless council branch
+  in `performHeadlessReview` (~`:976`–`1000`), PR interactive URL (`:665`),
+  `--model` gating (`:654`).
+- `src/local-review.js` — local URL + `--model`/`--council` gating (`:912`–`921`).
+- `src/ai/analyzer.js` — `runCouncilAnalysis` (`:3482`), `runReviewerCentricCouncil`
+  (`:2943`): confirm self-contained run-record creation and suggestion-store
+  columns match the headless query.
+- `src/routes/councils.js` — reuse `normalizeCouncilConfig` / `validateCouncilConfig`.
+- `public/js/pr.js` (`_buildDefaultAnalysisConfig` ~`:636`, `_maybeAutoAnalyze`
+  `:714`) and `public/js/local.js` (`:78`/`:88`) — read & clean the `council` URL param.
+- Tests + README + `.changeset/*.md` as above.

--- a/public/js/local.js
+++ b/public/js/local.js
@@ -86,6 +86,7 @@ class LocalManager {
       } finally {
         const cleanUrl = new URL(window.location);
         cleanUrl.searchParams.delete('analyze');
+        cleanUrl.searchParams.delete('council');
         history.replaceState(null, '', cleanUrl);
       }
     }

--- a/public/js/pr.js
+++ b/public/js/pr.js
@@ -638,6 +638,44 @@ class PRManager {
     const defaultTab = repoSettings?.default_tab || 'single';
     const councilId = repoSettings?.default_council_id || reviewSettings?.last_council_id || null;
 
+    // A `?council=<id>` URL param (set by the CLI when opening the browser) takes
+    // highest priority for council selection. When present we force the council
+    // branch regardless of default_tab/settings, and derive configType from the
+    // council's own type ('council' or 'advanced') rather than the repo default.
+    const urlSearch = (typeof window !== 'undefined' && window.location && window.location.search) || '';
+    const urlCouncilId = new URLSearchParams(urlSearch).get('council');
+    if (urlCouncilId) {
+      let councilConfig = null;
+      let councilName = null;
+      let councilType = null;
+      try {
+        const resp = await fetch(`/api/councils/${urlCouncilId}`);
+        if (resp.ok) {
+          const data = await resp.json();
+          councilConfig = data.council?.config || null;
+          councilName = data.council?.name || null;
+          councilType = data.council?.type || null;
+        } else {
+          console.warn(`Failed to fetch council "${urlCouncilId}" from URL param (status ${resp.status}); falling back to default analysis config`);
+        }
+      } catch (e) {
+        console.warn('Failed to fetch council config for URL council param:', e);
+      }
+
+      // Only honor the URL council if we successfully fetched its config.
+      // Otherwise fall through to the existing default-selection logic.
+      if (councilConfig) {
+        return {
+          isCouncil: true,
+          councilId: urlCouncilId,
+          councilConfig,
+          councilName,
+          configType: councilType || 'advanced',
+          customInstructions: null
+        };
+      }
+    }
+
     if ((defaultTab === 'council' || defaultTab === 'advanced') && councilId) {
       // Fetch the full council config so the progress modal can render correctly
       let councilConfig = null;
@@ -763,6 +801,7 @@ class PRManager {
           const cleanUrl = new URL(window.location);
           cleanUrl.searchParams.delete('analyze');
           cleanUrl.searchParams.delete('analysisConfigId');
+          cleanUrl.searchParams.delete('council');
           history.replaceState(null, '', cleanUrl);
         }
       }
@@ -7069,22 +7108,42 @@ class PRManager {
   }
 
   /**
+   * Build the worktree-not-found recovery URL. When the user arrived via
+   * auto-analyze (?analyze=true), the reload link preserves the auto-analyze
+   * state so analysis re-triggers after worktree setup. Both the
+   * `analysisConfigId` and `council` params are carried through, since
+   * `_buildDefaultAnalysisConfig()` treats `?council=<id>` as the
+   * highest-priority analysis source — dropping it would silently fall back to
+   * the repo/default analysis configuration on retry.
+   * @param {string} owner - Repository owner
+   * @param {string} repo - Repository name
+   * @param {number} number - PR number
+   * @returns {string} The recovery URL (unescaped)
+   */
+  _buildWorktreeRecoveryUrl(owner, repo, number) {
+    let setupUrl = `/pr/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/${encodeURIComponent(number)}`;
+    if (this._autoAnalyzeRequested) {
+      const currentParams = new URLSearchParams(window.location.search);
+      const params = new URLSearchParams({ analyze: 'true' });
+      const analysisConfigId = currentParams.get('analysisConfigId');
+      const councilId = currentParams.get('council');
+      if (analysisConfigId) params.set('analysisConfigId', analysisConfigId);
+      if (councilId) params.set('council', councilId);
+      setupUrl += `?${params.toString()}`;
+    }
+    return setupUrl;
+  }
+
+  /**
    * Show an error when the worktree is not found during analysis.
-   * Displays a helpful message with a reload link. If the user arrived
-   * via auto-analyze (?analyze=true), the reload link preserves that
-   * parameter so analysis re-triggers after setup.
+   * Displays a helpful message with a reload link that preserves any
+   * auto-analyze state (see _buildWorktreeRecoveryUrl).
    * @param {string} owner - Repository owner
    * @param {string} repo - Repository name
    * @param {number} number - PR number
    */
   showWorktreeNotFoundError(owner, repo, number) {
-    let setupUrl = `/pr/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/${encodeURIComponent(number)}`;
-    if (this._autoAnalyzeRequested) {
-      const params = new URLSearchParams({ analyze: 'true' });
-      const analysisConfigId = new URLSearchParams(window.location.search).get('analysisConfigId');
-      if (analysisConfigId) params.set('analysisConfigId', analysisConfigId);
-      setupUrl += `?${params.toString()}`;
-    }
+    const setupUrl = this._buildWorktreeRecoveryUrl(owner, repo, number);
     const container = document.getElementById('pr-container');
     if (container) {
       container.innerHTML = `

--- a/public/setup.html
+++ b/public/setup.html
@@ -770,6 +770,10 @@
                         var qs = new URLSearchParams(window.location.search);
                         if (qs.get('analyze') === 'true') targetUrl.searchParams.set('analyze', qs.get('analyze'));
                         if (qs.get('analysisConfigId')) targetUrl.searchParams.set('analysisConfigId', qs.get('analysisConfigId'));
+                        // Forward the CLI-supplied council selection (PR & local cold-start
+                        // and delegated paths route through here); the review page keys
+                        // council auto-analysis on this param.
+                        if (qs.get('council')) targetUrl.searchParams.set('council', qs.get('council'));
                         window.location.href = targetUrl.toString();
                         return;
                     }
@@ -831,6 +835,10 @@
                                     var qs = new URLSearchParams(window.location.search);
                                     if (qs.get('analyze') === 'true') targetUrl.searchParams.set('analyze', qs.get('analyze'));
                                     if (qs.get('analysisConfigId')) targetUrl.searchParams.set('analysisConfigId', qs.get('analysisConfigId'));
+                                    // Forward the CLI-supplied council selection (PR & local cold-start
+                                    // and delegated paths route through here); the review page keys
+                                    // council auto-analysis on this param.
+                                    if (qs.get('council')) targetUrl.searchParams.set('council', qs.get('council'));
                                     window.location.href = targetUrl.toString();
                                 }
                             }, 400);

--- a/src/councils/headless-council.js
+++ b/src/councils/headless-council.js
@@ -1,0 +1,118 @@
+// Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+
+const { v4: uuidv4 } = require('uuid');
+const { AnalysisRunRepository, CouncilRepository } = require('../database');
+const logger = require('../utils/logger');
+
+/**
+ * Run a council analysis without any server infrastructure.
+ *
+ * This is the server-free twin of `launchCouncilAnalysis` in
+ * `src/routes/analyses.js`. It exists for the CLI headless path, where the
+ * SSE broadcast helpers (`broadcastProgress`/`broadcastReviewEvent`), the
+ * `activeAnalyses` map, the worktree pool lifecycle, and the hook firing of
+ * the route are all absent. It reuses the SAME analyzer methods
+ * (`runReviewerCentricCouncil` / `runCouncilAnalysis`) and the SAME
+ * run-record semantics as the route.
+ *
+ * IMPORTANT: The two functions MUST stay in parity for run-record fields and
+ * completion semantics. Specifically:
+ *   - The parent `analysis_runs` row is PRE-CREATED here with
+ *     `model = council.id` and `runId` is passed into the analyzer. This is
+ *     what attributes the run to the council. The analyzer methods do not
+ *     create the parent row when a `runId` is supplied.
+ *   - The analyzer methods do NOT mark the parent run completed/failed; this
+ *     helper does it (mirroring the route's `.then()` / `.catch()`).
+ * Any change to run-record fields or completion handling must be applied to
+ * BOTH this function and `launchCouncilAnalysis`.
+ *
+ * @param {Object} db - Database instance
+ * @param {Object} params - Analysis parameters
+ * @param {Object} params.analyzer - Analyzer instance exposing
+ *   `runReviewerCentricCouncil` and `runCouncilAnalysis`
+ * @param {number} params.reviewId - Review ID (PR or local)
+ * @param {Object} params.council - Full council row (must have `.id`)
+ * @param {string} params.configType - 'council' (voice-centric) or 'advanced'
+ * @param {Object} params.councilConfig - The council's parsed config object
+ * @param {string} params.worktreePath - Path to the checked-out worktree
+ * @param {Object} [params.prMetadata] - PR metadata (head_sha used for the run row)
+ * @param {Object} params.instructions - { globalInstructions, repoInstructions, requestInstructions }
+ *   (requestInstructions may be null)
+ * @param {Object} [params.githubClient] - GitHub client passed through to the analyzer
+ * @returns {Promise<Object>} The analyzer result ({ suggestions, summary, levelOutcomes, ... })
+ */
+async function runHeadlessCouncilAnalysis(db, params) {
+  const {
+    analyzer,
+    reviewId,
+    council,
+    configType,
+    councilConfig,
+    worktreePath,
+    prMetadata,
+    instructions,
+    githubClient,
+  } = params;
+
+  const runId = uuidv4();
+
+  // Compute levelsConfig the same way launchCouncilAnalysis (analyses.js:533-541) does.
+  let levelsConfig = null;
+  if (configType === 'council') {
+    levelsConfig = councilConfig.levels || null;
+  } else if (councilConfig.levels) {
+    levelsConfig = {};
+    for (const [key, val] of Object.entries(councilConfig.levels)) {
+      levelsConfig[key] = val?.enabled !== false;
+    }
+  }
+
+  const runRepo = new AnalysisRunRepository(db);
+  await runRepo.create({
+    id: runId,
+    reviewId,
+    provider: 'council',
+    model: council.id,
+    tier: null,
+    globalInstructions: instructions.globalInstructions || null,
+    repoInstructions: instructions.repoInstructions || null,
+    requestInstructions: instructions.requestInstructions || null,
+    headSha: prMetadata?.head_sha || null,
+    configType,
+    levelsConfig
+  });
+
+  new CouncilRepository(db).touchLastUsedAt(council.id).catch(err => {
+    logger.warn(`Failed to update council last_used_at: ${err.message}`);
+  });
+
+  const reviewContext = {
+    reviewId,
+    worktreePath,
+    prMetadata,
+    changedFiles: null,
+    instructions
+  };
+
+  try {
+    const result = configType === 'council'
+      ? await analyzer.runReviewerCentricCouncil(reviewContext, councilConfig, { runId, progressCallback: null, githubClient })
+      : await analyzer.runCouncilAnalysis(reviewContext, councilConfig, { runId, progressCallback: null, githubClient });
+
+    await runRepo.update(runId, {
+      status: 'completed',
+      summary: result.summary,
+      totalSuggestions: result.suggestions.length,
+      ...(result.levelOutcomes ? { levelOutcomes: result.levelOutcomes } : {})
+    }).catch(err => {
+      logger.warn(`Failed to update analysis_run: ${err.message}`);
+    });
+
+    return result;
+  } catch (error) {
+    await runRepo.update(runId, { status: 'failed' }).catch(() => {});
+    throw error;
+  }
+}
+
+module.exports = { runHeadlessCouncilAnalysis };

--- a/src/councils/resolve-council.js
+++ b/src/councils/resolve-council.js
@@ -1,0 +1,167 @@
+// Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+/**
+ * Council handle resolution helpers.
+ *
+ * Resolves user-supplied CLI handles (id, id-prefix, name, normalized name) to a
+ * saved council row, and gathers "Last Used With" metadata for the council list.
+ */
+
+const { query, CouncilRepository } = require('../database');
+
+/**
+ * Normalize a string for fuzzy name matching: lowercase, trim, collapse any run
+ * of non-alphanumeric characters to a single dash, and strip leading/trailing dashes.
+ * @param {string} s - Input string
+ * @returns {string} Normalized slug-like string
+ */
+function normalizeForMatch(s) {
+  return String(s || '').toLowerCase().trim().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+}
+
+/**
+ * Truncate an id to its first 8 characters for display.
+ * @param {string} id - Full council id (UUID)
+ * @returns {string} Short id
+ */
+function shortId(id) {
+  return String(id || '').slice(0, 8);
+}
+
+/**
+ * Build a clear, multi-line ambiguity error for a handle that matched several councils.
+ * @param {string} handle - The user-supplied handle
+ * @param {Array<Object>} matches - The matching council rows
+ * @returns {Error} Error with a readable, aligned candidate list
+ * @private
+ */
+function _ambiguityError(handle, matches) {
+  const padTo = Math.max(...matches.map(c => String(c.name || '').length));
+  const lines = matches.map(c => {
+    const name = String(c.name || '').padEnd(padTo);
+    // Show the FULL id, not shortId: when the collision is on the 8-char prefix,
+    // every shortId would be identical and could not disambiguate.
+    return `  ${name}  (${c.id})`;
+  });
+  return new Error(
+    `Ambiguous council "${handle}" matches ${matches.length} councils. Disambiguate with the id:\n` +
+    lines.join('\n')
+  );
+}
+
+/**
+ * Resolve a user-supplied council handle to a full council row.
+ *
+ * Matching order (first unambiguous match wins):
+ *   1. Exact id
+ *   2. UUID-prefix (only for hex-ish handles of length >= 4)
+ *   3. Exact name (case-insensitive)
+ *   4. Normalized name
+ *   5. Partial (substring) name fragment (last resort, never shadows the above)
+ *
+ * @param {Database} db - Database instance
+ * @param {string} handle - The handle to resolve (id, id-prefix, or name)
+ * @returns {Promise<Object>} The matching council row
+ * @throws {Error} If the handle is missing, ambiguous, or matches nothing
+ */
+async function resolveCouncilHandle(db, handle) {
+  const all = await new CouncilRepository(db).list();
+
+  if (!handle) {
+    throw new Error('A council handle is required.');
+  }
+
+  // 1. Exact id
+  const exactId = all.find(c => c.id === handle);
+  if (exactId) return exactId;
+
+  // 2. UUID-prefix match (only for hex-ish handles of meaningful length)
+  if (handle.length >= 4 && /^[0-9a-f-]+$/i.test(handle)) {
+    const m = all.filter(c => c.id.toLowerCase().startsWith(handle.toLowerCase()));
+    if (m.length === 1) return m[0];
+    if (m.length > 1) throw _ambiguityError(handle, m);
+  }
+
+  // 3. Exact name (case-insensitive)
+  {
+    const m = all.filter(c => c.name.toLowerCase() === handle.toLowerCase());
+    if (m.length === 1) return m[0];
+    if (m.length > 1) throw _ambiguityError(handle, m);
+  }
+
+  // 4. Normalized name
+  {
+    const hn = normalizeForMatch(handle);
+    const m = all.filter(c => normalizeForMatch(c.name) === hn);
+    if (m.length === 1) return m[0];
+    if (m.length > 1) throw _ambiguityError(handle, m);
+  }
+
+  // 5. Partial (substring) name fragment — last resort. A council matches if its
+  // name contains the handle (case-insensitive) OR its normalized name contains
+  // the normalized handle. Union both, de-duplicated by id so a council matched
+  // both ways isn't double-counted.
+  {
+    const hl = handle.toLowerCase();
+    const hn = normalizeForMatch(handle);
+    const seen = new Set();
+    const m = [];
+    for (const c of all) {
+      const byName = String(c.name || '').toLowerCase().includes(hl);
+      const byNorm = hn !== '' && normalizeForMatch(c.name).includes(hn);
+      if ((byName || byNorm) && !seen.has(c.id)) {
+        seen.add(c.id);
+        m.push(c);
+      }
+    }
+    if (m.length === 1) return m[0];
+    if (m.length > 1) throw _ambiguityError(handle, m);
+  }
+
+  // No match
+  throw new Error(
+    `No council matches "${handle}". Run \`pair-review --list-councils\` to see available councils.`
+  );
+}
+
+/**
+ * Build a map of the most recent council RUN per saved council, for the
+ * "Last Used With" column in the council list.
+ *
+ * Only counts true council runs (provider = 'council', model != 'inline-config').
+ * Councils with no council run simply won't appear in the map.
+ *
+ * @param {Database} db - Database instance
+ * @returns {Promise<Map<string, {repository: string, review_type: string, pr_number: number, last_started: string}>>}
+ *   Map keyed by council id.
+ */
+async function getCouncilLastUsedRepos(db) {
+  const rows = await query(db, `
+    SELECT ar.model AS council_id,
+           r.repository AS repository,
+           r.review_type AS review_type,
+           r.pr_number AS pr_number,
+           MAX(ar.started_at) AS last_started
+    FROM analysis_runs ar
+    JOIN reviews r ON r.id = ar.review_id
+    WHERE ar.provider = 'council' AND ar.model != 'inline-config'
+    GROUP BY ar.model
+  `);
+
+  const map = new Map();
+  for (const row of rows) {
+    map.set(row.council_id, {
+      repository: row.repository,
+      review_type: row.review_type,
+      pr_number: row.pr_number,
+      last_started: row.last_started
+    });
+  }
+  return map;
+}
+
+module.exports = {
+  normalizeForMatch,
+  shortId,
+  resolveCouncilHandle,
+  getCouncilLastUsedRepos
+};

--- a/src/local-review.js
+++ b/src/local-review.js
@@ -13,6 +13,7 @@ const { buildReviewStartedPayload, buildReviewLoadedPayload, getCachedUser } = r
 const execAsync = promisify(exec);
 const { STOPS, scopeIncludes, includesBranch, DEFAULT_SCOPE, scopeLabel, reviewScope } = require('./local-scope');
 const { initializeDatabase, ReviewRepository, RepoSettingsRepository } = require('./database');
+const { resolveCouncilHandle } = require('./councils/resolve-council');
 const { startServer } = require('./server');
 const { localReviewDiffs } = require('./routes/shared');
 const summaryGenerator = require('./ai/summary-generator');
@@ -906,10 +907,18 @@ async function handleLocalReview(targetPath, flags = {}) {
     console.log('Initializing database...');
     db = await initializeDatabase(resolveDbName(config));
 
+    // Resolve the council handle FAIL-FAST before any further setup, so a bad
+    // handle surfaces as a clean error instead of after the browser opens.
+    let councilSelection = null;
+    if (flags.council) {
+      councilSelection = await resolveCouncilHandle(db, flags.council);
+    }
+
     const session = await setupLocalReviewSession({ db, config, repoPath, flags });
     setupComplete = true;
 
-    if (flags.model) {
+    // Skipped when --council is set: council voices carry their own per-voice models.
+    if (flags.model && !flags.council) {
       process.env.PAIR_REVIEW_MODEL = flags.model;
     }
 
@@ -917,9 +926,9 @@ async function handleLocalReview(targetPath, flags = {}) {
     const port = await startServer(db);
 
     let url = `http://localhost:${port}/local/${session.sessionId}`;
-    if (flags.ai) {
-      url += '?analyze=true';
-    }
+    const shouldAnalyze = flags.ai || flags.council;
+    if (shouldAnalyze) url += '?analyze=true';
+    if (councilSelection) url += `&council=${councilSelection.id}`;
     console.log(`\nOpening browser to: ${url}`);
     await open(url);
 

--- a/src/main.js
+++ b/src/main.js
@@ -1,7 +1,7 @@
 // Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
 const fs = require('fs');
-const { loadConfig, getConfigDir, getGitHubToken, resolveHostBinding, showWelcomeMessage, resolveDbName, resolveRepoOptions, resolvePoolConfig, getRepoResetScript, resolveLoadSkills } = require('./config');
-const { initializeDatabase, run, queryOne, query, migrateExistingWorktrees, WorktreeRepository, ReviewRepository, RepoSettingsRepository, GitHubReviewRepository, WorktreePoolRepository } = require('./database');
+const { loadConfig, getConfigDir, getGitHubToken, resolveHostBinding, showWelcomeMessage, resolveDbName, resolveRepoOptions, resolvePoolConfig, getRepoResetScript, resolveLoadSkills, buildCouncilProviderOverrides } = require('./config');
+const { initializeDatabase, run, queryOne, query, migrateExistingWorktrees, WorktreeRepository, ReviewRepository, RepoSettingsRepository, GitHubReviewRepository, WorktreePoolRepository, CouncilRepository } = require('./database');
 const { PRArgumentParser } = require('./github/parser');
 const { GitHubClient } = require('./github/client');
 const { GitWorktreeManager } = require('./git/worktree');
@@ -11,6 +11,9 @@ const { startServer } = require('./server');
 const Analyzer = require('./ai/analyzer');
 const { applyConfigOverrides } = require('./ai');
 const { handleLocalReview, findMainGitRoot } = require('./local-review');
+const { resolveCouncilHandle, getCouncilLastUsedRepos, shortId } = require('./councils/resolve-council');
+const { runHeadlessCouncilAnalysis } = require('./councils/headless-council');
+const { normalizeCouncilConfig, validateCouncilConfig } = require('./routes/councils');
 const { storePRData, registerRepositoryLocation, findRepositoryPath } = require('./setup/pr-setup');
 const { fireReviewStartedHook } = require('./hooks/payloads');
 const { normalizeRepository, resolveRenamedFile, resolveRenamedFileOld } = require('./utils/paths');
@@ -164,6 +167,9 @@ OPTIONS:
                                   opus-4.6-high, opus-4.6-1m, sonnet-4.6
                             (opus is Opus 4.7 XHigh, the default)
                             or use provider-specific models with Gemini/Codex
+    --council <handle>      Run analysis with a saved council (multi-voice). Handle is a
+                            council name, name-slug, or id (prefix). See --list-councils.
+    --list-councils         List saved councils (handles to use with --council) and exit
     --use-checkout          Use current directory instead of creating worktree
                             (automatic in GitHub Actions)
     --yolo                  Allow AI providers full system access (skip read-only
@@ -179,6 +185,8 @@ EXAMPLES:
     pair-review --local                # Review uncommitted local changes
     pair-review 123 --ai               # Auto-run AI analysis
     pair-review --ai-review            # CI mode: auto-detect PR, submit review
+    pair-review 123 --ai-draft --council security-review  # Headless council draft
+    pair-review --list-councils        # List saved councils and their handles
     pair-review --register                     # Register URL scheme handler
     pair-review --register --command "node bin/pair-review.js"  # Custom command
 
@@ -205,6 +213,74 @@ CONFIGURATION:
 MORE INFO:
     https://github.com/in-the-loop-labs/pair-review
 `);
+}
+
+/**
+ * Print the list of saved councils (handles, names, types, and "last used"
+ * metadata) as an aligned table, then exit guidance. Used by --list-councils.
+ *
+ * @param {Object} db - Database instance
+ */
+async function printCouncilList(db) {
+  const councils = await new CouncilRepository(db).list();
+
+  if (!councils || councils.length === 0) {
+    console.log('No councils found. Create one in the web UI under Analysis settings.');
+    return;
+  }
+
+  const repoMap = await getCouncilLastUsedRepos(db);
+
+  const rows = councils.map(c => {
+    const entry = repoMap.get(c.id);
+    const lastTs = entry?.last_started || c.last_used_at;
+    const lastUsed = lastTs ? String(lastTs).slice(0, 10) : 'never';
+    let lastUsedWith = '—';
+    if (entry) {
+      lastUsedWith = `${entry.repository}${entry.pr_number ? `#${entry.pr_number}` : ''}`;
+    }
+    return {
+      handle: shortId(c.id),
+      name: c.name || '',
+      type: c.type || '',
+      lastUsed,
+      lastUsedWith
+    };
+  });
+
+  const headers = {
+    handle: 'HANDLE',
+    name: 'NAME',
+    type: 'TYPE',
+    lastUsed: 'LAST USED',
+    lastUsedWith: 'LAST USED WITH'
+  };
+
+  const widths = {};
+  for (const key of Object.keys(headers)) {
+    widths[key] = Math.max(
+      headers[key].length,
+      ...rows.map(r => String(r[key]).length)
+    );
+  }
+
+  const formatRow = r =>
+    [
+      String(r.handle).padEnd(widths.handle),
+      String(r.name).padEnd(widths.name),
+      String(r.type).padEnd(widths.type),
+      String(r.lastUsed).padEnd(widths.lastUsed),
+      String(r.lastUsedWith).padEnd(widths.lastUsedWith)
+    ].join('  ');
+
+  console.log(formatRow(headers));
+  for (const r of rows) {
+    console.log(formatRow(r));
+  }
+
+  console.log('');
+  console.log('Pass a handle with --council, e.g.:');
+  console.log('  pair-review <pr> --ai-draft --council ' + shortId(councils[0].id));
 }
 
 /**
@@ -279,6 +355,8 @@ const KNOWN_FLAGS = new Set([
   '-l', '--local',
   '--mcp',
   '--model',
+  '--council',
+  '--list-councils',
   '--register',
   '--unregister',
   '--command',
@@ -328,6 +406,16 @@ function parseArgs(args) {
       } else {
         throw new Error('--model flag requires a model name (e.g., --model sonnet)');
       }
+    } else if (arg === '--council') {
+      // Next argument is the council handle (name, name-slug, or id prefix)
+      if (i + 1 < args.length && !args[i + 1].startsWith('-')) {
+        flags.council = args[i + 1];
+        i++; // Skip next argument since we consumed it
+      } else {
+        throw new Error('--council flag requires a council handle (e.g., --council my-council)');
+      }
+    } else if (arg === '--list-councils') {
+      flags.listCouncils = true;
     } else if (arg === '-l' || arg === '--local') {
       // -l/--local flag is always a boolean
       flags.local = true;
@@ -497,26 +585,84 @@ AI PROVIDERS:
       process.env.PAIR_REVIEW_YOLO = 'true';
     }
 
+    // --model is ignored when --council is set: council voices use their own
+    // per-voice models, so a top-level --model has no effect on the analysis.
+    if (flags.council && flags.model) {
+      console.warn('Warning: --model is ignored when --council is set; council voices use their own per-voice models.');
+    }
+
     // Apply provider config overrides (including yolo) for all code paths
     // (interactive, headless, local). server.js calls this independently on
     // startup, but headless paths (--ai-draft, --ai-review) never start the
     // server, so we must also apply here.
     applyConfigOverrides(config);
 
+    // --list-councils: print the saved councils and exit. Needs the database
+    // but no server, no PR/local context, and no single-port delegation.
+    if (flags.listCouncils) {
+      const listDb = await initializeDatabase(resolveDbName(config));
+      try {
+        await printCouncilList(listDb);
+      } finally {
+        try { listDb.close(); } catch { /* ignore */ }
+      }
+      process.exit(0);
+    }
+
+    // --council requires something to analyze: a PR identifier or --local.
+    // Reject early (before single-port delegation) so a contextless `--council`
+    // fails fast with a clear message instead of silently delegating to — or
+    // starting — the generic landing page with the council ignored.
+    //
+    // Exception: in GitHub Actions, `--ai-review --council <handle>` is a
+    // documented headless flow where the PR is auto-detected from the
+    // environment further below (detectPRFromGitHubEnvironment). At this point
+    // prArgs is still empty, so guarding on it alone would reject that valid CI
+    // invocation. Defer to the later `--ai-review` PR check, which reports a
+    // clear error if no PR can be detected.
+    if (
+      flags.council &&
+      prArgs.length === 0 &&
+      !flags.local &&
+      !(flags.aiReview && process.env.GITHUB_ACTIONS === 'true')
+    ) {
+      throw new Error('--council flag requires a pull request number/URL or --local to run analysis');
+    }
+
+    // Resolve the council handle FAIL-FAST, before single-port delegation, so
+    // that (a) a bad handle errors out for every mode (interactive, headless,
+    // and delegated) rather than only on a cold start, and (b) the resolved id
+    // can be threaded into the delegated URL — the browser-side council
+    // auto-analysis is keyed on the `council` query param. Resolution needs the
+    // DB, so when --council is set we open the shared connection now and the
+    // downstream handlers reuse it (they re-resolve for their own purposes;
+    // that is a cheap in-memory match against the same connection).
+    let cliCouncil = null;
+    if (flags.council) {
+      db = await initializeDatabase(resolveDbName(config));
+      cliCouncil = await resolveCouncilHandle(db, flags.council);
+    }
+
     // Single-port delegation: if a pair-review server is already running on the
     // configured port, delegate to it (open browser URL) and exit immediately.
     // Skipped for: headless modes (no browser), single_port: false (dev mode).
     if (config.single_port !== false && !flags.aiReview && !flags.aiDraft) {
-      const delegated = await attemptDelegation(config, flags, prArgs);
+      const delegated = await attemptDelegation(config, flags, prArgs, undefined, {
+        councilId: cliCouncil?.id || null
+      });
       if (delegated) {
+        if (db) { try { db.close(); } catch { /* ignore */ } }
         process.exit(0);
       }
       // Not delegated — no server running, proceed to start one
     }
 
-    // Initialize database
-    console.log('Initializing database...');
-    db = await initializeDatabase(resolveDbName(config));
+    // Initialize database (reuse the connection already opened for council
+    // resolution above, if any).
+    if (!db) {
+      console.log('Initializing database...');
+      db = await initializeDatabase(resolveDbName(config));
+    }
 
     // Migrate existing worktrees to database (if any)
     const path = require('path');
@@ -649,9 +795,18 @@ async function handlePullRequest(args, config, db, flags = {}, poolLifecycle = n
       await registerRepositoryLocation(db, currentDir, prInfo.owner, prInfo.repo);
     }
 
-    // Set model override if provided via CLI flag
-    if (flags.model) {
+    // Set model override if provided via CLI flag. Skipped when --council is
+    // set: council voices carry their own per-voice models.
+    if (flags.model && !flags.council) {
       process.env.PAIR_REVIEW_MODEL = flags.model;
+    }
+
+    // Resolve the council handle FAIL-FAST before starting the server, so a bad
+    // handle surfaces as a clean error (caught below) instead of after the
+    // browser has opened.
+    let councilSelection = null;
+    if (flags.council) {
+      councilSelection = await resolveCouncilHandle(db, flags.council);
     }
 
     // Start server and open browser to setup page
@@ -663,9 +818,9 @@ async function handlePullRequest(args, config, db, flags = {}, poolLifecycle = n
     startPoolBackgroundFetches(db, config);
 
     let url = `http://localhost:${port}/pr/${prInfo.owner}/${prInfo.repo}/${prInfo.number}`;
-    if (flags.ai) {
-      url += '?analyze=true';
-    }
+    const shouldAnalyze = flags.ai || flags.council;
+    if (shouldAnalyze) url += '?analyze=true';
+    if (councilSelection) url += `&council=${councilSelection.id}`;
 
     console.log(`Opening browser to: ${url}`);
     await open(url);
@@ -741,6 +896,21 @@ async function performHeadlessReview(args, config, db, flags, options, externalP
     // owner/repo before falling back to GitHub/Graphite parsers.
     const parser = new PRArgumentParser(config);
     prInfo = await parser.parsePRArguments(args);
+
+    // Resolve + validate the council FAIL-FAST, before any worktree/network
+    // work, so a bad handle or invalid config surfaces immediately.
+    let councilSelection = null;
+    if (flags.council) {
+      const council = await resolveCouncilHandle(db, flags.council);
+      const configType = council.type || 'advanced';
+      const councilConfig = normalizeCouncilConfig(council.config, configType);
+      // validateCouncilConfig returns an error string, or null when valid.
+      const validationError = validateCouncilConfig(councilConfig, configType);
+      if (validationError) {
+        throw new Error(`Invalid council "${council.name}": ${validationError}`);
+      }
+      councilSelection = { council, configType, councilConfig };
+    }
 
     // Resolve host binding for the target repo (handles alt-host).
     // Prefer `bindingRepository` (from url_pattern match) over the raw
@@ -972,13 +1142,11 @@ async function performHeadlessReview(args, config, db, flags, options, externalP
     const globalInstructions = config.globalInstructions || null;
 
     // Run AI analysis
-    console.log('Running AI analysis (all 3 levels)...');
     const cliProvider = repoSettings?.default_provider || config.default_provider || config.provider || 'claude';
     const model = flags.model || process.env.PAIR_REVIEW_MODEL || repoSettings?.default_model || config.default_model || config.model || 'opus';
     const providerLoadSkills = config.providers?.[cliProvider]?.load_skills;
     const loadSkills = resolveLoadSkills(config, repository, repoSettings, providerLoadSkills);
     const providerOverrides = { load_skills: loadSkills };
-    const analyzer = new Analyzer(db, model, cliProvider, providerOverrides);
 
     let analysisSummary = null;
     try {
@@ -986,7 +1154,33 @@ async function performHeadlessReview(args, config, db, flags, options, externalP
       // githubClient is forwarded so the analyzer can pre-fetch existing PR review
       // comments when callers opt in via excludePrevious.github.
       logger.debug(`analyzer githubClient wired for ${prInfo.owner}/${prInfo.repo}#${prInfo.number}`);
-      const analysisResult = await analyzer.analyzeAllLevels(review.id, worktreePath, storedPRData, null, { globalInstructions, repoInstructions }, null, { githubClient });
+      let analysisResult;
+      if (councilSelection) {
+        console.log(`Running council analysis: ${councilSelection.council.name} (${councilSelection.configType})...`);
+        // Council voices can span multiple providers, so resolve a per-provider
+        // load_skills map (tier-3 resolution per provider) the same way every
+        // other council invoker does (pr.js / local.js / stack-analysis.js).
+        // Passing only the shared `providerOverrides` would collapse every voice
+        // onto the default provider's load_skills — see buildVoiceContext.
+        const { providerOverrides: councilProviderOverrides, providerOverridesMap: councilProviderOverridesMap } =
+          buildCouncilProviderOverrides(config, repository, repoSettings);
+        const analyzer = new Analyzer(db, 'council', 'council', councilProviderOverrides, councilProviderOverridesMap);
+        analysisResult = await runHeadlessCouncilAnalysis(db, {
+          analyzer,
+          reviewId: review.id,
+          council: councilSelection.council,
+          configType: councilSelection.configType,
+          councilConfig: councilSelection.councilConfig,
+          worktreePath,
+          prMetadata: storedPRData,
+          instructions: { globalInstructions, repoInstructions, requestInstructions: null },
+          githubClient
+        });
+      } else {
+        console.log('Running AI analysis (all 3 levels)...');
+        const analyzer = new Analyzer(db, model, cliProvider, providerOverrides);
+        analysisResult = await analyzer.analyzeAllLevels(review.id, worktreePath, storedPRData, null, { globalInstructions, repoInstructions }, null, { githubClient });
+      }
       analysisSummary = analysisResult.summary;
       console.log('AI analysis completed successfully');
     } catch (analysisError) {
@@ -1402,4 +1596,4 @@ if (require.main === module) {
   main();
 }
 
-module.exports = { main, parseArgs, detectPRFromGitHubEnvironment };
+module.exports = { main, parseArgs, detectPRFromGitHubEnvironment, printCouncilList };

--- a/src/single-port.js
+++ b/src/single-port.js
@@ -95,18 +95,24 @@ function notifyVersion(port, currentVersion, _deps) {
  * @param {number} [context.number]
  * @param {string} [context.localPath]
  * @param {boolean} [context.analyze] - Whether to trigger auto-analysis
+ * @param {string} [context.councilId] - Resolved council id for council auto-analysis
  * @returns {string} Full URL
  */
 function buildDelegationUrl(port, mode, context = {}) {
   const base = `http://localhost:${port}`;
   if (mode === 'pr') {
     let url = `${base}/pr/${context.owner}/${context.repo}/${context.number}`;
-    if (context.analyze) url += '?analyze=true';
+    const query = [];
+    if (context.analyze) query.push('analyze=true');
+    if (context.councilId) query.push(`council=${encodeURIComponent(context.councilId)}`);
+    if (query.length) url += `?${query.join('&')}`;
     return url;
   }
   if (mode === 'local') {
+    // The `?path=` segment is always present, so analyze/council append with `&`.
     let url = `${base}/local?path=${encodeURIComponent(context.localPath)}`;
     if (context.analyze) url += '&analyze=true';
+    if (context.councilId) url += `&council=${encodeURIComponent(context.councilId)}`;
     return url;
   }
   return `${base}/`;
@@ -137,11 +143,21 @@ async function parsePRArgsForDelegation(prArgs, config = null, _deps) {
  * @param {object} flags - Parsed CLI flags
  * @param {string[]} prArgs - PR arguments from CLI
  * @param {object} [_deps] - Dependency overrides for testing
+ * @param {object} [options] - Pre-resolved values from the caller
+ * @param {string|null} [options.councilId] - Resolved council id (the caller
+ *   resolves `flags.council` against the DB before delegation, since this
+ *   module has no DB access). When set, the delegated URL carries
+ *   `&council=<id>` and auto-analysis is forced on.
  * @returns {Promise<boolean>} true if delegated, false if should start fresh
  */
-async function attemptDelegation(config, flags, prArgs, _deps) {
+async function attemptDelegation(config, flags, prArgs, _deps, options = {}) {
   const deps = { ...defaults, ..._deps };
   const port = config.port;
+  const councilId = options.councilId || null;
+  // A council selection implies analysis: the browser-side council
+  // auto-analysis is gated on the `council` param + `analyze=true`, mirroring
+  // the cold-start URL built in handlePullRequest/handleLocalReview.
+  const analyze = !!(flags.ai || flags.council);
 
   const result = await detectRunningServer(port, _deps);
 
@@ -164,10 +180,10 @@ async function attemptDelegation(config, flags, prArgs, _deps) {
   if (flags.local) {
     rejectUrlLikeLocalReviewPath(flags.localPath);
     const targetPath = path.resolve(flags.localPath || process.cwd());
-    url = buildDelegationUrl(port, 'local', { localPath: targetPath, analyze: flags.ai });
+    url = buildDelegationUrl(port, 'local', { localPath: targetPath, analyze, councilId });
   } else if (prArgs.length > 0) {
     const prInfo = await parsePRArgsForDelegation(prArgs, config, _deps);
-    url = buildDelegationUrl(port, 'pr', { ...prInfo, analyze: flags.ai });
+    url = buildDelegationUrl(port, 'pr', { ...prInfo, analyze, councilId });
   } else {
     url = buildDelegationUrl(port, 'server');
   }

--- a/tests/integration/cli-council-flags.test.js
+++ b/tests/integration/cli-council-flags.test.js
@@ -1,0 +1,185 @@
+// Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+/**
+ * Integration tests for the council-related CLI flags (--list-councils and
+ * --council), exercising the real CLI as a spawned child process.
+ *
+ * Unlike the direct-call unit tests (resolve-council, print-council-list),
+ * these run `bin/pair-review.js` end-to-end so they cover argv parsing, config
+ * + DB resolution from a real config dir, process exit codes, and the stderr
+ * formatting for bad handles — the class of behavior a direct function call
+ * cannot reach.
+ *
+ * The council is seeded by a separate child `node` process so it uses the real
+ * production `initializeDatabase` + `CouncilRepository` against the test's
+ * temp HOME (CONFIG_DIR is fixed at module load from os.homedir(), so the
+ * parent process can't write to the child's config dir directly).
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { spawnSync } from 'child_process';
+import { v4 as uuidv4 } from 'uuid';
+import fs from 'fs/promises';
+import path from 'path';
+import os from 'os';
+
+const REPO_ROOT = path.join(__dirname, '../..');
+const DB_MODULE = path.join(REPO_ROOT, 'src/database.js');
+
+const SAMPLE_CONFIG = {
+  levels: {
+    '1': { enabled: true, voices: [{ provider: 'claude', model: 'sonnet', tier: 'balanced' }] },
+    '2': { enabled: false, voices: [] },
+    '3': { enabled: false, voices: [] }
+  }
+};
+
+/**
+ * Run the CLI as a child process with the test's temp HOME.
+ * @param {string[]} args - CLI arguments
+ * @param {string} testHomeDir - temp HOME for config/DB isolation
+ * @param {Object<string,string>} [extraEnv] - extra env vars merged last (e.g.
+ *   to simulate a GitHub Actions environment). An empty-string value clears the
+ *   inherited variable, which matters when the test runner itself executes in
+ *   CI and would otherwise leak real GITHUB_* values into the child.
+ */
+function runCli(args, testHomeDir, extraEnv = {}) {
+  // Use process.execPath (not the literal 'node') so the child runs under the
+  // SAME Node major as the test runner — better-sqlite3 is a native module and
+  // only loads under the Node ABI its binary was built for.
+  return spawnSync(process.execPath, ['bin/pair-review.js', ...args], {
+    cwd: REPO_ROOT,
+    env: {
+      ...process.env,
+      HOME: testHomeDir,
+      GITHUB_TOKEN: '',
+      PAIR_REVIEW_NO_OPEN: '1',
+      ...extraEnv
+    },
+    timeout: 20000
+  });
+}
+
+/**
+ * Seed a council into the test HOME's database via a child node process using
+ * production code (no schema duplication). Council fields are passed via env
+ * vars to avoid inline-script quoting hazards.
+ */
+function seedCouncil(testHomeDir, { id, name, type }) {
+  const seedScript = `
+    const { initializeDatabase, CouncilRepository } = require(process.env.SEED_DB_MODULE);
+    (async () => {
+      const db = await initializeDatabase('database.db');
+      await new CouncilRepository(db).create({
+        id: process.env.SEED_COUNCIL_ID,
+        name: process.env.SEED_COUNCIL_NAME,
+        type: process.env.SEED_COUNCIL_TYPE,
+        config: JSON.parse(process.env.SEED_COUNCIL_CONFIG)
+      });
+      db.close();
+    })().catch((err) => { console.error(err); process.exit(1); });
+  `;
+  const result = spawnSync(process.execPath, ['-e', seedScript], {
+    cwd: REPO_ROOT,
+    env: {
+      ...process.env,
+      HOME: testHomeDir,
+      SEED_DB_MODULE: DB_MODULE,
+      SEED_COUNCIL_ID: id,
+      SEED_COUNCIL_NAME: name,
+      SEED_COUNCIL_TYPE: type,
+      SEED_COUNCIL_CONFIG: JSON.stringify(SAMPLE_CONFIG),
+      PAIR_REVIEW_NO_OPEN: '1'
+    },
+    timeout: 20000
+  });
+  if (result.status !== 0) {
+    throw new Error(`Council seed failed: ${result.stderr?.toString() || result.stdout?.toString()}`);
+  }
+}
+
+describe('CLI council flags (integration)', () => {
+  let testHomeDir;
+
+  beforeEach(async () => {
+    testHomeDir = await fs.mkdtemp(path.join(os.tmpdir(), 'pair-review-council-'));
+    // Pre-create the config dir + config.json so the DB file can be created and
+    // the first-run welcome banner is suppressed.
+    const configDir = path.join(testHomeDir, '.pair-review');
+    await fs.mkdir(configDir, { recursive: true });
+    await fs.writeFile(
+      path.join(configDir, 'config.json'),
+      JSON.stringify({ github_token: '', port: 7247, theme: 'light' }, null, 2)
+    );
+  });
+
+  afterEach(async () => {
+    if (testHomeDir) {
+      await fs.rm(testHomeDir, { recursive: true, force: true });
+    }
+  });
+
+  it('--list-councils exits 0 and prints the seeded council handle, name, and type', () => {
+    const councilId = uuidv4();
+    seedCouncil(testHomeDir, { id: councilId, name: 'Integration Council', type: 'council' });
+
+    const result = runCli(['--list-councils'], testHomeDir);
+    const stdout = result.stdout?.toString() || '';
+
+    expect(result.status).toBe(0);
+    expect(stdout).toContain(councilId.slice(0, 8)); // short handle
+    expect(stdout).toContain('Integration Council');
+    expect(stdout).toContain('council'); // type column
+  });
+
+  it('--list-councils reports an empty list when no councils are seeded', () => {
+    const result = runCli(['--list-councils'], testHomeDir);
+    const stdout = result.stdout?.toString() || '';
+
+    expect(result.status).toBe(0);
+    expect(stdout).toContain('No councils found');
+  });
+
+  it('--ai-draft with a bad --council handle exits non-zero with a clear error', () => {
+    seedCouncil(testHomeDir, { id: uuidv4(), name: 'Integration Council', type: 'council' });
+
+    const result = runCli(['1', '--ai-draft', '--council', 'definitely-not-a-real-handle'], testHomeDir);
+    const stderr = result.stderr?.toString() || '';
+
+    expect(result.status).not.toBe(0);
+    expect(stderr).toMatch(/No council matches/);
+  });
+
+  it('--council without a PR or --local exits non-zero with a usage error', () => {
+    seedCouncil(testHomeDir, { id: uuidv4(), name: 'Integration Council', type: 'council' });
+
+    const result = runCli(['--council', 'Integration Council'], testHomeDir);
+    const stderr = result.stderr?.toString() || '';
+
+    expect(result.status).not.toBe(0);
+    expect(stderr).toMatch(/--council flag requires a pull request/);
+  });
+
+  it('--ai-review --council in GitHub Actions bypasses the early --council guard', () => {
+    // Regression: the early --council guard must NOT reject the documented
+    // GitHub Actions `--ai-review --council` flow, where the PR is auto-detected
+    // from the environment. We deliberately leave the PR undetectable (no
+    // GITHUB_REF / GITHUB_EVENT_PATH) so the run still exits non-zero — but via
+    // the later --ai-review "no PR" check, NOT the early --council guard. This
+    // proves the guard was bypassed without triggering a real headless review.
+    seedCouncil(testHomeDir, { id: uuidv4(), name: 'Integration Council', type: 'council' });
+
+    const result = runCli(['--ai-review', '--council', 'Integration Council'], testHomeDir, {
+      GITHUB_ACTIONS: 'true',
+      GITHUB_REPOSITORY: 'owner/repo',
+      // Clear inherited CI values so PR auto-detection deterministically fails.
+      GITHUB_REF: '',
+      GITHUB_EVENT_PATH: ''
+    });
+    const stderr = result.stderr?.toString() || '';
+
+    expect(result.status).not.toBe(0);
+    // The early --council guard did NOT fire...
+    expect(stderr).not.toMatch(/--council flag requires a pull request/);
+    // ...it fell through to the --ai-review PR auto-detect path instead.
+    expect(stderr).toMatch(/--ai-review flag requires a pull request/);
+  });
+});

--- a/tests/unit/build-default-analysis-config.test.js
+++ b/tests/unit/build-default-analysis-config.test.js
@@ -288,6 +288,44 @@ describe('PRManager._buildDefaultAnalysisConfig', () => {
     const config = await manager._buildDefaultAnalysisConfig(null, reviewSettings);
     expect(config.customInstructions).toBeNull();
   });
+
+  it('honors a ?council=<id> URL param with highest priority (CLI --council)', async () => {
+    // Simulate the CLI-provided ?council=<id> param via the URLSearchParams stub.
+    globalThis.URLSearchParams = class { get(k) { return k === 'council' ? 'url-council-id' : null; } };
+    globalThis.fetch = vi.fn(() => Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({
+        council: {
+          id: 'url-council-id',
+          name: 'URL Council',
+          type: 'council',
+          config: { voices: [{ provider: 'claude', model: 'opus' }], levels: { '1': true } },
+        },
+      }),
+    }));
+
+    // Repo defaults point at a single-model config; the URL param must still win.
+    const repoSettings = { default_tab: 'single', default_provider: 'gemini', default_model: 'pro' };
+    const config = await manager._buildDefaultAnalysisConfig(repoSettings, {});
+
+    expect(config.isCouncil).toBe(true);
+    expect(config.councilId).toBe('url-council-id');
+    expect(config.councilName).toBe('URL Council');
+    expect(config.configType).toBe('council'); // derived from the council's own type
+    expect(config.councilConfig).toEqual({ voices: [{ provider: 'claude', model: 'opus' }], levels: { '1': true } });
+    expect(globalThis.fetch).toHaveBeenCalledWith('/api/councils/url-council-id');
+  });
+
+  it('falls back to default selection when the URL council fetch fails', async () => {
+    globalThis.URLSearchParams = class { get(k) { return k === 'council' ? 'bad-id' : null; } };
+    globalThis.fetch = vi.fn(() => Promise.resolve({ ok: false, status: 404 }));
+
+    const config = await manager._buildDefaultAnalysisConfig(null, {});
+    // Unknown URL council -> not forced into council mode; single-provider default.
+    expect(config.isCouncil).toBeUndefined();
+    expect(config.provider).toBe('claude');
+    expect(config.model).toBe('opus');
+  });
 });
 
 describe('PRManager.showWorktreeNotFoundError', () => {

--- a/tests/unit/headless-council.test.js
+++ b/tests/unit/headless-council.test.js
@@ -1,0 +1,187 @@
+// Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+/**
+ * Unit tests for runHeadlessCouncilAnalysis (src/councils/headless-council.js)
+ *
+ * The headless helper is the server-free twin of launchCouncilAnalysis in
+ * src/routes/analyses.js. These tests use a real in-memory database (the same
+ * createTestDatabase helper the rest of the suite uses) and the real
+ * AnalysisRunRepository / CouncilRepository, but a FAKE analyzer stub so no
+ * real AI is invoked. They verify run-record creation, dispatch by configType,
+ * completion/failure semantics, and the last_used_at touch.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createTestDatabase, seedTestReview } from '../utils/schema.js';
+
+const { runHeadlessCouncilAnalysis } = require('../../src/councils/headless-council.js');
+const { CouncilRepository, queryOne } = require('../../src/database.js');
+
+/**
+ * Build a fake analyzer that records the args it was called with and returns a
+ * canned result. Only one of the two methods should be invoked per run; both
+ * are stubbed so we can assert the correct one fired.
+ */
+function createFakeAnalyzer({ throwOn } = {}) {
+  const calls = { runReviewerCentricCouncil: [], runCouncilAnalysis: [] };
+
+  const makeMethod = (name) => async (reviewContext, councilConfig, options) => {
+    calls[name].push({ reviewContext, councilConfig, options });
+    if (throwOn === name) {
+      throw new Error('analyzer boom');
+    }
+    return {
+      runId: options.runId,
+      suggestions: [{}, {}],
+      summary: 'ok',
+      levelOutcomes: { '1': 'done' }
+    };
+  };
+
+  return {
+    calls,
+    runReviewerCentricCouncil: makeMethod('runReviewerCentricCouncil'),
+    runCouncilAnalysis: makeMethod('runCouncilAnalysis')
+  };
+}
+
+const sampleConfig = {
+  levels: {
+    '1': { enabled: true, voices: [{ provider: 'claude', model: 'sonnet', tier: 'balanced' }] },
+    '2': { enabled: false, voices: [] },
+    '3': { enabled: false, voices: [] }
+  }
+};
+
+describe('runHeadlessCouncilAnalysis', () => {
+  let db;
+  let councilRepo;
+  let reviewId;
+
+  async function seedCouncil({ id, type }) {
+    return councilRepo.create({ id, name: `Council ${id}`, config: sampleConfig, type });
+  }
+
+  beforeEach(async () => {
+    db = await createTestDatabase();
+    councilRepo = new CouncilRepository(db);
+    reviewId = seedTestReview(db, { prNumber: 42, repository: 'test/repo' });
+  });
+
+  it('configType "council" dispatches to runReviewerCentricCouncil and records a completed run', async () => {
+    const council = await seedCouncil({ id: 'council-vc', type: 'council' });
+    const analyzer = createFakeAnalyzer();
+
+    const result = await runHeadlessCouncilAnalysis(db, {
+      analyzer,
+      reviewId,
+      council,
+      configType: 'council',
+      councilConfig: sampleConfig,
+      worktreePath: '/tmp/worktree',
+      prMetadata: { head_sha: 'abc123' },
+      instructions: { globalInstructions: 'g', repoInstructions: 'r', requestInstructions: null },
+      githubClient: null
+    });
+
+    // Voice-centric path used, advanced path untouched.
+    expect(analyzer.calls.runReviewerCentricCouncil).toHaveLength(1);
+    expect(analyzer.calls.runCouncilAnalysis).toHaveLength(0);
+
+    // The analyzer received options.runId.
+    const passedRunId = analyzer.calls.runReviewerCentricCouncil[0].options.runId;
+    expect(typeof passedRunId).toBe('string');
+    expect(passedRunId.length).toBeGreaterThan(0);
+    // The result echoes the runId the helper generated.
+    expect(result.runId).toBe(passedRunId);
+
+    // An analysis_runs row exists, attributed to the council, with that exact runId.
+    const run = await queryOne(
+      db,
+      'SELECT id, provider, model, status, summary, total_suggestions FROM analysis_runs WHERE id = ?',
+      [passedRunId]
+    );
+    expect(run).toBeTruthy();
+    expect(run.provider).toBe('council');
+    expect(run.model).toBe(council.id);
+
+    // After completion the run is marked completed with summary + suggestion count.
+    expect(run.status).toBe('completed');
+    expect(run.summary).toBe('ok');
+    expect(run.total_suggestions).toBe(2);
+  });
+
+  it('configType "advanced" dispatches to runCouncilAnalysis', async () => {
+    const council = await seedCouncil({ id: 'council-adv', type: 'advanced' });
+    const analyzer = createFakeAnalyzer();
+
+    await runHeadlessCouncilAnalysis(db, {
+      analyzer,
+      reviewId,
+      council,
+      configType: 'advanced',
+      councilConfig: sampleConfig,
+      worktreePath: '/tmp/worktree',
+      prMetadata: { head_sha: 'def456' },
+      instructions: { globalInstructions: null, repoInstructions: null, requestInstructions: null },
+      githubClient: null
+    });
+
+    expect(analyzer.calls.runCouncilAnalysis).toHaveLength(1);
+    expect(analyzer.calls.runReviewerCentricCouncil).toHaveLength(0);
+
+    const passedRunId = analyzer.calls.runCouncilAnalysis[0].options.runId;
+    const run = await queryOne(db, 'SELECT model, status FROM analysis_runs WHERE id = ?', [passedRunId]);
+    expect(run.model).toBe(council.id);
+    expect(run.status).toBe('completed');
+  });
+
+  it('rethrows analyzer errors and marks the run failed', async () => {
+    const council = await seedCouncil({ id: 'council-fail', type: 'council' });
+    const analyzer = createFakeAnalyzer({ throwOn: 'runReviewerCentricCouncil' });
+
+    await expect(
+      runHeadlessCouncilAnalysis(db, {
+        analyzer,
+        reviewId,
+        council,
+        configType: 'council',
+        councilConfig: sampleConfig,
+        worktreePath: '/tmp/worktree',
+        prMetadata: { head_sha: 'sha' },
+        instructions: { globalInstructions: null, repoInstructions: null, requestInstructions: null },
+        githubClient: null
+      })
+    ).rejects.toThrow('analyzer boom');
+
+    // Exactly one run row exists, and it is marked failed.
+    const run = await queryOne(
+      db,
+      'SELECT status FROM analysis_runs WHERE review_id = ? AND model = ?',
+      [reviewId, council.id]
+    );
+    expect(run).toBeTruthy();
+    expect(run.status).toBe('failed');
+  });
+
+  it('touches the council last_used_at after a run', async () => {
+    const council = await seedCouncil({ id: 'council-touch', type: 'council' });
+    const before = await councilRepo.getById(council.id);
+    expect(before.last_used_at).toBeNull();
+
+    const analyzer = createFakeAnalyzer();
+    await runHeadlessCouncilAnalysis(db, {
+      analyzer,
+      reviewId,
+      council,
+      configType: 'council',
+      councilConfig: sampleConfig,
+      worktreePath: '/tmp/worktree',
+      prMetadata: { head_sha: 'sha' },
+      instructions: { globalInstructions: null, repoInstructions: null, requestInstructions: null },
+      githubClient: null
+    });
+
+    const after = await councilRepo.getById(council.id);
+    expect(after.last_used_at).toBeTruthy();
+  });
+});

--- a/tests/unit/main.test.js
+++ b/tests/unit/main.test.js
@@ -34,6 +34,33 @@ describe('main.js parseArgs', () => {
       expect(() => parseArgs(['123', '--model', '--ai'])).toThrow('--model flag requires a model name');
     });
 
+    it('should parse --council flag with value', () => {
+      const result = parseArgs(['123', '--council', 'my-council']);
+      expect(result.flags.council).toBe('my-council');
+      expect(result.prArgs).toEqual(['123']);
+    });
+
+    it('should throw error when --council flag has no value', () => {
+      expect(() => parseArgs(['123', '--council'])).toThrow('--council flag requires a council handle');
+    });
+
+    it('should throw error when --council flag is followed by another flag', () => {
+      expect(() => parseArgs(['123', '--council', '--ai'])).toThrow('--council flag requires a council handle');
+    });
+
+    it('should parse --list-councils flag', () => {
+      const result = parseArgs(['--list-councils']);
+      expect(result.flags.listCouncils).toBe(true);
+      expect(result.prArgs).toEqual([]);
+    });
+
+    it('should parse --ai-draft together with --council', () => {
+      const result = parseArgs(['123', '--ai-draft', '--council', 'x']);
+      expect(result.flags.aiDraft).toBe(true);
+      expect(result.flags.council).toBe('x');
+      expect(result.prArgs).toEqual(['123']);
+    });
+
     it('should parse --local flag without path', () => {
       const result = parseArgs(['--local']);
       expect(result.flags.local).toBe(true);

--- a/tests/unit/print-council-list.test.js
+++ b/tests/unit/print-council-list.test.js
@@ -1,0 +1,110 @@
+// Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+/**
+ * Unit tests for printCouncilList (src/main.js, used by --list-councils).
+ *
+ * These tests use a real in-memory database (the same createTestDatabase helper
+ * the rest of the suite uses) plus the real CouncilRepository /
+ * AnalysisRunRepository, and capture console.log output to assert on the
+ * rendered table. They verify the empty-DB message, the populated table
+ * (handles, names, types, last-used repo), and the header/footer guidance.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { v4 as uuidv4 } from 'uuid';
+import { createTestDatabase, seedTestReview } from '../utils/schema.js';
+
+const { printCouncilList } = require('../../src/main');
+const { CouncilRepository, AnalysisRunRepository } = require('../../src/database.js');
+const { shortId } = require('../../src/councils/resolve-council.js');
+
+const sampleConfig = {
+  levels: {
+    '1': { enabled: true, voices: [{ provider: 'claude', model: 'sonnet', tier: 'balanced' }] },
+    '2': { enabled: false, voices: [] },
+    '3': { enabled: false, voices: [] }
+  }
+};
+
+describe('printCouncilList', () => {
+  let db;
+  let logs;
+  let spy;
+
+  beforeEach(async () => {
+    db = await createTestDatabase();
+    logs = [];
+    spy = vi.spyOn(console, 'log').mockImplementation((...a) => logs.push(a.join(' ')));
+  });
+
+  afterEach(() => {
+    if (spy) spy.mockRestore();
+    if (db) db.close();
+  });
+
+  it('prints a helpful message when there are no councils', async () => {
+    await printCouncilList(db);
+
+    const output = logs.join('\n');
+    expect(output).toContain('No councils found');
+  });
+
+  it('renders a table with handles, names, types, and last-used repo', async () => {
+    const councilRepo = new CouncilRepository(db);
+    const runRepo = new AnalysisRunRepository(db);
+
+    const council1Id = uuidv4();
+    const council2Id = uuidv4();
+    await councilRepo.create({ id: council1Id, name: 'Security Review', type: 'council', config: sampleConfig });
+    await councilRepo.create({ id: council2Id, name: 'Architecture Review', type: 'advanced', config: sampleConfig });
+
+    // Seed a completed council run for council1 against acme/widget #7.
+    const reviewId = seedTestReview(db, { prNumber: 7, repository: 'acme/widget' });
+    await runRepo.create({
+      id: uuidv4(),
+      reviewId,
+      provider: 'council',
+      model: council1Id,
+      status: 'completed',
+      configType: 'council'
+    });
+
+    await printCouncilList(db);
+    const output = logs.join('\n');
+
+    // Both councils' short ids (first 8 chars) appear.
+    expect(output).toContain(shortId(council1Id));
+    expect(output).toContain(shortId(council2Id));
+
+    // Both names appear.
+    expect(output).toContain('Security Review');
+    expect(output).toContain('Architecture Review');
+
+    // Both type strings appear.
+    expect(output).toContain('council');
+    expect(output).toContain('advanced');
+
+    // council1's most recent run repo (and PR number) appears.
+    expect(output).toContain('acme/widget');
+    expect(output).toContain('#7');
+
+    // council2 has no run, so it shows the "never used" placeholder.
+    expect(output).toMatch(/—|never/);
+
+    // Footer guidance mentions --council.
+    expect(output).toContain('--council');
+  });
+
+  it('includes the table header row', async () => {
+    const councilRepo = new CouncilRepository(db);
+    await councilRepo.create({ id: uuidv4(), name: 'Some Council', type: 'council', config: sampleConfig });
+
+    await printCouncilList(db);
+    const output = logs.join('\n');
+
+    expect(output).toContain('HANDLE');
+    expect(output).toContain('NAME');
+    expect(output).toContain('TYPE');
+    expect(output).toContain('LAST USED');
+    expect(output).toContain('LAST USED WITH');
+  });
+});

--- a/tests/unit/resolve-council.test.js
+++ b/tests/unit/resolve-council.test.js
@@ -1,0 +1,334 @@
+// Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+/**
+ * Unit tests for the council handle resolver.
+ *
+ * Covers resolveCouncilHandle (id / id-prefix / name / normalized-name matching,
+ * ambiguity, and not-found) and getCouncilLastUsedRepos (most-recent council run
+ * per council, with inline-config and run-less councils excluded).
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { v4 as uuidv4 } from 'uuid';
+import { createTestDatabase, seedTestReview } from '../utils/schema.js';
+
+const {
+  normalizeForMatch,
+  shortId,
+  resolveCouncilHandle,
+  getCouncilLastUsedRepos
+} = require('../../src/councils/resolve-council.js');
+const { CouncilRepository, AnalysisRunRepository } = require('../../src/database.js');
+
+const sampleConfig = {
+  levels: {
+    '1': { enabled: true, voices: [{ provider: 'claude', model: 'sonnet', tier: 'balanced' }] },
+    '2': { enabled: false, voices: [] },
+    '3': { enabled: false, voices: [] }
+  }
+};
+
+describe('normalizeForMatch', () => {
+  it('lowercases, trims, and slugifies', () => {
+    expect(normalizeForMatch('  My Council  ')).toBe('my-council');
+    expect(normalizeForMatch('Security_Review!!')).toBe('security-review');
+    expect(normalizeForMatch('--Edge--')).toBe('edge');
+  });
+
+  it('handles null/undefined safely', () => {
+    expect(normalizeForMatch(null)).toBe('');
+    expect(normalizeForMatch(undefined)).toBe('');
+  });
+});
+
+describe('shortId', () => {
+  it('truncates to the first 8 characters', () => {
+    expect(shortId('a1b2c3d4-e5f6-7890')).toBe('a1b2c3d4');
+    expect(shortId('abc')).toBe('abc');
+    expect(shortId(null)).toBe('');
+  });
+});
+
+describe('resolveCouncilHandle', () => {
+  let db;
+  let councilRepo;
+
+  beforeEach(async () => {
+    db = await createTestDatabase();
+    councilRepo = new CouncilRepository(db);
+  });
+
+  it('resolves an exact id match', async () => {
+    const id = uuidv4();
+    await councilRepo.create({ id, name: 'Security Review', config: sampleConfig });
+
+    const result = await resolveCouncilHandle(db, id);
+    expect(result.id).toBe(id);
+    expect(result.name).toBe('Security Review');
+  });
+
+  it('resolves a unique UUID-prefix match', async () => {
+    const id = uuidv4();
+    await councilRepo.create({ id, name: 'Security Review', config: sampleConfig });
+
+    const result = await resolveCouncilHandle(db, id.slice(0, 8));
+    expect(result.id).toBe(id);
+  });
+
+  it('throws on an ambiguous UUID-prefix match, listing the full ids', async () => {
+    const id1 = 'aaaa1111-1111-4111-8111-111111111111';
+    const id2 = 'aaaa2222-2222-4222-8222-222222222222';
+    await councilRepo.create({ id: id1, name: 'First Council', config: sampleConfig });
+    await councilRepo.create({ id: id2, name: 'Second Council', config: sampleConfig });
+
+    let err;
+    try {
+      await resolveCouncilHandle(db, 'aaaa');
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeDefined();
+    expect(err.message).toMatch(/Ambiguous council "aaaa" matches 2 councils/);
+    // Full UUIDs must appear so the user can actually disambiguate.
+    expect(err.message).toContain(id1);
+    expect(err.message).toContain(id2);
+  });
+
+  it('ambiguity error shows the FULL id, not the truncated shortId, when prefixes collide', async () => {
+    // Both ids share the same 8-char prefix, so shortId() would be identical for
+    // both rows and could not disambiguate. The full UUIDs must be present.
+    const id1 = 'abcd1234-1111-4111-8111-111111111111';
+    const id2 = 'abcd1234-2222-4222-8222-222222222222';
+    await councilRepo.create({ id: id1, name: 'First Council', config: sampleConfig });
+    await councilRepo.create({ id: id2, name: 'Second Council', config: sampleConfig });
+
+    let err;
+    try {
+      await resolveCouncilHandle(db, 'abcd1234');
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeDefined();
+    expect(err.message).toMatch(/Ambiguous council "abcd1234" matches 2 councils/);
+    expect(err.message).toContain(id1);
+    expect(err.message).toContain(id2);
+    // The shared prefix alone is insufficient: each candidate line must carry a
+    // distinct full UUID (i.e. the parenthesized portion is not just the prefix).
+    expect(err.message).toContain('(abcd1234-1111-4111-8111-111111111111)');
+    expect(err.message).toContain('(abcd1234-2222-4222-8222-222222222222)');
+  });
+
+  it('resolves an exact name match case-insensitively', async () => {
+    const id = uuidv4();
+    await councilRepo.create({ id, name: 'My Council', config: sampleConfig });
+
+    const result = await resolveCouncilHandle(db, 'my council');
+    expect(result.id).toBe(id);
+  });
+
+  it('resolves a normalized-name match', async () => {
+    const id = uuidv4();
+    await councilRepo.create({ id, name: 'My Council', config: sampleConfig });
+
+    const result = await resolveCouncilHandle(db, 'my-council');
+    expect(result.id).toBe(id);
+  });
+
+  it('throws on duplicate-name ambiguity with a candidate list', async () => {
+    const id1 = uuidv4();
+    const id2 = uuidv4();
+    await councilRepo.create({ id: id1, name: 'Review', config: sampleConfig });
+    await councilRepo.create({ id: id2, name: 'Review', config: sampleConfig });
+
+    let err;
+    try {
+      await resolveCouncilHandle(db, 'Review');
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeDefined();
+    expect(err.message).toMatch(/Ambiguous council "Review" matches 2 councils/);
+    // Full ids (which subsume the shortId prefix) are shown for disambiguation.
+    expect(err.message).toContain(id1);
+    expect(err.message).toContain(id2);
+  });
+
+  it('throws a not-found error with the --list-councils hint', async () => {
+    await councilRepo.create({ id: uuidv4(), name: 'Something Else', config: sampleConfig });
+
+    await expect(resolveCouncilHandle(db, 'nonexistent'))
+      .rejects.toThrow(/No council matches "nonexistent"\. Run `pair-review --list-councils`/);
+  });
+
+  it('throws when the handle is missing', async () => {
+    await expect(resolveCouncilHandle(db, '')).rejects.toThrow('A council handle is required.');
+    await expect(resolveCouncilHandle(db, undefined)).rejects.toThrow('A council handle is required.');
+  });
+
+  it('treats a short non-hex handle as a name match, not a prefix', async () => {
+    // 'rev' is length 3 and not hex-only, so it must not be treated as a UUID prefix.
+    // It should resolve by normalized name only when it exactly matches a council name.
+    const id = uuidv4();
+    await councilRepo.create({ id, name: 'rev', config: sampleConfig });
+
+    const result = await resolveCouncilHandle(db, 'rev');
+    expect(result.id).toBe(id);
+  });
+
+  it('resolves a partial (substring) name fragment that matches exactly one council', async () => {
+    const id = uuidv4();
+    await councilRepo.create({ id, name: 'Dream Team Review', config: sampleConfig });
+    await councilRepo.create({ id: uuidv4(), name: 'Security Audit', config: sampleConfig });
+
+    const result = await resolveCouncilHandle(db, 'dream');
+    expect(result.id).toBe(id);
+  });
+
+  it('throws an ambiguity error listing all partial matches with full ids', async () => {
+    const id1 = uuidv4();
+    const id2 = uuidv4();
+    await councilRepo.create({ id: id1, name: 'Dream Team Review', config: sampleConfig });
+    await councilRepo.create({ id: id2, name: 'Daydream Council', config: sampleConfig });
+    await councilRepo.create({ id: uuidv4(), name: 'Security Audit', config: sampleConfig });
+
+    let err;
+    try {
+      await resolveCouncilHandle(db, 'dream');
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeDefined();
+    expect(err.message).toMatch(/Ambiguous council "dream" matches 2 councils/);
+    expect(err.message).toContain(id1);
+    expect(err.message).toContain(id2);
+  });
+
+  it('matches a fragment via the normalized name (spaces/punctuation collapsed)', async () => {
+    const id = uuidv4();
+    await councilRepo.create({ id, name: 'Front-End Review', config: sampleConfig });
+
+    // 'front end' normalizes to 'front-end', a substring of the normalized name.
+    const result = await resolveCouncilHandle(db, 'front end');
+    expect(result.id).toBe(id);
+  });
+
+  it('does not double-count a council matched by both raw and normalized substring', async () => {
+    // 'Review' matches both c.name.includes (raw) and the normalized substring.
+    // De-duplication by id means a single matching council resolves, not throws.
+    const id = uuidv4();
+    await councilRepo.create({ id, name: 'Review Board', config: sampleConfig });
+
+    const result = await resolveCouncilHandle(db, 'review');
+    expect(result.id).toBe(id);
+  });
+
+  it('still throws "No council matches" when a fragment matches nothing', async () => {
+    await councilRepo.create({ id: uuidv4(), name: 'Security Review', config: sampleConfig });
+
+    await expect(resolveCouncilHandle(db, 'zzz-nomatch'))
+      .rejects.toThrow(/No council matches "zzz-nomatch"\. Run `pair-review --list-councils`/);
+  });
+
+  it('lets an exact name win over a substring match (precedence preserved)', async () => {
+    // 'Review' is an exact name for one council and a substring of another.
+    // The exact-name tier must win and return the exact match, not throw on the
+    // substring collision.
+    const exactId = uuidv4();
+    const substringId = uuidv4();
+    await councilRepo.create({ id: exactId, name: 'Review', config: sampleConfig });
+    await councilRepo.create({ id: substringId, name: 'Review Board', config: sampleConfig });
+
+    const result = await resolveCouncilHandle(db, 'Review');
+    expect(result.id).toBe(exactId);
+  });
+
+  it('lets a unique id-prefix win over a substring name match (precedence preserved)', async () => {
+    // Construct a hex-ish handle that is a unique id prefix AND a substring of
+    // another council's name. The id-prefix tier must win.
+    const targetId = 'abcdef12-1111-4111-8111-111111111111';
+    await councilRepo.create({ id: targetId, name: 'Target Council', config: sampleConfig });
+    // This council's name contains 'abcdef' as a substring, so it would match the
+    // substring tier — but the id-prefix tier resolves first.
+    await councilRepo.create({ id: uuidv4(), name: 'The abcdef Review', config: sampleConfig });
+
+    const result = await resolveCouncilHandle(db, 'abcdef');
+    expect(result.id).toBe(targetId);
+  });
+});
+
+describe('getCouncilLastUsedRepos', () => {
+  let db;
+  let councilRepo;
+  let runRepo;
+
+  beforeEach(async () => {
+    db = await createTestDatabase();
+    councilRepo = new CouncilRepository(db);
+    runRepo = new AnalysisRunRepository(db);
+  });
+
+  it('returns the most recent council run repo per council and excludes inline-config and run-less councils', async () => {
+    const councilId = uuidv4();
+    const councilNoRuns = uuidv4();
+    await councilRepo.create({ id: councilId, name: 'Used Council', config: sampleConfig });
+    await councilRepo.create({ id: councilNoRuns, name: 'Unused Council', config: sampleConfig });
+
+    // Older run against owner/repo PR #5
+    const reviewOld = seedTestReview(db, { prNumber: 5, repository: 'owner/repo' });
+    const runOldId = uuidv4();
+    await runRepo.create({
+      id: runOldId,
+      reviewId: reviewOld,
+      provider: 'council',
+      model: councilId,
+      status: 'completed',
+      configType: 'council',
+      levelsConfig: sampleConfig.levels
+    });
+
+    // Newer run against other/repo PR #9
+    const reviewNew = seedTestReview(db, { prNumber: 9, repository: 'other/repo' });
+    const runNewId = uuidv4();
+    await runRepo.create({
+      id: runNewId,
+      reviewId: reviewNew,
+      provider: 'council',
+      model: councilId,
+      status: 'completed',
+      configType: 'council',
+      levelsConfig: sampleConfig.levels
+    });
+
+    // Force deterministic ordering: old run earlier than new run.
+    db.prepare("UPDATE analysis_runs SET started_at = '2026-01-01 00:00:00' WHERE id = ?").run(runOldId);
+    db.prepare("UPDATE analysis_runs SET started_at = '2026-06-01 00:00:00' WHERE id = ?").run(runNewId);
+
+    // An inline-config run should be ignored entirely.
+    const reviewInline = seedTestReview(db, { prNumber: 11, repository: 'inline/repo' });
+    const runInlineId = uuidv4();
+    await runRepo.create({
+      id: runInlineId,
+      reviewId: reviewInline,
+      provider: 'council',
+      model: 'inline-config',
+      status: 'completed',
+      configType: 'council',
+      levelsConfig: sampleConfig.levels
+    });
+
+    const map = await getCouncilLastUsedRepos(db);
+
+    // The used council maps to the MORE RECENT run's repo.
+    expect(map.has(councilId)).toBe(true);
+    const entry = map.get(councilId);
+    expect(entry.repository).toBe('other/repo');
+    expect(entry.review_type).toBe('pr');
+    expect(entry.pr_number).toBe(9);
+    expect(entry.last_started).toBe('2026-06-01 00:00:00');
+
+    // inline-config is excluded.
+    expect(map.has('inline-config')).toBe(false);
+
+    // A council with no runs is absent.
+    expect(map.has(councilNoRuns)).toBe(false);
+  });
+});

--- a/tests/unit/single-port.test.js
+++ b/tests/unit/single-port.test.js
@@ -188,8 +188,23 @@ describe('buildDelegationUrl', () => {
   });
 
   it('encodes special characters in local path', () => {
-    const url = buildDelegationUrl(7247, 'local', { localPath: '/path with spaces/dir' });
-    expect(url).toContain(encodeURIComponent('/path with spaces/dir'));
+    const urlSpaces = buildDelegationUrl(7247, 'local', { localPath: '/path with spaces/dir' });
+    expect(urlSpaces).toBe('http://localhost:7247/local?path=%2Fpath%20with%20spaces%2Fdir');
+  });
+
+  it('appends council to PR URL after analyze', () => {
+    const url = buildDelegationUrl(7247, 'pr', { owner: 'acme', repo: 'widgets', number: 42, analyze: true, councilId: 'abc-123' });
+    expect(url).toBe('http://localhost:7247/pr/acme/widgets/42?analyze=true&council=abc-123');
+  });
+
+  it('appends council to PR URL even without analyze', () => {
+    const url = buildDelegationUrl(7247, 'pr', { owner: 'acme', repo: 'widgets', number: 42, councilId: 'abc-123' });
+    expect(url).toBe('http://localhost:7247/pr/acme/widgets/42?council=abc-123');
+  });
+
+  it('appends council to local URL after analyze', () => {
+    const url = buildDelegationUrl(7247, 'local', { localPath: '/tmp/project', analyze: true, councilId: 'abc-123' });
+    expect(url).toBe('http://localhost:7247/local?path=%2Ftmp%2Fproject&analyze=true&council=abc-123');
   });
 
   it('builds server landing URL', () => {
@@ -326,6 +341,40 @@ describe('attemptDelegation', () => {
     expect(deps.open).toHaveBeenCalledWith(
       expect.stringContaining('&analyze=true')
     );
+  });
+
+  it('appends council to PR delegation URL when a resolved councilId is provided', async () => {
+    const deps = createMockDeps();
+    await attemptDelegation(baseConfig, { council: 'my-council' }, ['42'], deps, { councilId: 'abc-123' });
+    expect(deps.open).toHaveBeenCalledWith(
+      expect.stringContaining('/pr/test-owner/test-repo/42?analyze=true&council=abc-123')
+    );
+  });
+
+  it('appends council to local delegation URL when a resolved councilId is provided', async () => {
+    const deps = createMockDeps();
+    await attemptDelegation(
+      baseConfig,
+      { local: true, localPath: '/tmp/project', council: 'my-council' },
+      [],
+      deps,
+      { councilId: 'abc-123' }
+    );
+    const url = deps.open.mock.calls[0][0];
+    expect(url).toContain('&analyze=true');
+    expect(url).toContain('&council=abc-123');
+  });
+
+  it('treats flags.council as implying analyze=true even without flags.ai', async () => {
+    const deps = createMockDeps();
+    await attemptDelegation(baseConfig, { council: 'my-council' }, ['42'], deps, { councilId: 'abc-123' });
+    expect(deps.open).toHaveBeenCalledWith(expect.stringContaining('analyze=true'));
+  });
+
+  it('does not append council when no councilId is resolved', async () => {
+    const deps = createMockDeps();
+    await attemptDelegation(baseConfig, { ai: true }, ['42'], deps);
+    expect(deps.open).toHaveBeenCalledWith(expect.not.stringContaining('council='));
   });
 
   it('notifies version when current is newer than running server', async () => {

--- a/tests/unit/worktree-recovery-url.test.js
+++ b/tests/unit/worktree-recovery-url.test.js
@@ -1,0 +1,100 @@
+// Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+/**
+ * Unit tests for PRManager._buildWorktreeRecoveryUrl().
+ *
+ * The worktree-not-found recovery link must preserve auto-analyze state so a
+ * retry re-triggers the SAME analysis. In particular it must carry the
+ * `council` query param through, since _buildDefaultAnalysisConfig() treats
+ * `?council=<id>` as the highest-priority analysis source — dropping it would
+ * silently fall back to the repo/default analysis configuration on retry.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { URLSearchParams as NativeURLSearchParams } from 'url';
+
+const { PRManager } = require('../../public/js/pr.js');
+
+let saved;
+
+beforeEach(() => {
+  saved = {
+    window: globalThis.window,
+    URLSearchParams: globalThis.URLSearchParams,
+  };
+  // Use the real URLSearchParams so query parsing/serialization behaves as in
+  // the browser.
+  globalThis.URLSearchParams = NativeURLSearchParams;
+  globalThis.window = { location: { search: '' } };
+});
+
+afterEach(() => {
+  globalThis.window = saved.window;
+  globalThis.URLSearchParams = saved.URLSearchParams;
+});
+
+describe('PRManager._buildWorktreeRecoveryUrl', () => {
+  let manager;
+
+  beforeEach(() => {
+    manager = Object.create(PRManager.prototype);
+  });
+
+  it('returns a bare PR URL when auto-analyze was not requested', () => {
+    manager._autoAnalyzeRequested = false;
+    globalThis.window.location.search = '?analyze=true&council=abc-123';
+
+    const url = manager._buildWorktreeRecoveryUrl('acme', 'widgets', 42);
+
+    expect(url).toBe('/pr/acme/widgets/42');
+  });
+
+  it('preserves the council param when auto-analyze was requested', () => {
+    manager._autoAnalyzeRequested = true;
+    globalThis.window.location.search = '?analyze=true&council=abc-123';
+
+    const url = manager._buildWorktreeRecoveryUrl('acme', 'widgets', 42);
+
+    expect(url).toContain('analyze=true');
+    expect(url).toContain('council=abc-123');
+  });
+
+  it('preserves the analysisConfigId param when auto-analyze was requested', () => {
+    manager._autoAnalyzeRequested = true;
+    globalThis.window.location.search = '?analyze=true&analysisConfigId=cfg-7';
+
+    const url = manager._buildWorktreeRecoveryUrl('acme', 'widgets', 42);
+
+    expect(url).toContain('analyze=true');
+    expect(url).toContain('analysisConfigId=cfg-7');
+    expect(url).not.toContain('council=');
+  });
+
+  it('preserves both analysisConfigId and council together', () => {
+    manager._autoAnalyzeRequested = true;
+    globalThis.window.location.search = '?analyze=true&analysisConfigId=cfg-7&council=abc-123';
+
+    const url = manager._buildWorktreeRecoveryUrl('acme', 'widgets', 42);
+
+    expect(url).toContain('analyze=true');
+    expect(url).toContain('analysisConfigId=cfg-7');
+    expect(url).toContain('council=abc-123');
+  });
+
+  it('only includes analyze=true when no extra params are present', () => {
+    manager._autoAnalyzeRequested = true;
+    globalThis.window.location.search = '?analyze=true';
+
+    const url = manager._buildWorktreeRecoveryUrl('acme', 'widgets', 42);
+
+    expect(url).toBe('/pr/acme/widgets/42?analyze=true');
+  });
+
+  it('encodes owner, repo, and number path segments', () => {
+    manager._autoAnalyzeRequested = false;
+    globalThis.window.location.search = '';
+
+    const url = manager._buildWorktreeRecoveryUrl('acme corp', 'wid/gets', 9);
+
+    expect(url).toBe('/pr/acme%20corp/wid%2Fgets/9');
+  });
+});


### PR DESCRIPTION
## Summary

Adds CLI selection of saved multi-voice **councils**, plus a `--list-councils` discovery command. Works in all analysis modes: headless PR (`--ai-draft`/`--ai-review`), interactive PR (`--ai`), and local (`--local --ai`).

- **Smart handle resolver** (`src/councils/resolve-council.js`): a `--council <handle>` resolves by id → id-prefix (git-style) → exact name (case-insensitive) → normalized name. Ambiguous matches fail loudly and list candidates with their short ids. No schema change — a strict subset of a future slug scheme.
- **`--list-councils`**: prints an aligned table of handles, names, types, and last-used repo, then exits (no server, no PR context).
- **Headless council analysis** (`src/councils/headless-council.js`) wired into `performHeadlessReview`, with per-provider `load_skills` resolution so multi-provider voices don't collapse onto the default provider.
- **Fail-fast resolution** before single-port delegation, so a bad handle errors in every mode (interactive, headless, delegated) rather than only on a cold start. The resolved id is threaded into the opened URL as `?analyze=true&council=<id>`.
- `--model` is ignored (with a warning) when `--council` is set, since council voices carry their own per-voice models.

## Critical fixes found in review

1. **GitHub Actions `--ai-review --council` guard** — the early `--council` guard ran before `detectPRFromGitHubEnvironment()`, so the documented CI flow (`pair-review --ai-review --council <handle>` with no positional PR) failed with a usage error before the PR could be auto-detected. The guard now exempts the GitHub Actions `--ai-review` path; outside CI it still fails fast via the later `--ai-review` PR check.
2. **`council` dropped through `setup.html` redirect** — the setup page forwarded only `analyze`/`analysisConfigId` on its post-setup redirect (both the existing-review and setup-complete branches), silently losing the council selection on every cold-start and delegated path that routes through setup — for **both PR and local mode**. Now forwarded alongside the others. This single fix also resolves the delegated-local drop from `single-port.js`.

## Testing

- Unit: resolver, `--list-councils` printer, headless council.
- Integration (`cli-council-flags.test.js`): real CLI spawn for `--list-councils`, bad-handle errors, the contextless-`--council` guard, **and a new regression test** asserting `--ai-review --council` under a simulated GitHub Actions env bypasses the early guard.
- E2E: `auto-analyze`, `local-start`, `council-save-button` (setup-redirect + council flow) — 15/15.
- Full suite: 7884/7888 passing; the 4 failures are pre-existing/environmental (3 known-local `first-run` CLI-spawn hangs from a local dev server on :7247 + `single_port:false`; 1 two-millisecond timestamp flake in `external-comments-sync`). This branch touches none of those files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)