### PR TITLE
Drop Node 20, add Node 26, bump pnpm to 11

### DIFF
--- a/.changeset/drop-node-20.md
+++ b/.changeset/drop-node-20.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": major
+---
+
+Drop support for Node.js 20 and add Node.js 26. The minimum supported version is now Node.js 22. CI tests against Node 22, 24, and 26, and the project now pins pnpm 11 via the `packageManager` field.

--- a/.changeset/drop-node-20.md
+++ b/.changeset/drop-node-20.md
@@ -3,3 +3,5 @@
 ---
 
 Drop support for Node.js 20 and add Node.js 26. The minimum supported version is now Node.js 22. CI tests against Node 22, 24, and 26, and the project now pins pnpm 11 via the `packageManager` field.
+
+Upgrades `better-sqlite3` from 11.x to 12.x, which ships prebuilt binaries for Node.js 26 (11.x fails to compile against Node 26's V8). The 12.0 major bump only drops EOL Node/Electron build targets — no runtime API changes.

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -26,8 +26,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 11
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10
+          version: 11
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/changeset.yml
+++ b/.github/workflows/changeset.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10
+          version: 11
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/changeset.yml
+++ b/.github/workflows/changeset.yml
@@ -20,8 +20,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 11
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: ['20', '22', '24']
+        node-version: ['22', '24', '26']
 
     steps:
       - name: Checkout code
@@ -27,7 +27,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10
+          version: 11
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -52,12 +52,12 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10
+          version: 11
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'pnpm'
 
       - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,8 +26,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 11
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -51,8 +49,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 11
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/README.md
+++ b/README.md
@@ -959,8 +959,8 @@ These commands update your MCP configuration in `~/.claude/settings.json` (user-
 
 ### Prerequisites
 
-- Node.js 20.0.0 or higher
-- [pnpm](https://pnpm.io/) 10.x
+- Node.js 22.0.0 or higher
+- [pnpm](https://pnpm.io/) 11.x
 - Git
 
 ### Running Locally

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "vitest": "^4.0.16"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@agentclientprotocol/sdk": {
@@ -2962,9 +2962,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.2.0.tgz",
-      "integrity": "sha512-3lGxdTXCLfe1MYfTz1y2ksAAUM4NAOP6rPEjxGJVKO7TZ5+tvHCaQWGpC4Y3IXvW3ece0Cz1cIP4FWBxOnGCTQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.0.tgz",
+      "integrity": "sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==",
       "dev": true,
       "license": "MIT"
     },
@@ -6477,9 +6477,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6789,9 +6789,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.1.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.2.tgz",
-      "integrity": "sha512-6YYPbRXTxx6bRXmOn7XdnQAy5DQNHhDgtjhDHI13oe4pY93kkcdGJWxpGwOm++/Wh0QpQhDrpIoVMrmrsI5AGQ==",
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.3.tgz",
+      "integrity": "sha512-Ds+gBRbj0lwRO2Y5hwnUBdxSwlAve9LeRyU4sNnAr0ewW0gWF0n5bgXgUzbgZ49MV9BVUAQUFYVcDUcilUExMA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6882,9 +6882,9 @@
       }
     },
     "node_modules/vite/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6985,9 +6985,9 @@
       }
     },
     "node_modules/vitest/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@agentclientprotocol/sdk": "^0.14.1",
         "@modelcontextprotocol/sdk": "^1.25.3",
         "@octokit/rest": "^19.0.11",
-        "better-sqlite3": "^11.8.1",
+        "better-sqlite3": "^12.11.1",
         "express": "^4.18.2",
         "glob": "^13.0.6",
         "markdown-it": "^13.0.2",
