### PR TITLE
Remove analysis progress dots from the toolbar

### DIFF
--- a/.changeset/remove-analysis-progress-dots.md
+++ b/.changeset/remove-analysis-progress-dots.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Remove the analysis progress dots that appeared to the left of the Analyze button during analysis. The dots tracked the four analysis phases (Level 1/2/3 and consolidation), which only mapped meaningfully onto a single-model run; for a council the four-dot indicator showed an aggregate status across many voices that conveyed nothing useful. The detailed Council Progress modal and the "Analyzing..." button state already communicate progress, so the dots are removed from both PR and Local mode toolbars.

--- a/public/css/pr.css
+++ b/public/css/pr.css
@@ -6939,66 +6939,6 @@ body:not([data-theme="dark"]) .theme-icon-light {
   border-color: var(--color-border-secondary);
 }
 
-/* ============================================
-   Analysis Progress Dots
-   ============================================ */
-
-.analysis-progress-dots {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  margin-right: 8px;
-}
-
-.progress-dot {
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  border: 1.5px solid var(--color-accent-ai);
-  background: transparent;
-  transition: all 0.3s ease;
-}
-
-.progress-dot.active {
-  animation: pulse-dot 1.2s ease-in-out infinite;
-}
-
-.progress-dot.completed {
-  background: var(--color-accent-ai);
-  border-color: var(--color-accent-ai);
-}
-
-.progress-dot.error {
-  background: #ef4444;
-  border-color: #ef4444;
-}
-
-@keyframes pulse-dot {
-  0%, 100% {
-    transform: scale(1);
-    opacity: 1;
-  }
-  50% {
-    transform: scale(1.3);
-    opacity: 0.9;
-  }
-}
-
-/* Dark theme for progress dots */
-[data-theme="dark"] .progress-dot {
-  border-color: var(--color-accent-ai-dark);
-}
-
-[data-theme="dark"] .progress-dot.completed {
-  background: var(--color-accent-ai-dark);
-  border-color: var(--color-accent-ai-dark);
-}
-
-[data-theme="dark"] .progress-dot.error {
-  background: #f87171;
-  border-color: #f87171;
-}
-
 /* Magical Analyze Button - Amber AI CTA */
 #analyze-btn {
   background: linear-gradient(135deg, #fef3c7 0%, #fde68a 100%);
@@ -12957,6 +12897,18 @@ body.resizing * {
 .status-setting_up .stack-progress-status-icon {
   color: var(--color-text-secondary, #656d76);
   animation: pulse-dot 1.2s ease-in-out infinite;
+}
+
+/* Pulse used by the running/setting-up stack-progress status icons above. */
+@keyframes pulse-dot {
+  0%, 100% {
+    transform: scale(1);
+    opacity: 1;
+  }
+  50% {
+    transform: scale(1.3);
+    opacity: 0.9;
+  }
 }
 
 .status-pending .stack-progress-status-icon {

--- a/public/js/components/CouncilProgressModal.js
+++ b/public/js/components/CouncilProgressModal.js
@@ -304,16 +304,6 @@ class CouncilProgressModal {
       }
     }
 
-    // Update toolbar progress dots
-    const manager = window.prManager || window.localManager;
-    if (manager?.updateProgressDot) {
-      for (let level = 1; level <= 4; level++) {
-        if (status.levels[level]) {
-          manager.updateProgressDot(level, status.levels[level].status);
-        }
-      }
-    }
-
     // Terminal states
     if (status.status === 'completed') {
       this._handleCompletion(status);

--- a/public/js/local.js
+++ b/public/js/local.js
@@ -1893,55 +1893,6 @@ class LocalManager {
     };
     document.addEventListener('keydown', keyHandler);
   }
-
-  /**
-   * Get the progress dots container element
-   * @returns {HTMLElement|null}
-   */
-  getProgressDotsContainer() {
-    return document.getElementById('analysis-progress-dots');
-  }
-
-  /**
-   * Update a specific progress dot during analysis
-   * Maps level numbers to phase names:
-   * - Level 4 -> orchestration (finalization)
-   * - Level 1 -> level1
-   * - Level 2 -> level2
-   * - Level 3 -> level3
-   * @param {number} level - The level number (1, 2, 3, or 4)
-   * @param {string} status - The status ('running', 'completed', 'failed')
-   */
-  updateProgressDot(level, status) {
-    const container = this.getProgressDotsContainer();
-    if (!container) return;
-
-    // Map levels to dot phases
-    const phaseMap = {
-      4: 'orchestration', // Orchestration/finalization is level 4 in progress modal
-      1: 'level1',
-      2: 'level2',
-      3: 'level3'
-    };
-
-    const phase = phaseMap[level];
-    if (!phase) return;
-
-    const dot = container.querySelector(`[data-phase="${phase}"]`);
-    if (!dot) return;
-
-    // Remove existing states
-    dot.classList.remove('active', 'completed', 'error');
-
-    // Apply new state
-    if (status === 'running') {
-      dot.classList.add('active');
-    } else if (status === 'completed') {
-      dot.classList.add('completed');
-    } else if (status === 'failed') {
-      dot.classList.add('error');
-    }
-  }
 }
 
 // Initialize LocalManager when in local mode

--- a/public/js/pr.js
+++ b/public/js/pr.js
@@ -6588,9 +6588,6 @@ class PRManager {
     } else {
       btn.innerHTML = '<span class="analyzing-icon">✨</span> Analyzing...';
     }
-
-    // Show progress dots
-    this.showProgressDots();
   }
 
   /**
@@ -6614,9 +6611,6 @@ class PRManager {
       btn.innerHTML = '✓ Analysis Complete';
     }
     btn.disabled = true;
-
-    // Complete all progress dots (they'll be hidden when button resets)
-    this.completeAllProgressDots();
 
     // Revert to normal after 2 seconds
     setTimeout(() => this.resetButton(), 2000);
@@ -6645,114 +6639,6 @@ class PRManager {
     } else {
       btn.innerHTML = 'Analyze with AI';
     }
-
-    // Hide progress dots when resetting
-    this.hideProgressDots();
-  }
-
-  // ============================================
-  // Progress Dots Controller
-  // ============================================
-
-  /**
-   * Get the progress dots container
-   * @returns {HTMLElement|null}
-   */
-  getProgressDotsContainer() {
-    return document.getElementById('analysis-progress-dots');
-  }
-
-  /**
-   * Show progress dots (called when analysis starts)
-   */
-  showProgressDots() {
-    const container = this.getProgressDotsContainer();
-    if (!container) return;
-
-    container.style.display = 'flex';
-
-    // Reset all dots to initial state
-    const dots = container.querySelectorAll('.progress-dot');
-    dots.forEach(dot => {
-      dot.classList.remove('active', 'completed', 'error');
-    });
-
-    // Set first dot (orchestration) as active
-    const firstDot = container.querySelector('[data-phase="orchestration"]');
-    if (firstDot) {
-      firstDot.classList.add('active');
-    }
-  }
-
-  /**
-   * Hide progress dots (called when analysis completes or is cancelled)
-   */
-  hideProgressDots() {
-    const container = this.getProgressDotsContainer();
-    if (!container) return;
-
-    container.style.display = 'none';
-
-    // Reset all dots
-    const dots = container.querySelectorAll('.progress-dot');
-    dots.forEach(dot => {
-      dot.classList.remove('active', 'completed', 'error');
-    });
-  }
-
-  /**
-   * Update progress dots based on level status
-   * Maps level numbers to phases:
-   * - Level 4 (orchestration/finalization) -> orchestration
-   * - Level 1 -> level1
-   * - Level 2 -> level2
-   * - Level 3 -> level3
-   * @param {number} level - The level number (1, 2, 3, or 4)
-   * @param {string} status - The status ('running', 'completed', 'failed')
-   */
-  updateProgressDot(level, status) {
-    const container = this.getProgressDotsContainer();
-    if (!container) return;
-
-    // Map levels to dot phases
-    const phaseMap = {
-      4: 'orchestration', // Orchestration/finalization is level 4 in progress modal
-      1: 'level1',
-      2: 'level2',
-      3: 'level3'
-    };
-
-    const phase = phaseMap[level];
-    if (!phase) return;
-
-    const dot = container.querySelector(`[data-phase="${phase}"]`);
-    if (!dot) return;
-
-    // Remove existing states
-    dot.classList.remove('active', 'completed', 'error');
-
-    // Apply new state
-    if (status === 'running') {
-      dot.classList.add('active');
-    } else if (status === 'completed') {
-      dot.classList.add('completed');
-    } else if (status === 'failed') {
-      dot.classList.add('error');
-    }
-  }
-
-  /**
-   * Complete all progress dots (called briefly before hiding)
-   */
-  completeAllProgressDots() {
-    const container = this.getProgressDotsContainer();
-    if (!container) return;
-
-    const dots = container.querySelectorAll('.progress-dot');
-    dots.forEach(dot => {
-      dot.classList.remove('active', 'error');
-      dot.classList.add('completed');
-    });
   }
 
   /**

--- a/public/local.html
+++ b/public/local.html
@@ -435,13 +435,6 @@
                     </div>
                     <div class="diff-stats" id="diff-stats"></div>
                     <div class="toolbar-actions">
-                        <!-- Progress Dots (visible during analysis) -->
-                        <div class="analysis-progress-dots" id="analysis-progress-dots" style="display: none;">
-                            <span class="progress-dot" data-phase="level1" title="Level 1: Diff"></span>
-                            <span class="progress-dot" data-phase="level2" title="Level 2: File"></span>
-                            <span class="progress-dot" data-phase="level3" title="Level 3: Codebase"></span>
-                            <span class="progress-dot" data-phase="orchestration" title="Consolidation"></span>
-                        </div>
                         <button class="btn btn-sm btn-secondary" id="analyze-btn" title="Analyze with AI">
                             <svg class="analyze-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="14" height="14">
                                 <path d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09z"/>

--- a/public/pr.html
+++ b/public/pr.html
@@ -231,13 +231,6 @@
                     </div>
                     <div class="diff-stats" id="diff-stats"></div>
                     <div class="toolbar-actions">
-                        <!-- Progress Dots (visible during analysis) -->
-                        <div class="analysis-progress-dots" id="analysis-progress-dots" style="display: none;">
-                            <span class="progress-dot" data-phase="level1" title="Level 1: Diff"></span>
-                            <span class="progress-dot" data-phase="level2" title="Level 2: File"></span>
-                            <span class="progress-dot" data-phase="level3" title="Level 3: Codebase"></span>
-                            <span class="progress-dot" data-phase="orchestration" title="Consolidation"></span>
-                        </div>
                         <button class="btn btn-sm btn-secondary" id="analyze-btn" title="Analyze with AI">
                             <svg class="analyze-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="14" height="14">
                                 <path d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09z"/>


### PR DESCRIPTION
## Summary

Removes the four status dots that appeared to the left of the **Analyze** button while AI analysis was running.

The dots tracked the L1 → L2 → L3 → consolidation phases. That mapping only makes sense for a **single-model** run; for a **council** the dots were fed an aggregate of `status.levels[level].status` across many voices, which doesn't correspond to any real linear progression — i.e. meaningless. The detailed **Council Progress modal** and the `Analyzing… → Complete` button state already communicate progress, so the dots were redundant at best and misleading at worst.

In Local mode they were arguably already dead: `LocalManager` never called `showProgressDots` (it doesn't extend `PRManager`), so the container stayed `display:none` and `updateProgressDot` toggled classes on invisible elements. Removal also tidies a PR-vs-Local inconsistency.

## Changes

- **`public/pr.html` / `public/local.html`** — remove the `.analysis-progress-dots` container + four `.progress-dot` spans.
- **`public/css/pr.css`** — remove the dots' styles (base, `.active/.completed/.error`, dark-theme variants).
- **`public/js/pr.js`** — remove `showProgressDots` / `hideProgressDots` / `completeAllProgressDots` / `updateProgressDot` / `getProgressDotsContainer` and their three call sites in the button-state handlers.
- **`public/js/local.js`** — remove `getProgressDotsContainer` / `updateProgressDot`.
- **`public/js/components/CouncilProgressModal.js`** — remove the block that fanned level status out to `manager.updateProgressDot(...)`.

Backend progress callbacks (`src/routes/shared.js`, `src/ai/analyzer.js`) are untouched — they still drive the Council Progress modal.

## Keyframe fix (caught in review)

`@keyframes pulse-dot` was defined **only** inside the deleted dots block, but it is still referenced by the Stack Progress modal's `.status-running` / `.status-setting_up .stack-progress-status-icon` rules. CSS silently ignores an `animation` naming an undefined keyframe, so those icons would have quietly stopped pulsing. The keyframe is relocated next to its real consumer (the `.stack-progress-*` rules) with a comment naming the owner, so neither feature can silently break the other in future.

## Testing

- Unit suite green (pre-existing local CLI-spawn first-run timeouts are unrelated — documented `config.local.json` local-hang issue).
- Analysis/toolbar E2E specs pass (`ai-analysis`, `ai-analysis-actions`, `auto-analyze`, `council-save-button`): 51/51.
- `@keyframes pulse-dot` now defined exactly once and still referenced twice; all JS files pass `node --check`.

A `patch` changeset is included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)