### PR TITLE
Make provider availability-check timeout configurable

### DIFF
--- a/.changeset/configurable-availability-timeout.md
+++ b/.changeset/configurable-availability-timeout.md
@@ -1,0 +1,7 @@
+---
+"@in-the-loop-labs/pair-review": minor
+---
+
+Make the provider availability-check timeout configurable. The probe run at startup (and on availability refresh) was fixed at 10 seconds, which was too short for providers whose check runs a slow build/compile step. Set `availability_timeout_seconds` on an AI analysis provider (`providers.<id>`, including executable and aliased providers) or a chat provider (`chat_providers.<id>`) to raise it. Unset or invalid values fall back to the existing 10-second default. The Gemini, Copilot, and OpenCode availability probes now terminate a hung `--version` check on expiry instead of leaking the child process.
+
+Also fixes chat-provider availability detection for Pi: a custom `type: "pi"` chat provider (or the built-in Pi overridden with a different `command`) now runs its own `<command> --version` probe — honoring `availability_timeout_seconds` — instead of incorrectly reporting the AI provider's cached Pi status for a different binary.

--- a/README.md
+++ b/README.md
@@ -407,6 +407,8 @@ You can override provider settings and define custom models in your config file.
 | `extra_args` | Additional arguments to pass to the CLI |
 | `env` | Environment variables to set when running the CLI |
 | `installInstructions` | Custom installation instructions shown in UI |
+| `availability_timeout_seconds` | Seconds to allow for the startup availability probe before the provider is reported unavailable (default `10`). Raise it for providers whose check runs a slow build/compile step. Also supported per chat provider under `chat_providers.<id>`. |
+| `availability_command` | Command run to decide availability. Executable providers default to always-available when omitted; chat providers fall back to `<command> --version` (or, for the built-in Pi, the cached AI-provider status). Pair with `availability_timeout_seconds` when the probe runs a slow build. |
 | `models` | Array of model definitions (see below) |
 
 #### Model Configuration Fields

--- a/config.example.json
+++ b/config.example.json
@@ -238,6 +238,9 @@
       "diff_args": [],
       "output_glob": "**/results.json",
       "mapping_instructions": "The tool outputs JSON with a 'findings' array and a 'summary' string. Each finding has: category (bug/style/perf), priority (high/medium/low), title, body, fix, path, start_line, end_line. Map path to file, body to description, fix to suggestion. Map priority to severity: high=critical, medium=medium, low=minor. Map confidence: high=0.9, medium=0.7, low=0.4.",