@@ -2117,14 +2117,17 @@
       }
     },
     "node_modules/better-sqlite3": {
-      "version": "11.10.0",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-11.10.0.tgz",
-      "integrity": "sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==",
+      "version": "12.11.1",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.11.1.tgz",
+      "integrity": "sha512-dq9AtApgg5PGFtBzPFSBl3HZQjHok5gaQCM6zh2Yk0aSmDCs1CbnVI8/HgASQkNKsWFpseIO9beg5xxpYhbIfA==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "bindings": "^1.5.0",
         "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x || 26.x"
       }
     },
     "node_modules/bidi-js": {

--- a/package.json
+++ b/package.json
@@ -19,8 +19,9 @@
     "LICENSE"
   ],
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
+  "packageManager": "pnpm@11.9.0",
   "scripts": {
     "start": "node src/server.js",
     "dev": "node bin/pair-review.js",
@@ -83,10 +84,5 @@
     "jsdom": "^29.0.1",
     "supertest": "^7.1.4",
     "vitest": "^4.0.16"
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "better-sqlite3"
-    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "@agentclientprotocol/sdk": "^0.14.1",
     "@modelcontextprotocol/sdk": "^1.25.3",
     "@octokit/rest": "^19.0.11",
-    "better-sqlite3": "^11.8.1",
+    "better-sqlite3": "^12.11.1",
     "express": "^4.18.2",
     "glob": "^13.0.6",
     "markdown-it": "^13.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: ^19.0.11
         version: 19.0.13
       better-sqlite3:
-        specifier: ^11.8.1
-        version: 11.10.0
+        specifier: ^12.11.1
+        version: 12.11.1
       express:
         specifier: ^4.18.2
         version: 4.22.1
@@ -617,8 +617,9 @@ packages:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
 
-  better-sqlite3@11.10.0:
-    resolution: {integrity: sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==}
+  better-sqlite3@12.11.1:
+    resolution: {integrity: sha512-dq9AtApgg5PGFtBzPFSBl3HZQjHok5gaQCM6zh2Yk0aSmDCs1CbnVI8/HgASQkNKsWFpseIO9beg5xxpYhbIfA==}
+    engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x || 26.x}
 
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
@@ -2911,7 +2912,7 @@ snapshots:
     dependencies:
       is-windows: 1.0.2
 
-  better-sqlite3@11.10.0:
+  better-sqlite3@12.11.1:
     dependencies:
       bindings: 1.5.0
       prebuild-install: 7.1.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+# pnpm 11+ reads build-script allowlists from here, not the package.json "pnpm" field.
+onlyBuiltDependencies:
+  - better-sqlite3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,5 @@
-# pnpm 11+ reads build-script allowlists from here, not the package.json "pnpm" field.
-onlyBuiltDependencies:
-  - better-sqlite3
+# pnpm 11+ reads build-script policy from here, not the package.json "pnpm" field.
+# allowBuilds is a map of package -> true/false (replaces v10's onlyBuiltDependencies list).
+# strictDepBuilds defaults to true in v11, so native modules must be explicitly allowed.
+allowBuilds:
+  better-sqlite3: true

--- a/tests/CONVENTIONS.md
+++ b/tests/CONVENTIONS.md
@@ -66,6 +66,21 @@ because violating it produced a real, observed flake or measurable waste.
 - **No real network. Ever.** Mock every GitHub/API/git-clone path. A test
   that works only when github.com answers is a flake with extra steps.
 
+## Browser globals (jsdom)
+
+- **Do not rely on jsdom's ambient `localStorage`/`sessionStorage`.** Node 22.4+
+  (flagged) and Node 26 (default-on) expose the Web Storage API as a global.
+  That global pre-exists the jsdom environment, so vitest's `populateGlobal`
+  sees the key already present and skips copying jsdom's real `localStorage`
+  onto `window`; the leftover native accessor reads back `undefined` (or throws
+  under `--experimental-webstorage`). Result: a `@vitest-environment jsdom`
+  test that calls `window.localStorage.clear()` passes on Node 24 and fails on
+  Node 26 — a version-correlated flake, not fork ordering. A shared setup file
+  (`tests/setup/web-storage-polyfill.js`, wired via `setupFiles`) installs a
+  configurable in-memory Storage so jsdom tests are Node-version-agnostic.
+  Reproduce the Node 26 condition on any Node with
+  `NODE_OPTIONS="--experimental-webstorage --localstorage-file=$(mktemp)"`.
+
 ## Mock hygiene
 
 - **Do not call `vi.clearAllMocks()` in files that create many `vi.fn()` per

