### PR TITLE
Make headless --json agent-friendly: quiet stderr + JSON failure envelope

### DIFF
--- a/.changeset/headless-json-quiet-and-error-envelope.md
+++ b/.changeset/headless-json-quiet-and-error-envelope.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": minor
+---
+
+Make `--headless --json` an agent-friendly contract. stderr is now quiet by default in this mode (only warnings and errors, not progress narration) since coding agents capture stderr into their context — add `--debug`/`-d` to restore verbose logging. Failures now emit a structured `{ "ok": false, "error": { "message": … } }` envelope on stdout (with a non-zero exit) instead of leaving stdout empty, and the success document gains an `ok: true` field, so a consumer parses one stream and branches on `ok`.

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ pair-review --local [path]
 | `--ai` | Automatically run AI analysis when the review loads |
 | `--ai-draft` | Run AI analysis and save suggestions as a draft review on GitHub |
 | `--headless` | Run AI analysis, store it in the local database, report the results, then exit. No server, no browser, no GitHub post. Implies analysis (does not require `--ai`). Works with a `<PR-number-or-URL>` or with `--local`. See [Headless analysis mode](#headless-analysis-mode). |
-| `--json` | With `--headless`, emit the completed run plus its consolidated suggestions as a single JSON document on a clean stdout (all logs go to stderr). Only valid together with `--headless`. |
+| `--json` | With `--headless`, emit the completed run plus its consolidated suggestions as a single JSON document on a clean stdout. For any outcome of the headless run (success, zero findings, or an error raised while running it), stdout carries a JSON document with an `ok` field; failures emit an `{ "ok": false, "error": … }` envelope on stdout with a non-zero exit. (Pre-flight config/startup failures are the exception: they exit non-zero with a stderr message and no JSON envelope — branch on the exit code first.) stderr is quiet by default (only warnings/errors) — add `--debug` for verbose progress logs. Only valid together with `--headless`. |
 | `--instructions <text>` | Per-run custom instructions for this analysis. Applies to any mode that runs analysis — `--headless`, `--ai-draft`, `--ai-review` (consumed directly), and `--ai`/`--council` (carried into the browser-triggered analysis). Rejected with a clear error if no analysis mode is selected, so it is never silently dropped. Default: none. |
 | `--instructions-file <path>` | Read per-run custom instructions from a file (5000-character cap). Mutually exclusive with `--instructions`. |
 | `--council <handle>` | Run analysis with a saved multi-voice council. Implies analysis. The handle resolves by council name, name-slug, id (prefix), or a partial name fragment (resolving when it matches a single council, otherwise listing the candidates). When set, `--model` is ignored (council voices use their own per-voice models). Works in headless PR (`--ai-draft`/`--ai-review`/`--headless`), interactive PR (`--ai`), and local (`--local --ai`) modes. |
@@ -265,19 +265,25 @@ Non-zero exit is reserved for operational errors — invalid flags, an unreadabl
 `--instructions-file`, or an analysis failure.
 
 **Machine-readable output (`--json`):** add `--json` to emit the completed run
-plus its consolidated final suggestions as a single JSON document on stdout. In
-this mode all logs are redirected to stderr, so stdout is a clean, parseable
-document suitable for scripting and AI coding agents:
+plus its consolidated final suggestions as a single JSON document on stdout, so
+stdout is a clean, parseable document suitable for scripting and AI coding
+agents:
 
 ```bash
 pair-review --local --headless --json | jq '.suggestions | length'
 ```
+
+Because this mode is consumed mostly by coding agents — whose shell tools capture
+stderr alongside stdout — **stderr is quiet by default**: only genuine warnings
+and errors are emitted, not progress narration. Add `--debug` to restore the full
+verbose log stream on stderr when diagnosing a run.
 
 The JSON document has this shape (fields reflect the stored run and the
 consolidated suggestion layer the app shows by default):
 
 ```jsonc
 {
+  "ok": true,                 // false on failure (see below)
   "mode": "local",            // "pr" or "local"
   "run": {
     "id": "…",                 // analysis run id
@@ -324,6 +330,25 @@ consolidated suggestion layer the app shows by default):
 }
 ```
 
+**On failure** (invalid flags, an unreadable `--instructions-file`, or an
+analysis error raised while running the headless flow) `--json` emits a JSON
+document on stdout — a compact failure envelope — and the exit code is non-zero,
+so a consumer parses one stream and branches on `ok`:
+
+```jsonc
+{
+  "ok": false,
+  "mode": "local",            // "pr" or "local"
+  "error": { "message": "…" }
+}
+```
+
+The envelope covers errors raised once the headless run is under way. A fatal
+*pre-flight* failure — an unreadable or malformed `~/.pair-review/config.json`, an
+unwritable config directory, or an invalid port — exits non-zero with a message
+on **stderr** and does **not** emit a JSON envelope on stdout. Branch on the exit
+code first (as the example below does), then parse stdout.
+
 **Agent workflow.** A coding agent can run a headless analysis against its own
 uncommitted work, parse the JSON, and act on the suggestions:
 
@@ -332,17 +357,24 @@ result=$(pair-review --local --headless --json \
   --council security-review \
   --instructions "Review the changes I just made for security issues.")
 
+# Bail out on failure: non-zero exit, and `ok` is false in the JSON envelope.
+if [ $? -ne 0 ] || [ "$(echo "$result" | jq -r '.ok')" != "true" ]; then
+  echo "analysis failed: $(echo "$result" | jq -r '.error.message')" >&2
+  exit 1
+fi
+
 # Act on high-severity findings
 echo "$result" | jq -r '.suggestions[]
   | select(.severity == "high")
   | "\(.file):\(.line_start) [\(.type)] \(.title)"'
-
-# Exit code 0 = analysis ran (any number of findings); non-zero = operational error
 ```
 
-Because `--json` keeps stdout clean and exit `0` means "analysis ran," the agent
-can branch on `count`/`severity` rather than on the exit code, reserving non-zero
-handling for genuine failures.
+Once the run starts, `--json` produces a JSON document on stdout for any outcome
+— `{ "ok": true, … }` on success (any number of findings, including zero) and
+`{ "ok": false, … }` with a non-zero exit on an error raised while running it —
+so the agent reads exactly one stream and branches on `ok`. Because a pre-flight
+config/startup failure is the one case that exits without a JSON envelope,
+checking the exit code first (as above) covers every outcome.
 
 ## Configuration
 

--- a/plans/headless-json-quiet-and-error-envelope.md
+++ b/plans/headless-json-quiet-and-error-envelope.md
@@ -1,0 +1,177 @@
+# Headless `--json`: quiet-by-default stderr + structured failure envelope
+
+## Context
+
+`--headless --json` is primarily consumed by **coding agents**, not humans. An agent's
+shell tool captures *both* stdout and stderr into its context window, so the human
+escape hatch (`2>/dev/null`) doesn't apply — every progress line costs the agent
+tokens. Two problems follow:
+
+1. **Noise on success.** During a headless JSON run, stdout is already clean (only the
+   JSON document), but stderr is flooded with progress narration. `redirectConsoleToStderr()`
+   (`src/mcp-stdio.js:27`) routes the ~13 ungated `console.log` narration calls in the
+   headless path *and* the analyzer's `logger.section/info/success` chatter to stderr —
+   it relocates the noise but doesn't reduce it. The agent eats all of it.
+
+2. **Unstructured failures.** On any error the `main()` catch (`src/main.js:882`) writes a
+   prose `❌ Error: …` line to stderr and exits 1, leaving **empty stdout**. An agent that
+   parses stdout-as-JSON gets a parse failure and must scrape English from stderr to learn
+   what broke. The README "Agent workflow" section (`README.md:327`) even tells agents
+   "exit `0` means analysis ran" — there is no machine-readable failure shape.
+
+**Outcome:** make `--headless --json` an agent-native contract — one stream (stdout),
+always JSON, success and failure alike; near-silent stderr on success. `--debug`/`-d`
+restores verbose stderr for humans diagnosing a run.
+
+## Change 1 — `--json` implies quiet (unless `--debug`)
+
+Suppress progress narration by default in `--headless --json` mode; keep warnings and
+errors. `--debug`/`-d` brings the full narration back (on stderr).
+
+**Logger: add a "quiet" concept** — `src/utils/logger.js`
+- Add `this.quietEnabled = false;` to the constructor (alongside `debugEnabled`, line 30).
+- Add `setQuietEnabled(enabled)` (mirror `setDebugEnabled`, line 49).
+- Gate the **chatty** methods only — `info` (107), `success` (120), `log` (169),
+  `section` (183): change guard to `if (!this.enabled || this.quietEnabled) return;`.
+- Leave `warn` (153) and `error` (135) **ungated by quiet** — they must still emit
+  (never swallow warnings/errors). `warn` writes to `this._stdout`, which we redirect to
+  stderr below, so it never corrupts the JSON on real stdout.
+- Leave `debug`/`streamDebug` as-is (already opt-in via their own flags).
+
+**Centralize the quiet wiring in the existing helper** — `src/mcp-stdio.js`
+- Extend `redirectConsoleToStderr(opts)` to accept `{ quiet = false } = {}`:
+  - **Default / MCP path (`quiet: false`)** — unchanged: `console.log/info/warn = console.error`,
+    `logger.setOutputStream(process.stderr)`, set `PAIR_REVIEW_QUIET_STDOUT`. MCP mode
+    (`startMCPStdio`) keeps calling it with no args, so its behavior is untouched.
+  - **Quiet path (`quiet: true`)** — drop narration instead of relocating it:
+    `console.log = console.info = console.warn = () => {};`, keep `console.error` real
+    (→ stderr), `logger.setOutputStream(process.stderr)` (so any `logger.warn` lands on
+    stderr, never the JSON stdout), `logger.setQuietEnabled(true)`, set `PAIR_REVIEW_QUIET_STDOUT`.
+
+**Wire at the early lock-down point** — `src/main.js:619-626`
+- `parseArgs()` runs *after* this point, so peek raw `args` (same pattern already used for
+  `isHeadlessJson`):
+  ```js
+  const isHeadlessJson = args.includes('--headless') && args.includes('--json');
+  if (isHeadlessJson) {
+    const wantsDebug = args.includes('-d') || args.includes('--debug');
+    redirectConsoleToStderr({ quiet: !wantsDebug });
+  }
+  ```
+- Net effect: success run → stdout = JSON only; stderr = only genuine `logger.warn`/`error`.
+  With `--debug`, narration returns on stderr (current behavior).
+
+## Change 2 — failures emit a JSON envelope on stdout
+
+**Symmetry on success** — `src/main.js:2193` (`buildHeadlessJson` return)
+- Add `ok: true` to the returned doc: `{ ok: true, mode, run, suggestions, count }`.
+  Additive; the human-summary path (`emitHeadlessResult`) ignores it; existing
+  `buildHeadlessJson` unit tests still pass.
+
+**Extract a pure error-envelope builder** (testable, mirrors `buildHeadlessJson`) —
+`src/main.js`
+- Add and export `buildHeadlessErrorJson({ mode, error })` →
+  `{ ok: false, mode, error: { message: error.message } }`.
+
+**Emit it from the `main()` catch** — `src/main.js:882-885`
+- `flags` is block-scoped to the try and unavailable here; detect mode from `args`:
+  ```js
+  } catch (error) {
+    const jsonMode = args.includes('--headless') && args.includes('--json');
+    if (jsonMode) {
+      const mode = (args.includes('--local') || args.includes('-l')) ? 'local' : 'pr';
+      process.stdout.write(JSON.stringify(buildHeadlessErrorJson({ mode, error }), null, 2) + '\n');
+    } else {
+      console.error(`\n❌ Error: ${error.message}\n`);
+    }
+    process.exit(1);
+  }
+  ```
+- Exit stays **non-zero** — exit-code consumers are unaffected; new consumers parse stdout
+  and branch on `ok`. Covers all headless failures (flag validation at 644-649, bad
+  `--instructions-file`, prep/network/provider errors) since they all propagate here.
+- Optional hardening: apply the same JSON-on-stdout treatment to the
+  `unhandledRejection` handler (`src/main.js:2421`) using `process.argv`. Low priority;
+  the awaited headless path funnels through the `main()` catch.
+
+## Docs
+
+- **Help text** — `src/main.js:166-169` (`--json`): note stderr is quiet by default and
+  `--debug` restores verbose logs; mention failures are emitted as JSON (`ok:false`) too.
+- **README** — update the `--json` table row (`README.md:197`), the "Headless analysis
+  mode" / "Machine-readable output" section (`README.md:267`), and especially the **Agent
+  workflow** subsection (`README.md:327-343`): document quiet-by-default stderr, the
+  `ok` field, and that failures now produce a JSON envelope on stdout with exit 1 (replace
+  the "exit 0 means analysis ran" framing with "parse `ok`; non-zero exit + `ok:false` on
+  failure").
+
+## Changeset
+
+- Add `.changeset/*.md`, package `"@in-the-loop-labs/pair-review": minor` (user-facing
+  behavior change to the headless JSON contract: quieter stderr + new failure envelope +
+  `ok` field). Mirror frontmatter of an existing changeset.
+
+## Hazards
+
+- **`redirectConsoleToStderr` has two callers.** MCP mode (`startMCPStdio` in
+  `src/mcp-stdio.js`) and the headless-json lock-down (`src/main.js:625`). The new `quiet`
+  param defaults to `false`, so MCP behavior is preserved — verify the MCP call site is
+  left arg-less.
+- **`logger.warn` must reach stderr, not stdout, in quiet mode.** It writes to
+  `this._stdout`; the quiet path must call `setOutputStream(process.stderr)` or a warning
+  during a run will corrupt the JSON document. (Quiet keeps warn enabled by design.)
+- **Timing: redirect precedes `parseArgs`.** `flags.debug` isn't set at line 625; the
+  quiet decision must peek raw `args` for `-d`/`--debug`, consistent with the existing
+  `isHeadlessJson` peek.
+- **Three council analysis paths** (`src/ai/analyzer.js`: `analyzeAllLevels`,
+  `runReviewerCentricCouncil`, `runCouncilAnalysis`) all log via the shared `logger`, so
+  the quiet gating covers them automatically — no per-path change needed. No new
+  `console.*` calls should be introduced in the headless path; route any through `logger`.
+- **Both entry points / both modes.** Headless dispatch (`handleHeadlessAnalysis`,
+  `src/main.js:1992`) serves both PR and `--local`; the catch-based envelope is mode-derived
+  from `args` and covers both. No web-route parity needed (headless is CLI-only).
+
+## Testing
+
+Per CLAUDE.md, test coverage is mandatory. Reuse existing harnesses.
+
+1. **Logger quiet (unit, new `tests/unit/logger.test.js`).** Inject a fake `_stdout`
+   (`logger.setOutputStream(fakeStream)`); with `setQuietEnabled(true)` assert
+   `info/success/log/section` produce no output, while `warn` still writes (to the fake
+   stream) and `error` still writes to stderr. With quiet off, all emit. Restore logger
+   state in `afterEach`.
+2. **`redirectConsoleToStderr({ quiet })` (unit, extend `tests/unit/mcp-stdio.test.js`).**
+   Save/restore `console.*` in `afterEach`. Assert: `quiet: true` → `console.log` is a
+   no-op (does **not** equal `console.error`), `logger.quietEnabled === true`,
+   `_stdout === process.stderr`; default → `console.log === console.error` (unchanged).
+3. **Success envelope `ok: true` (unit, extend `tests/unit/headless-json.test.js`).**
+   Assert `buildHeadlessJson(...)` returns `ok: true` (plus existing assertions unchanged).
+4. **Error envelope (unit, extend `tests/unit/headless-json.test.js`).** Assert
+   `buildHeadlessErrorJson({ mode: 'local', error: new Error('boom') })` deep-equals
+   `{ ok: false, mode: 'local', error: { message: 'boom' } }`.
+5. **Failure path end-to-end (integration, `tests/integration/`).** Mirror
+   `first-run.test.js`'s `spawnSync` harness (temp `HOME` with a minimal config so it
+   passes first-run, `PAIR_REVIEW_NO_OPEN: '1'`). Run
+   `--local --headless --json --instructions-file /no/such/file` (resolves first in
+   `handleHeadlessAnalysis`, `src/main.js:2001`, so it fails deterministically with no
+   network/provider). Assert: exit code `1`, **stdout is the only output and parses as
+   JSON** with `ok === false` and a non-empty `error.message`, and stdout contains nothing
+   but the JSON document.
+6. **Frontend E2E:** none — this is CLI/stderr only, no frontend code touched. Run
+   `pnpm test` for the unit/integration suites above.
+
+## Verification
+
+- `pnpm test` (targeted: `logger.test.js`, `mcp-stdio.test.js`, `headless-json.test.js`,
+  the new integration test).
+- Manual, quiet-by-default (clean success):
+  `DEV_NO_AUTO_UPDATE=1 /opt/dev/bin/dev` run of
+  `pair-review --local --headless --json 2>/tmp/err.log` → stdout parses as JSON with
+  `ok:true`; `/tmp/err.log` is near-empty (no `[AI]` section banners, no `Finding git
+  repository…`).
+- Manual, debug restores narration:
+  `pair-review --local --headless --json --debug 2>/tmp/err.log` → `/tmp/err.log` shows the
+  full progress narration again; stdout still clean JSON.
+- Manual, failure envelope:
+  `pair-review --local --headless --json --instructions-file /no/such/file; echo "exit=$?"`
+  → a single JSON object on stdout with `ok:false`, `error.message`, and `exit=1`.

--- a/src/main.js
+++ b/src/main.js
@@ -165,8 +165,17 @@ OPTIONS:
                             <pr> argument or --local.
     --json                  With --headless, emit the completed run plus its
                             consolidated final suggestions as a single JSON
-                            document on a clean stdout (all logs go to stderr).
-                            Only valid together with --headless.
+                            document on a clean stdout. For any outcome of the
+                            headless run — success, zero findings, or an error
+                            raised while running it — stdout carries a JSON
+                            document with an "ok" field; on failure that envelope
+                            is { "ok": false, "error": ... } and the exit code is
+                            non-zero. Pre-flight config/startup failures are the
+                            exception: they exit non-zero with a stderr message
+                            and no JSON envelope, so branch on the exit code
+                            first. stderr is quiet by default (only
+                            warnings/errors); add --debug for verbose progress
+                            logs. Only valid together with --headless.
     --instructions <text>   Per-run custom instructions for the analysis.
                             Applies to any mode that runs analysis: --headless,
                             --ai, --ai-draft, --ai-review, or --council (with
@@ -618,11 +627,18 @@ AI PROVIDERS:
     // first-run welcome box below, both of which would otherwise corrupt the
     // JSON. Peek the raw args here: neither flag takes a value, parseArgs() still
     // runs afterwards for full validation, and redirectConsoleToStderr() is
-    // idempotent (it only reassigns console.* → console.error), so the later
+    // idempotent (it only reassigns console.* / the logger stream), so the later
     // gated call is unnecessary once this fires.
+    //
+    // Quiet by default: --headless --json is consumed mostly by coding agents,
+    // whose shell tools capture stderr into context — so we DROP progress
+    // narration rather than relocating it to stderr (warnings/errors still emit).
+    // --debug/-d restores the full verbose stderr stream for humans diagnosing a
+    // run. parseArgs() hasn't run yet, so peek raw args for the debug flags too.
     const isHeadlessJson = args.includes('--headless') && args.includes('--json');
     if (isHeadlessJson) {
-      redirectConsoleToStderr();
+      const wantsDebug = args.includes('-d') || args.includes('--debug');
+      redirectConsoleToStderr({ quiet: !wantsDebug });
     }
 
     // Load configuration
@@ -878,8 +894,33 @@ AI PROVIDERS:
       console.log('No pull request specified. Starting server...');
       await startServerOnly(config, poolLifecycle);
     }
-    
+
   } catch (error) {
+    // In headless --json mode the consumer (typically a coding agent) parses
+    // stdout as JSON. A prose error on stderr + empty stdout forces it to scrape
+    // English to learn what broke, so emit a structured failure envelope on
+    // stdout instead — one stream, JSON for success and failure alike. Read
+    // process.argv directly: `args`/`flags` are block-scoped to the try and
+    // unavailable here, and the throw may even predate parseArgs(). Exit stays
+    // non-zero so exit-code consumers are unaffected.
+    const argv = process.argv.slice(2);
+    const jsonMode = argv.includes('--headless') && argv.includes('--json');
+    if (jsonMode) {
+      // Canonical source for local-mode detection is parseArgs' -l/--local
+      // handling; we re-check argv here only because `flags` is block-scoped to
+      // the try and may not exist yet if the throw predates parseArgs. Keep any
+      // future local-mode alias in sync with that handling. Mode is best-effort
+      // (agents branch on `ok`, not `mode`).
+      const mode = (argv.includes('--local') || argv.includes('-l')) ? 'local' : 'pr';
+      // stdout may be a pipe (e.g. `pair-review … | jq`); a synchronous
+      // process.exit() can truncate a buffered write, so exit only once the
+      // envelope has flushed. The non-JSON branch below keeps the immediate exit.
+      process.stdout.write(
+        JSON.stringify(buildHeadlessErrorJson({ mode, error }), null, 2) + '\n',
+        () => process.exit(1)
+      );
+      return;
+    }
     console.error(`\n❌ Error: ${error.message}\n`);
     process.exit(1);
   }
@@ -2175,7 +2216,7 @@ async function handleHeadlessAnalysis(prArgs, config, db, flags, poolLifecycle) 
  * @param {Object} db - Database instance
  * @param {string} runId - Analysis run id
  * @param {'pr'|'local'} mode - Review mode (passthrough)
- * @returns {Promise<Object>} { mode, run, suggestions, count }
+ * @returns {Promise<Object>} { ok, mode, run, suggestions, count }
  */
 async function buildHeadlessJson(db, runId, mode) {
   const run = await new AnalysisRunRepository(db).getById(runId, { includeDiff: false });
@@ -2191,10 +2232,36 @@ async function buildHeadlessJson(db, runId, mode) {
   }));
 
   return {
+    // `ok` lets a machine consumer branch on success/failure with a single field;
+    // see buildHeadlessErrorJson for the failure shape.
+    ok: true,
     mode,
     run,
     suggestions,
     count: suggestions.length
+  };
+}
+
+/**
+ * Build the machine-readable JSON document for a FAILED headless run.
+ *
+ * Mirrors buildHeadlessJson's envelope so a --headless --json consumer parses one
+ * stream and branches on `ok`: success → { ok: true, ... }, failure → this. The
+ * process still exits non-zero, so exit-code-based consumers are unaffected.
+ * Exported for unit testing.
+ *
+ * @param {Object} params
+ * @param {'pr'|'local'} params.mode - Review mode (best-effort, derived from args)
+ * @param {Error} params.error - The thrown error
+ * @returns {Object} { ok: false, mode, error: { message } }
+ */
+function buildHeadlessErrorJson({ mode, error }) {
+  return {
+    ok: false,
+    mode,
+    error: {
+      message: error && error.message ? error.message : String(error)
+    }
   };
 }
 
