### PR TITLE
Add provider-level default_model and disabled_models config

### DIFF
--- a/.changeset/provider-default-and-disabled-models.md
+++ b/.changeset/provider-default-and-disabled-models.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": minor
+---
+
+Add provider-level `default_model` and `disabled_models` config options. Set `providers.<id>.default_model` to choose a provider's default model (preferred over the now-deprecated per-model `default: true` flag), and `providers.<id>.disabled_models` to hide specific built-in or custom model IDs from the picker.

--- a/README.md
+++ b/README.md
@@ -372,11 +372,11 @@ You can override provider settings and define custom models in your config file.
       "command": "opencode",
       "extra_args": ["--verbose"],
       "env": { "OPENCODE_TELEMETRY": "off" },
+      "default_model": "anthropic/claude-sonnet-4",
       "models": [
         {
           "id": "anthropic/claude-sonnet-4",
           "tier": "balanced",
-          "default": true,
           "name": "Claude Sonnet 4",
           "description": "Fast and capable for most reviews",
           "tagline": "Best balance of speed and quality"
@@ -410,6 +410,8 @@ You can override provider settings and define custom models in your config file.
 | `availability_timeout_seconds` | Seconds to allow for the startup availability probe before the provider is reported unavailable (default `10`). Raise it for providers whose check runs a slow build/compile step. Also supported per chat provider under `chat_providers.<id>`. |
 | `availability_command` | Command run to decide availability. Executable providers default to always-available when omitted; chat providers fall back to `<command> --version` (or, for the built-in Pi, the cached AI-provider status). Pair with `availability_timeout_seconds` when the probe runs a slow build. |
 | `models` | Array of model definitions (see below) |
+| `default_model` | Model `id` to use as the provider's default (in the picker and when no model is specified). Preferred over the per-model `default: true` flag. If it names an unknown or disabled model, the provider falls back to automatic selection. |
+| `disabled_models` | Array of model `id`s to hide. Disabled models disappear from the model picker for that provider. Works on built-in models too, so you can remove a built-in option without redefining the rest. A list that would hide *every* model is ignored. |
 
 #### Model Configuration Fields
 
@@ -422,9 +424,28 @@ You can override provider settings and define custom models in your config file.
 | `tagline` | No | Short description shown in model picker |
 | `badge` | No | Badge text (e.g., "NEW", "BETA") |
 | `badgeClass` | No | CSS class for badge styling |
-| `default` | No | Set to `true` to make this the default model for the provider |
+| `default` | No | **Deprecated** — use the provider-level `default_model` field instead. Set to `true` to make this the default model for the provider. Still honored for backward compatibility, but `default_model` takes precedence when both are present. |
 | `extra_args` | No | Model-specific CLI arguments |
 | `env` | No | Model-specific environment variables |
+
+#### Choosing and Hiding Models
+
+Use the provider-level `default_model` and `disabled_models` fields to tailor which models a provider exposes — these work on **built-in** models too, so you can adjust a provider without redefining its entire model list.
+
+```json
+{
+  "providers": {
+    "claude": {
+      "default_model": "sonnet-4.6",
+      "disabled_models": ["haiku", "fable"]
+    }
+  }
+}
+```
+
+- `disabled_models` removes those model IDs from the picker. To find the built-in IDs for a provider, see the comments in `config.example.json` (e.g. Claude ships `opus`, `sonnet-4.6`, `haiku`, …).
+- `default_model` selects which of the *remaining* models is the default. If it points at a model that is unknown or also disabled, the provider falls back to automatic selection (the model marked `default: true`, then the first `balanced`-tier model, then the first model).
+- Prefer `default_model` over the per-model `default: true` flag, which is deprecated. Setting `default_model` suppresses the deprecation warning.
 
 #### Model Tiers
 

--- a/config.example.json
+++ b/config.example.json
@@ -47,11 +47,11 @@
         "OPENCODE_TELEMETRY": "off"
       },
       "installInstructions": "Install OpenCode: curl -fsSL https://opencode.ai/install | bash",
+      "default_model": "anthropic/claude-sonnet-4",
       "models": [
         {
           "id": "anthropic/claude-sonnet-4",
           "tier": "balanced",
-          "default": true,
           "name": "Claude Sonnet 4",
           "description": "Fast and capable for most reviews",
           "tagline": "Best balance of speed and quality",
@@ -96,10 +96,14 @@
 
     "claude": {
       "_comment": "Override Claude's built-in configuration. Useful for custom paths, wrapper scripts, or additional arguments. Built-in models include fable, fable-5-high, opus, opus-4.7-high, opus-4.8-xhigh, opus-4.8-high, opus-4.6-high, sonnet-4.6, opus-4.6-1m, and haiku. Use 'cli_model' to decouple the app-level model ID from the CLI --model argument. Use 'env' for model-specific environment variables.",
+      "_comment_default_model": "Provider-level 'default_model' selects which model is the default in the picker and when no model is specified. Preferred over the per-model 'default: true' flag (which is deprecated). If it names an unknown or disabled model, the provider falls back to automatic selection.",
+      "_comment_disabled_models": "'disabled_models' hides specific model IDs (built-in or config-defined) from the picker for this provider. A list that would hide every model is ignored. Example below removes the fast-tier 'haiku' model and the thorough-tier 'fable' model.",
       "command": "claude",
       "extra_args": [],
       "env": {},
       "installInstructions": "Install Claude CLI: npm install -g @anthropic-ai/claude-code",
+      "default_model": "opus",
+      "disabled_models": ["haiku", "fable"],
       "models": [
         {
           "_comment": "Example: simple override — customize the display name and description of a built-in model. Note: 'tier' is required even for overrides (valid values: fast, balanced, thorough, premium).",
@@ -182,11 +186,11 @@
       "extra_args": [],
       "env": {},
       "installInstructions": "Install Pi: npm install -g @mariozechner/pi-coding-agent",
+      "default_model": "gemini-2.5-flash",
       "models": [
         {
           "id": "gemini-2.5-flash",
           "tier": "fast",
-          "default": true,
           "name": "Gemini 2.5 Flash",
           "description": "Google's fast model (suggested default)",
           "tagline": "Lightning Fast",
@@ -243,12 +247,12 @@
       "_comment_availability": "availability_command is run at startup to decide if the provider is available (defaults to 'true', i.e. always available). availability_timeout_seconds bounds that check (default 10); raise it when the command runs a slow build/compile step. Also supported on chat_providers entries.",
       "env": {},
       "installInstructions": "Install my-review-tool: pip install my-review-tool",
+      "default_model": "default",
       "models": [
         {
           "id": "default",
           "name": "Default",
-          "tier": "thorough",
-          "default": true
+          "tier": "thorough"
         }
       ]
     }

--- a/src/ai/index.js
+++ b/src/ai/index.js
@@ -24,6 +24,9 @@ const {
   getProviderConfigOverrides,
   inferModelDefaults,
   resolveDefaultModel,
+  mergeModels,
+  applyModelOverrides,
+  normalizeDisabledModels,
   prettifyModelId,
   createAliasedProviderClass,
   getTierForModel
@@ -81,6 +84,9 @@ module.exports = {
   getProviderConfigOverrides,
   inferModelDefaults,
   resolveDefaultModel,
+  mergeModels,
+  applyModelOverrides,
+  normalizeDisabledModels,
   prettifyModelId,
   getTierForModel,
 

--- a/src/ai/provider.js
+++ b/src/ai/provider.js
@@ -170,7 +170,8 @@ class AIProvider {
    * @returns {string} Model ID for extraction
    */
   getFastTierModel() {
-    const models = this.constructor.getModels();
+    const overrides = providerConfigOverrides.get(this.constructor.getProviderId());
+    const models = applyModelOverrides(this.constructor.getModels(), overrides);
     const fastModel = models.find(m => m.tier === 'fast');
     if (fastModel) {
       return fastModel.id;
@@ -446,17 +447,35 @@ function inferModelDefaults(model) {
 }
 
 /**
- * Resolve the default model from an array of model definitions
- * Priority: model with default:true > first balanced tier model > first model
- * @param {Array<Object>} models - Array of model definitions
+ * Resolve the default model from an array of model definitions.
+ * Priority: provider-level `default_model` (preferredId) > legacy model with
+ * `default:true` > first balanced tier model > first model.
+ *
+ * `preferredId` is the provider-level `default_model` config value. It is the
+ * preferred way to pick a default; the per-model `default:true` flag is the
+ * deprecated legacy mechanism, kept for backward compatibility. When
+ * `preferredId` names a model that isn't present (e.g. it was disabled or
+ * mistyped), resolution falls through to the legacy/automatic logic — the
+ * mismatch is warned about once at config-apply time, not here.
+ *
+ * @param {Array<Object>} models - Array of model definitions (already filtered)
+ * @param {string|null} [preferredId] - Provider-level `default_model` id
  * @returns {string|null} - Default model ID or null if no models
  */
-function resolveDefaultModel(models) {
+function resolveDefaultModel(models, preferredId = null) {
   if (!models || models.length === 0) {
     return null;
   }
 
-  // First, look for a model explicitly marked as default
+  // Provider-level `default_model` wins when it names an available model
+  if (preferredId) {
+    const preferred = models.find(m => m.id === preferredId);
+    if (preferred) {
+      return preferred.id;
+    }
+  }
+
+  // Legacy: model explicitly marked default:true (deprecated in favor of default_model)
   const explicitDefault = models.find(m => m.default === true);
   if (explicitDefault) {
     return explicitDefault.id;
@@ -493,7 +512,7 @@ function createAliasedProviderClass(aliasId, BaseClass, aliasConfig) {
   AliasedProvider.getProviderId = () => aliasId;
   if (processedModels) {
     AliasedProvider.getModels = () => processedModels;
-    AliasedProvider.getDefaultModel = () => resolveDefaultModel(processedModels);
+    AliasedProvider.getDefaultModel = () => resolveDefaultModel(processedModels, aliasConfig.default_model || null);
   }
   if (aliasConfig.installInstructions) {
     AliasedProvider.getInstallInstructions = () => aliasConfig.installInstructions;
@@ -539,7 +558,15 @@ function applyConfigOverrides(config) {
       const { createExecutableProviderClass } = require('./executable-provider');
       const ExecClass = createExecutableProviderClass(providerId, providerConfig);
       registerProvider(providerId, ExecClass);
-      providerConfigOverrides.set(providerId, { ...providerConfig, models: ExecClass.getModels() });
+      const execDisabled = normalizeDisabledModels(providerId, providerConfig.disabled_models);
+      const execDefault = providerConfig.default_model || null;
+      validateModelSelectors(providerId, ExecClass.getModels(), null, execDisabled, execDefault);
+      providerConfigOverrides.set(providerId, {
+        ...providerConfig,
+        models: ExecClass.getModels(),
+        disabled_models: execDisabled,
+        default_model: execDefault
+      });
       logger.debug(`Registered executable provider: ${providerId}`);
       continue;
     }
@@ -549,6 +576,10 @@ function applyConfigOverrides(config) {
       const BaseClass = providerRegistry.get(providerConfig.type);
       const AliasClass = createAliasedProviderClass(providerId, BaseClass, providerConfig);
       registerProvider(providerId, AliasClass);
+
+      const aliasDisabled = normalizeDisabledModels(providerId, providerConfig.disabled_models);
+      const aliasDefault = providerConfig.default_model || null;
+      validateModelSelectors(providerId, AliasClass.getModels(), null, aliasDisabled, aliasDefault);
 
       // Aliases reuse the base provider's implementation class, not its config.
       // Only universal override fields are forwarded; provider-specific fields
@@ -561,7 +592,9 @@ function applyConfigOverrides(config) {
         load_skills: providerConfig.load_skills,
         app_extensions: providerConfig.app_extensions,
         availability_timeout_seconds: providerConfig.availability_timeout_seconds,
-        models: AliasClass.getModels() !== BaseClass.getModels() ? AliasClass.getModels() : null
+        models: AliasClass.getModels() !== BaseClass.getModels() ? AliasClass.getModels() : null,
+        disabled_models: aliasDisabled,
+        default_model: aliasDefault
       });
       logger.debug(`Registered aliased provider: ${providerId} (base: ${providerConfig.type})`);
       continue;
@@ -578,7 +611,16 @@ function applyConfigOverrides(config) {
     if (Array.isArray(providerConfig.models) && providerConfig.models.length > 0) {
       processedModels = providerConfig.models.map(inferModelDefaults);
       logger.debug(`Configured ${processedModels.length} models for ${providerId}`);
+      // Deprecation: per-model `default: true` is superseded by provider-level `default_model`.
+      // Only warn when the user didn't already adopt the new field.
+      if (providerConfig.default_model == null && processedModels.some(m => m.default === true)) {
+        logger.warn(`Provider "${providerId}": per-model "default: true" is deprecated. Set provider-level "default_model": "<id>" instead.`);
+      }
     }
+
+    const disabledModels = normalizeDisabledModels(providerId, providerConfig.disabled_models);
+    const defaultModel = providerConfig.default_model || null;
+    validateModelSelectors(providerId, providerRegistry.get(providerId)?.getModels(), processedModels, disabledModels, defaultModel);
 
     // Store the overrides
     providerConfigOverrides.set(providerId, {
@@ -589,7 +631,9 @@ function applyConfigOverrides(config) {
       load_skills: providerConfig.load_skills,
       app_extensions: providerConfig.app_extensions,
       availability_timeout_seconds: providerConfig.availability_timeout_seconds,
-      models: processedModels
+      models: processedModels,
+      disabled_models: disabledModels,
+      default_model: defaultModel
     });
   }
 
@@ -674,6 +718,94 @@ function mergeModels(builtInModels, configModels) {
 }
 
 /**
+ * Compute the effective model list for a provider: built-in models merged with
+ * config-override models, then with any `disabled_models` IDs removed.
+ *
+ * This is the single source of truth for "which models does this provider
+ * actually expose" — every call site that surfaces or selects a model should go
+ * through here so a disabled model is hidden consistently (UI, default
+ * resolution, instance creation).
+ *
+ * If `disabled_models` would remove every model, the filter is ignored (a
+ * provider with zero models is unusable). Unknown/empty-list validation and
+ * warnings happen once at config-apply time in {@link applyConfigOverrides};
+ * this function is intentionally silent so it can run on every request.
+ *
+ * @param {Array<Object>} builtInModels - Models from ProviderClass.getModels()
+ * @param {Object} [overrides] - Stored config overrides for the provider
+ * @returns {Array<Object>} Effective model list
+ */
+function applyModelOverrides(builtInModels, overrides) {
+  const merged = mergeModels(builtInModels, overrides?.models);
+  const disabled = overrides?.disabled_models;
+  if (!Array.isArray(disabled) || disabled.length === 0) {
+    return merged;
+  }
+  const disabledSet = new Set(disabled);
+  const filtered = merged.filter(m => !disabledSet.has(m.id));
+  // Never strip a provider down to zero models — fall back to the unfiltered set.
+  return filtered.length > 0 ? filtered : merged;
+}
+
+/**
+ * Normalize a `disabled_models` config value into a clean array of string IDs
+ * (or null when absent/empty). Warns on malformed input.
+ * @param {string} providerId - Provider ID (for log messages)
+ * @param {*} raw - Raw config value
+ * @returns {string[]|null}
+ */
+function normalizeDisabledModels(providerId, raw) {
+  if (raw == null) {
+    return null;
+  }
+  if (!Array.isArray(raw)) {
+    logger.warn(`Provider "${providerId}": "disabled_models" must be an array of model IDs; ignoring.`);
+    return null;
+  }
+  const ids = raw.filter(id => typeof id === 'string' && id.length > 0);
+  if (ids.length !== raw.length) {
+    logger.warn(`Provider "${providerId}": "disabled_models" contained non-string entries which were ignored.`);
+  }
+  return ids.length > 0 ? ids : null;
+}
+
+/**
+ * Validate provider-level model selectors against the effective model set and
+ * warn about mistakes. Never throws — bad selectors degrade gracefully at
+ * resolution time (a disabled-everything list is ignored, an unknown
+ * default_model falls back to automatic selection).
+ * @param {string} providerId - Provider ID (for log messages)
+ * @param {Array<Object>} builtInModels - Provider's built-in models
+ * @param {Array<Object>|null} configModels - Processed config-override models
+ * @param {string[]|null} disabledModels - Normalized disabled list
+ * @param {string|null} defaultModel - Provider-level default_model id
+ */
+function validateModelSelectors(providerId, builtInModels, configModels, disabledModels, defaultModel) {
+  const merged = mergeModels(builtInModels || [], configModels);
+  const ids = new Set(merged.map(m => m.id));
+
+  if (disabledModels) {
+    for (const id of disabledModels) {
+      if (!ids.has(id)) {
+        logger.warn(`Provider "${providerId}": disabled_models references unknown model "${id}".`);
+      }
+    }
+    const remaining = merged.filter(m => !disabledModels.includes(m.id));
+    if (merged.length > 0 && remaining.length === 0) {
+      logger.warn(`Provider "${providerId}": disabled_models removes every model; the filter will be ignored.`);
+    }
+  }
+
+  if (defaultModel != null) {
+    if (!ids.has(defaultModel)) {
+      logger.warn(`Provider "${providerId}": default_model "${defaultModel}" is not a known model; falling back to automatic default.`);
+    } else if (disabledModels && disabledModels.includes(defaultModel)) {
+      logger.warn(`Provider "${providerId}": default_model "${defaultModel}" is also listed in disabled_models; falling back to automatic default.`);
+    }
+  }
+}
+
+/**
  * Get provider info for all registered providers
  * Uses config overrides for models/installInstructions if available
  * @returns {Array<Object>}
@@ -683,11 +815,17 @@ function getAllProvidersInfo() {
   for (const [id, ProviderClass] of providerRegistry) {
     const overrides = providerConfigOverrides.get(id);
 
-    // Merge config models with built-in models (config wins on ID collision)
-    const models = mergeModels(ProviderClass.getModels(), overrides?.models);
+    // Effective models: config merged with built-ins, minus disabled_models
+    const effectiveModels = applyModelOverrides(ProviderClass.getModels(), overrides);
 
-    // Resolve default model from merged models array
-    const defaultModel = resolveDefaultModel(models) || ProviderClass.getDefaultModel();
+    // Resolve default model: provider-level default_model wins, then legacy/auto
+    const defaultModel = resolveDefaultModel(effectiveModels, overrides?.default_model) || ProviderClass.getDefaultModel();
+
+    // Normalize per-model `default` flags to agree with the resolved defaultModel.
+    // Many frontend consumers derive the default via models.find(m => m.default),
+    // so the payload's flags must reflect the new source of truth (default_model).
+    // Produce NEW objects — never mutate the shared built-in model objects.
+    const models = effectiveModels.map(m => ({ ...m, default: m.id === defaultModel }));
 
     // Use overridden install instructions if available
     const installInstructions = overrides?.installInstructions || ProviderClass.getInstallInstructions();
@@ -736,11 +874,13 @@ function createProvider(providerId, model = null, overrides = {}) {
   // Determine the actual model to use
   let actualModel = model;
   if (!actualModel) {
-    // Resolve default from merged models (config + built-in).
+    // Resolve default from effective models (config + built-in, minus disabled).
     // Checks both sources because some providers (e.g., Pi) define built-in
-    // modes with default:true that aren't in config overrides.
+    // modes with default:true that aren't in config overrides. Honors the
+    // provider-level `default_model` selector.
     if (configOverrides?.models || ProviderClass.getModels().length > 0) {
-      actualModel = resolveDefaultModel(mergeModels(ProviderClass.getModels(), configOverrides?.models));
+      const effectiveModels = applyModelOverrides(ProviderClass.getModels(), configOverrides);
+      actualModel = resolveDefaultModel(effectiveModels, configOverrides?.default_model);
     }
     // Fall back to provider's built-in default
     if (!actualModel) {
@@ -855,6 +995,9 @@ module.exports = {
   getProviderConfigOverrides,
   inferModelDefaults,
   resolveDefaultModel,
+  mergeModels,
+  applyModelOverrides,
+  normalizeDisabledModels,
   prettifyModelId,
   getTierForModel
 };

--- a/tests/unit/provider-config.test.js
+++ b/tests/unit/provider-config.test.js
@@ -8,7 +8,13 @@
  * - Config override application (applyConfigOverrides)
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+// NOTE: production code (src/ai/provider.js) loads the logger via CommonJS
+// `require('../utils/logger')`. Under vitest the ESM `import` of this CJS
+// singleton resolves to a DIFFERENT instance than `require`, so a spy on the
+// imported binding would never see production's calls. Spy on the require'd
+// instance instead (matches the pattern in github-client.test.js).
+const logger = require('../../src/utils/logger');
 import {
   prettifyModelId,
   inferModelDefaults,
@@ -16,6 +22,8 @@ import {
   applyConfigOverrides,
   getProviderConfigOverrides,
   getAllProvidersInfo,
+  applyModelOverrides,
+  normalizeDisabledModels,
   getRegisteredProviderIds,
   getProviderClass,
   createProvider,
@@ -192,6 +200,45 @@ describe('Provider Configuration', () => {
       ];
 
       expect(resolveDefaultModel(models)).toBe('model-a');
+    });
+
+    it('should honor preferredId (default_model) over legacy default:true', () => {
+      const models = [
+        { id: 'model-a', tier: 'fast', default: true },
+        { id: 'model-b', tier: 'balanced' },
+        { id: 'model-c', tier: 'thorough' }
+      ];
+
+      expect(resolveDefaultModel(models, 'model-c')).toBe('model-c');
+    });
+
+    it('should fall through to legacy default:true when preferredId is not present', () => {
+      const models = [
+        { id: 'model-a', tier: 'fast' },
+        { id: 'model-b', tier: 'balanced', default: true }
+      ];
+
+      // preferredId names a model that was disabled/removed → fall through
+      expect(resolveDefaultModel(models, 'model-disabled')).toBe('model-b');
+    });
+
+    it('should fall through to automatic selection when preferredId is absent and no default:true', () => {
+      const models = [
+        { id: 'model-a', tier: 'fast' },
+        { id: 'model-b', tier: 'balanced' }
+      ];
+
+      expect(resolveDefaultModel(models, 'nope')).toBe('model-b');
+    });
+
+    it('should ignore a null/undefined preferredId', () => {
+      const models = [
+        { id: 'model-a', tier: 'fast' },
+        { id: 'model-b', tier: 'balanced', default: true }
+      ];
+
+      expect(resolveDefaultModel(models, null)).toBe('model-b');
+      expect(resolveDefaultModel(models, undefined)).toBe('model-b');
     });
   });
 
@@ -775,6 +822,20 @@ describe('Provider Configuration', () => {
       expect(AliasClass.getModels()).toEqual(BaseClass.getModels());
     });
 
+    it('wires disabled_models and default_model onto the aliased provider overrides', () => {
+      applyConfigOverrides({
+        providers: {
+          myalias: {
+            type: 'claude',
+            disabled_models: ['haiku'],
+            default_model: 'sonnet-4.6'
+          }
+        }
+      });
+      expect(getProviderConfigOverrides('myalias').disabled_models).toEqual(['haiku']);
+      expect(getProviderConfigOverrides('myalias').default_model).toBe('sonnet-4.6');
+    });
+
     it('should store config overrides for the aliased provider', () => {
       applyConfigOverrides({
         providers: {
@@ -1182,6 +1243,221 @@ describe('Provider Configuration', () => {
       it('exposes 10000 as the default timeout constant', () => {
         expect(DEFAULT_AVAILABILITY_TIMEOUT_MS).toBe(10000);
       });
+    });
+  });
+
+  describe('normalizeDisabledModels', () => {
+    // Spy on logger.warn so the warning-behavior tests can assert it fires.
+    // Scoped to this describe block and restored after each test so call
+    // counts don't leak across tests or into other describe blocks.
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('returns null for null/undefined', () => {
+      expect(normalizeDisabledModels('claude', null)).toBe(null);
+      expect(normalizeDisabledModels('claude', undefined)).toBe(null);
+    });
+
+    it('returns null and warns for a non-array value', () => {
+      const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+      expect(normalizeDisabledModels('claude', 'haiku')).toBe(null);
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns the list of string ids', () => {
+      expect(normalizeDisabledModels('claude', ['haiku', 'fable'])).toEqual(['haiku', 'fable']);
+    });
+
+    it('filters out non-string entries', () => {
+      const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+      expect(normalizeDisabledModels('claude', ['haiku', 42, null, ''])).toEqual(['haiku']);
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns null for an empty (or all-invalid) array', () => {
+      expect(normalizeDisabledModels('claude', [])).toBe(null);
+      expect(normalizeDisabledModels('claude', [123, null])).toBe(null);
+    });
+  });
+
+  describe('applyModelOverrides (disabled_models filtering)', () => {
+    const builtIns = [
+      { id: 'a', tier: 'fast' },
+      { id: 'b', tier: 'balanced' },
+      { id: 'c', tier: 'thorough' }
+    ];
+
+    it('returns merged models unchanged when no disabled_models', () => {
+      expect(applyModelOverrides(builtIns, {}).map(m => m.id)).toEqual(['a', 'b', 'c']);
+      expect(applyModelOverrides(builtIns, undefined).map(m => m.id)).toEqual(['a', 'b', 'c']);
+    });
+
+    it('removes disabled model ids from the effective list', () => {
+      const result = applyModelOverrides(builtIns, { disabled_models: ['b'] });
+      expect(result.map(m => m.id)).toEqual(['a', 'c']);
+    });
+
+    it('removes disabled config-added models too', () => {
+      const result = applyModelOverrides(builtIns, {
+        models: [{ id: 'd', tier: 'fast' }],
+        disabled_models: ['a', 'd']
+      });
+      expect(result.map(m => m.id)).toEqual(['b', 'c']);
+    });
+
+    it('ignores the filter when it would remove every model', () => {
+      const result = applyModelOverrides(builtIns, { disabled_models: ['a', 'b', 'c'] });
+      expect(result.map(m => m.id)).toEqual(['a', 'b', 'c']);
+    });
+
+    it('ignores unknown disabled ids without affecting real ones', () => {
+      const result = applyModelOverrides(builtIns, { disabled_models: ['b', 'does-not-exist'] });
+      expect(result.map(m => m.id)).toEqual(['a', 'c']);
+    });
+  });
+
+  describe('disabled_models via config (end to end)', () => {
+    beforeEach(() => {
+      applyConfigOverrides({ providers: {} });
+    });
+
+    afterEach(() => {
+      applyConfigOverrides({ providers: {} });
+    });
+
+    it('hides a disabled built-in model from getAllProvidersInfo', () => {
+      applyConfigOverrides({
+        providers: { claude: { disabled_models: ['haiku'] } }
+      });
+      const claude = getAllProvidersInfo().find(p => p.id === 'claude');
+      expect(claude.models.find(m => m.id === 'haiku')).toBeUndefined();
+      // Other built-ins are still present
+      expect(claude.models.find(m => m.id === 'opus')).toBeDefined();
+    });
+
+    it('stores the normalized disabled_models on the overrides', () => {
+      applyConfigOverrides({
+        providers: { claude: { disabled_models: ['haiku', 'fable'] } }
+      });
+      expect(getProviderConfigOverrides('claude').disabled_models).toEqual(['haiku', 'fable']);
+    });
+
+    it('moves the default off a disabled model', () => {
+      // claude's built-in default is 'opus'; disable it and the resolver picks another
+      applyConfigOverrides({
+        providers: { claude: { disabled_models: ['opus'] } }
+      });
+      const claude = getAllProvidersInfo().find(p => p.id === 'claude');
+      expect(claude.models.find(m => m.id === 'opus')).toBeUndefined();
+      expect(claude.defaultModel).not.toBe('opus');
+      // The resolved default must be one of the still-available models
+      expect(claude.models.find(m => m.id === claude.defaultModel)).toBeDefined();
+    });
+
+    it('does not pick a disabled model as the default in createProvider', () => {
+      applyConfigOverrides({
+        providers: { claude: { disabled_models: ['opus'] } }
+      });
+      const provider = createProvider('claude');
+      expect(provider.model).not.toBe('opus');
+    });
+
+    it('wires disabled_models and default_model onto executable provider overrides', () => {
+      applyConfigOverrides({
+        providers: {
+          'exec-tool': {
+            type: 'executable',
+            command: 'exec-tool',
+            disabled_models: ['fast-model'],
+            default_model: 'thorough-model',
+            models: [
+              { id: 'fast-model', tier: 'fast' },
+              { id: 'thorough-model', tier: 'thorough' }
+            ]
+          }
+        }
+      });
+      const overrides = getProviderConfigOverrides('exec-tool');
+      expect(overrides.disabled_models).toEqual(['fast-model']);
+      expect(overrides.default_model).toBe('thorough-model');
+    });
+  });
+
+  describe('provider-level default_model', () => {
+    beforeEach(() => {
+      applyConfigOverrides({ providers: {} });
+    });
+
+    afterEach(() => {
+      applyConfigOverrides({ providers: {} });
+    });
+
+    it('selects the configured default_model in getAllProvidersInfo', () => {
+      applyConfigOverrides({
+        providers: { claude: { default_model: 'haiku' } }
+      });
+      const claude = getAllProvidersInfo().find(p => p.id === 'claude');
+      expect(claude.defaultModel).toBe('haiku');
+    });
+
+    it('selects the configured default_model in createProvider', () => {
+      applyConfigOverrides({
+        providers: { claude: { default_model: 'sonnet-4.6' } }
+      });
+      const provider = createProvider('claude');
+      expect(provider.model).toBe('sonnet-4.6');
+    });
+
+    it('falls back to automatic default when default_model names an unknown model', () => {
+      applyConfigOverrides({
+        providers: { claude: { default_model: 'no-such-model' } }
+      });
+      const claude = getAllProvidersInfo().find(p => p.id === 'claude');
+      // Falls back to the built-in default ('opus')
+      expect(claude.defaultModel).toBe('opus');
+    });
+
+    it('falls back to automatic default when default_model is also disabled', () => {
+      applyConfigOverrides({
+        providers: { claude: { default_model: 'haiku', disabled_models: ['haiku'] } }
+      });
+      const claude = getAllProvidersInfo().find(p => p.id === 'claude');
+      expect(claude.models.find(m => m.id === 'haiku')).toBeUndefined();
+      expect(claude.defaultModel).not.toBe('haiku');
+    });
+
+    it('default_model wins over a config model marked default:true', () => {
+      applyConfigOverrides({
+        providers: {
+          claude: {
+            default_model: 'haiku',
+            models: [{ id: 'sonnet-4.6', tier: 'balanced', default: true }]
+          }
+        }
+      });
+      const claude = getAllProvidersInfo().find(p => p.id === 'claude');
+      expect(claude.defaultModel).toBe('haiku');
+    });
+
+    it('stores default_model on the overrides', () => {
+      applyConfigOverrides({
+        providers: { claude: { default_model: 'haiku' } }
+      });
+      expect(getProviderConfigOverrides('claude').default_model).toBe('haiku');
+    });
+
+    it('normalizes per-model default flags so models.find(m => m.default) agrees with default_model', () => {
+      // 'sonnet-4.6' does not carry a legacy default:true flag; the built-in
+      // default ('opus') does. After resolving default_model, exactly one model
+      // — the targeted one — should be flagged default:true.
+      applyConfigOverrides({
+        providers: { claude: { default_model: 'sonnet-4.6' } }
+      });
+      const claude = getAllProvidersInfo().find(p => p.id === 'claude');
+      expect(claude.defaultModel).toBe('sonnet-4.6');
+      expect(claude.models.find(m => m.default).id).toBe('sonnet-4.6');
+      expect(claude.models.filter(m => m.default === true)).toHaveLength(1);
     });
   });
 });


### PR DESCRIPTION
## Summary

Adds two userspace config options under `providers.<id>` so users can tailor which models a provider exposes — without redefining the whole model list:

- **`disabled_models`** — array of model IDs (built-in *or* custom) to hide. They disappear from the picker, default resolution, and instance creation. A list that would hide *every* model is ignored.
- **`default_model`** — provider-level default selector, preferred over the now-deprecated per-model `default: true` flag. An unknown or disabled target falls back to automatic selection.

```json
{
  "providers": {
    "claude": {
      "default_model": "sonnet-4.6",
      "disabled_models": ["haiku", "fable"]
    }
  }
}
```

## Implementation

- New `applyModelOverrides` helper is the single source of truth for "effective models" (merge built-ins + config, then strip `disabled_models`). Every consumption site routes through it: `getAllProvidersInfo`, `createProvider`, and `getFastTierModel` (used for JSON extraction).
- `resolveDefaultModel` gained a `preferredId` param: `default_model` > legacy `default: true` > first balanced-tier > first model.
- `getAllProvidersInfo` normalizes the returned `default` flags so exactly the resolved default carries `default: true` — keeping the payload internally consistent and letting existing `models.find(m => m.default)` consumers honor `default_model` with no frontend changes.
- Wired + validated across all three `applyConfigOverrides` branches (standard, alias, executable), with startup warnings for unknown IDs, hide-everything lists, and deprecated `default: true` usage.

## Docs

- `README.md`: documented both fields, marked per-model `default` deprecated, migrated examples to `default_model`.
- `config.example.json`: added active demo on the Claude block (default restated as `opus` so copying doesn't change behavior; `disabled_models` shown).

## Testing

Added unit coverage for `applyModelOverrides`, `normalizeDisabledModels`, `resolveDefaultModel` preferredId, end-to-end disabled/default behavior, alias/executable branch wiring, and the `default`-flag normalization. **898 tests pass.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)