+      "availability_command": "my-review-tool --version",
+      "availability_timeout_seconds": 30,
+      "_comment_availability": "availability_command is run at startup to decide if the provider is available (defaults to 'true', i.e. always available). availability_timeout_seconds bounds that check (default 10); raise it when the command runs a slow build/compile step. Also supported on chat_providers entries.",
       "env": {},
       "installInstructions": "Install my-review-tool: pip install my-review-tool",
       "models": [
@@ -252,7 +255,7 @@
   },
 
   "chat_providers": {
-    "_comment": "Chat provider command overrides. Separate from 'providers' (AI analysis). Chat providers are: pi, claude, codex, copilot-acp, gemini-acp, opencode-acp, cursor-acp. Supports 'command', 'args' (replaces defaults), 'extra_args' (appends), 'env', 'load_skills' (Pi: false suppresses skill auto-discovery), and 'app_extensions' (Pi: false omits pair-review task extension) overrides. Codex also supports 'sandbox' ('workspace-write' or 'read-only').",
+    "_comment": "Chat provider command overrides. Separate from 'providers' (AI analysis). Chat providers are: pi, claude, codex, copilot-acp, gemini-acp, opencode-acp, cursor-acp. Supports 'command', 'args' (replaces defaults), 'extra_args' (appends), 'env', 'load_skills' (Pi: false suppresses skill auto-discovery), and 'app_extensions' (Pi: false omits pair-review task extension) overrides. Codex also supports 'sandbox' ('workspace-write' or 'read-only'). 'availability_command' overrides the startup availability probe and 'availability_timeout_seconds' bounds it (default 10; raise for slow build commands).",
     "claude": {
       "_comment": "Example: use a wrapper script for Claude chat",
       "command": "claude"

--- a/plans/configurable-availability-timeout.md
+++ b/plans/configurable-availability-timeout.md
@@ -1,0 +1,151 @@
+# Configurable Provider Availability-Check Timeout
+
+## Context
+
+When pair-review starts, it probes each configured AI provider to decide whether
+it is available (and the same happens for chat providers, and on the
+`/api/providers/refresh-availability` route). Each probe is bounded by a **fixed
+10-second timeout**. For providers whose availability check runs a slow command —
+e.g. an `executable` provider whose `availability_command` triggers a build/compile
+step, or a chat provider with a build-based `availability_command` — 10s is too
+short, so the provider is wrongly reported as unavailable.
+
+This change makes the availability-check timeout **configurable per provider**, in
+**seconds** (mirroring the existing `checkout_timeout_seconds` convention), for
+both AI analysis providers and chat providers. When unset/invalid it stays at the
+current 10s default, so existing setups are unaffected.
+
+Decisions (confirmed with user): unit = **seconds**; scope = **analysis + chat
+providers**; granularity = **per-provider only** (no global/top-level key).
+
+## Config contract
+
+New optional field, in seconds, positive number:
+
+- AI analysis providers: `providers.<id>.availability_timeout_seconds`
+  (applies to built-in, `executable`, and aliased providers)
+- Chat providers: `chat_providers.<id>.availability_timeout_seconds`
+
+Absent, non-numeric, or `<= 0` → falls back to the 10s default. Resolution mirrors
+`getRepoCheckoutTimeout` in `src/config.js:1266` (`seconds > 0 ? seconds * 1000 : DEFAULT`).
+
+## Where the 10s lives today (all three must be addressed)
+
+1. **Outer race** in `testProviderAvailability(providerId, timeout = 10000)` —
+   `src/ai/provider.js:733`. Sole caller of `provider.testAvailability()`
+   (`provider.js:743`). This is the *only* timeout for `gemini`, `copilot`,
+   `opencode` (their `testAvailability()` has no internal timeout).
+2. **Per-provider internal timeouts** (hardcoded `setTimeout(..., 10000)` that also
+   `child.kill()`): `claude-provider.js:889`, `codex-provider.js:794`,
+   `cursor-agent-provider.js:813`, `pi-provider.js:1135`, `executable-provider.js:471`.
+3. **Chat-provider check**: `runCommandAvailabilityCheck` in
+   `src/chat/chat-providers.js:307` uses `spawn(..., { timeout: 10000 })`.
+
+## Implementation
+
+### `src/ai/provider.js`
+- Add `const DEFAULT_AVAILABILITY_TIMEOUT_MS = 10000;`.
+- Add `resolveAvailabilityTimeoutMs(providerId)`: read
+  `providerConfigOverrides.get(providerId)?.availability_timeout_seconds`; if a
+  positive finite number, return `* 1000`, else `DEFAULT_AVAILABILITY_TIMEOUT_MS`.
+  Export it (for unit testing).
+- `testProviderAvailability(providerId, timeoutMs)`: when `timeoutMs == null`,
+  set `timeoutMs = resolveAvailabilityTimeoutMs(providerId)`. Use `timeoutMs` for
+  the outer race **and** pass it through: `provider.testAvailability(timeoutMs)`.
+  Include the duration in the timeout error (`Provider test timed out after Ns`).
+- In `applyConfigOverrides`, add `availability_timeout_seconds` to the stored
+  override object for the **built-in** path (`provider.js:557`) and the **alias**
+  path (`provider.js:530`). The **executable** path already spreads the full config
+  (`provider.js:516`), so it is covered automatically.
+- Update the base `testAvailability()` JSDoc (`provider.js:118`) to document the
+  optional `timeoutMs` param.
+
+### Per-provider internal timeouts
+For `claude`, `codex`, `cursor-agent`, `pi`, `executable`: change the signature to
+`async testAvailability(timeoutMs = 10000)` and use `timeoutMs` in the internal
+`setTimeout`; update the "timed out after 10s" log to reflect the actual value
+(e.g. `after ${Math.round(timeoutMs / 1000)}s`).
+
+`gemini`, `copilot`, `opencode` have no internal timeout and are left unchanged —
+the outer race in `testProviderAvailability` already enforces the resolved value
+for them.
+
+### `src/ai/executable-provider.js`
+- In the constructor, store `this.availabilityTimeoutMs` from
+  `config.availability_timeout_seconds` (positive → `* 1000`, else default) —
+  same pattern as the existing `this.timeout = config.timeout || 600000`
+  (`executable-provider.js:137`).
+- `testAvailability(timeoutMs = this.availabilityTimeoutMs)` uses `timeoutMs`
+  for the internal timeout. (Authoritative value still arrives via the param from
+  `testProviderAvailability`; the stored field is the default for direct calls.)
+
+### `src/chat/chat-providers.js`
+- `getChatProvider`: pass through `availability_timeout_seconds` in **both**
+  branches — the dynamic-only branch (~`:123`) and the base+override merge
+  (~`:147`), alongside the existing `availability_command` passthrough.
+- `checkChatProviderAvailability`: resolve `timeoutMs` from
+  `provider.availability_timeout_seconds` (positive → `* 1000`, else 10000) and
+  pass it to **both** `runCommandAvailabilityCheck` calls (the
+  `availability_command` path and the `<command> --version` fallback).
+- `runCommandAvailabilityCheck`: accept a `timeout` (ms) option and use it in
+  `spawn(..., { timeout })` instead of the hardcoded `10000`.
+
+### Docs
+- `config.example.json`: add `availability_timeout_seconds` to the executable
+  provider example, with a short comment noting it also applies to chat providers.
+- `README.md`: document the field where executable/provider config and chat
+  providers are described.
+
+### Out of scope
+- `src/ai/claude-cli.js` `testAvailability` (`:151`): `ClaudeCLI` is **not** a
+  registered provider (only `claude-provider.js` registers `'claude'`), so its
+  `{ timeout: 10000 }` is unrelated to availability checks — left untouched.
+- No config UI control (availability timeout is a startup/infra setting, unlike the
+  per-reviewer analysis `timeout` surfaced in `VoiceCentricConfigTab`).
+
+## Hazards
+
+- `testProviderAvailability` is the **sole** caller of `provider.testAvailability()`
+  (`provider.js:743`); both external callers (`provider-availability.js:52`,
+  `routes/config.js:463`) omit the timeout arg, so resolving when `timeoutMs == null`
+  covers them without edits.
+- `runCommandAvailabilityCheck` has **two** callers inside
+  `checkChatProviderAvailability` — both must receive the resolved timeout.
+- `getChatProvider` has **two** return branches; the passthrough must be added to both.
+- Provider override storage in `applyConfigOverrides` has **three** shapes
+  (executable spreads full config; alias and built-in forward explicit fields only) —
+  alias and built-in need the field added explicitly.
+- `gemini`/`copilot`/`opencode` rely solely on the outer race — confirm the resolved
+  timeout reaches them through `testProviderAvailability` (it does, via the race arg).
+
+## Tests (mandatory)
+
+- `tests/unit/executable-provider.test.js` (existing `testAvailability` block,
+  ~`:876`): keep the default-10s timeout test; add a test constructing with
+  `availability_timeout_seconds: 30` and asserting the probe is still pending at
+  29999ms and resolves `false` + `child.kill()` at 30001ms (fake timers).
+- `src/ai/provider.js` (add to the existing provider unit test file, or
+  `tests/unit/provider-availability.test.js`): unit-test `resolveAvailabilityTimeoutMs`
+  (per-provider override, missing → default, invalid/`<=0` → default) and that
+  `testProviderAvailability` passes the resolved ms to `provider.testAvailability`
+  and to the race (inject a fake provider via the registry / config overrides).
+- One representative built-in provider (e.g. `pi` or `claude`) test: assert the
+  internal timeout honors a passed `timeoutMs`.
+- `tests/unit/chat/chat-providers.test.js` (existing timeout test ~`:577`): keep the
+  default-timeout test; add a test that `availability_timeout_seconds` is passed
+  through `getChatProvider` and into the `spawn` `timeout` option.
+- Run E2E (`pnpm run test:e2e`) since no frontend changes are made, this is mainly to
+  confirm startup availability checks still pass; primary verification is unit tests.
+
+## Verification
+
+1. `pnpm test` — all unit/integration tests pass, including the new ones.
+2. Manual: add to `~/.pair-review/config.json` an executable provider with
+   `"availability_command": "sleep 20 && true"` and `"availability_timeout_seconds": 30`;
+   start pair-review and confirm the provider is reported **available** (with the
+   field removed or set low, confirm it reports **unavailable** after ~10s).
+3. Repeat for a `chat_providers.<id>` entry with a slow `availability_command` and
+   `availability_timeout_seconds`.
+4. Add a `patch`/`minor` changeset (`minor` — new feature) for
+   `@in-the-loop-labs/pair-review`.
+5. Rename this plan file to `plans/configurable-availability-timeout.md`.

--- a/src/ai/claude-provider.js
+++ b/src/ai/claude-provider.js
@@ -858,9 +858,10 @@ class ClaudeProvider extends AIProvider {
    * Test if Claude CLI is available
    * Uses fast `--version` check instead of running a prompt.
    * Uses the command configured in the instance (respects ENV > config > default precedence)
+   * @param {number} [timeoutMs=10000] - Timeout in milliseconds for the probe
    * @returns {Promise<boolean>}
    */
-  async testAvailability() {
+  async testAvailability(timeoutMs = 10000) {
     return new Promise((resolve) => {
       // For availability test, we just need to check --version
       // Use the already-resolved command from the constructor (this.claudeCmd)
@@ -889,10 +890,10 @@ class ClaudeProvider extends AIProvider {
       const availabilityTimeout = setTimeout(() => {
         if (settled) return;
         settled = true;
-        logger.warn('Claude CLI availability check timed out after 10s');
+        logger.warn(`Claude CLI availability check timed out after ${Math.round(timeoutMs / 1000)}s`);
         try { claude.kill(); } catch { /* ignore */ }
         resolve(false);
-      }, 10000);
+      }, timeoutMs);
 
       claude.stdout.on('data', (data) => {
         stdout += data.toString();

--- a/src/ai/codex-provider.js
+++ b/src/ai/codex-provider.js
@@ -763,9 +763,10 @@ class CodexProvider extends AIProvider {
    * Test if Codex CLI is available
    * Uses fast `--version` check instead of running a prompt.
    * Uses the command configured in the instance (respects ENV > config > default precedence)
+   * @param {number} [timeoutMs=10000] - Timeout in milliseconds for the probe
    * @returns {Promise<boolean>}
    */
-  async testAvailability() {
+  async testAvailability(timeoutMs = 10000) {
     return new Promise((resolve) => {
       // For availability test, we just need to check --version
       // Use the already-resolved command from the constructor (this.codexCmd)
@@ -794,10 +795,10 @@ class CodexProvider extends AIProvider {
       const availabilityTimeout = setTimeout(() => {
         if (settled) return;
         settled = true;
-        logger.warn('Codex CLI availability check timed out after 10s');
+        logger.warn(`Codex CLI availability check timed out after ${Math.round(timeoutMs / 1000)}s`);
         try { codex.kill(); } catch { /* ignore */ }
         resolve(false);
-      }, 10000);
+      }, timeoutMs);
 
       codex.stdout.on('data', (data) => {
         stdout += data.toString();

--- a/src/ai/copilot-provider.js
+++ b/src/ai/copilot-provider.js
@@ -439,9 +439,11 @@ class CopilotProvider extends AIProvider {
   /**
    * Test if Copilot CLI is available
    * Uses the command configured in the instance (respects ENV > config > default precedence)
+   * @param {number} [timeoutMs=10000] - Timeout in milliseconds for the probe.
+   *   Production passes the per-provider resolved value; the default is only hit by tests.
    * @returns {Promise<boolean>}
    */
-  async testAvailability() {
+  async testAvailability(timeoutMs = 10000) {
     return new Promise((resolve) => {
       // For availability test, check --version
       // Use the already-resolved command from the constructor (this.copilotCmd)
@@ -465,6 +467,16 @@ class CopilotProvider extends AIProvider {
       let stdout = '';
       let settled = false;
 
+      // Timeout guard: if the CLI hangs, kill it and resolve false so the probe
+      // does not leak a child process.
+      const availabilityTimeout = setTimeout(() => {
+        if (settled) return;
+        settled = true;
+        logger.warn(`Copilot CLI availability check timed out after ${Math.round(timeoutMs / 1000)}s`);
+        try { copilot.kill(); } catch { /* ignore */ }
+        resolve(false);
+      }, timeoutMs);
+
       copilot.stdout.on('data', (data) => {
         stdout += data.toString();
       });
@@ -472,6 +484,7 @@ class CopilotProvider extends AIProvider {
       copilot.on('close', (code) => {
         if (settled) return;
         settled = true;
+        clearTimeout(availabilityTimeout);
         // Copilot CLI typically outputs version info on success
         if (code === 0) {
           logger.info(`Copilot CLI available: ${stdout.trim()}`);
@@ -485,6 +498,7 @@ class CopilotProvider extends AIProvider {
       copilot.on('error', (error) => {
         if (settled) return;
         settled = true;
+        clearTimeout(availabilityTimeout);
         logger.warn(`Copilot CLI not available: ${error.message}`);
         resolve(false);
       });

--- a/src/ai/cursor-agent-provider.js
+++ b/src/ai/cursor-agent-provider.js
@@ -783,9 +783,10 @@ class CursorAgentProvider extends AIProvider {
   /**
    * Test if Cursor Agent CLI is available
    * Uses the command configured in the instance (respects ENV > config > default precedence)
+   * @param {number} [timeoutMs=10000] - Timeout in milliseconds for the probe
    * @returns {Promise<boolean>}
    */
-  async testAvailability() {
+  async testAvailability(timeoutMs = 10000) {
     return new Promise((resolve) => {
       // For availability test, we just need to check --version
       // Use the already-resolved command from the constructor (this.agentCmd)
@@ -813,10 +814,10 @@ class CursorAgentProvider extends AIProvider {
       const availabilityTimeout = setTimeout(() => {
         if (settled) return;
         settled = true;
-        logger.warn('Cursor Agent CLI availability check timed out after 10s');
+        logger.warn(`Cursor Agent CLI availability check timed out after ${Math.round(timeoutMs / 1000)}s`);
         try { agent.kill(); } catch { /* ignore */ }
         resolve(false);
-      }, 10000);
+      }, timeoutMs);
 
       agent.stdout.on('data', (data) => {
         stdout += data.toString();

--- a/src/ai/executable-provider.js
+++ b/src/ai/executable-provider.js
@@ -12,7 +12,7 @@
  */
 
 const providerModule = require('./provider');
-const { AIProvider, resolveDefaultModel, inferModelDefaults } = providerModule;
+const { AIProvider, resolveDefaultModel, inferModelDefaults, secondsToTimeoutMs } = providerModule;
 const { spawn } = require('child_process');
 const { glob } = require('glob');
 const fs = require('fs').promises;
@@ -136,6 +136,10 @@ function createExecutableProviderClass(id, config) {
       this.mappingInstructions = config.mapping_instructions || '';
       this.timeout = config.timeout || 600000; // Default 10 minutes
       this.availabilityCommand = config.availability_command || 'true';
+      // Availability-probe timeout. Configured in seconds (mirrors
+      // checkout_timeout_seconds); falls back to the shared default when
+      // unset/invalid.
+      this.availabilityTimeoutMs = secondsToTimeoutMs(config.availability_timeout_seconds);
       this.extraEnv = {
         ...(config.env || {}),
         ...(configOverrides.env || {}),
@@ -454,9 +458,13 @@ function createExecutableProviderClass(id, config) {
      * Test if the external tool is available.
      * Runs the configured availability_command (defaults to 'true', i.e. always available).
      *
+     * @param {number} [timeoutMs] - Timeout in milliseconds for the probe.
+     *   Defaults to the provider's configured availability_timeout_seconds
+     *   (or 10s). Tools with slow build-based availability commands can raise
+     *   this via `availability_timeout_seconds` in their provider config.
      * @returns {Promise<boolean>}
      */
-    async testAvailability() {
+    async testAvailability(timeoutMs = this.availabilityTimeoutMs) {
       return new Promise((resolve) => {
         const command = this.availabilityCommand;
         logger.debug(`${id} availability check: ${command}`);
@@ -471,10 +479,10 @@ function createExecutableProviderClass(id, config) {
         const availabilityTimeout = setTimeout(() => {
           if (settled) return;
           settled = true;
-          logger.warn(`${id} availability check timed out after 10s`);
+          logger.warn(`${id} availability check timed out after ${Math.round(timeoutMs / 1000)}s`);
           try { child.kill(); } catch { /* ignore */ }
           resolve(false);
-        }, 10000);
+        }, timeoutMs);
 
         child.on('close', (code) => {
           if (settled) return;

--- a/src/ai/gemini-provider.js
+++ b/src/ai/gemini-provider.js
@@ -659,9 +659,11 @@ class GeminiProvider extends AIProvider {
   /**
    * Test if Gemini CLI is available
    * Uses the command configured in the instance (respects ENV > config > default precedence)
+   * @param {number} [timeoutMs=10000] - Timeout in milliseconds for the probe.
+   *   Production passes the per-provider resolved value; the default is only hit by tests.
    * @returns {Promise<boolean>}
    */
-  async testAvailability() {
+  async testAvailability(timeoutMs = 10000) {
     return new Promise((resolve) => {
       // For availability test, we just need to check --version
       // Use the already-resolved command from the constructor (this.geminiCmd)
@@ -685,6 +687,16 @@ class GeminiProvider extends AIProvider {
       let stdout = '';
       let settled = false;
 
+      // Timeout guard: if the CLI hangs, kill it and resolve false so the probe
+      // does not leak a child process.
+      const availabilityTimeout = setTimeout(() => {
+        if (settled) return;
+        settled = true;
+        logger.warn(`Gemini CLI availability check timed out after ${Math.round(timeoutMs / 1000)}s`);
+        try { gemini.kill(); } catch { /* ignore */ }
+        resolve(false);
+      }, timeoutMs);
+
       gemini.stdout.on('data', (data) => {
         stdout += data.toString();
       });
@@ -692,6 +704,7 @@ class GeminiProvider extends AIProvider {
       gemini.on('close', (code) => {
         if (settled) return;
         settled = true;
+        clearTimeout(availabilityTimeout);
         if (code === 0 && stdout.includes('.')) {
           logger.info(`Gemini CLI available: ${stdout.trim()}`);
           resolve(true);
@@ -704,6 +717,7 @@ class GeminiProvider extends AIProvider {
       gemini.on('error', (error) => {
         if (settled) return;
         settled = true;
+        clearTimeout(availabilityTimeout);
         logger.warn(`Gemini CLI not available: ${error.message}`);
         resolve(false);
       });

--- a/src/ai/index.js
+++ b/src/ai/index.js
@@ -17,6 +17,9 @@ const {
   getAllProvidersInfo,
   createProvider,
   testProviderAvailability,
+  resolveAvailabilityTimeoutMs,
+  secondsToTimeoutMs,
+  DEFAULT_AVAILABILITY_TIMEOUT_MS,
   applyConfigOverrides,
   getProviderConfigOverrides,
   inferModelDefaults,
@@ -69,6 +72,9 @@ module.exports = {
 
   // Utilities
   testProviderAvailability,
+  resolveAvailabilityTimeoutMs,
+  secondsToTimeoutMs,
+  DEFAULT_AVAILABILITY_TIMEOUT_MS,
 
   // Config override support
   applyConfigOverrides,

--- a/src/ai/opencode-provider.js
+++ b/src/ai/opencode-provider.js
@@ -587,9 +587,11 @@ class OpenCodeProvider extends AIProvider {
   /**
    * Test if OpenCode CLI is available
    * Uses the command configured in the instance (respects ENV > config > default precedence)
+   * @param {number} [timeoutMs=10000] - Timeout in milliseconds for the probe.
+   *   Production passes the per-provider resolved value; the default is only hit by tests.
    * @returns {Promise<boolean>}
    */
-  async testAvailability() {
+  async testAvailability(timeoutMs = 10000) {
     return new Promise((resolve) => {
       // For availability test, we just need to check --version
       // Use the already-resolved command from the constructor (this.opencodeCmd)
@@ -613,6 +615,16 @@ class OpenCodeProvider extends AIProvider {
       let stdout = '';
       let settled = false;
 
+      // Timeout guard: if the CLI hangs, kill it and resolve false so the probe
+      // does not leak a child process.
+      const availabilityTimeout = setTimeout(() => {
+        if (settled) return;
+        settled = true;
+        logger.warn(`OpenCode CLI availability check timed out after ${Math.round(timeoutMs / 1000)}s`);
+        try { opencode.kill(); } catch { /* ignore */ }
+        resolve(false);
+      }, timeoutMs);
+
       opencode.stdout.on('data', (data) => {
         stdout += data.toString();
       });
@@ -620,6 +632,7 @@ class OpenCodeProvider extends AIProvider {
       opencode.on('close', (code) => {
         if (settled) return;
         settled = true;
+        clearTimeout(availabilityTimeout);
         if (code === 0) {
           logger.info(`OpenCode CLI available: ${stdout.trim()}`);
           resolve(true);
@@ -632,6 +645,7 @@ class OpenCodeProvider extends AIProvider {
       opencode.on('error', (error) => {
         if (settled) return;
         settled = true;
+        clearTimeout(availabilityTimeout);
         logger.warn(`OpenCode CLI not available: ${error.message}`);
         resolve(false);
       });

--- a/src/ai/pi-provider.js
+++ b/src/ai/pi-provider.js
@@ -1103,9 +1103,10 @@ class PiProvider extends AIProvider {
   /**
    * Test if Pi CLI is available
    * Uses the command configured in the instance (respects ENV > config > default precedence)
+   * @param {number} [timeoutMs=10000] - Timeout in milliseconds for the probe
    * @returns {Promise<boolean>}
    */
-  async testAvailability() {
+  async testAvailability(timeoutMs = 10000) {
     return new Promise((resolve) => {
       // For availability test, we just need to check --version
       // Use the already-resolved command from the constructor (this.piCmd)
@@ -1135,10 +1136,10 @@ class PiProvider extends AIProvider {
       const availabilityTimeout = setTimeout(() => {
         if (settled) return;
         settled = true;
-        logger.warn(`${name} CLI availability check timed out after 10s`);
+        logger.warn(`${name} CLI availability check timed out after ${Math.round(timeoutMs / 1000)}s`);
         try { pi.kill(); } catch { /* ignore */ }
         resolve(false);
-      }, 10000);
+      }, timeoutMs);
 
       pi.stdout.on('data', (data) => {
         stdout += data.toString();

--- a/src/ai/provider.js
+++ b/src/ai/provider.js
@@ -113,9 +113,13 @@ class AIProvider {
 
   /**
    * Test if the provider's CLI is available
+   * @param {number} [timeoutMs] - Optional timeout in milliseconds for the
+   *   availability probe. Subclasses that spawn a child process should use this
+   *   to bound the check (the value is resolved per-provider by
+   *   testProviderAvailability). Defaults to DEFAULT_AVAILABILITY_TIMEOUT_MS.
    * @returns {Promise<boolean>}
    */
-  async testAvailability() {
+  async testAvailability(timeoutMs) {
     throw new Error('testAvailability() must be implemented by subclass');
   }
 
@@ -354,6 +358,28 @@ const providerRegistry = new Map();
 const providerConfigOverrides = new Map();
 
 /**
+ * Default timeout (ms) for a provider availability probe when no
+ * per-provider `availability_timeout_seconds` is configured.
+ */
+const DEFAULT_AVAILABILITY_TIMEOUT_MS = 10000;
+
+/**
+ * Convert a configured `availability_timeout_seconds` value to milliseconds.
+ * Single source of truth for the "valid positive seconds" predicate shared by
+ * every availability-probe timeout (AI providers, executable providers, and
+ * chat providers); falls back to `defaultMs` when the value is unset,
+ * non-numeric, non-finite, or <= 0.
+ * @param {*} seconds - Raw config value, expected to be a number of seconds
+ * @param {number} [defaultMs=DEFAULT_AVAILABILITY_TIMEOUT_MS] - Fallback in ms
+ * @returns {number} Timeout in milliseconds
+ */
+function secondsToTimeoutMs(seconds, defaultMs = DEFAULT_AVAILABILITY_TIMEOUT_MS) {
+  return (typeof seconds === 'number' && Number.isFinite(seconds) && seconds > 0)
+    ? seconds * 1000
+    : defaultMs;
+}
+
+/**
  * Whether yolo mode is enabled (skips fine-grained provider permissions)
  */
 let yoloMode = false;
@@ -534,6 +560,7 @@ function applyConfigOverrides(config) {
         env: providerConfig.env,
         load_skills: providerConfig.load_skills,
         app_extensions: providerConfig.app_extensions,
+        availability_timeout_seconds: providerConfig.availability_timeout_seconds,
         models: AliasClass.getModels() !== BaseClass.getModels() ? AliasClass.getModels() : null
       });
       logger.debug(`Registered aliased provider: ${providerId} (base: ${providerConfig.type})`);
@@ -561,6 +588,7 @@ function applyConfigOverrides(config) {
       env: providerConfig.env,
       load_skills: providerConfig.load_skills,
       app_extensions: providerConfig.app_extensions,
+      availability_timeout_seconds: providerConfig.availability_timeout_seconds,
       models: processedModels
     });
   }
@@ -725,26 +753,53 @@ function createProvider(providerId, model = null, overrides = {}) {
 }
 
 /**
+ * Resolve the availability-probe timeout (ms) for a provider.
+ * Reads the per-provider `availability_timeout_seconds` config override
+ * (in seconds, mirroring `checkout_timeout_seconds`); falls back to
+ * DEFAULT_AVAILABILITY_TIMEOUT_MS when unset, non-numeric, or <= 0.
+ * @param {string} providerId - Provider ID
+ * @returns {number} Timeout in milliseconds
+ */
+function resolveAvailabilityTimeoutMs(providerId) {
+  const seconds = providerConfigOverrides.get(providerId)?.availability_timeout_seconds;
+  return secondsToTimeoutMs(seconds);
+}
+
+/**
  * Test availability of a provider with timeout
  * @param {string} providerId - Provider ID
- * @param {number} timeout - Timeout in milliseconds (default 10 seconds)
+ * @param {number} [timeoutMs] - Timeout in milliseconds. When omitted, resolved
+ *   per-provider from `availability_timeout_seconds` (default 10 seconds).
  * @returns {Promise<{available: boolean, error?: string}>}
  */
-async function testProviderAvailability(providerId, timeout = 10000) {
+async function testProviderAvailability(providerId, timeoutMs) {
+  const effectiveTimeoutMs = timeoutMs != null ? timeoutMs : resolveAvailabilityTimeoutMs(providerId);
   try {
     const provider = createProvider(providerId);
 
-    // Race between availability test and timeout
+    // Race between availability test and timeout. The provider's own probe
+    // receives the same timeout so it can kill its child process on expiry;
+    // this race is the only guard for providers without an internal timeout.
+    // Capture the timer handle so we can clear it once the race settles —
+    // otherwise a fast probe with a large configured timeout would keep the
+    // Node event loop alive (and its rejection unobserved) until the timer fires.
+    let timeoutId;
     const timeoutPromise = new Promise((_, reject) => {
-      setTimeout(() => reject(new Error('Provider test timed out')), timeout);
+      timeoutId = setTimeout(
+        () => reject(new Error(`Provider test timed out after ${Math.round(effectiveTimeoutMs / 1000)}s`)),
+        effectiveTimeoutMs
+      );
     });
 
-    const available = await Promise.race([
-      provider.testAvailability(),
-      timeoutPromise
-    ]);
-
-    return { available };
+    try {
+      const available = await Promise.race([
+        provider.testAvailability(effectiveTimeoutMs),
+        timeoutPromise
+      ]);
+      return { available };
+    } finally {
+      clearTimeout(timeoutId);
+    }
   } catch (error) {
     const ProviderClass = providerRegistry.get(providerId);
     const installInstructions = ProviderClass?.getInstallInstructions() || 'Check the provider documentation.';
@@ -791,6 +846,9 @@ module.exports = {
   getAllProvidersInfo,
   createProvider,
   testProviderAvailability,
+  resolveAvailabilityTimeoutMs,
+  secondsToTimeoutMs,
+  DEFAULT_AVAILABILITY_TIMEOUT_MS,
   // Config override support
   applyConfigOverrides,
   createAliasedProviderClass,

--- a/src/chat/chat-providers.js
+++ b/src/chat/chat-providers.js
@@ -7,7 +7,7 @@
  */
 
 const { spawn } = require('child_process');
-const { getCachedAvailability } = require('../ai');
+const { getCachedAvailability, secondsToTimeoutMs, DEFAULT_AVAILABILITY_TIMEOUT_MS } = require('../ai');
 const logger = require('../utils/logger');
 
 // Default dependencies (overridable for testing)
@@ -123,6 +123,9 @@ function getChatProvider(id) {
     if (overrides.availability_command !== undefined) {
       provider.availability_command = overrides.availability_command;
     }
+    if (overrides.availability_timeout_seconds !== undefined) {
+      provider.availability_timeout_seconds = overrides.availability_timeout_seconds;
+    }
     if (overrides.extra_args && Array.isArray(overrides.extra_args)) {
       provider.args = [...provider.args, ...overrides.extra_args];
     }
@@ -146,6 +149,9 @@ function getChatProvider(id) {
   if (overrides.provider) merged.provider = overrides.provider;
   if (overrides.availability_command !== undefined) {
     merged.availability_command = overrides.availability_command;
+  }
+  if (overrides.availability_timeout_seconds !== undefined) {
+    merged.availability_timeout_seconds = overrides.availability_timeout_seconds;
   }
   if (overrides.env) merged.env = { ...merged.env, ...overrides.env };
   if (overrides.args) {
@@ -230,9 +236,10 @@ function isCodexProvider(id) {
 /**
  * Check availability of a single chat provider.
  * Providers with `availability_command` run that command first.
- * Without an availability command, Pi delegates to the existing AI provider
- * availability cache and other providers spawn `<command> --version` to verify
- * the binary exists.
+ * Without an availability command, the built-in Pi provider (no `command`
+ * override) delegates to the existing AI provider availability cache; every
+ * other provider — including custom `type: 'pi'` providers and built-in Pi with
+ * a `command` override — spawns `<command> --version` to verify the binary exists.
  * @param {string} id - Provider ID
  * @param {Object} [_deps] - Dependency overrides for testing
  * @returns {Promise<{available: boolean, error?: string}>}
@@ -245,6 +252,12 @@ async function checkChatProviderAvailability(id, _deps) {
 
   const deps = { ...defaults, ..._deps };
 
+  // Per-provider availability-probe timeout. Configured in seconds (mirrors
+  // checkout_timeout_seconds); falls back to the shared default when
+  // unset/invalid. Build-based availability commands can raise this via
+  // `availability_timeout_seconds`.
+  const timeout = secondsToTimeoutMs(provider.availability_timeout_seconds);
+
   if (provider.availability_command) {
     return runCommandAvailabilityCheck({
       deps,
@@ -253,11 +266,18 @@ async function checkChatProviderAvailability(id, _deps) {
       displayCommand: 'availability command',
       shell: true,
       env: provider.env,
+      timeout,
     });
   }
 
-  // Pi delegates to existing AI provider availability
-  if (provider.type === 'pi') {
+  // Delegate to the AI provider's cached availability only for the built-in Pi
+  // chat provider with no command override — i.e. the same binary the AI
+  // provider already probed. The built-in `pi` definition intentionally omits
+  // `command` (PiBridge resolves its own default at runtime), so `!provider.command`
+  // cleanly distinguishes it. Custom `type: 'pi'` providers and built-in Pi
+  // overridden with a different `command` point at a different binary, so they
+  // fall through to the `<command> --version` probe below (which honors `timeout`).
+  if (provider.type === 'pi' && !provider.command) {
     const cached = getCachedAvailability('pi');
     return { available: cached?.available || false, error: cached?.error };
   }
@@ -278,6 +298,7 @@ async function checkChatProviderAvailability(id, _deps) {
     displayCommand: `${command} --version`,
     shell: useShell,
     env: provider.env,
+    timeout,
   });
 }
 
@@ -296,15 +317,15 @@ async function checkChatProviderAvailability(id, _deps) {
  * - `displayCommand` is used in error messages so user-configured shell strings
  *   do not need to be printed verbatim.
  *
- * @param {{deps: {spawn: Function}, command: string, args: string[], displayCommand: string, shell: boolean, env?: Object}} opts
+ * @param {{deps: {spawn: Function}, command: string, args: string[], displayCommand: string, shell: boolean, env?: Object, timeout?: number}} opts
  * @returns {Promise<{available: boolean, error?: string}>}
  */
-function runCommandAvailabilityCheck({ deps, command, args, displayCommand, shell, env }) {
+function runCommandAvailabilityCheck({ deps, command, args, displayCommand, shell, env, timeout = DEFAULT_AVAILABILITY_TIMEOUT_MS }) {
   return new Promise((resolve) => {
     try {
       const proc = deps.spawn(command, args, {
         stdio: ['ignore', 'ignore', 'ignore'],
-        timeout: 10000,
+        timeout,
         shell,
         env: { ...process.env, ...(env || {}) },
       });

--- a/tests/unit/chat/chat-providers.test.js
+++ b/tests/unit/chat/chat-providers.test.js
@@ -411,6 +411,47 @@ describe('chat-providers', () => {
       expect(result).toEqual({ available: false, error: undefined });
     });
 
+    it('does not consult the pi cache for a custom type:pi provider with its own command', async () => {
+      // A custom type:'pi' provider points at a different binary than the
+      // AI-provider's pi, so the cached AI-provider status would be a wrong
+      // answer. It must run its own probe and respect its configured timeout.
+      applyConfigOverrides({
+        'river': { type: 'pi', command: '/bin/false', availability_timeout_seconds: 5 },
+      });
+      mockGetCachedAvailability.mockReturnValue({ available: true });
+
+      const { EventEmitter } = require('events');
+      const fakeProc = new EventEmitter();
+      const mockSpawn = vi.fn().mockReturnValue(fakeProc);
+
+      const promise = checkChatProviderAvailability('river', { spawn: mockSpawn });
+      fakeProc.emit('close', 1);
+
+      const result = await promise;
+      expect(result.available).toBe(false);
+      expect(mockGetCachedAvailability).not.toHaveBeenCalled();
+      expect(mockSpawn).toHaveBeenCalledWith(
+        '/bin/false', ['--version'], expect.objectContaining({ timeout: 5000 })
+      );
+    });
+
+    it('does not consult the pi cache when built-in pi is overridden with a command', async () => {
+      applyConfigOverrides({ 'pi': { command: '/opt/pi' } });
+      mockGetCachedAvailability.mockReturnValue({ available: true });
+
+      const { EventEmitter } = require('events');
+      const fakeProc = new EventEmitter();
+      const mockSpawn = vi.fn().mockReturnValue(fakeProc);
+
+      const promise = checkChatProviderAvailability('pi', { spawn: mockSpawn });
+      fakeProc.emit('close', 0);
+
+      const result = await promise;
+      expect(result).toEqual({ available: true });
+      expect(mockGetCachedAvailability).not.toHaveBeenCalled();
+      expect(mockSpawn).toHaveBeenCalledWith('/opt/pi', ['--version'], expect.any(Object));
+    });
+
     it('should return unavailable for unknown provider', async () => {
       const result = await checkChatProviderAvailability('unknown');
       expect(result).toEqual({ available: false, error: 'Unknown provider: unknown' });
@@ -591,6 +632,71 @@ describe('chat-providers', () => {
       expect(result.error).toContain('availability command timed out or was terminated (SIGTERM)');
       expect(result.error).not.toContain('sleep 30');
       expect(mockSpawn).toHaveBeenCalledWith('sleep 30', [], expect.objectContaining({ timeout: 10000 }));
+    });
+
+    it('passes availability_timeout_seconds through to getChatProvider', () => {
+      applyConfigOverrides({
+        'custom-chat': { command: 'custom-chat', availability_timeout_seconds: 45 },
+      });
+      expect(getChatProvider('custom-chat').availability_timeout_seconds).toBe(45);
+    });
+
+    it('uses configured availability_timeout_seconds for the availability_command spawn timeout', async () => {
+      applyConfigOverrides({
+        'custom-chat': {
+          command: 'custom-chat',
+          availability_command: 'slow-build',
+          availability_timeout_seconds: 30,
+        },
+      });
+
+      const { EventEmitter } = require('events');
+      const fakeProc = new EventEmitter();
+      const mockSpawn = vi.fn().mockReturnValue(fakeProc);
+
+      const promise = checkChatProviderAvailability('custom-chat', { spawn: mockSpawn });
+      fakeProc.emit('close', 0);
+
+      const result = await promise;
+      expect(result).toEqual({ available: true });
+      expect(mockSpawn).toHaveBeenCalledWith('slow-build', [], expect.objectContaining({ timeout: 30000 }));
+    });
+
+    it('uses configured availability_timeout_seconds for the --version fallback spawn timeout', async () => {
+      applyConfigOverrides({
+        'custom-chat': { command: 'custom-chat', availability_timeout_seconds: 25 },
+      });
+
+      const { EventEmitter } = require('events');
+      const fakeProc = new EventEmitter();
+      const mockSpawn = vi.fn().mockReturnValue(fakeProc);
+
+      const promise = checkChatProviderAvailability('custom-chat', { spawn: mockSpawn });
+      fakeProc.emit('close', 0);
+
+      const result = await promise;
+      expect(result).toEqual({ available: true });
+      expect(mockSpawn).toHaveBeenCalledWith('custom-chat', ['--version'], expect.objectContaining({ timeout: 25000 }));
+    });
+
+    it('falls back to 10s when availability_timeout_seconds is invalid', async () => {
+      applyConfigOverrides({
+        'custom-chat': {
+          command: 'custom-chat',
+          availability_command: 'true',
+          availability_timeout_seconds: 0,
+        },
+      });
+
+      const { EventEmitter } = require('events');
+      const fakeProc = new EventEmitter();
+      const mockSpawn = vi.fn().mockReturnValue(fakeProc);
+
+      const promise = checkChatProviderAvailability('custom-chat', { spawn: mockSpawn });
+      fakeProc.emit('close', 0);
+
+      await promise;
+      expect(mockSpawn).toHaveBeenCalledWith('true', [], expect.objectContaining({ timeout: 10000 }));
     });
 
     it('should merge provider.env over process.env when running availability_command', async () => {

--- a/tests/unit/copilot-provider.test.js
+++ b/tests/unit/copilot-provider.test.js
@@ -21,6 +21,11 @@ vi.mock('../../src/utils/logger', () => ({
   section: vi.fn()
 }));
 
+// Spy on child_process.spawn BEFORE the provider is required, so the provider's
+// destructured `spawn` reference resolves to the spy. vi.mock does not intercept
+// CJS requires of Node built-in modules in vitest (see executable-provider.test.js).
+const mockSpawn = vi.spyOn(require('child_process'), 'spawn');
+
 // Import after mocks are set up
 const CopilotProvider = require('../../src/ai/copilot-provider');
 
@@ -36,6 +41,61 @@ describe('CopilotProvider', () => {
   afterEach(() => {
     // Restore original environment
     process.env = { ...originalEnv };
+  });
+
+  describe('testAvailability', () => {
+    it('kills the child and resolves false when the probe exceeds timeoutMs', async () => {
+      const { EventEmitter } = require('events');
+      vi.useFakeTimers();
+      try {
+        const child = new EventEmitter();
+        child.stdout = new EventEmitter();
+        child.kill = vi.fn();
+        mockSpawn.mockReturnValue(child);
+
+        const provider = new CopilotProvider();
+        const p = provider.testAvailability(5000);
+
+        let settled = false;
+        p.then(() => { settled = true; });
+
+        // Before the configured timeout the probe is still pending.
+        vi.advanceTimersByTime(4999);
+        await Promise.resolve();
+        expect(settled).toBe(false);
+        expect(child.kill).not.toHaveBeenCalled();
+
+        // Crossing the timeout kills the child and resolves false.
+        vi.advanceTimersByTime(2);
+        expect(await p).toBe(false);
+        expect(child.kill).toHaveBeenCalled();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('clears the timeout when the probe succeeds', async () => {
+      const { EventEmitter } = require('events');
+      vi.useFakeTimers();
+      try {
+        const child = new EventEmitter();
+        child.stdout = new EventEmitter();
+        child.kill = vi.fn();
+        mockSpawn.mockReturnValue(child);
+
+        const provider = new CopilotProvider();
+        const p = provider.testAvailability(5000);
+
+        child.emit('close', 0);
+        expect(await p).toBe(true);
+
+        // The timer was cleared, so advancing past it does not kill anything.
+        vi.advanceTimersByTime(10000);
+        expect(child.kill).not.toHaveBeenCalled();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
   });
 
   describe('static methods', () => {

--- a/tests/unit/executable-provider.test.js
+++ b/tests/unit/executable-provider.test.js
@@ -31,24 +31,25 @@ const { mockGetProviderClass, mockCreateProvider, mockGetRegisteredProviderIds }
   mockGetRegisteredProviderIds: vi.fn(() => [])
 }));
 
-vi.mock('../../src/ai/provider', () => ({
-  AIProvider: class AIProvider {
-    constructor(model) { this.model = model; }
-  },
-  getProviderClass: mockGetProviderClass,
-  createProvider: mockCreateProvider,
-  getRegisteredProviderIds: mockGetRegisteredProviderIds,
-  // Mirror the production helper, routed through the mocked lookup fns so the
-  // existing tests that configure mockGetProviderClass /
-  // mockGetRegisteredProviderIds continue to control resolution.
-  // Note: this entry only exists because vi.mock requires us to declare every
-  // export. The actual implementation used by the source is spied on below
-  // (actualMockResolveNonExecutableProviderId) to match how getProviderClass
-  // and similar are handled.
-  resolveNonExecutableProviderId: vi.fn(() => null),
-  resolveDefaultModel: vi.fn((models) => models.find(m => m.default)?.id || models[0]?.id),
-  inferModelDefaults: vi.fn((m) => m)
-}));
+vi.mock('../../src/ai/provider', async () => {
+  // importActual loads the real module so we inherit any exports we don't
+  // explicitly override (AIProvider, resolveDefaultModel, inferModelDefaults,
+  // secondsToTimeoutMs, …). Newly added helpers come along for free and won't
+  // silently become `undefined` — destructuring a missing mock export does not
+  // throw at import, it just yields `undefined` and blows up the first time the
+  // source calls it. Spreading the real module prevents that class of drift.
+  const actual = await vi.importActual('../../src/ai/provider');
+  return {
+    ...actual,
+    // Only override the lookup fns these tests need to control. The default
+    // resolveNonExecutableProviderId is a vi.fn so the spy installed below
+    // (actualMockResolveNonExecutableProviderId) can attach an implementation.
+    getProviderClass: mockGetProviderClass,
+    createProvider: mockCreateProvider,
+    getRegisteredProviderIds: mockGetRegisteredProviderIds,
+    resolveNonExecutableProviderId: vi.fn(() => null)
+  };
+});
 
 vi.mock('../../src/utils/json-extractor', () => ({
   extractJSON: mockExtractJSON
@@ -914,6 +915,48 @@ describe('createExecutableProviderClass', () => {
       mockSpawn.mockReturnValue(child);
       const p = instance.testAvailability();
       vi.advanceTimersByTime(10001);
+      expect(await p).toBe(false);
+      expect(child.kill).toHaveBeenCalled();
+      vi.useRealTimers();
+    });
+
+    it('honors a configured availability_timeout_seconds (seconds → ms)', async () => {
+      vi.useFakeTimers();
+      const si = new (createExecutableProviderClass('slow-tool', {
+        command: 'slow-tool', availability_timeout_seconds: 30
+      }))();
+      const child = createMockChild();
+      mockSpawn.mockReturnValue(child);
+      const p = si.testAvailability();
+
+      let settled = false;
+      p.then(() => { settled = true; });
+
+      // Past the old 10s default, but not yet at the configured 30s — still pending.
+      vi.advanceTimersByTime(29999);
+      await Promise.resolve();
+      expect(settled).toBe(false);
+      expect(child.kill).not.toHaveBeenCalled();
+
+      // Crossing 30s times out and kills the child.
+      vi.advanceTimersByTime(2);
+      expect(await p).toBe(false);
+      expect(child.kill).toHaveBeenCalled();
+      vi.useRealTimers();
+    });
+
+    it('honors a timeoutMs argument passed by testProviderAvailability', async () => {
+      vi.useFakeTimers();
+      const child = createMockChild();
+      mockSpawn.mockReturnValue(child);
+      // Default instance is 10s, but an explicit arg overrides it.
+      const p = instance.testAvailability(20000);
+      vi.advanceTimersByTime(10001);
+      let settled = false;
+      p.then(() => { settled = true; });
+      await Promise.resolve();
+      expect(settled).toBe(false);
+      vi.advanceTimersByTime(10000);
       expect(await p).toBe(false);
       expect(child.kill).toHaveBeenCalled();
       vi.useRealTimers();

--- a/tests/unit/gemini-provider.test.js
+++ b/tests/unit/gemini-provider.test.js
@@ -27,6 +27,11 @@ vi.mock('../../src/utils/logger', () => {
   };
 });
 
+// Spy on child_process.spawn BEFORE the provider is required, so the provider's
+// destructured `spawn` reference resolves to the spy. vi.mock does not intercept
+// CJS requires of Node built-in modules in vitest (see executable-provider.test.js).
+const mockSpawn = vi.spyOn(require('child_process'), 'spawn');
+
 // Import after mocks are set up
 const GeminiProvider = require('../../src/ai/gemini-provider');
 
@@ -42,6 +47,64 @@ describe('GeminiProvider', () => {
   afterEach(() => {
     // Restore original environment
     process.env = { ...originalEnv };
+  });
+
+  describe('testAvailability', () => {
+    it('kills the child and resolves false when the probe exceeds timeoutMs', async () => {
+      const { EventEmitter } = require('events');
+      vi.useFakeTimers();
+      try {
+        const child = new EventEmitter();
+        child.stdout = new EventEmitter();
+        child.kill = vi.fn();
+        mockSpawn.mockReturnValue(child);
+
+        const provider = new GeminiProvider('gemini-2.5-pro');
+        const p = provider.testAvailability(5000);
+
+        let settled = false;
+        p.then(() => { settled = true; });
+
+        // Before the configured timeout the probe is still pending.
+        vi.advanceTimersByTime(4999);
+        await Promise.resolve();
+        expect(settled).toBe(false);
+        expect(child.kill).not.toHaveBeenCalled();
+
+        // Crossing the timeout kills the child and resolves false.
+        vi.advanceTimersByTime(2);
+        expect(await p).toBe(false);
+        expect(child.kill).toHaveBeenCalled();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('clears the timeout when the probe succeeds', async () => {
+      const { EventEmitter } = require('events');
+      vi.useFakeTimers();
+      try {
+        const child = new EventEmitter();
+        child.stdout = new EventEmitter();
+        child.kill = vi.fn();
+        mockSpawn.mockReturnValue(child);
+
+        const provider = new GeminiProvider('gemini-2.5-pro');
+        const p = provider.testAvailability(5000);
+
+        // Gemini requires a "." in the version output to be considered available.
+        child.stdout.emit('data', Buffer.from('0.1.2\n'));
+        child.emit('close', 0);
+
+        expect(await p).toBe(true);
+
+        // The timer was cleared, so advancing past it does not kill anything.
+        vi.advanceTimersByTime(10000);
+        expect(child.kill).not.toHaveBeenCalled();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
   });
 
   describe('static methods', () => {

--- a/tests/unit/opencode-provider.test.js
+++ b/tests/unit/opencode-provider.test.js
@@ -27,6 +27,11 @@ vi.mock('../../src/utils/logger', () => {
   };
 });
 
+// Spy on child_process.spawn BEFORE the provider is required, so the provider's
+// destructured `spawn` reference resolves to the spy. vi.mock does not intercept
+// CJS requires of Node built-in modules in vitest (see executable-provider.test.js).
+const mockSpawn = vi.spyOn(require('child_process'), 'spawn');
+
 // Import after mocks are set up
 const OpenCodeProvider = require('../../src/ai/opencode-provider');
 
@@ -42,6 +47,61 @@ describe('OpenCodeProvider', () => {
   afterEach(() => {
     // Restore original environment
     process.env = { ...originalEnv };
+  });
+
+  describe('testAvailability', () => {
+    it('kills the child and resolves false when the probe exceeds timeoutMs', async () => {
+      const { EventEmitter } = require('events');
+      vi.useFakeTimers();
+      try {
+        const child = new EventEmitter();
+        child.stdout = new EventEmitter();
+        child.kill = vi.fn();
+        mockSpawn.mockReturnValue(child);
+
+        const provider = new OpenCodeProvider('anthropic/claude-sonnet-4');
+        const p = provider.testAvailability(5000);
+
+        let settled = false;
+        p.then(() => { settled = true; });
+
+        // Before the configured timeout the probe is still pending.
+        vi.advanceTimersByTime(4999);
+        await Promise.resolve();
+        expect(settled).toBe(false);
+        expect(child.kill).not.toHaveBeenCalled();
+
+        // Crossing the timeout kills the child and resolves false.
+        vi.advanceTimersByTime(2);
+        expect(await p).toBe(false);
+        expect(child.kill).toHaveBeenCalled();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('clears the timeout when the probe succeeds', async () => {
+      const { EventEmitter } = require('events');
+      vi.useFakeTimers();
+      try {
+        const child = new EventEmitter();
+        child.stdout = new EventEmitter();
+        child.kill = vi.fn();
+        mockSpawn.mockReturnValue(child);
+
+        const provider = new OpenCodeProvider('anthropic/claude-sonnet-4');
+        const p = provider.testAvailability(5000);
+
+        child.emit('close', 0);
+        expect(await p).toBe(true);
+
+        // The timer was cleared, so advancing past it does not kill anything.
+        vi.advanceTimersByTime(10000);
+        expect(child.kill).not.toHaveBeenCalled();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
   });
 
   describe('static methods', () => {

--- a/tests/unit/pi-provider.test.js
+++ b/tests/unit/pi-provider.test.js
@@ -1286,6 +1286,34 @@ describe('PiProvider', () => {
       expect(fakeChild.kill).toHaveBeenCalled();
     });
 
+    it('should honor a custom timeoutMs argument for the hang guard', async () => {
+      vi.useFakeTimers();
+      const { EventEmitter } = require('events');
+
+      const fakeChild = new EventEmitter();
+      fakeChild.stdout = new EventEmitter();
+      fakeChild.kill = vi.fn();
+
+      mockSpawn.mockReturnValueOnce(fakeChild);
+
+      const provider = new PiProvider('test-model');
+      const resultPromise = provider.testAvailability(20000);
+
+      // Past the 10s default but before the 20s argument — still pending.
+      vi.advanceTimersByTime(10001);
+      let settled = false;
+      resultPromise.then(() => { settled = true; });
+      await Promise.resolve();
+      expect(settled).toBe(false);
+      expect(fakeChild.kill).not.toHaveBeenCalled();
+
+      // Crossing 20s times out and kills the child.
+      vi.advanceTimersByTime(10000);
+      const result = await resultPromise;
+      expect(result).toBe(false);
+      expect(fakeChild.kill).toHaveBeenCalled();
+    });
+
     it('should not kill the process when CLI exits before timeout', async () => {
       vi.useFakeTimers();
       const { EventEmitter } = require('events');

--- a/tests/unit/provider-config.test.js
+++ b/tests/unit/provider-config.test.js
@@ -20,7 +20,10 @@ import {
   getProviderClass,
   createProvider,
   createAliasedProviderClass,
-  getTierForModel
+  getTierForModel,
+  resolveAvailabilityTimeoutMs,
+  secondsToTimeoutMs,
+  DEFAULT_AVAILABILITY_TIMEOUT_MS
 } from '../../src/ai/index.js';
 
 describe('Provider Configuration', () => {
@@ -1082,6 +1085,103 @@ describe('Provider Configuration', () => {
       expect(BaseClass.defaultTimeout).toBe(900000);
       // The alias should not have its own
       expect(Object.hasOwn(AliasClass, 'defaultTimeout')).toBe(false);
+    });
+  });
+
+  describe('availability_timeout_seconds', () => {
+    beforeEach(() => {
+      applyConfigOverrides({ providers: {} });
+    });
+
+    afterEach(() => {
+      applyConfigOverrides({ providers: {} });
+    });
+
+    it('stores availability_timeout_seconds in overrides for standard providers', () => {
+      applyConfigOverrides({
+        providers: { pi: { availability_timeout_seconds: 30 } }
+      });
+      expect(getProviderConfigOverrides('pi').availability_timeout_seconds).toBe(30);
+    });
+
+    it('stores availability_timeout_seconds in overrides for alias providers', () => {
+      applyConfigOverrides({
+        providers: {
+          'pi-custom': {
+            type: 'pi',
+            name: 'Custom Pi',
+            availability_timeout_seconds: 45,
+            models: [{ id: 'default', tier: 'balanced', default: true }]
+          }
+        }
+      });
+      expect(getProviderConfigOverrides('pi-custom').availability_timeout_seconds).toBe(45);
+    });
+
+    it('stores availability_timeout_seconds in overrides for executable providers', () => {
+      applyConfigOverrides({
+        providers: {
+          'my-tool': {
+            type: 'executable',
+            command: 'my-tool',
+            availability_timeout_seconds: 60
+          }
+        }
+      });
+      expect(getProviderConfigOverrides('my-tool').availability_timeout_seconds).toBe(60);
+    });
+
+    describe('secondsToTimeoutMs', () => {
+      it('converts a positive number of seconds to ms', () => {
+        expect(secondsToTimeoutMs(30)).toBe(30000);
+        expect(secondsToTimeoutMs(0.5)).toBe(500);
+      });
+
+      it('falls back to the default for non-positive or non-numeric values', () => {
+        for (const bad of [0, -5, NaN, Infinity, 'abc', null, undefined, {}]) {
+          expect(secondsToTimeoutMs(bad)).toBe(DEFAULT_AVAILABILITY_TIMEOUT_MS);
+        }
+      });
+
+      it('honors a custom defaultMs when the value is invalid', () => {
+        expect(secondsToTimeoutMs(0, 5000)).toBe(5000);
+        expect(secondsToTimeoutMs('nope', 5000)).toBe(5000);
+      });
+
+      it('uses the configured value even when a custom defaultMs is supplied', () => {
+        expect(secondsToTimeoutMs(12, 5000)).toBe(12000);
+      });
+    });
+
+    describe('resolveAvailabilityTimeoutMs', () => {
+      it('converts a configured positive value from seconds to ms', () => {
+        applyConfigOverrides({
+          providers: { pi: { availability_timeout_seconds: 30 } }
+        });
+        expect(resolveAvailabilityTimeoutMs('pi')).toBe(30000);
+      });
+
+      it('falls back to the default when unset', () => {
+        applyConfigOverrides({ providers: { pi: { command: '/custom/pi' } } });
+        expect(resolveAvailabilityTimeoutMs('pi')).toBe(DEFAULT_AVAILABILITY_TIMEOUT_MS);
+      });
+
+      it('falls back to the default for an unknown provider id', () => {
+        expect(resolveAvailabilityTimeoutMs('does-not-exist')).toBe(DEFAULT_AVAILABILITY_TIMEOUT_MS);
+      });
+
+      it('falls back to the default for non-positive or non-numeric values', () => {
+        for (const bad of [0, -5, NaN, 'abc', null]) {
+          applyConfigOverrides({
+            providers: { pi: { availability_timeout_seconds: bad } }
+          });
+          expect(resolveAvailabilityTimeoutMs('pi')).toBe(DEFAULT_AVAILABILITY_TIMEOUT_MS);
+        }
+      });
+
+      it('exposes 10000 as the default timeout constant', () => {
+        expect(DEFAULT_AVAILABILITY_TIMEOUT_MS).toBe(10000);
+      });
     });
   });
 });


### PR DESCRIPTION
## Summary

The provider availability probe — run at startup and on availability refresh — was hard-coded to a 10-second timeout. That is too short for providers whose `--version`/availability command triggers a slow build or compile step, causing them to be reported as unavailable even when they work.

This makes the timeout configurable and tightens up child-process cleanup along the way.

## Changes

- **Configurable timeout.** Add `availability_timeout_seconds` to AI analysis providers (`providers.<id>`, including executable and aliased providers) and chat providers (`chat_providers.<id>`). Unset or invalid values fall back to the existing 10s default via a shared `secondsToTimeoutMs` helper in `src/ai/provider.js`.
- **No more leaked probes.** The Gemini, Copilot, and OpenCode availability probes now terminate a hung `--version` check on expiry instead of leaking the child process.
- **Pi chat-provider fix.** A custom `type: "pi"` chat provider (or the built-in Pi overridden with a different `command`) now runs its own `<command> --version` probe — honoring `availability_timeout_seconds` — instead of incorrectly reporting the AI provider's cached Pi status for a different binary.
- Docs (`README.md`) and `config.example.json` updated; changeset included (`minor`).

## Testing

All affected provider unit suites pass (547 tests): executable, copilot, gemini, opencode, pi, provider-config, and chat-providers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)