@@ -2412,7 +2479,14 @@ function gracefulShutdown(signal) {
 process.on('SIGINT', () => gracefulShutdown('SIGINT'));
 process.on('SIGTERM', () => gracefulShutdown('SIGTERM'));
 
-// Handle uncaught exceptions
+// Handle uncaught exceptions.
+//
+// Note: in --headless --json mode, errors that ESCAPE main()'s try (floating
+// promises, timer/child-process callbacks) reach here and are reported as prose
+// on stderr, not the JSON failure envelope. The headless flow awaits its full
+// analysis, so this is a narrow gap; a JSON envelope here would need an
+// emit-once guard to avoid a second document on stdout during post-success
+// teardown.
 process.on('uncaughtException', (error) => {
   console.error('Uncaught exception:', error);
   process.exit(1);
@@ -2428,4 +2502,4 @@ if (require.main === module) {
   main();
 }
 
-module.exports = { main, parseArgs, detectPRFromGitHubEnvironment, printCouncilList, runHeadlessAnalysis, recordEmptyScopeRun, buildHeadlessJson, resolveCliInstructions };
+module.exports = { main, parseArgs, detectPRFromGitHubEnvironment, printCouncilList, runHeadlessAnalysis, recordEmptyScopeRun, buildHeadlessJson, buildHeadlessErrorJson, resolveCliInstructions };

--- a/src/mcp-stdio.js
+++ b/src/mcp-stdio.js
@@ -23,12 +23,37 @@ const logger = require('./utils/logger');
  * src/git/worktree.js). In both modes that call this function — MCP stdio (stdout
  * is JSON-RPC) and headless `--json` (stdout is the JSON document) — keeping that
  * child output off stdout is the correct, desired behavior.
+ *
+ * @param {Object} [opts]
+ * @param {boolean} [opts.quiet=false] - When true (headless `--json` without
+ *   `--debug`), *drop* progress narration entirely rather than relocating it to
+ *   stderr. A coding agent's shell tool captures stderr into its context window,
+ *   so relocated narration still costs tokens; quiet mode no-ops the ungated
+ *   `console.log/info` narration and puts the logger into quiet mode
+ *   (suppressing info/success/log/section). `console.warn`, `console.error`,
+ *   `logger.warn`, and `logger.error` still emit to stderr — quiet drops only
+ *   progress narration and never swallows warnings/errors.
  */
-function redirectConsoleToStderr() {
-  console.log = console.error;
-  console.info = console.error;
-  console.warn = console.error;
-  logger.setOutputStream(process.stderr);
+function redirectConsoleToStderr({ quiet = false } = {}) {
+  if (quiet) {
+    // Drop ungated narration; keep console.error real (→ stderr).
+    const noop = () => {};
+    console.log = noop;
+    console.info = noop;
+    // console.warn carries genuine diagnostics agents need (e.g. the
+    // --council/--model advisory, worktree-migration warnings) — route it to
+    // stderr rather than swallowing it. Quiet drops progress narration only.
+    console.warn = console.error;
+    // logger.warn writes to _stdout — point it at stderr so a warning during a
+    // run never corrupts the JSON document on real stdout.
+    logger.setOutputStream(process.stderr);
+    logger.setQuietEnabled(true);
+  } else {
+    console.log = console.error;
+    console.info = console.error;
+    console.warn = console.error;
+    logger.setOutputStream(process.stderr);
+  }
   // Process-level signal for raw process.stdout.write paths (see JSDoc above).
   process.env.PAIR_REVIEW_QUIET_STDOUT = '1';
 }

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -30,6 +30,7 @@ class AILogger {
     this.enabled = true;
     this.debugEnabled = false;
     this.streamDebugEnabled = false;
+    this.quietEnabled = false;
     this._stdout = process.stdout;
   }
 
@@ -75,6 +76,26 @@ class AILogger {
   }
 
   /**
+   * Enable or disable quiet mode.
+   * Quiet suppresses chatty progress output (info/success/log/section) while
+   * still allowing warn and error through. Used in headless --json mode (the
+   * machine-readable sink for coding agents) so stderr carries only genuine
+   * warnings and errors, not progress narration.
+   * @param {boolean} enabled - Whether quiet mode should be enabled
+   */
+  setQuietEnabled(enabled) {
+    this.quietEnabled = enabled;
+  }
+
+  /**
+   * Check if quiet mode is enabled
+   * @returns {boolean} Whether quiet mode is enabled
+   */
+  isQuietEnabled() {
+    return this.quietEnabled;
+  }
+
+  /**
    * Log debug message (only shown when debug is enabled)
    */
   debug(message) {
@@ -105,7 +126,7 @@ class AILogger {
    * Log AI analysis info
    */
   info(message) {
-    if (!this.enabled) return;
+    if (!this.enabled || this.quietEnabled) return;
     const timestamp = new Date().toISOString().split('T')[1].split('.')[0];
     this._stdout.write(
       `${COLORS.cyan}[${timestamp}]${COLORS.reset} ` +
@@ -118,7 +139,7 @@ class AILogger {
    * Log AI analysis success
    */
   success(message) {
-    if (!this.enabled) return;
+    if (!this.enabled || this.quietEnabled) return;
     const timestamp = new Date().toISOString().split('T')[1].split('.')[0];
     this._stdout.write(
       `${COLORS.cyan}[${timestamp}]${COLORS.reset} ` +
@@ -167,7 +188,7 @@ class AILogger {
    * Log with custom prefix
    */
   log(prefix, message, color = 'blue') {
-    if (!this.enabled) return;
+    if (!this.enabled || this.quietEnabled) return;
     const timestamp = new Date().toISOString().split('T')[1].split('.')[0];
     const prefixColor = COLORS[color] || COLORS.blue;
     this._stdout.write(
@@ -181,7 +202,7 @@ class AILogger {
    * Start a progress section
    */
   section(title) {
-    if (!this.enabled) return;
+    if (!this.enabled || this.quietEnabled) return;
     this._stdout.write(
       `\n${COLORS.bright}${COLORS.cyan}${'─'.repeat(60)}${COLORS.reset}\n` +
       `${COLORS.bright}${COLORS.cyan}▶ ${title}${COLORS.reset}\n` +

--- a/tests/integration/headless-json-error.test.js
+++ b/tests/integration/headless-json-error.test.js
@@ -1,0 +1,102 @@
+// Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+/**
+ * Integration test: in --headless --json mode, a failure must emit the
+ * machine-readable failure envelope on STDOUT (not prose on stderr) and exit
+ * non-zero, so an agent parses one stream and branches on `ok`.
+ *
+ * We trigger an early, deterministic flag-validation error (--instructions and
+ * --instructions-file are mutually exclusive). It throws right after parseArgs,
+ * BEFORE any DB/server/git/network work, which keeps this spawn test fast and
+ * avoids the local single-port dev-server hang that deeper headless paths risk.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { spawnSync } from 'child_process';
+import fs from 'fs/promises';
+import path from 'path';
+import os from 'os';
+
+const REPO_ROOT = path.join(__dirname, '../..');
+
+function runCli(args, homeDir) {
+  // Use process.execPath (not the literal 'node') so the child runs under the
+  // SAME Node major as the test runner — better-sqlite3 is a native module and
+  // only loads under the Node ABI its binary was built for.
+  return spawnSync(process.execPath, ['bin/pair-review.js', ...args], {
+    cwd: REPO_ROOT,
+    env: {
+      ...process.env,
+      HOME: homeDir,
+      GITHUB_TOKEN: '',
+      PAIR_REVIEW_NO_OPEN: '1'
+    },
+    timeout: 15000
+  });
+}
+
+describe('headless --json failure envelope', () => {
+  let testHomeDir;
+  let originalHome;
+
+  beforeEach(async () => {
+    testHomeDir = await fs.mkdtemp(path.join(os.tmpdir(), 'pair-review-headless-json-err-'));
+    originalHome = process.env.HOME;
+    // Pre-create config so this is not a first-run (no welcome path to interfere).
+    const configDir = path.join(testHomeDir, '.pair-review');
+    await fs.mkdir(configDir, { recursive: true });
+    await fs.writeFile(
+      path.join(configDir, 'config.json'),
+      JSON.stringify({ github_token: '', port: 7247, theme: 'light' }, null, 2)
+    );
+  });
+
+  afterEach(async () => {
+    process.env.HOME = originalHome;
+    if (testHomeDir) {
+      await fs.rm(testHomeDir, { recursive: true, force: true });
+    }
+  });
+
+  it('emits { ok: false, error } as JSON on stdout and exits non-zero', () => {
+    const result = runCli(
+      ['--headless', '--json', '--instructions', 'a', '--instructions-file', '/no/such/file'],
+      testHomeDir
+    );
+
+    expect(result.status).toBe(1);
+
+    const stdout = (result.stdout?.toString() || '').trim();
+    // stdout must be ONLY the JSON document — JSON.parse throws otherwise.
+    const doc = JSON.parse(stdout);
+    expect(doc.ok).toBe(false);
+    expect(doc.mode).toBe('pr');
+    expect(typeof doc.error.message).toBe('string');
+    expect(doc.error.message.length).toBeGreaterThan(0);
+    expect(doc.error.message).toContain('mutually exclusive');
+  });
+
+  it('derives mode: "local" from --local in the failure envelope', () => {
+    const result = runCli(
+      ['--local', '--headless', '--json', '--instructions', 'a', '--instructions-file', '/no/such/file'],
+      testHomeDir
+    );
+
+    expect(result.status).toBe(1);
+    const doc = JSON.parse((result.stdout?.toString() || '').trim());
+    expect(doc.ok).toBe(false);
+    expect(doc.mode).toBe('local');
+  });
+
+  it('without --json, the same failure stays prose-on-stderr with empty stdout', () => {
+    const result = runCli(
+      ['--headless', '--instructions', 'a', '--instructions-file', '/no/such/file'],
+      testHomeDir
+    );
+
+    expect(result.status).toBe(1);
+    const stdout = (result.stdout?.toString() || '').trim();
+    const stderr = result.stderr?.toString() || '';
+    expect(stdout).toBe('');
+    expect(stderr).toContain('Error:');
+    expect(stderr).toContain('mutually exclusive');
+  });
+});

--- a/tests/unit/headless-json.test.js
+++ b/tests/unit/headless-json.test.js
@@ -19,7 +19,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { createTestDatabase, closeTestDatabase, seedTestReview } from '../utils/schema.js';
 
-const { buildHeadlessJson } = require('../../src/main.js');
+const { buildHeadlessJson, buildHeadlessErrorJson } = require('../../src/main.js');
 
 const RUN_ID = 'run-under-test';
 const OTHER_RUN_ID = 'some-other-run';
@@ -134,6 +134,11 @@ describe('buildHeadlessJson', () => {
     closeTestDatabase(db);
   });
 
+  it('marks the success envelope with ok: true', async () => {
+    const doc = await buildHeadlessJson(db, RUN_ID, 'pr');
+    expect(doc.ok).toBe(true);
+  });
+
   it('returns ONLY the consolidated finals for the run, with a matching count', async () => {
     const doc = await buildHeadlessJson(db, RUN_ID, 'pr');
 
@@ -233,5 +238,23 @@ describe('buildHeadlessJson', () => {
     expect(doc.suggestions).toEqual([]);
     expect(doc.count).toBe(0);
     expect(doc.mode).toBe('pr');
+  });
+});
+
+describe('buildHeadlessErrorJson', () => {
+  it('builds the failure envelope with ok:false, mode, and the error message', () => {
+    const doc = buildHeadlessErrorJson({ mode: 'local', error: new Error('boom') });
+    expect(doc).toEqual({ ok: false, mode: 'local', error: { message: 'boom' } });
+  });
+
+  it('passes the mode through unchanged', () => {
+    const doc = buildHeadlessErrorJson({ mode: 'pr', error: new Error('nope') });
+    expect(doc.mode).toBe('pr');
+  });
+
+  it('falls back to String(error) when there is no message', () => {
+    const doc = buildHeadlessErrorJson({ mode: 'pr', error: 'plain string failure' });
+    expect(doc.ok).toBe(false);
+    expect(doc.error.message).toBe('plain string failure');
   });
 });

--- a/tests/unit/logger.test.js
+++ b/tests/unit/logger.test.js
@@ -1,0 +1,96 @@
+// Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { PassThrough } from 'stream';
+
+const logger = require('../../src/utils/logger');
+
+describe('logger quiet mode', () => {
+  let origStdout;
+  let origQuiet;
+  let origEnabled;
+  let stream;
+  let writeSpy;
+
+  beforeEach(() => {
+    origStdout = logger._stdout;
+    origQuiet = logger.quietEnabled;
+    origEnabled = logger.enabled;
+    logger.enabled = true;
+    stream = new PassThrough();
+    logger.setOutputStream(stream);
+    writeSpy = vi.spyOn(stream, 'write');
+  });
+
+  afterEach(() => {
+    logger._stdout = origStdout;
+    logger.quietEnabled = origQuiet;
+    logger.enabled = origEnabled;
+    vi.restoreAllMocks();
+  });
+
+  it('setQuietEnabled / isQuietEnabled toggle the flag', () => {
+    logger.setQuietEnabled(true);
+    expect(logger.isQuietEnabled()).toBe(true);
+    logger.setQuietEnabled(false);
+    expect(logger.isQuietEnabled()).toBe(false);
+  });
+
+  describe('when quiet is enabled', () => {
+    beforeEach(() => {
+      logger.setQuietEnabled(true);
+    });
+
+    it('suppresses info()', () => {
+      logger.info('chatter');
+      expect(writeSpy).not.toHaveBeenCalled();
+    });
+
+    it('suppresses success()', () => {
+      logger.success('done');
+      expect(writeSpy).not.toHaveBeenCalled();
+    });
+
+    it('suppresses log()', () => {
+      logger.log('PREFIX', 'chatter');
+      expect(writeSpy).not.toHaveBeenCalled();
+    });
+
+    it('suppresses section()', () => {
+      logger.section('A Section');
+      expect(writeSpy).not.toHaveBeenCalled();
+    });
+
+    it('still emits warn() (never swallowed)', () => {
+      logger.warn('heads up');
+      expect(writeSpy).toHaveBeenCalled();
+      expect(writeSpy.mock.calls[0][0]).toContain('heads up');
+    });
+
+    it('still emits error() to process.stderr (never swallowed)', () => {
+      const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+      logger.error('boom');
+      expect(stderrSpy).toHaveBeenCalledTimes(1);
+      expect(stderrSpy.mock.calls[0][0]).toContain('boom');
+      // error never uses the chatty stream.
+      expect(writeSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when quiet is disabled (default)', () => {
+    beforeEach(() => {
+      logger.setQuietEnabled(false);
+    });
+
+    it('emits info()', () => {
+      logger.info('chatter');
+      expect(writeSpy).toHaveBeenCalled();
+      expect(writeSpy.mock.calls[0][0]).toContain('chatter');
+    });
+
+    it('emits section()', () => {
+      logger.section('A Section');
+      expect(writeSpy).toHaveBeenCalled();
+      expect(writeSpy.mock.calls.some(c => c[0].includes('A Section'))).toBe(true);
+    });
+  });
+});

--- a/tests/unit/mcp-stdio.test.js
+++ b/tests/unit/mcp-stdio.test.js
@@ -10,12 +10,14 @@ describe('redirectConsoleToStderr', () => {
   let origInfo;
   let origWarn;
   let origLoggerStdout;
+  let origQuiet;
 
   beforeEach(() => {
     origLog = console.log;
     origInfo = console.info;
     origWarn = console.warn;
     origLoggerStdout = logger._stdout;
+    origQuiet = logger.quietEnabled;
   });
 
   afterEach(() => {
@@ -23,26 +25,64 @@ describe('redirectConsoleToStderr', () => {
     console.info = origInfo;
     console.warn = origWarn;
     logger._stdout = origLoggerStdout;
+    logger.quietEnabled = origQuiet;
   });
 
-  it('should redirect console.log to console.error', () => {
-    redirectConsoleToStderr();
-    expect(console.log).toBe(console.error);
+  describe('default (non-quiet) mode — relocates output to stderr', () => {
+    it('should redirect console.log to console.error', () => {
+      redirectConsoleToStderr();
+      expect(console.log).toBe(console.error);
+    });
+
+    it('should redirect console.info to console.error', () => {
+      redirectConsoleToStderr();
+      expect(console.info).toBe(console.error);
+    });
+
+    it('should redirect console.warn to console.error', () => {
+      redirectConsoleToStderr();
+      expect(console.warn).toBe(console.error);
+    });
+
+    it('should set logger._stdout to process.stderr', () => {
+      redirectConsoleToStderr();
+      expect(logger._stdout).toBe(process.stderr);
+    });
+
+    it('should NOT put the logger into quiet mode', () => {
+      logger.quietEnabled = false;
+      redirectConsoleToStderr();
+      expect(logger.quietEnabled).toBe(false);
+    });
   });
 
-  it('should redirect console.info to console.error', () => {
-    redirectConsoleToStderr();
-    expect(console.info).toBe(console.error);
-  });
+  describe('quiet mode — drops narration, keeps errors', () => {
+    it('drops console.log/info but preserves console.warn', () => {
+      redirectConsoleToStderr({ quiet: true });
+      // log/info are progress narration — no-op'd (not relocated to error).
+      expect(console.log).not.toBe(console.error);
+      expect(console.info).not.toBe(console.error);
+      // warn carries genuine diagnostics — preserved and routed to stderr.
+      expect(console.warn).toBe(console.error);
+      // Dropped narration must not throw and must produce no output.
+      expect(() => console.log('dropped')).not.toThrow();
+    });
 
-  it('should redirect console.warn to console.error', () => {
-    redirectConsoleToStderr();
-    expect(console.warn).toBe(console.error);
-  });
+    it('should keep console.error intact', () => {
+      const before = console.error;
+      redirectConsoleToStderr({ quiet: true });
+      expect(console.error).toBe(before);
+    });
 
-  it('should set logger._stdout to process.stderr', () => {
-    redirectConsoleToStderr();
-    expect(logger._stdout).toBe(process.stderr);
+    it('should put the logger into quiet mode', () => {
+      redirectConsoleToStderr({ quiet: true });
+      expect(logger.quietEnabled).toBe(true);
+    });
+
+    it('should still point logger output at stderr so logger.warn never hits stdout', () => {
+      redirectConsoleToStderr({ quiet: true });
+      expect(logger._stdout).toBe(process.stderr);
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

`--headless --json` is consumed mostly by **coding agents**, whose shell tools capture *both* stdout and stderr into the agent's context window — so the human escape hatch (`2>/dev/null`) doesn't apply, and an empty-stdout-on-failure forces the agent to scrape prose from stderr. This PR makes the mode an agent-native contract: one stream (stdout), always JSON, near-silent stderr on success.

### 1. Quiet-by-default stderr (unless `--debug`)
- `src/utils/logger.js` — new `quietEnabled` flag (`setQuietEnabled`/`isQuietEnabled`) that suppresses chatty output (`info`/`success`/`log`/`section`) while **keeping `warn` and `error`**.
- `src/mcp-stdio.js` — `redirectConsoleToStderr({ quiet })` no-ops `console.log`/`console.info` narration but routes `console.warn` to stderr (genuine diagnostics are never swallowed). MCP's arg-less call is unchanged.
- `src/main.js` — wired at the early stdout lock-down; `-d`/`--debug` restores the full verbose stream for humans.

### 2. Structured failure envelope
- `buildHeadlessJson` gains `ok: true`; new exported `buildHeadlessErrorJson({ mode, error })` produces `{ ok: false, mode, error: { message } }`.
- `main()`'s catch emits the envelope to stdout (still exits non-zero). The write **flushes before exit** (`process.stdout.write(..., () => process.exit(1))`) so a piped envelope can't be truncated.
- **Documented exception:** pre-flight config/startup failures (`loadConfig` calls `process.exit` directly, which doesn't unwind the try) and errors escaping `main()`'s try (async global handlers) exit non-zero with a stderr message and **no** JSON envelope. Docs scope the guarantee to errors raised *while running* the headless flow and tell consumers to branch on the exit code first.

## Tests
- New `tests/unit/logger.test.js` (quiet gating), extended `tests/unit/mcp-stdio.test.js` (quiet vs default param, `console.warn` preserved), extended `tests/unit/headless-json.test.js` (`ok:true` + `buildHeadlessErrorJson`), new `tests/integration/headless-json-error.test.js` (end-to-end failure envelope on stdout, mode derivation, prose-on-stderr without `--json`).
- **40/40 targeted tests pass.** Full suite green except 3 pre-existing local timeouts in `first-run.test.js` (documented `config.local.json` dev-server hang, unrelated to this change).

## Docs
README `--json` table row + headless/agent-workflow sections and the `--json` help text updated; `minor` changeset included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)