### PR TITLE
Fix trailing-context suggestions failing to expand under lazy rendering

### DIFF
--- a/.changeset/fix-trailing-suggestion-expansion.md
+++ b/.changeset/fix-trailing-suggestion-expansion.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Fix AI suggestions and comments on trailing unchanged lines failing to expand and anchor after lazy diff rendering. The end-of-file gap is created with sentinel coordinates and resolved asynchronously as each file body renders; with lazy bodies that resolution no longer completed before `expandForSuggestion` tried to match the gap, so a suggestion targeting an unchanged line after the last hunk silently failed to expand, was not navigatable from the sidebar, and stayed hidden even after manual expansion. The gap-expansion path now awaits that per-file end-of-file validation before matching, so trailing-context suggestions reveal and anchor correctly in both PR and Local modes.

--- a/public/js/pr.js
+++ b/public/js/pr.js
@@ -3745,7 +3745,13 @@ class PRManager {
       // /file-content fetches) entirely when this body has none. The selector
       // mirrors the one validatePendingEofGaps scans for.
       if (entry.fileBody.querySelector('tr.context-expand-row[data-pending-eof-validation="true"]')) {
-        this.validatePendingEofGaps(entry.fileBody);
+        // Keep the in-flight promise on the entry. Until it resolves, the
+        // trailing EOF gap still carries EOF_SENTINEL coords, which makes
+        // findMatchingGap()'s overlap test unmatchable for a real target line.
+        // Line-anchoring callers (expandForSuggestion) await this so a
+        // suggestion/comment on a trailing unchanged line doesn't silently fail
+        // to expand. Fire-and-forget for everyone else.
+        entry.eofValidationPromise = this.validatePendingEofGaps(entry.fileBody);
       }
     }
 