--- a/tests/setup/web-storage-polyfill.js
+++ b/tests/setup/web-storage-polyfill.js
@@ -1,0 +1,43 @@
+// Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+//
+// Guarantee a working `localStorage`/`sessionStorage` in jsdom test files.
+//
+// Node 22.4+ (flagged) and Node 26 (default-on) expose the Web Storage API as
+// a global. That global exists *before* vitest builds the jsdom environment,
+// so vitest's `populateGlobal` sees `'localStorage' in globalThis` is already
+// true and — because `localStorage` is not in its protected key list — skips
+// copying jsdom's real `localStorage` onto the global. The remaining native
+// accessor is unconfigured, so `window.localStorage` reads back as `undefined`
+// (Node 26) or throws (`--experimental-webstorage` on 24), and any jsdom test
+// that touches ambient `localStorage` blows up with
+// `Cannot read properties of undefined (reading 'clear')`.
+//
+// This ran green on Node 24 (no native global) and red on Node 26, which is
+// how adding Node 26 to the CI matrix surfaced it. Installing our own
+// configurable in-memory Storage below is Node-version-agnostic and
+// deterministic. Node-environment test files have no `window` and are skipped;
+// they keep managing `global.localStorage` themselves.
+
+if (typeof window !== 'undefined') {
+  const makeStorage = () => {
+    const store = new Map();
+    return {
+      getItem: (key) => (store.has(String(key)) ? store.get(String(key)) : null),
+      setItem: (key, value) => { store.set(String(key), String(value)); },
+      removeItem: (key) => { store.delete(String(key)); },
+      clear: () => { store.clear(); },
+      key: (index) => {
+        const keys = [...store.keys()];
+        return index >= 0 && index < keys.length ? keys[index] : null;
+      },
+      get length() { return store.size; },
+    };
+  };
+
+  for (const name of ['localStorage', 'sessionStorage']) {
+    const storage = makeStorage();
+    // configurable:true so this overrides Node's native (unconfigured) accessor
+    // and so re-running setup in a reused worker does not throw.
+    Object.defineProperty(window, name, { configurable: true, get: () => storage });
+  }
+}

--- a/tests/setup/web-storage-polyfill.js
+++ b/tests/setup/web-storage-polyfill.js
@@ -21,7 +21,7 @@
 if (typeof window !== 'undefined') {
   const makeStorage = () => {
     const store = new Map();
-    return {
+    const api = {
       getItem: (key) => (store.has(String(key)) ? store.get(String(key)) : null),
       setItem: (key, value) => { store.set(String(key), String(value)); },
       removeItem: (key) => { store.delete(String(key)); },
@@ -32,6 +32,17 @@ if (typeof window !== 'undefined') {
       },
       get length() { return store.size; },
     };
+    // Real Storage also supports property/bracket access that stays in sync with
+    // the store (`localStorage.theme = 'dark'` <-> `getItem('theme')`). Route
+    // unknown string keys to the method API so a test that writes one way and
+    // reads the other doesn't silently diverge. Symbol keys (Symbol.toPrimitive,
+    // util.inspect.custom, etc.) fall through untouched so framework internals
+    // probing the object aren't misrouted into the store.
+    return new Proxy(api, {
+      get: (t, prop) => (typeof prop === 'symbol' || prop in t ? t[prop] : t.getItem(prop)),
+      set: (t, prop, value) => (typeof prop === 'symbol' ? (t[prop] = value) : t.setItem(prop, value), true),
+      deleteProperty: (t, prop) => (typeof prop === 'symbol' ? delete t[prop] : t.removeItem(prop), true),
+    });
   };
 
   for (const name of ['localStorage', 'sessionStorage']) {

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -20,6 +20,11 @@ export default defineConfig({
     // Enable globals (describe, it, expect) without imports
     globals: true,
 
+    // Ensure jsdom test files get a working localStorage/sessionStorage.
+    // Node 26 ships Web Storage as a default global, which shadows jsdom's and
+    // makes vitest skip copying it — see tests/setup/web-storage-polyfill.js.
+    setupFiles: ['./tests/setup/web-storage-polyfill.js'],
+
     // Coverage configuration
     coverage: {
       provider: 'v8',


### PR DESCRIPTION
## Summary

Drops Node.js 20 support, adds Node.js 26, and moves the toolchain to pnpm 11.

- **CI matrix**: Node `20, 22, 24` → `22, 24, 26`; lint job Node `22` → `24`
- **engines**: `node >=20` → `>=22` — this is a **major** bump (drops Node 20)
- **pnpm 10 → 11** across all three workflows (`test`, `changeset`, `ai-review`); pinned `packageManager: pnpm@11.9.0` for dev parity
- **better-sqlite3 build allowlist** moved to `pnpm-workspace.yaml` — pnpm 11 no longer reads the `pnpm` field in `package.json`, so the old config was silently ignored and the native module would not build on a clean install
- README prerequisites updated (Node 22, pnpm 11.x); `package-lock.json` regenerated

## Verification

- `pnpm install` runs clean — no "field no longer read" warning
- `better-sqlite3` native binary builds; in-memory open + query smoke test passes
- Changeset added (`major`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)