@@ -4664,6 +4670,26 @@ class PRManager {
     // Render the body first — gap rows (and code rows) only exist once the
     // lazy body has rendered. Without this the gap query below returns nothing.
     await this.ensureFileBodyRendered(file);
+
+    // The trailing end-of-file gap is created with EOF_SENTINEL (-1) coords and
+    // resolved to real line numbers asynchronously by validatePendingEofGaps(),
+    // which _renderFileBodyNow fires fire-and-forget as the body renders. Until
+    // it settles the gap's NEW/OLD end is negative, so findMatchingGap()'s
+    // overlap test can never match a real target line — a suggestion (or
+    // comment, via ensureLinesVisible) on a trailing unchanged line silently
+    // fails to expand and never anchors. Pre-lazy-render this validation ran at
+    // renderDiff time, long before any suggestion was placed; lazy rendering
+    // collapsed that head start to nothing, which is the regression. Await the
+    // same in-flight promise (not a second /file-content fetch) so the EOF gap
+    // carries real coordinates before we match below.
+    const lazyEntry = this._lazyFileBodies?.get(fileElement.dataset?.fileName || file);
+    if (lazyEntry?.eofValidationPromise) {
+      try {
+        await lazyEntry.eofValidationPromise;
+      } catch {
+        // Validation removes the gap on fetch failure; matching simply misses.
+      }
+    }
 
     // Check if file is collapsed (generated files)
     if (fileElement.classList.contains('collapsed')) {

--- a/tests/unit/lazy-file-body.test.js
+++ b/tests/unit/lazy-file-body.test.js
@@ -142,6 +142,40 @@ describe('PRManager.ensureFileBodyRendered', () => {
     expect(m.renderPatch).not.toHaveBeenCalled();
   });
 
+  it('captures the EOF-gap validation promise on the entry when a gap is pending', async () => {
+    // Line-anchoring callers (expandForSuggestion) await this promise so the
+    // trailing EOF gap's sentinel coords are resolved before findMatchingGap.
+    const m = makeManager();
+    m.validatePendingEofGaps = vi.fn().mockResolvedValue();
+    // makeManager stubs renderPatch as a no-op; append a pending EOF gap row so
+    // _renderFileBodyNow's post-render validation kicks in.
+    m.renderPatch = vi.fn((tbody) => {
+      const gapRow = document.createElement('tr');
+      gapRow.className = 'context-expand-row';
+      gapRow.dataset.pendingEofValidation = 'true';
+      tbody.appendChild(gapRow);
+    });
+
+    m.renderFileDiff({ file: 'a.js', patch: '@@ -1 +1 @@\n+x\n' });
+    await m.ensureFileBodyRendered('a.js');
+
+    const entry = m._lazyFileBodies.get('a.js');
+    expect(m.validatePendingEofGaps).toHaveBeenCalledWith(entry.fileBody);
+    expect(entry.eofValidationPromise).toBeInstanceOf(Promise);
+  });
+
+  it('leaves eofValidationPromise unset when there is no pending EOF gap', async () => {
+    const m = makeManager();
+    m.validatePendingEofGaps = vi.fn().mockResolvedValue();
+    // Default no-op renderPatch appends no gap rows.
+    m.renderFileDiff({ file: 'a.js', patch: '@@ -1 +1 @@\n+x\n' });
+    await m.ensureFileBodyRendered('a.js');
+
+    const entry = m._lazyFileBodies.get('a.js');
+    expect(m.validatePendingEofGaps).not.toHaveBeenCalled();
+    expect(entry.eofValidationPromise).toBeUndefined();
+  });
+
   it('skips hunk-anchor registration for a body from a superseded render', async () => {
     const m = makeManager();
     m.renderFileDiff({ file: 'a.js', patch: '@@ -1 +1 @@\n+x\n' });

--- a/tests/unit/lazy-render-hooks.test.js
+++ b/tests/unit/lazy-render-hooks.test.js
@@ -54,6 +54,47 @@ describe('PRManager.expandForSuggestion force-render', () => {
     // No matching gap → returns false (the line wasn't in a collapsed gap).
     expect(result).toBe(false);
   });
+
+  it('awaits the pending EOF-gap validation before matching gaps', async () => {
+    // Regression: with lazy rendering, _renderFileBodyNow fires
+    // validatePendingEofGaps() fire-and-forget. Until it resolves, the trailing
+    // EOF gap still carries EOF_SENTINEL coords, so findMatchingGap() can never
+    // match a real target line and a suggestion on a trailing unchanged line
+    // silently fails to expand/anchor. expandForSuggestion must await that
+    // in-flight validation before matching.
+    const m = Object.create(PRManager.prototype);
+    const wrapper = document.createElement('div');
+    wrapper.className = 'd2h-file-wrapper';
+    wrapper.dataset.fileName = 'a.js';
+    document.body.appendChild(wrapper);
+
+    m.findFileElement = vi.fn(() => wrapper);
+    m.ensureFileBodyRendered = vi.fn(async () => {});
+
+    const order = [];
+    let resolveValidation;
+    const eofValidationPromise = new Promise((resolve) => {
+      resolveValidation = () => { order.push('eof-validated'); resolve(); };
+    });
+    m._lazyFileBodies = new Map([['a.js', { eofValidationPromise }]]);
+
+    // Capture-at-call: expandForSuggestion destructures findMatchingGap from
+    // window.GapCoordinates at entry, so install the ordering spy beforehand.
+    window.GapCoordinates.findMatchingGap = vi.fn(() => { order.push('match'); return null; });
+
+    const pending = m.expandForSuggestion('a.js', 100, 100, 'RIGHT');
+
+    // Flush microtasks: the gap match must NOT run while EOF validation is
+    // still pending. This is the guard that would fail before the fix.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(window.GapCoordinates.findMatchingGap).not.toHaveBeenCalled();
+
+    resolveValidation();
+    await pending;
+
+    // Validation resolved before the gap was matched.
+    expect(order).toEqual(['eof-validated', 'match']);
+  });
 });
 
 describe('SuggestionManager.displayAISuggestions force-render', () => {


### PR DESCRIPTION
## Problem

A regression introduced by lazy diff-body rendering: AI suggestions (and comments) targeting an **unchanged line after the last hunk** silently failed to expand and anchor. The symptoms:

- The suggestion was **not navigatable** from the sidebar (clicking did nothing).
- It stayed **hidden even after manually expanding** that part of the file.

## Root cause

The trailing end-of-file gap is created with `EOF_SENTINEL` (`-1`) coordinates and resolved to real line numbers asynchronously by `validatePendingEofGaps()`, which `_renderFileBodyNow` fires **fire-and-forget** as each body renders.

With lazy rendering, `displayAISuggestions` forces a below-the-fold body to render and then immediately calls `expandForSuggestion` → `findMatchingGap`. That runs **before** the validation fetch resolves, so the gap still carries `gapEnd = -1`, and `findMatchingGap`'s `rangesOverlap` check can never match a real target line — the suggestion is never revealed or anchored.

Pre-lazy-render, this validation ran at `renderDiff` time, seconds before any suggestion was placed. Lazy rendering collapsed that head start to nothing.

This funnels through `expandForSuggestion`, the chokepoint shared by AI suggestions and `ensureLinesVisible` (external comments, tours, chat) — so trailing-context comments were affected too.

## Fix (`public/js/pr.js`)

1. `_renderFileBodyNow` keeps the in-flight validation promise on the lazy entry as `entry.eofValidationPromise` (instead of discarding it).
2. `expandForSuggestion` awaits that same promise after `ensureFileBodyRendered`, before matching gaps — so the EOF gap has real coordinates when matched. Reuses the existing fetch (no extra `/file-content` request) and preserves the synchronous `_pendingHunkRecords` invariant.

Works in both PR and Local modes.

## Tests

- New regression tests in `tests/unit/lazy-render-hooks.test.js` (asserts `expandForSuggestion` waits for EOF validation before matching) and `tests/unit/lazy-file-body.test.js` (asserts the promise is captured only when a pending EOF gap exists).
- Full unit/integration suite passes under Node 24; `lazy-diff` and suggestion/navigation E2E specs pass. (The only failures are pre-existing known-flaky/local-env tests unrelated to this change.)
- Added a `patch` changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)