### PR TITLE
feat: per-PR host resolution for dual GitHub/alt-host repos

### DIFF
--- a/.changeset/per-pr-host-resolution.md
+++ b/.changeset/per-pr-host-resolution.md
@@ -1,0 +1,25 @@
+---
+"@in-the-loop-labs/pair-review": minor
+---
+
+feat: dual-host repositories with per-PR host resolution
+
+A repo configured with `api_host` can now set `exclusive: false` to indicate
+that its pull requests live on both `github.com` and the configured alternate
+host, rather than exclusively on the alt host. pair-review resolves the host
+per PR instead of per repo.
+
+- New per-repo config boolean `exclusive` (only valid alongside `api_host`).
+  Omitted or `true` keeps today's behavior (the repo lives exclusively on the
+  alt host); `false` marks the repo as dual-host.
+- Each PR's host is stored locally and detected from the URL pattern that
+  matched a pasted URL, the host a PR was found on during a dashboard
+  collections refresh, and setup-time probing for bare PR numbers (alt host
+  first, falling back to github.com only on a 404 — auth/network errors fail
+  loudly with no fallback).
+- Dashboard collections now also list open PRs from every configured alt host,
+  best-effort per host with partial results when a host is unavailable.
+- Links and host-named text render per PR: a dual repo's github-hosted PR shows
+  GitHub/Graphite links; its alt-hosted PR shows the configured external link.
+
+Repos with `api_host` and no `exclusive` key behave exactly as before.

--- a/README.md
+++ b/README.md
@@ -427,7 +427,7 @@ Nested objects (like `chat`, `providers`, `chat_providers`, `monorepos`) are dee
 
 ### Alternate Git Hosts
 
-pair-review can review pull requests on self-hosted Git platforms that expose a GitHub-compatible REST API, configured per-repository via `repos["owner/repo"].api_host` and related keys. See [docs/alt-host.md](docs/alt-host.md) for the full configuration guide.
+pair-review can review pull requests on self-hosted Git platforms that expose a GitHub-compatible REST API, configured per-repository via `repos["owner/repo"].api_host` and related keys. By default an `api_host` repo is treated as living exclusively on the alt host; set `exclusive: false` on the repo entry to mark it as **dual-host**, where some PRs live on `github.com` and others on the alt host and pair-review resolves the host per PR. See [docs/alt-host.md](docs/alt-host.md) for the full configuration guide.
 
 ### Environment Variables
 

--- a/docs/alt-host.md
+++ b/docs/alt-host.md
@@ -29,9 +29,15 @@ All alt-host settings live under a per-repository entry in
     "owner/repo": {
       // Existing keys (path, worktree_directory, ...) still apply
 
-      // REST API base URL for this host. When set, pair-review routes all
-      // API traffic for this repo to this host instead of api.github.com.
+      // REST API base URL for this host. When set, pair-review routes API
+      // traffic for this repo to this host instead of api.github.com.
       "api_host": "https://althost.example/api/v3",
+
+      // Whether every PR for this repo lives on the alt host (default true).
+      // Set false for a "dual-host" repo whose PRs live on github.com OR the
+      // alt host; pair-review then resolves the host per PR. Only meaningful
+      // alongside api_host. See "Dual-Host Repositories" below.
+      "exclusive": false,
 
       // Token resolution for this repo. Use exactly one of these.
       "token": "...",            // literal token
@@ -67,10 +73,29 @@ All alt-host settings live under a per-repository entry in
 
 The REST API base URL for the host, e.g. `https://althost.example/api/v3`.
 When this key is present, pair-review treats the repository as an alt-host
-repo and dispatches API calls accordingly.
+repo and dispatches API calls accordingly. By default this applies to every
+PR of the repo; set `exclusive: false` (below) to make the host resolve per
+PR instead.
 
 When `api_host` is unset, the repo uses the default `github.com` behaviour
 and all other alt-host keys are ignored.
+
+### `exclusive`
+
+Whether **every** PR for this repo lives on the alt host. Only meaningful
+alongside `api_host` — setting it without `api_host` is a startup error, and
+its value must be a boolean.
+
+- **`exclusive: true`** (the default when the key is omitted) — the repo lives
+  exclusively on the alt host. Every PR is resolved against `api_host`, exactly
+  as before this key existed.
+- **`exclusive: false`** — the repo is **dual-host**: some PRs live on
+  `github.com` (or Graphite) and others on the alt host. pair-review resolves
+  the host on a per-PR basis. See "Dual-Host Repositories" below for how the
+  host is detected, stored, and used.
+
+A repo configured with `api_host` and no `exclusive` key behaves identically
+to earlier versions of pair-review — this feature is opt-in.
 
 ### `token` / `token_command`
 
@@ -212,6 +237,111 @@ Note that the host's web URL frequently cannot be derived from `api_host`
 be three different domains), which is why `url_template` exists and is used
 for every host-facing link.
 
+## Dual-Host Repositories
+
+A repo with `api_host` and `exclusive: false` is **dual-host**: its PRs live on
+`github.com` (or Graphite) OR on the alt host, and pair-review resolves the
+host per PR rather than per repo. This matches real migration scenarios, where
+older PRs still live on GitHub while newer ones exist only on the alternate
+host.
+
+The no-collision assumption still holds: a given `(owner/repo, number)`
+identifies exactly one PR, on whichever host it lives. The
+`/pr/:owner/:repo/:number` URL scheme is unchanged.
+
+### Per-PR host storage
+
+Each PR's host is remembered locally (in the pair-review database) once it has
+been determined. The stored value is the `api_host` URL string for an
+alt-hosted PR, or empty (github.com) for a GitHub-hosted PR. Storing the URL
+string — rather than a config key — means the token and features are
+re-resolved from config at runtime by matching that string.
+
+The host is learned, in decreasing order of confidence, from:
+
+1. **The URL that opened the PR.** When you paste a PR URL, the pattern it
+   matches decides the host: a `url_pattern` match records the alt host; a
+   `github.com` or Graphite URL records github.com.
+2. **The dashboard listing it appeared in.** A collections refresh (below)
+   lists open PRs from github.com *and* every configured alt host, stamping
+   each row with the host it was found on. Opening a PR from a dashboard row
+   carries that host through.
+3. **Setup-time probing** for a bare PR number, when neither of the above is
+   available (see "Probing" below).
+
+Once learned, the host is stored and reused, and re-stamped on every
+subsequent fetch — so a stale or not-yet-known row self-heals the next time the
+PR is opened.
+
+### Ambiguity rule
+
+When a dual-host repo needs a host and none is stored, known from a URL, or
+probeable:
+
+- **Dual-host repo → github.com.** The repo also exists on github.com and
+  top-level credentials exist there, so github is the safe default. (An
+  `exclusive` alt-host repo in the same situation resolves to the alt host, as
+  it always has.)
+
+### Probing (bare PR numbers)
+
+When you open a dual-host PR by bare number (no URL to reveal the host, no
+stored row), pair-review probes to find it:
+
+1. Try the **alt host** first (`GET /repos/{owner}/{repo}/pulls/{number}`). A
+   repo configured with `api_host` is actively using it, so alt-first is the
+   common case.
+2. On a **404**, fall back to **github.com** and fetch there.
+3. On an **auth or network error** (e.g. `401`/`403`, timeout), **fail loudly
+   — no fallback.** A `401` on the alt host must not silently fall through to
+   github.com and fetch a same-numbered but entirely different PR.
+
+The host that answers is stored, so the probe happens at most once per PR.
+
+### Per-binding credentials and features
+
+A dual-host repo has two bindings, and they use different credentials and
+feature defaults:
+
+- **Alt-host binding** (alt-hosted PRs) — uses the repo's `token` /
+  `token_command` and the repo's explicit `features` block, with alt-host
+  defaults (`rest` / `host`), exactly as an exclusive alt-host repo does.
+- **GitHub binding** (github-hosted PRs) — uses the standard github.com
+  credential chain only (`GITHUB_TOKEN` → top-level `github_token` /
+  `github_token_command`) and the standard GitHub feature defaults
+  (GraphQL-preferred). The repo-scoped `token` / `token_command` are alt-host
+  credentials and are **not** sent to github.com, and the repo's explicit
+  `features` block (written for the alt host) does **not** apply to the github
+  binding.
+
+In other words, the repo's alt-host settings describe only the alt-host side
+of a dual repo; the github side behaves like any ordinary github.com repo.
+
+### Collections (dashboard listings)
+
+With dual-host repos configured, a dashboard collections refresh lists open
+PRs from github.com and from every configured `api_host` (both exclusive and
+dual repos), classifying each into your collections (your PRs, review
+requests, team reviews) and stamping the host it came from.
+
+Alt hosts expose only a REST subset, so this uses
+`GET /repos/{owner}/{repo}/pulls?state=open` rather than GitHub's Search API,
+and classifies results locally.
+
+Alt-host listing is **best-effort per host**: if one alt host times out,
+errors, or does not implement the required endpoint, that failure is logged
+and the refresh still returns github.com results plus whatever other hosts
+succeeded. The refresh reports per-host status so the dashboard can show
+partial results honestly rather than failing the whole refresh.
+
+### Recovering from a stale stored host
+
+If you later change or remove a repo's `api_host`, a previously stored host may
+no longer match the configuration. Rather than binding to a dead host,
+pair-review fails with a clear error explaining that the stored host no longer
+matches config. Re-open the PR from its URL to re-stamp it with the correct
+host.
+
 ## Host Extensions
 
 Some operations cannot be expressed in GitHub's REST surface (most notably,
@@ -311,6 +441,20 @@ the default.
 
 Host extensions only make sense against a configured `api_host`. Either
 set `api_host` for this repo or remove the `"host"` value.
+
+### `exclusive` set but `api_host` unset
+
+The `exclusive` flag only makes sense for an alt-host repo. Either add
+`api_host` for this repo or remove `exclusive`. (Its value must also be a
+boolean.)
+
+### Stored host no longer matches config
+
+You changed or removed a repo's `api_host` after opening one of its PRs, so
+the host recorded for that PR points at a host that is no longer configured.
+pair-review refuses to bind to it rather than silently querying the wrong (or
+a dead) host. Re-open the PR from its URL to re-stamp it with the current
+host.
 
 ### `Invalid regex in repos["<repo>"].url_pattern`
 

--- a/plans/per-pr-host-resolution.md
+++ b/plans/per-pr-host-resolution.md
@@ -1,0 +1,277 @@
+# Per-PR Host Resolution (dual GitHub + alt-host repos)
+
+## Problem
+
+Alt-host support (`api_host` in repo config, see `docs/alt-host.md`) is repo-exclusive:
+if a repo has `api_host` configured, **every** PR for that repo is resolved against the
+alternate host. Real migration scenarios are mixed — some PRs for a repo still live on
+GitHub/Graphite while newer ones exist only on the alternate host.
+
+Additionally, the dashboard collections (`src/routes/github-collections.js`) query
+github.com only, with the top-level token. Alt-host PRs never appear in any list today;
+they are reachable only by pasting a URL.
+
+**Assumption (confirmed):** PR numbers do NOT collide between systems for the same repo.
+A given `(repository, pr_number)` identifies exactly one PR, whichever host it lives on.
+Therefore `UNIQUE(pr_number, repository)` stays; the `/pr/:owner/:repo/:number` URL
+scheme is unchanged.
+
+## Design summary
+
+1. **Config:** new per-repo boolean `exclusive` (only valid alongside `api_host`).
+   `exclusive: true` (the default) = today's behavior, alt host only.
+   `exclusive: false` = dual repo — PRs may live on github.com OR the alt host.
+2. **Persistence:** new `host TEXT` column on `pr_metadata` and `github_pr_cache`.
+   `NULL` = github.com; otherwise the `api_host` URL string. Store the URL string, not
+   the config key — config keys can be renamed; token/features are re-resolved from
+   config at runtime by matching the string.
+3. **Resolution:** `resolveHostBinding(repository, config, { host })` gains an optional
+   per-PR host override. `resolveBindingForRequest` (PR-mode routes) reads the stored
+   host from `pr_metadata` and passes it through.
+4. **Derivation:** host is learned from (a) which URL pattern matched a pasted URL,
+   (b) which host a PR was found on during collections refresh, (c) probing at setup
+   time for bare PR numbers, in that order of confidence. Once learned, it is stored.
+
+## Backward compatibility rules
+
+- Repo with `api_host`, no `exclusive` key → `exclusive: true` → identical to today.
+- Existing `pr_metadata` rows have `host = NULL`. Fallback rule when stored host is
+  NULL/missing: derive from repo config exactly as today (exclusive alt-host repo →
+  alt host; otherwise github). No migration backfill needed — the fallback makes old
+  rows resolve identically, and rows are re-stamped on next fetch.
+- Repos without `api_host`: completely unaffected on every path.
+
+## Ambiguity rule (dual repo, host unknown)
+
+When a dual repo (`exclusive: false`) needs a binding and no per-PR host is available:
+
+- **Probing contexts** (PR setup with a bare number): probe the alt host first
+  (`GET /repos/{owner}/{repo}/pulls/{n}`), on 404 fall back to github.com. A repo
+  configured with `api_host` is actively using it, so alt-first is the common case.
+  Record the winner in `pr_metadata.host`.
+- **Non-probing contexts** (local-mode branch enrichment, repo-level operations with
+  no PR identity): use the **github** binding. The repo also exists on github.com and
+  top-level credentials exist there; this is opt-in behavior only for repos newly
+  marked `exclusive: false`.
+
+---
+
+## Phase 1 — Config: `exclusive` flag
+
+**Files:** `src/config.js`, `docs/alt-host.md`, `README.md`
+
+- `getRepoConfig` output gains `exclusive`. Resolution helper (new):
+  `isExclusiveAltHost(repoConfig)` → `repoConfig.api_host && repoConfig.exclusive !== false`.
+- `validateRepoConfig` (`src/config.js:790`):
+  - `exclusive` must be a boolean if present.
+  - `exclusive` without `api_host` → startup error (meaningless).
+- **Feature resolution per binding, not per repo.** `_resolveFeatures(apiHost, explicit)`
+  (`src/config.js:508`) already keys on `apiHost`. For a dual repo:
+  - alt-host binding → explicit repo `features` apply, defaults as today (`rest`/`host`).
+  - github binding → standard github defaults (`graphql`-preferred); the repo's explicit
+    `features` block does NOT apply (it was written for the alt host). Document this.
+- Token resolution split (inside `resolveHostBinding`):
+  - alt-host binding → repo `token` / `token_command` only (unchanged).
+  - github binding of a dual repo → the normal github.com chain (`GITHUB_TOKEN` →
+    top-level `github_token` / `github_token_command`). Do **not** use the repo-scoped
+    alt-host token for github.com. If the repo config has BOTH github and alt
+    credentials needs in future, that's a follow-up (`github_token` override per repo
+    already exists via the top-level chain).
+
+## Phase 2 — Database: `host` column
+
+**Files:** `src/database.js`, `tests/e2e/global-setup.js`, `tests/integration/routes.test.js`
+
+- Migration v50 (`CURRENT_SCHEMA_VERSION` 49 → 50):
+  - `ALTER TABLE pr_metadata ADD COLUMN host TEXT` — guarded by `columnExists`.
+  - `ALTER TABLE github_pr_cache ADD COLUMN host TEXT` — guarded by `columnExists`.
+  - No backfill (see back-compat rules). No table rebuild, no uniqueness change.
+- Update `SCHEMA_SQL` for fresh databases.
+- Update BOTH test schemas (e2e global-setup, integration routes.test.js) — column and
+  any index names must match production exactly.
+- `storePRData` (`src/setup/pr-setup.js:79-114`) accepts and writes `host` on both the
+  UPDATE and INSERT arms.
+- New read helper on database: `getPRHost(repository, prNumber)` → stored host or
+  `undefined` (row missing) — distinguish "no row" from "row says github (NULL)".
+  NOTE: with the NULL-means-github convention, an old row (NULL from before migration)
+  and a new github row (NULL on purpose) resolve identically under the fallback rule
+  only for non-dual repos. For dual repos, a NULL stored host means "github" — that is
+  correct for rows written after this change, and old rows for such repos get
+  re-stamped on next fetch. Acceptable: a repo becomes dual only when the user edits
+  config, and the probe path self-heals stale rows (see Phase 4).
+
+## Phase 3 — Core resolution: per-PR host override
+
+**Files:** `src/config.js`, `src/routes/pr.js`, `src/github/client.js` (no change
+expected — it already takes a binding object)
+
+- `resolveHostBinding(repository, config, options = {})`:
+  - `options.host === undefined` → legacy behavior + ambiguity rule: exclusive alt-host
+    repo → alt binding; dual repo → github binding; plain repo → github binding.
+  - `options.host === null` → github binding. For an **exclusive** alt-host repo this is
+    a caller bug — throw with a clear message rather than silently using github.
+  - `options.host === '<url>'` → alt binding; must equal the repo's configured
+    `api_host` (else throw: stale stored host after a config change — the error message
+    should say the stored host no longer matches config and suggest re-opening the PR
+    from a URL).
+  - Returned binding gains a `host` echo field so callers can persist what was used.
+- `resolveBindingForRequest(req, repository)` (`src/routes/pr.js:138`):
+  - Extract `prNumber` from `req.params` (all 11 current call sites are
+    `/:owner/:repo/:number` routes — verify each), call `getPRHost`, pass
+    `{ host }` when a row exists; omit when not.
+  - Keep the existing loud failure for alt-host bindings with no token.
+- Repo-level callers keep two-arg calls (ambiguity rule applies):
+  `src/routes/config.js:152,313`, `src/routes/setup.js:70`, `src/git/base-branch.js:17`,
+  `src/routes/mcp.js:797`, local-mode sites (see Phase 7).
+
+## Phase 4 — Derivation at setup time
+
+**Files:** `src/github/parser.js`, `src/routes/pr.js` (parse-pr-url), `src/routes/setup.js`,
+`src/setup/pr-setup.js`, `src/main.js`
+
+- **Parser carries host.** `parsePRUrl` result gains `host`:
+  - `_matchUrlPatternFromConfig` matched → the matched repo's `api_host`.
+  - `parseGitHubURL` / `parseGraphiteURL` / protocol URL → `host: null`.
+  - Bare number / git-remote paths → `host: undefined` (unknown; probe later).
+- **Fix `POST /api/parse-pr-url`** (`src/routes/pr.js:1948-1955`): it currently drops
+  `bindingRepository`. Return `host` (and `bindingRepository`) so the web client can
+  pass them to setup.
+- **Setup endpoint** `POST /api/setup/pr/:owner/:repo/:number` (`src/routes/setup.js:53`)
+  accepts an optional `host` in the body. Precedence when choosing the fetch binding:
+  1. explicit `host` from the request (URL paste knows best),
+  2. stored `pr_metadata.host`,
+  3. ambiguity rule + probe for dual repos: fetch from alt host, on 404 retry github.
+     Distinguish 404 (try next host) from auth/network errors (fail loudly — a 401 on
+     the alt host must NOT silently fall back to github and fetch the wrong PR).
+- **CLI path** (`src/main.js:947-957`, `src/setup/pr-setup.js:436-467`): same precedence.
+  The parser's `host` (URL paste into CLI) or DB row wins; bare numbers probe.
+- After a successful fetch, `storePRData` stamps the host actually used — this is the
+  self-healing step for stale/NULL rows.
+
+## Phase 5 — Collections: list PRs from both systems
+
+**Files:** `src/routes/github-collections.js`, `src/github/client.js` (maybe a small
+list helper), frontend dashboard JS that renders collection rows
+
+- Refresh handler (`github-collections.js:148-201`), after the existing github.com
+  search, iterates config repos with `api_host` (both exclusive and dual):
+  - Build an alt-host client from `resolveHostBinding(repoKey, config, { host: apiHost })`.
+  - Alt hosts speak a REST subset — the Search API very likely doesn't exist. Use
+    `GET /repos/{owner}/{repo}/pulls?state=open` (octokit `pulls.list`) and classify
+    locally into collections: `my-prs` → `pr.user.login === login`; `review-requests` →
+    `requested_reviewers` contains login; `team-reviews` → `requested_teams` non-empty
+    match. Get `login` from `GET /user` on the alt host once per refresh, cached.
+  - **Best-effort per host:** wrap each alt-host repo in try/catch; log failures via
+    `logger`; never let an alt-host timeout or 501 break the github.com refresh. Include
+    per-host status in the refresh response so the UI can show partial results honestly.
+- Stamp `host` on every `github_pr_cache` row (NULL for github.com results).
+- `GET /api/github/:collection` returns `host` per row.
+- **Frontend:** when a collection row is clicked, pass its `host` through to the setup
+  call (`POST /api/setup/pr/...` body) so a dual repo's alt-host PR opens against the
+  right system without probing.
+- Dedup note: for a dual repo, the same PR cannot appear on both hosts (no-collision
+  assumption + a PR lives in exactly one system), so no cross-host dedup is needed;
+  `UNIQUE(collection, owner, repo, number)` already collapses accidental duplicates —
+  last write wins, and both writes would describe the same logical PR only if a host
+  lies. Acceptable.
+
+## Phase 6 — Links and display
+
+**Files:** `src/links/repo-links.js`, `src/routes/pr.js:1752` (resolveHostName caller),
+frontend header rendering
+
+- `resolveRepoLinks` / `resolveHostName` become host-aware: accept the PR's resolved
+  host. For a dual repo:
+  - github-hosted PR → GitHub (and Graphite, if enabled) links; hide the external link
+    unless configured otherwise.
+  - alt-hosted PR → external link from `links.external`; hide GitHub/Graphite links.
+  - `links.github: false` etc. remain user overrides on top of this default.
+- Exclusive repos and plain repos render exactly as today.
+
+## Phase 7 — Local mode parity
+
+**Files:** `src/routes/local.js`, `src/local-review.js`
+
+- Local mode has no PR identity; it uses the host binding for best-effort enrichment
+  (`local.js:501-509, 723-724, 2119-2120`; `local-review.js:802`). Apply the ambiguity
+  rule: dual repo → github binding; exclusive alt-host repo → alt binding (unchanged).
+  All these sites stay two-arg `resolveHostBinding` calls and must keep swallowing
+  absence (best-effort), never throwing like PR mode.
+- No local-mode DB changes: `reviews.review_type='local'` rows have no PR host.
+
+## Phase 8 — Tests
+
+- **Unit** (`tests/unit/`):
+  - config: `exclusive` validation (boolean check, requires `api_host`); binding
+    resolution matrix — {plain, exclusive, dual} × {host undefined, null, url,
+    stale-url} including the throw cases.
+  - parser: `host` on every parse path (url_pattern, github URL, graphite URL, bare
+    number, git remote).
+  - probe logic: alt 200 → alt; alt 404 → github; alt 401 → loud error, no fallback.
+  - migration v50: fresh DB has columns; v49 DB migrates; migration is idempotent
+    (re-run guarded by `columnExists`).
+  - repo-links host-awareness matrix.
+- **Integration** (`tests/integration/`): setup endpoint host precedence (body host >
+  stored host > probe); parse-pr-url returns host; collections refresh stamps host and
+  survives a failing alt host (mock server per `tests/CONVENTIONS.md` — loopback
+  server, no real network, no fixed sleeps).
+- **E2E**: dashboard row with alt host opens PR against alt host (mocked); dual-repo
+  PR page shows the correct link set. Frontend changed → run `pnpm run test:e2e`.
+- Regression: a repo with `api_host` and no `exclusive` key behaves byte-identically
+  to today across the existing alt-host test suite.
+
+## Phase 9 — Docs, changeset
+
+- `docs/alt-host.md`: `exclusive` flag, per-PR host storage, derivation order,
+  ambiguity rule, feature-resolution-per-binding note, collections behavior.
+- `README.md`: brief mention under alt-host config.
+- Changeset: `minor` — new user-facing feature ("dual-host repos: per-PR host
+  resolution").
+- Regenerate skill prompts only if `src/ai/prompts/` is touched (not expected).
+
+---
+
+## Hazards
+
+- **`resolveHostBinding` has ~25 call sites** (`src/main.js:957,1110,1124,1739,1751`;
+  `src/routes/pr.js` via `resolveBindingForRequest` ×11; `src/routes/stack-analysis.js:213,256`;
+  `src/routes/external-comments.js:119` (adapter); `src/routes/mcp.js:797`;
+  `src/routes/config.js:152,313`; `src/routes/setup.js:70`; `src/setup/pr-setup.js:436`;
+  `src/setup/stack-setup.js:49`; `src/routes/local.js:501,723,2119`;
+  `src/local-review.js:802`; `src/git/base-branch.js:17`). Every caller must be
+  classified as PR-scoped (pass `{host}`) or repo-scoped (ambiguity rule). The
+  signature change is additive (optional third arg) so unclassified callers get the
+  ambiguity rule — which CHANGES behavior for dual repos (github instead of alt).
+  That is the intended default, but each repo-scoped caller must be checked against it.
+- **`resolveBindingForRequest` is the shared chokepoint for 11 PR-mode routes** (get,
+  refresh, diff, drafts, submit-review, analyses, council, share, stack-info). Verify
+  each has `:number` in its route params before assuming PR scope; any repo-scoped
+  route piggybacking on it must not pass a PR host.
+- **Token semantics change for dual repos:** alt binding skips ALL github credentials
+  by design (`config.js:582-644`). The github binding of a dual repo must take the
+  normal top-level chain. A mistake here silently authenticates against the wrong host.
+- **Probe fallback must distinguish 404 from auth failure.** 401/403 on the alt host
+  falling through to github.com would fetch a same-numbered PR from the wrong system
+  and stamp the wrong host. Only 404 (and the host's documented "not found" shape)
+  may trigger fallback.
+- **Async: collections refresh now fans out to N hosts.** The completion handler
+  previously assumed one search was the only thing in flight. Partial failure must not
+  poison the cache: write github rows and alt rows independently; a thrown alt-host
+  error after github rows are written must not roll them back or double-write on retry
+  (`UNIQUE(collection, owner, repo, number)` upsert semantics protect the latter).
+- **Stale stored host after config edit** (user removes/changes `api_host`): stored
+  `pr_metadata.host` no longer matches config. `resolveHostBinding` throws a targeted
+  error (Phase 3) rather than binding to a dead host; re-opening from a URL re-stamps.
+- **`POST /api/parse-pr-url` currently drops `bindingRepository`** (`pr.js:1948-1955`)
+  — the web setup path re-derives it. Returning host/bindingRepository changes this
+  endpoint's response shape; check all frontend consumers of the response.
+- **Migration test schemas are duplicated** in `tests/e2e/global-setup.js` and
+  `tests/integration/routes.test.js` — both must add the `host` columns or CI diverges
+  from production.
+- **Local vs PR mode parity:** local mode treats bindings as optional enrichment and
+  swallows absence; PR mode throws. Phase 7 must preserve that split — the ambiguity
+  rule must not introduce a throw on any local path.
+- **Prior guard to preserve:** `syncPendingDraftFromGitHub` (`pr.js:187`) already
+  tolerates alt-host REST responses lacking `node_id`; the github binding of a dual
+  repo re-enables GraphQL paths — verify the graphql/rest dispatch per binding doesn't
+  regress that reconciliation.

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -445,8 +445,14 @@
       ? ''
       : '<td class="col-author">' + authorDisplay + '</td>';
 
+    // `data-host` carries the alt-host api_host string for PRs that live on an
+    // alternate host; github.com rows have no host and render an empty
+    // attribute. The click handler threads it into the setup call so a dual
+    // repo's alt-host PR opens against the right system without re-probing.
+    var hostAttr = pr.host ? ' data-host="' + escapeHtml(pr.host) + '"' : '';
+
     return '' +
-      '<tr class="collection-pr-row" data-pr-url="' + escapeHtml(prUrl) + '" data-owner="' + escapeHtml(pr.owner) + '" data-repo="' + escapeHtml(pr.repo) + '" data-number="' + pr.number + '">' +
+      '<tr class="collection-pr-row" data-pr-url="' + escapeHtml(prUrl) + '" data-owner="' + escapeHtml(pr.owner) + '" data-repo="' + escapeHtml(pr.repo) + '" data-number="' + pr.number + '"' + hostAttr + '>' +
         '<td class="col-repo">' + escapeHtml(repoFull) + '</td>' +
         '<td class="col-pr"><span class="collection-pr-number">#' + pr.number + '</span></td>' +
         '<td class="col-title" title="' + escapeHtml(pr.title || '') + '">' + escapeHtml(pr.title || '') + '</td>' +
@@ -1293,7 +1299,14 @@
         return {
           owner: data.owner,
           repo: data.repo,
-          prNumber: data.prNumber
+          prNumber: data.prNumber,
+          // `host` tells setup which system the PR lives on: an api_host URL
+          // string = alt host, null = github.com, undefined = unknown.
+          host: data.host,
+          bindingRepository: data.bindingRepository,
+          // Whether the repo is dual (github + alt-host). Only dual repos probe,
+          // so only they need an explicit github pick when the URL is a github URL.
+          isDualHost: data.isDualHost
         };
       }
 
@@ -1343,7 +1356,22 @@
     // Navigate to the PR route which serves setup.html (with step-by-step progress)
     // for new PRs, or pr.html directly for PRs already in the database
     let href = '/pr/' + encodeURIComponent(parsed.owner) + '/' + encodeURIComponent(parsed.repo) + '/' + encodeURIComponent(parsed.prNumber);
-    if (analyze) href += '?analyze=true';
+    var params = new URLSearchParams();
+    if (analyze) params.set('analyze', 'true');
+    // Forward the parsed host so setup binds directly instead of probing:
+    //  - alt-host URL string → the api_host (setup binds that alt host)
+    //  - github URL (host === null) on a DUAL repo → the "github" sentinel, so
+    //    setup binds github.com instead of probing alt-first (which would fail
+    //    loudly if the alt host is down for a PR we KNOW is on github)
+    //  - anything else (plain/exclusive repo, unknown host) → omit; no probe
+    //    happens for those and omitting avoids the exclusive-null throw.
+    if (typeof parsed.host === 'string' && parsed.host) {
+      params.set('host', parsed.host);
+    } else if (parsed.host === null && parsed.isDualHost) {
+      params.set('host', 'github');
+    }
+    var qs = params.toString();
+    if (qs) href += '?' + qs;
     window.location.href = href;
   }
 
@@ -1891,7 +1919,7 @@
    * Read selected collection rows as PR descriptors.
    * @param {Set} selectedIds - PR URLs (data-pr-url values)
    * @param {string} tbodyId - tbody element ID
-   * @returns {Array<{owner: string, repo: string, number: string, prUrl: string}>}
+   * @returns {Array<{owner: string, repo: string, number: string, prUrl: string, host: string|undefined}>}
    */
   function getSelectedCollectionRows(selectedIds, tbodyId) {
     var tbody = document.getElementById(tbodyId);
@@ -1908,7 +1936,11 @@
           owner: tr.dataset.owner,
           repo: tr.dataset.repo,
           number: tr.dataset.number,
-          prUrl: prUrl
+          prUrl: prUrl,
+          // Alt-host rows carry a host; github.com rows leave it undefined. The
+          // single-row click path threads this the same way (see the collection
+          // row click handler) so bulk-open binds to the right system too.
+          host: tr.dataset.host
         });
       }
     }
@@ -1917,7 +1949,14 @@
 
   function buildReviewUrlsFromRows(rows, query) {
     return rows.map(function (row) {
-      return '/pr/' + encodeURIComponent(row.owner) + '/' + encodeURIComponent(row.repo) + '/' + row.number + (query || '');
+      // Preserve any existing params (analyze / analysisConfigId) and append the
+      // alt host so setup opens the PR against the system it lives on instead of
+      // re-probing. github.com rows (no host) keep the URL unchanged.
+      var qs = query || '';
+      if (row.host) {
+        qs += (qs ? '&' : '?') + 'host=' + encodeURIComponent(row.host);
+      }
+      return '/pr/' + encodeURIComponent(row.owner) + '/' + encodeURIComponent(row.repo) + '/' + row.number + qs;
     });
   }
 
@@ -2160,6 +2199,21 @@
           cb.checked = !cb.checked;
           cb.dispatchEvent(new Event('change'));
         }
+        return;
+      }
+
+      // Alt-host PR: we already know owner/repo/number and the host it lives
+      // on, so navigate straight to the PR route with the host as a query
+      // param (setup.html forwards it into the setup POST body). This bypasses
+      // the URL-parse round trip, which can't reliably recover the host from a
+      // pasted alt-host html_url. github.com rows (no host) keep the existing
+      // parse-and-submit flow below, byte-identical.
+      var rowHost = collectionRow.dataset.host;
+      if (rowHost) {
+        var o = encodeURIComponent(collectionRow.dataset.owner);
+        var r = encodeURIComponent(collectionRow.dataset.repo);
+        var n = encodeURIComponent(collectionRow.dataset.number);
+        window.location.href = '/pr/' + o + '/' + r + '/' + n + '?host=' + encodeURIComponent(rowHost);
         return;
       }
 
@@ -2541,5 +2595,15 @@
   // Expose for use after data loads (loadRecentReviews / loadLocalReviews)
   window.__pairReview = window.__pairReview || {};
   window.__pairReview.refreshAnalysisSpinners = fetchAndApplyActiveAnalyses;
+
+  // Test-only exports. In the browser `module` is undefined, so this is a
+  // no-op; under Vitest (CommonJS) it exposes the internal bulk-open helpers
+  // for direct unit testing rather than duplicating their logic in a test.
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = {
+      buildReviewUrlsFromRows: buildReviewUrlsFromRows,
+      getSelectedCollectionRows: getSelectedCollectionRows
+    };
+  }
 
 })();

--- a/public/js/repo-links.js
+++ b/public/js/repo-links.js
@@ -246,9 +246,17 @@
     _currentLinks = null;
     _currentContext = context || null;
     try {
-      const response = await fetch(
-        '/api/repos/' + encodeURIComponent(owner) + '/' + encodeURIComponent(repo) + '/links'
-      );
+      // Pass the PR number (when known) so the server can resolve the link set
+      // against this PR's host for a dual-host repo (github links for a
+      // github-hosted PR, the external link for an alt-hosted one). Local mode
+      // has no PR number, so the query is omitted and the server returns the
+      // repo-level default.
+      let url = '/api/repos/' + encodeURIComponent(owner) + '/' + encodeURIComponent(repo) + '/links';
+      const number = context && context.number;
+      if (number !== undefined && number !== null && number !== '') {
+        url += '?number=' + encodeURIComponent(String(number));
+      }
+      const response = await fetch(url);
       if (!response.ok) {
         console.warn('[repo-links] Failed to fetch repo links:', response.status);
         return;

--- a/public/setup.html
+++ b/public/setup.html
@@ -752,6 +752,19 @@
                     if (mode === 'local') {
                         fetchOptions.headers = { 'Content-Type': 'application/json' };
                         fetchOptions.body = JSON.stringify({ path: context.path });
+                    } else if (mode === 'pr') {
+                        // A `host` query param (set when opening a PR from a dashboard
+                        // collection row or a pasted URL) tells setup which system the
+                        // PR lives on, so the fetch binds there directly instead of
+                        // probing. Sentinel: the literal "github" means github.com and
+                        // maps to body host null; any other value is an api_host URL
+                        // string (alt host) — an api_host is always a URL, so "github"
+                        // is unambiguous. Absent = unknown; the server derives the host.
+                        var setupHost = new URLSearchParams(window.location.search).get('host');
+                        if (setupHost) {
+                            fetchOptions.headers = { 'Content-Type': 'application/json' };
+                            fetchOptions.body = JSON.stringify({ host: setupHost === 'github' ? null : setupHost });
+                        }
                     }
 
                     var response = await fetch(postUrl, fetchOptions);

--- a/src/config.js
+++ b/src/config.js
@@ -535,24 +535,59 @@ function _resolveFeatures(apiHost, explicit) {
 }
 
 /**
+ * Whether a repo config describes an *exclusive* alt-host repo — one whose
+ * every PR lives on the configured `api_host` and which has no github.com
+ * presence. True iff `api_host` is a non-empty string AND `exclusive` is not
+ * explicitly `false`. Omitting `exclusive` therefore preserves today's
+ * behaviour (an `api_host` repo is alt-host-only). Setting `exclusive: false`
+ * marks a *dual* repo whose PRs may live on github.com OR the alt host.
+ *
+ * @param {Object|null|undefined} repoConfig - A single `repos[...]` entry
+ * @returns {boolean}
+ */
+function isExclusiveAltHost(repoConfig) {
+  if (!repoConfig || typeof repoConfig !== 'object') return false;
+  const apiHost = typeof repoConfig.api_host === 'string' && repoConfig.api_host;
+  if (!apiHost) return false;
+  return repoConfig.exclusive !== false;
+}
+
+/**
  * Resolves the host binding for a given repository. The binding describes
  * which API host pair-review should talk to, the token to authenticate
  * with, and per-area dispatch flags.
  *
- * Token resolution priority for a repo with no `api_host` (github.com):
+ * The optional `options.host` selects the binding *flavor* for repos that can
+ * live on more than one host (dual repos, `exclusive: false`):
+ *   - `undefined` (or no options) — legacy + ambiguity rule: an EXCLUSIVE
+ *     alt-host repo binds to its alt host (today's behaviour); a DUAL repo or
+ *     a plain github.com repo binds to github.com.
+ *   - `null` — force a github.com binding. For an EXCLUSIVE alt-host repo this
+ *     is a caller bug (that repo has no github.com presence) and throws.
+ *   - `'<url>'` — force an alt-host binding; the string must equal the repo's
+ *     configured `api_host`, otherwise the stored host no longer matches
+ *     config and this throws.
+ *
+ * Token resolution priority for a github.com (github-flavored) binding of a
+ * plain repo:
  *   1. GITHUB_TOKEN environment variable
  *   2. repo-level `token`
  *   3. repo-level `token_command` (cached per (repo, command))
  *   4. top-level `github_token`
  *   5. top-level `github_token_command` (cached per (repo, command))
  *
- * For a repo with an `api_host` (alt-host), the github.com top-level
- * credentials are NOT used — `GITHUB_TOKEN`, `config.github_token`, and
- * `config.github_token_command` are all github.com-only and would be
- * the wrong token for an alt-host endpoint. Only the repo-scoped
- * `token` / `token_command` keys are consulted; missing those, the
- * lookup returns an empty token so the caller can surface a clear
+ * For an alt-host binding, the github.com top-level credentials are NOT used —
+ * `GITHUB_TOKEN`, `config.github_token`, and `config.github_token_command` are
+ * all github.com-only and would be the wrong token for an alt-host endpoint.
+ * Only the repo-scoped `token` / `token_command` keys are consulted; missing
+ * those, the lookup returns an empty token so the caller can surface a clear
  * "missing credential" error.
+ *
+ * For the github.com binding of a DUAL repo, the reverse holds: the repo-scoped
+ * `token` / `token_command` are alt-host credentials and are NOT used — only
+ * the top-level github.com chain (env → `github_token` → `github_token_command`)
+ * is consulted. The repo's explicit `features` block (written for the alt host)
+ * also does not apply to its github.com binding.
  *
  * Refreshable sources (`repo:token_command`, `config:github_token_command`)
  * additionally carry a `refresh` closure on the returned binding. Calling
@@ -564,58 +599,101 @@ function _resolveFeatures(apiHost, explicit) {
  *
  * @param {string|null|undefined} repository - "owner/repo" identifier, or null/undefined for no-repo fallback
  * @param {Object} config - Configuration object from loadConfig()
- * @returns {{ apiHost: string|null, token: string, features: Object, source: string, refresh: (function(): string)|null }}
+ * @param {{ host?: string|null }} [options] - Per-PR host override (see above)
+ * @returns {{ apiHost: string|null, host: string|null, token: string, features: Object, source: string, refresh: (function(): string)|null }}
  */
-function resolveHostBinding(repository, config) {
+function resolveHostBinding(repository, config, options = {}) {
   const safeConfig = config || {};
   const repoConfig = repository ? getRepoConfig(safeConfig, repository) : null;
-  const apiHost = (repoConfig && typeof repoConfig.api_host === 'string' && repoConfig.api_host)
+  const configuredApiHost = (repoConfig && typeof repoConfig.api_host === 'string' && repoConfig.api_host)
     ? repoConfig.api_host
     : null;
-  const features = _resolveFeatures(apiHost, repoConfig?.features);
+  const requestedHost = options ? options.host : undefined;
+  const exclusive = isExclusiveAltHost(repoConfig);
+
+  // Decide the binding flavor from the requested host + repo config.
+  // `apiHost` null → github.com binding; non-null → alt-host binding.
+  let apiHost;
+  if (requestedHost === undefined) {
+    // Ambiguity rule: exclusive alt-host repo → alt binding (legacy);
+    // dual repo and plain github repo → github binding.
+    apiHost = exclusive ? configuredApiHost : null;
+  } else if (requestedHost === null) {
+    if (exclusive) {
+      throw new Error(
+        `resolveHostBinding: repository "${repository}" is an exclusive alt-host repo (api_host "${configuredApiHost}") and has no github.com presence, but a github.com binding was requested (host=null). This is a caller bug; pass the api_host string, or set "exclusive": false on the repo config.`
+      );
+    }
+    apiHost = null;
+  } else {
+    // A specific alt host was requested; it must match this repo's config.
+    if (requestedHost !== configuredApiHost) {
+      throw new Error(
+        `resolveHostBinding: requested host "${requestedHost}" for repository "${repository}" does not match its configured api_host (${configuredApiHost === null ? 'none' : `"${configuredApiHost}"`}). The stored host no longer matches config — re-open the PR from a URL to re-resolve its host.`
+      );
+    }
+    apiHost = configuredApiHost;
+  }
+
+  // Binding flavor booleans:
+  //  - alt binding uses ONLY repo-scoped credentials + the repo's features.
+  //  - github binding uses ONLY the top-level github.com chain.
+  //  - the github binding of a DUAL repo must skip the repo-scoped
+  //    credentials/features (they belong to the alt host).
+  const isAltBinding = apiHost !== null;
+  const isDualGithubBinding = !isAltBinding && configuredApiHost !== null;
+  const useRepoScopedToken = !isDualGithubBinding;
+  const useGithubChain = !isAltBinding;
+
+  // A dual repo's explicit `features` block was authored for its alt host, so
+  // it does not apply to the github.com binding; use plain github defaults.
+  const explicitFeatures = isDualGithubBinding ? undefined : repoConfig?.features;
+  const features = _resolveFeatures(apiHost, explicitFeatures);
 
   // Token resolution
   let token = '';
   let source = 'none';
 
-  // 1. GITHUB_TOKEN env var, only for github.com (no api_host)
-  if (apiHost === null && process.env.GITHUB_TOKEN) {
+  // 1. GITHUB_TOKEN env var, only for a github.com binding
+  if (useGithubChain && process.env.GITHUB_TOKEN) {
     token = process.env.GITHUB_TOKEN;
     source = 'env:GITHUB_TOKEN';
     logger.debug('Using GitHub token from GITHUB_TOKEN environment variable');
-    return { apiHost, token, features, source, refresh: null };
+    return { apiHost, host: apiHost, token, features, source, refresh: null };
   }
 
-  // 2. Repo-level literal token
-  if (repoConfig && typeof repoConfig.token === 'string' && repoConfig.token) {
+  // 2. Repo-level literal token (alt-host credential; not used for a dual
+  // repo's github.com binding)
+  if (useRepoScopedToken && repoConfig && typeof repoConfig.token === 'string' && repoConfig.token) {
     token = repoConfig.token;
     source = 'repo:token';
     logger.debug(`Using token from repos[${repository}].token`);
-    return { apiHost, token, features, source, refresh: null };
+    return { apiHost, host: apiHost, token, features, source, refresh: null };
   }
 
   // 3. Repo-level token_command
-  if (repoConfig && typeof repoConfig.token_command === 'string' && repoConfig.token_command) {
+  if (useRepoScopedToken && repoConfig && typeof repoConfig.token_command === 'string' && repoConfig.token_command) {
     const result = _runTokenCommand(repoConfig.token_command, repository, 'repo:token_command');
     if (result) {
       return {
         apiHost,
+        host: apiHost,
         token: result,
         features,
         source: 'repo:token_command',
-        refresh: _makeRefresh(repository, safeConfig, 'repo:token_command')
+        refresh: _makeRefresh(repository, safeConfig, 'repo:token_command', options)
       };
     }
   }
 
-  // 4. Top-level github_token. Only consulted for github.com bindings —
+  // 4. Top-level github_token. Only consulted for a github.com binding —
   // the top-level token is a github.com credential and would fail
   // authentication when sent to an alt-host.
-  if (apiHost === null && typeof safeConfig.github_token === 'string' && safeConfig.github_token) {
+  if (useGithubChain && typeof safeConfig.github_token === 'string' && safeConfig.github_token) {
     token = safeConfig.github_token;
     source = 'config:github_token';
     logger.debug('Using GitHub token from config.github_token');
-    return { apiHost, token, features, source, refresh: null };
+    return { apiHost, host: apiHost, token, features, source, refresh: null };
   }
 
   // 5. Top-level github_token_command. Like step 4, github.com-only.
@@ -623,25 +701,26 @@ function resolveHostBinding(repository, config) {
   // command only — keying on repository would re-invoke the (often
   // slow) command per repo per session. Repo-level `token_command`
   // above keeps its per-(repo, command) cache key.
-  if (apiHost === null && typeof safeConfig.github_token_command === 'string' && safeConfig.github_token_command) {
+  if (useGithubChain && typeof safeConfig.github_token_command === 'string' && safeConfig.github_token_command) {
     const result = _runTokenCommand(safeConfig.github_token_command, null, 'config:github_token_command');
     if (result) {
       return {
         apiHost,
+        host: apiHost,
         token: result,
         features,
         source: 'config:github_token_command',
-        refresh: _makeRefresh(repository, safeConfig, 'config:github_token_command')
+        refresh: _makeRefresh(repository, safeConfig, 'config:github_token_command', options)
       };
     }
   }
 
-  if (apiHost !== null && repository) {
+  if (isAltBinding && repository) {
     logger.debug(`No repo-scoped token resolved for alt-host repo ${repository} (${apiHost}); github.com top-level credentials are not used for alt-hosts`);
   } else {
     logger.debug('No token resolved for host binding');
   }
-  return { apiHost, token: '', features, source: 'none', refresh: null };
+  return { apiHost, host: apiHost, token: '', features, source: 'none', refresh: null };
 }
 
 /**
@@ -656,14 +735,15 @@ function resolveHostBinding(repository, config) {
  * @param {string|null|undefined} repository - "owner/repo" identifier as supplied to resolveHostBinding
  * @param {Object} config - Configuration object from loadConfig()
  * @param {('repo:token_command'|'config:github_token_command')} source - The refreshable source backing the binding
+ * @param {{ host?: string|null }} [options] - The same host override the binding was resolved with, so the refresh re-resolves the SAME flavor (a two-arg re-resolve would apply the ambiguity rule and could pick the wrong host for a dual repo)
  * @returns {function(): string} - Closure resolving to the fresh token (empty string on failure)
  */
-function _makeRefresh(repository, config, source) {
+function _makeRefresh(repository, config, source, options = {}) {
   return function refresh() {
     invalidateTokenCache(repository, config, source);
     // Re-resolve after invalidation so _runTokenCommand re-executes the
     // command. Returns '' if the command now fails or yields nothing.
-    return resolveHostBinding(repository, config).token;
+    return resolveHostBinding(repository, config, options).token;
   };
 }
 
@@ -795,6 +875,22 @@ function validateRepoConfig(config) {
     const apiHost = (typeof repoEntry.api_host === 'string' && repoEntry.api_host) ? repoEntry.api_host : null;
     const features = (repoEntry.features && typeof repoEntry.features === 'object') ? repoEntry.features : {};
 
+    // `exclusive` marks whether an alt-host repo's PRs live ONLY on its
+    // `api_host` (default) or may also live on github.com (`exclusive: false`,
+    // a dual repo). It is meaningless without `api_host`.
+    if (repoEntry.exclusive !== undefined && repoEntry.exclusive !== null) {
+      if (typeof repoEntry.exclusive !== 'boolean') {
+        throw new Error(
+          `Invalid pair-review config: repos["${repoKey}"].exclusive must be a boolean.`
+        );
+      }
+      if (!apiHost) {
+        throw new Error(
+          `Invalid pair-review config: repos["${repoKey}"].exclusive is only valid when api_host is set.`
+        );
+      }
+    }
+
     for (const [area, value] of Object.entries(features)) {
       // Endpoint-override sub-keys (e.g. `pending_review_comments_endpoint`)
       // are validated separately below. Reject anything that ends in
@@ -909,6 +1005,31 @@ function validateRepoConfig(config) {
         throw new Error(
           `Invalid pair-review config: repos["${repoKey}"].url_pattern is not a valid regular expression: ${err.message}`
         );
+      }
+
+      // An `api_host`-bearing pattern must never match a canonical github.com /
+      // Graphite URL — doing so pre-pins a github PR to the alt host and bypasses
+      // the setup probe (a silent, durable wrong binding). Warn (do NOT throw —
+      // we must not break existing configs; parsePRUrl also guards this at
+      // runtime by discarding such matches) when the pattern is over-broad.
+      if (typeof repoEntry.api_host === 'string' && repoEntry.api_host) {
+        try {
+          const rx = new RegExp(repoEntry.url_pattern);
+          const canaries = [
+            'https://github.com/o/r/pull/1',
+            'https://app.graphite.dev/github/pr/o/r/1',
+            'https://app.graphite.com/github/o/r/pull/1'
+          ];
+          if (canaries.some((u) => rx.test(u))) {
+            logger.warn(
+              `repos["${repoKey}"].url_pattern also matches canonical github.com / Graphite URLs; ` +
+              `anchor it (e.g. start with "^https://<your-alt-host>/") so it never pre-pins a github.com ` +
+              `PR to the alt host. pair-review will still route such URLs to github.com.`
+            );
+          }
+        } catch {
+          // Invalid regex already reported above; nothing more to check.
+        }
       }
     }
 
@@ -1512,6 +1633,7 @@ module.exports = {
   validatePort,
   getGitHubToken,
   resolveHostBinding,
+  isExclusiveAltHost,
   invalidateTokenCache,
   validateRepoConfig,
   matchRepoByUrl,

--- a/src/database.js
+++ b/src/database.js
@@ -21,7 +21,7 @@ function getDbPath() {
 /**
  * Current schema version - increment this when adding new migrations
  */
-const CURRENT_SCHEMA_VERSION = 49;
+const CURRENT_SCHEMA_VERSION = 51;
 
 /**
  * Database schema SQL statements
@@ -123,6 +123,7 @@ const SCHEMA_SQL = {
       pr_data TEXT,
       last_ai_run_id TEXT,
       last_accessed_at TEXT,
+      host TEXT,
       UNIQUE(pr_number, repository)
     )
   `,
@@ -312,6 +313,7 @@ const SCHEMA_SQL = {
       html_url TEXT,
       state TEXT DEFAULT 'open',
       collection TEXT NOT NULL,
+      host TEXT,
       fetched_at DATETIME DEFAULT CURRENT_TIMESTAMP
     )
   `,
@@ -398,8 +400,14 @@ const INDEX_SQL = [
   'CREATE INDEX IF NOT EXISTS idx_context_files_review ON context_files(review_id)',
   // Hunk summaries indexes
   'CREATE INDEX IF NOT EXISTS idx_hunk_summaries_review ON hunk_summaries(review_id)',
-  // GitHub PR cache indexes
-  'CREATE UNIQUE INDEX IF NOT EXISTS idx_github_pr_cache_unique ON github_pr_cache(collection, owner, repo, number)',
+  // GitHub PR cache indexes. `host` is part of the unique key so a dual-host
+  // repo can cache the same (collection, owner, repo, number) from github.com
+  // (host NULL) AND its alt host (host = api_host URL) without colliding —
+  // independently-numbered PRs across systems overlap on small numbers. SQLite
+  // treats NULLs as distinct in unique indexes, so two NULL-host rows would not
+  // collide, but the collections refresh DELETEs the collection before
+  // re-inserting, so duplicate NULL-host rows can't accumulate. See migration 51.
+  'CREATE UNIQUE INDEX IF NOT EXISTS idx_github_pr_cache_unique ON github_pr_cache(collection, owner, repo, number, host)',
   // Worktree pool indexes
   'CREATE INDEX IF NOT EXISTS idx_worktree_pool_repo ON worktree_pool(repository)',
   'CREATE INDEX IF NOT EXISTS idx_worktree_pool_status ON worktree_pool(repository, status)',
@@ -1306,6 +1314,9 @@ const MIGRATIONS = {
           fetched_at DATETIME DEFAULT CURRENT_TIMESTAMP
         )
       `);
+      // Historical shape: no `host` column exists at v26 (added in migration
+      // 50). Migration 51 widens this index to include `host`. Do NOT add
+      // `host` here — it would reference a column that doesn't exist yet.
       db.exec('CREATE UNIQUE INDEX IF NOT EXISTS idx_github_pr_cache_unique ON github_pr_cache(collection, owner, repo, number)');
       console.log('  Created github_pr_cache table');
     } else {
@@ -2180,6 +2191,52 @@ const MIGRATIONS = {
       console.log('  Column is_file_level already exists');
     }
     console.log('Migration to schema version 49 complete');
+  },
+
+  // Migration to version 50: Add host column to pr_metadata and github_pr_cache
+  // for per-PR host resolution (dual GitHub + alt-host repos). NULL means
+  // github.com; otherwise the configured api_host URL string. No backfill — the
+  // NULL-means-github fallback makes existing rows resolve identically, and rows
+  // are re-stamped on next fetch. Each ALTER is guarded by columnExists so the
+  // migration is idempotent; single DDL statements need no transaction wrapper.
+  50: (db) => {
+    console.log('Running migration to schema version 50: Add host to pr_metadata and github_pr_cache...');
+    if (tableExists(db, 'pr_metadata') && !columnExists(db, 'pr_metadata', 'host')) {
+      db.exec('ALTER TABLE pr_metadata ADD COLUMN host TEXT');
+      console.log('  Added host column to pr_metadata');
+    } else {
+      console.log('  Column host already exists on pr_metadata (or table absent)');
+    }
+    if (tableExists(db, 'github_pr_cache') && !columnExists(db, 'github_pr_cache', 'host')) {
+      db.exec('ALTER TABLE github_pr_cache ADD COLUMN host TEXT');
+      console.log('  Added host column to github_pr_cache');
+    } else {
+      console.log('  Column host already exists on github_pr_cache (or table absent)');
+    }
+    console.log('Migration to schema version 50 complete');
+  },
+
+  // Migration to version 51: widen idx_github_pr_cache_unique to include host.
+  // The collections refresh inserts github rows (host NULL) and alt-host rows
+  // (host = api_host URL) under the same collection in one transaction. For a
+  // dual-host repo whose PRs are numbered independently per system, a shared
+  // (collection, owner, repo, number) would violate the old 4-column unique
+  // index — and the single throw rolls back the DELETE plus BOTH insert loops,
+  // so the user sees zero PRs for that collection. Adding host to the key lets
+  // the two systems' same-numbered PRs coexist. The new index is strictly wider
+  // than the old one, so existing data can never violate it. Idempotent:
+  // DROP IF EXISTS then CREATE IF NOT EXISTS yields the same shape on re-run and
+  // is safe on both a v50 DB (old 4-column index) and a fresh DB.
+  51: (db) => {
+    console.log('Running migration to schema version 51: widen idx_github_pr_cache_unique to include host...');
+    if (tableExists(db, 'github_pr_cache')) {
+      db.exec('DROP INDEX IF EXISTS idx_github_pr_cache_unique');
+      db.exec('CREATE UNIQUE INDEX IF NOT EXISTS idx_github_pr_cache_unique ON github_pr_cache(collection, owner, repo, number, host)');
+      console.log('  Rebuilt idx_github_pr_cache_unique with host in the key');
+    } else {
+      console.log('  Table github_pr_cache absent; nothing to reindex');
+    }
+    console.log('Migration to schema version 51 complete');
   }
 };
 
@@ -4998,6 +5055,52 @@ class PRMetadataRepository {
       head_sha: prData.head_sha,
       pr_data_parsed: prData
     };
+  }
+
+  /**
+   * Get the stored host binding for a PR.
+   *
+   * Distinguishes "no row" from "row says github". Used by per-PR host
+   * resolution (dual GitHub + alt-host repos) to decide which system a PR
+   * lives on before building a binding.
+   *
+   * @param {string} repository - Repository in owner/repo format
+   * @param {number} prNumber - Pull request number
+   * @returns {Promise<string|null|undefined>} The stored api_host URL string,
+   *   `null` when the row exists but host is unset (github.com), or `undefined`
+   *   when no pr_metadata row exists for the PR.
+   */
+  async getPRHost(repository, prNumber) {
+    const row = await queryOne(this.db, `
+      SELECT host FROM pr_metadata
+      WHERE pr_number = ? AND repository = ? COLLATE NOCASE
+    `, [prNumber, repository]);
+
+    if (!row) return undefined;
+    return row.host;
+  }
+
+  /**
+   * Update ONLY the host binding for a PR's metadata row.
+   *
+   * Used to persist an explicit host correction (e.g. a `?host` query param on
+   * the /pr fast path) without re-running full setup. Leaves every other column
+   * untouched.
+   *
+   * @param {string} repository - Repository in owner/repo format
+   * @param {number} prNumber - Pull request number
+   * @param {string|null} host - api_host URL string, or null for github.com
+   * @returns {Promise<boolean>} True if a matching row was updated, false when
+   *   no pr_metadata row exists for the PR.
+   */
+  async updatePRHost(repository, prNumber, host) {
+    const result = await run(this.db, `
+      UPDATE pr_metadata
+      SET host = ?, updated_at = CURRENT_TIMESTAMP
+      WHERE pr_number = ? AND repository = ? COLLATE NOCASE
+    `, [host, prNumber, repository]);
+
+    return result.changes > 0;
   }
 
   /**

--- a/src/external/github-adapter.js
+++ b/src/external/github-adapter.js
@@ -24,6 +24,7 @@ const {
   resolveHostBinding,
   resolveBindingRepositoryFromPR
 } = require('../config');
+const { storedHostToOption } = require('../utils/host-resolution');
 
 const name = 'github';
 
@@ -63,14 +64,26 @@ const credentialEnvVar = 'GITHUB_TOKEN';
  * diff-relative `position` field, so `mapComment` must anchor by `line`
  * instead — see its docstring.
  *
+ * Per-PR host: for a DUAL repo (github + alt-host) the binding depends on which
+ * system the PR actually lives on. The caller passes the PR's stored
+ * `pr_metadata.host` via `options.storedHost` (undefined | null | api_host URL);
+ * this method applies the legacy-NULL convention (`storedHostToOption`) and
+ * threads the resulting `{ host }` into `resolveHostBinding`, so a dual repo's
+ * alt-hosted PR resolves to the alt binding (and the line-based anchoring path)
+ * instead of always hitting api.github.com two-arg. When `options.storedHost`
+ * is omitted the two-arg ambiguity rule applies, unchanged.
+ *
  * @param {Object} config - Server config (see `loadConfig()`)
  * @param {string} [repository] - "owner/repo" identifier for binding-aware resolution
  * @param {Object} [_deps] - Test overrides for
  *   { GitHubClient, getGitHubToken, resolveHostBinding, resolveBindingRepositoryFromPR }
+ * @param {Object} [options] - Runtime resolution inputs
+ * @param {string|null|undefined} [options.storedHost] - The PR's stored
+ *   pr_metadata.host (undefined = no row / unknown, null = github.com, URL = alt host)
  * @returns {{ client: Object, isAltHost: boolean }}
  * @throws {GitHubApiError} with status 401 when no token is configured
  */
-function resolveCredentials(config, repository, _deps) {
+function resolveCredentials(config, repository, _deps, options = {}) {
   const deps = {
     GitHubClient,
     getGitHubToken,
@@ -82,10 +95,12 @@ function resolveCredentials(config, repository, _deps) {
 
   if (repository) {
     // Binding-aware path. Mirrors resolveBindingForRequest in routes/pr.js:
-    // resolve the PR identity to a binding key, then to a host binding.
+    // resolve the PR identity to a binding key, then to a host binding —
+    // pinned to the PR's stored host for dual repos.
     const [owner, repo] = String(repository).split('/');
     const bindingRepository = deps.resolveBindingRepositoryFromPR(owner, repo, safeConfig);
-    const binding = deps.resolveHostBinding(bindingRepository, safeConfig);
+    const hostOption = storedHostToOption(safeConfig, bindingRepository, options.storedHost);
+    const binding = deps.resolveHostBinding(bindingRepository, safeConfig, hostOption || {});
     if (!binding || !binding.token) {
       throw new GitHubApiError(
         `GitHub token not configured for ${repository}. Set ${credentialEnvVar}, add github_token to ~/.pair-review/config.json, or configure repos["${bindingRepository}"].token / token_command (required for alt-host repos)`,

--- a/src/github/client.js
+++ b/src/github/client.js
@@ -1138,6 +1138,43 @@ class GitHubClient {
   }
 
   /**
+   * List open pull requests for a single repository via the REST API.
+   *
+   * Used by the dashboard collections sweep against alt-hosts, which speak a
+   * REST subset and generally have no Search API. The returned rows carry the
+   * classification fields (`author`, `requested_reviewers`, `requested_teams`)
+   * so the caller can bucket each PR into a collection locally, plus the same
+   * display fields `searchPullRequests` returns so both paths cache uniformly.
+   *
+   * @param {string} owner - Repository owner
+   * @param {string} repo - Repository name
+   * @returns {Promise<Array<{owner: string, repo: string, number: number, title: string, author: string|null, updated_at: string, html_url: string, state: string, requested_reviewers: string[], requested_teams: string[]}>>}
+   */
+  async listOpenPullRequests(owner, repo) {
+    const pulls = await this.octokit.paginate(
+      this.octokit.rest.pulls.list,
+      { owner, repo, state: 'open', per_page: 100 }
+    );
+
+    return pulls.map(pr => ({
+      owner,
+      repo,
+      number: pr.number,
+      title: pr.title,
+      author: pr.user?.login || null,
+      updated_at: pr.updated_at,
+      html_url: pr.html_url,
+      state: pr.state,
+      requested_reviewers: Array.isArray(pr.requested_reviewers)
+        ? pr.requested_reviewers.map(r => r && r.login).filter(Boolean)
+        : [],
+      requested_teams: Array.isArray(pr.requested_teams)
+        ? pr.requested_teams.map(t => t && t.slug).filter(Boolean)
+        : []
+    }));
+  }
+
+  /**
    * Get the authenticated user's information.
    * @returns {Promise<{login: string, name: string, avatar_url: string}>}
    */

--- a/src/github/parser.js
+++ b/src/github/parser.js
@@ -90,11 +90,20 @@ class PRArgumentParser {
     if (!owner || !repo || typeof number !== 'number' || isNaN(number) || number <= 0) {
       return null;
     }
+    // Carry the matched repo's `api_host` so downstream setup binds the PR to
+    // the alternate host without probing. A `url_pattern` match on a repo with
+    // no `api_host` (a plain github.com entry) resolves to `host: null`.
+    const matchedApiHost = (match.repoConfig
+      && typeof match.repoConfig.api_host === 'string'
+      && match.repoConfig.api_host)
+      ? match.repoConfig.api_host
+      : null;
     return {
       owner,
       repo,
       number,
-      bindingRepository: match.bindingRepository
+      bindingRepository: match.bindingRepository,
+      host: matchedApiHost
     };
   }
 
@@ -114,16 +123,30 @@ class PRArgumentParser {
       return null;
     }
 
+    // Clean up the URL - trim whitespace
+    const trimmedUrl = url.trim();
+
     // Try config-driven URL pattern matching first. This handles
     // alternate-host URLs and lets host-specific repos override the
     // built-in github.com path if they choose.
-    const configMatch = this._matchUrlPatternFromConfig(url.trim());
+    const configMatch = this._matchUrlPatternFromConfig(trimmedUrl);
     if (configMatch) {
-      return configMatch;
+      // INVARIANT: an `api_host`-bearing `url_pattern` must NEVER bind a
+      // canonical github.com / Graphite URL. An over-broad or unanchored pattern
+      // can match one and pre-pin it to the alt host (an explicit host bypasses
+      // the setup probe → a silent, durable wrong binding). When the config
+      // match carries an alt host but the URL is a canonical github/graphite URL,
+      // discard the match and fall through to the built-in parsers (host: null).
+      const sansProtocol = trimmedUrl.replace(/^https?:\/\//i, '');
+      const isCanonicalHostUrl = sansProtocol.startsWith('github.com/')
+        || sansProtocol.startsWith('app.graphite.dev/')
+        || sansProtocol.startsWith('app.graphite.com/');
+      if (!(configMatch.host && isCanonicalHostUrl)) {
+        return configMatch;
+      }
     }
 
-    // Clean up the URL - trim whitespace
-    let normalizedUrl = url.trim();
+    let normalizedUrl = trimmedUrl;
 
     // Add https:// if no protocol is present
     if (normalizedUrl.startsWith('github.com')) {
@@ -222,7 +245,9 @@ class PRArgumentParser {
    * @param {string} repo - Repository name
    * @param {string} numberStr - PR number as string
    * @param {string} source - Source name for error messages ('GitHub' or 'Graphite')
-   * @returns {Object} Validated PR info { owner, repo, number }
+   * @returns {Object} Validated PR info `{ owner, repo, number, host? }`. `host`
+   *   is `null` for github.com/Graphite URLs (definitively github); it is OMITTED
+   *   (undefined) for the pair-review:// scheme, which carries no host in its path.
    * @private
    */
   _createPRInfo(owner, repo, numberStr, source) {
@@ -237,7 +262,16 @@ class PRArgumentParser {
       throw new Error(`Invalid ${source} URL format. Expected: ${exampleUrl}`);
     }
 
-    return { owner, repo, number };
+    // A github.com or Graphite URL unambiguously identifies a github.com PR, so
+    // the host is explicitly null (not "unknown"). The pair-review:// scheme
+    // carries NO host in its path and is not github-only, so leave `host`
+    // undefined — it flows into the probe/derive path like a bare number,
+    // instead of self-healing (dual repo) or throwing (exclusive alt) on github.
+    const result = { owner, repo, number };
+    if (source !== 'pair-review://') {
+      result.host = null;
+    }
+    return result;
   }
 
   /**

--- a/src/links/repo-links.js
+++ b/src/links/repo-links.js
@@ -31,6 +31,7 @@
  */
 
 const { getRepoConfig } = require('../config');
+const { isDualHostRepoConfig } = require('../utils/host-resolution');
 const logger = require('../utils/logger');
 
 // Whitelist of allowed `{placeholder}` names. Anything else in the template
@@ -158,13 +159,28 @@ function sanitizeSvgIcon(svg) {
  * malformed), a warning is logged and `icon` becomes `null` — the link
  * is still rendered, just without a custom icon.
  *
+ * **Per-PR host awareness (dual-host repos only).** `host` is the PR's
+ * resolved host: `null` = github.com, an `api_host` URL string = the alt
+ * host, `undefined` = unknown / not applicable. It only affects a
+ * *dual-host* repo (`api_host` + `exclusive: false`):
+ *   - `host === null` (github-hosted PR) → keep the GitHub/Graphite links
+ *     (subject to any explicit `links.github/graphite: false`) and hide the
+ *     alt-host external link.
+ *   - `host === '<url>'` (alt-hosted PR) → keep the external link and hide
+ *     the GitHub/Graphite links.
+ * Exclusive alt-host repos and plain github repos ignore `host` entirely, so
+ * existing two-arg callers (and `host === undefined`) render byte-identically
+ * to before this parameter existed.
+ *
  * @param {Object} config
  * @param {string} repository  Canonical `owner/repo` identifier
+ * @param {string|null} [host]  PR's resolved host: null=github, url=alt,
+ *                              undefined=unknown/not applicable
  * @returns {{ external: { label: string, url_template: string, icon: string|null }|null,
  *             github: boolean,
  *             graphite: boolean }}
  */
-function resolveRepoLinks(config, repository) {
+function resolveRepoLinks(config, repository, host = undefined) {
   const result = { external: null, github: true, graphite: true };
   if (!config || !repository) return result;
 
@@ -172,33 +188,47 @@ function resolveRepoLinks(config, repository) {
   if (!repoConfig || typeof repoConfig !== 'object') return result;
 
   const links = repoConfig.links;
-  if (!links || typeof links !== 'object') return result;
+  if (links && typeof links === 'object') {
+    if (links.github === false) result.github = false;
+    if (links.graphite === false) result.graphite = false;
 
-  if (links.github === false) result.github = false;
-  if (links.graphite === false) result.graphite = false;
-
-  const ext = links.external;
-  if (ext && typeof ext === 'object'
-      && typeof ext.label === 'string' && ext.label
-      && typeof ext.url_template === 'string'
-      && ext.url_template.startsWith('https://')) {
-    let icon = null;
-    if (ext.icon !== undefined && ext.icon !== null && ext.icon !== '') {
-      icon = sanitizeSvgIcon(ext.icon);
-      if (icon === null) {
-        logger.warn(
-          `Dropping links.external.icon for "${repository}" — failed sanitisation.`
-        );
+    const ext = links.external;
+    if (ext && typeof ext === 'object'
+        && typeof ext.label === 'string' && ext.label
+        && typeof ext.url_template === 'string'
+        && ext.url_template.startsWith('https://')) {
+      let icon = null;
+      if (ext.icon !== undefined && ext.icon !== null && ext.icon !== '') {
+        icon = sanitizeSvgIcon(ext.icon);
+        if (icon === null) {
+          logger.warn(
+            `Dropping links.external.icon for "${repository}" — failed sanitisation.`
+          );
+        }
       }
+      result.external = {
+        // Optional host display name (e.g. "Meteorite"). When absent, the
+        // field is null and consumers fall back to "GitHub" via resolveHostName.
+        name: (typeof ext.name === 'string' && ext.name) ? ext.name : null,
+        label: ext.label,
+        url_template: ext.url_template,
+        icon
+      };
     }
-    result.external = {
-      // Optional host display name (e.g. "Meteorite"). When absent, the
-      // field is null and consumers fall back to "GitHub" via resolveHostName.
-      name: (typeof ext.name === 'string' && ext.name) ? ext.name : null,
-      label: ext.label,
-      url_template: ext.url_template,
-      icon
-    };
+  }
+
+  // Per-PR host awareness for dual-host repos. A `host` of `undefined`
+  // (omitted arg, unknown host) leaves the repo-level result untouched, so
+  // non-dual repos and legacy two-arg callers are unaffected.
+  if (host !== undefined && isDualHostRepoConfig(repoConfig)) {
+    if (host === null) {
+      // github-hosted PR: the alt-host external link does not apply.
+      result.external = null;
+    } else {
+      // alt-hosted PR: hide the GitHub/Graphite links, keep the external one.
+      result.github = false;
+      result.graphite = false;
+    }
   }
 
   return result;
@@ -212,12 +242,20 @@ function resolveRepoLinks(config, repository) {
  * `"GitHub"`. This is the server-side counterpart to the frontend
  * `window.RepoLinks.hostName()` accessor.
  *
+ * Host-aware for dual-host repos: a github-hosted PR (`host === null`)
+ * reports "GitHub" even when an external name is configured, because
+ * `resolveRepoLinks` clears the external link for that host. See
+ * `resolveRepoLinks` for the `host` semantics. Non-dual repos and two-arg
+ * callers behave exactly as before.
+ *
  * @param {Object} config
  * @param {string} repository  Canonical `owner/repo` identifier
+ * @param {string|null} [host]  PR's resolved host: null=github, url=alt,
+ *                              undefined=unknown/not applicable
  * @returns {string} The configured host name, or "GitHub" by default
  */
-function resolveHostName(config, repository) {
-  const links = resolveRepoLinks(config, repository);
+function resolveHostName(config, repository, host = undefined) {
+  const links = resolveRepoLinks(config, repository, host);
   return (links.external && links.external.name) ? links.external.name : 'GitHub';
 }
 

--- a/src/main.js
+++ b/src/main.js
@@ -1,7 +1,7 @@
 // Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
 const fs = require('fs');
 const { v4: uuidv4 } = require('uuid');
-const { loadConfig, getConfigDir, getGitHubToken, resolveHostBinding, showWelcomeMessage, resolveDbName, resolveRepoOptions, resolvePoolConfig, getRepoResetScript, resolveLoadSkills, buildCouncilProviderOverrides } = require('./config');
+const { loadConfig, getConfigDir, showWelcomeMessage, resolveDbName, resolveRepoOptions, resolvePoolConfig, getRepoResetScript, resolveLoadSkills, buildCouncilProviderOverrides } = require('./config');
 const { initializeDatabase, run, queryOne, query, migrateExistingWorktrees, WorktreeRepository, ReviewRepository, RepoSettingsRepository, GitHubReviewRepository, WorktreePoolRepository, CouncilRepository, CommentRepository, AnalysisRunRepository } = require('./database');
 const { PRArgumentParser } = require('./github/parser');
 const { GitHubClient } = require('./github/client');
@@ -21,7 +21,8 @@ const { redirectConsoleToStderr } = require('./mcp-stdio');
 const { getChangedFiles } = require('./routes/executable-analysis');
 const { safeParseJson } = require('./utils/safe-parse-json');
 const { includesBranch } = require('./local-scope');
-const { storePRData, registerRepositoryLocation, findRepositoryPath } = require('./setup/pr-setup');
+const { storePRData, resolvePrHostBinding, registerRepositoryLocation, findRepositoryPath } = require('./setup/pr-setup');
+const { isDualHostRepo, resolvePreflightBinding, hostSetupParamValue } = require('./utils/host-resolution');
 const { fireReviewStartedHook } = require('./hooks/payloads');
 const { normalizeRepository, resolveRenamedFile, resolveRenamedFileOld } = require('./utils/paths');
 const { rejectUrlLikeLocalReviewPath } = require('./utils/local-path-input');
@@ -954,7 +955,12 @@ async function handlePullRequest(args, config, db, flags = {}, poolLifecycle = n
     // captured `${owner}/${repo}` for monorepo-style patterns.
     const repositoryForBinding = prInfo.bindingRepository
       || normalizeRepository(prInfo.owner, prInfo.repo);
-    const binding = resolveHostBinding(repositoryForBinding, config);
+    // A pasted URL tells us the host up front (alt-host `url_pattern` match →
+    // api_host string; github/graphite URL → null), so preflight the token
+    // against that host. A bare number leaves host undefined → ambiguity rule,
+    // but a dual repo with only an alt token is still usable (the setup probe
+    // tries the alt host first) — resolvePreflightBinding tolerates that.
+    const binding = resolvePreflightBinding(repositoryForBinding, config, prInfo.host);
     if (!binding.token) {
       throw new Error(buildMissingTokenError({
         owner: prInfo.owner,
@@ -1009,6 +1015,15 @@ async function handlePullRequest(args, config, db, flags = {}, poolLifecycle = n
       url += `&analysisConfigId=${analysisConfigId}`;
     } else if (councilSelection) {
       url += `&council=${councilSelection.id}`;
+    }
+
+    // Thread the pasted URL's host to setup so it binds directly instead of
+    // probing (shared mapping — see hostSetupParamValue): an alt-host string
+    // forwards the api_host; a github URL on a DUAL repo forwards the 'github'
+    // sentinel; bare numbers / plain / exclusive repos omit it.
+    const hostParam = hostSetupParamValue(prInfo.host, isDualHostRepo(config, repositoryForBinding));
+    if (hostParam) {
+      url += (url.includes('?') ? '&' : '?') + `host=${encodeURIComponent(hostParam)}`;
     }
 
     console.log(`Opening browser to: ${url}`);
@@ -1107,29 +1122,34 @@ async function performHeadlessReview(args, config, db, flags, options, externalP
     // serves many monorepo-shaped URLs.
     const repositoryForBinding = prInfo.bindingRepository
       || normalizeRepository(prInfo.owner, prInfo.repo);
-    const headlessBinding = resolveHostBinding(repositoryForBinding, config);
-    if (!headlessBinding.token) {
+    // Preflight the token so a missing credential fails fast before any network
+    // work. Tolerates a dual repo with only an alt token when the host is
+    // unknown (the setup probe tries the alt host first).
+    const preflightBinding = resolvePreflightBinding(repositoryForBinding, config, prInfo.host);
+    if (!preflightBinding.token) {
       throw new Error(buildMissingTokenError({
         owner: prInfo.owner,
         repo: prInfo.repo,
         bindingRepository: repositoryForBinding,
-        apiHost: headlessBinding.apiHost
+        apiHost: preflightBinding.apiHost
       }));
     }
-    const githubToken = headlessBinding.token;
 
     console.log(`Processing pull request #${prInfo.number} from ${prInfo.owner}/${prInfo.repo} in ${options.modeLabel}`);
 
-    // Create GitHub client and verify repository access
-    const githubClient = new GitHubClient(headlessBinding);
-    const repoExists = await githubClient.repositoryExists(prInfo.owner, prInfo.repo);
-    if (!repoExists) {
-      throw new Error(`Repository ${prInfo.owner}/${prInfo.repo} not found or not accessible`);
-    }
-
-    // Fetch PR data from GitHub
+    // Resolve the per-PR host binding and fetch the PR. Applies host precedence
+    // (URL-paste host → stored host → ambiguity/probe for dual repos) and
+    // returns the chosen binding so its host is stamped by storePRData below.
     console.log('Fetching pull request data from GitHub...');
-    const prData = await githubClient.fetchPullRequest(prInfo.owner, prInfo.repo, prInfo.number);
+    const { binding: headlessBinding, prData, githubClient } = await resolvePrHostBinding({
+      db, config, bindingRepository: repositoryForBinding,
+      owner: prInfo.owner, repo: prInfo.repo, prNumber: prInfo.number,
+      // Only forward a github.com token as the github fallback; if the preflight
+      // resolved an ALT binding (dual repo, alt-only token), there is no github
+      // fallback token, so pass '' rather than sending the alt token to github.com.
+      host: prInfo.host, githubToken: preflightBinding.apiHost === null ? preflightBinding.token : ''
+    });
+    const githubToken = headlessBinding.token || preflightBinding.token;
 
     let worktreePath;
     let diff;
@@ -1290,7 +1310,8 @@ async function performHeadlessReview(args, config, db, flags, options, externalP
     // Store PR data in database
     console.log('Storing pull request data...');
     const { isNewReview, reviewId: storedReviewId } = await storePRData(db, prInfo, prData, diff, changedFiles, worktreePath, {
-      skipWorktreeRecord: !!flags.useCheckout
+      skipWorktreeRecord: !!flags.useCheckout,
+      host: headlessBinding.host
     });
 
     // Persist review→worktree mapping in DB for pool usage tracking
@@ -1736,26 +1757,30 @@ async function preparePrHeadless(db, config, flags, prArgs, externalPoolLifecycl
 
   const repositoryForBinding = prInfo.bindingRepository
     || normalizeRepository(prInfo.owner, prInfo.repo);
-  const headlessBinding = resolveHostBinding(repositoryForBinding, config);
-  if (!headlessBinding.token) {
+  // Preflight the token so a missing credential fails fast before any network
+  // work. Tolerates a dual repo with only an alt token when the host is unknown
+  // (the setup probe tries the alt host first).
+  const preflightBinding = resolvePreflightBinding(repositoryForBinding, config, prInfo.host);
+  if (!preflightBinding.token) {
     throw new Error(buildMissingTokenError({
       owner: prInfo.owner,
       repo: prInfo.repo,
       bindingRepository: repositoryForBinding,
-      apiHost: headlessBinding.apiHost
+      apiHost: preflightBinding.apiHost
     }));
   }
 
   console.log(`Processing pull request #${prInfo.number} from ${prInfo.owner}/${prInfo.repo} in headless mode`);
 
-  const githubClient = new GitHubClient(headlessBinding);
-  const repoExists = await githubClient.repositoryExists(prInfo.owner, prInfo.repo);
-  if (!repoExists) {
-    throw new Error(`Repository ${prInfo.owner}/${prInfo.repo} not found or not accessible`);
-  }
-
+  // Resolve the per-PR host binding and fetch (host precedence: URL-paste host
+  // → stored host → ambiguity/probe for dual repos).
   console.log('Fetching pull request data from GitHub...');
-  const prData = await githubClient.fetchPullRequest(prInfo.owner, prInfo.repo, prInfo.number);
+  const { binding: headlessBinding, prData, githubClient } = await resolvePrHostBinding({
+    db, config, bindingRepository: repositoryForBinding,
+    owner: prInfo.owner, repo: prInfo.repo, prNumber: prInfo.number,
+    // Only forward a github.com token as the github fallback (see performHeadlessReview).
+    host: prInfo.host, githubToken: preflightBinding.apiHost === null ? preflightBinding.token : ''
+  });
 
   let worktreePath;
   let diff;
@@ -1903,7 +1928,8 @@ async function preparePrHeadless(db, config, flags, prArgs, externalPoolLifecycl
 
   console.log('Storing pull request data...');
   const { isNewReview, reviewId: storedReviewId } = await storePRData(db, prInfo, prData, diff, changedFiles, worktreePath, {
-    skipWorktreeRecord: !!flags.useCheckout
+    skipWorktreeRecord: !!flags.useCheckout,
+    host: headlessBinding.host
   });
 
   if (poolWorktreeId && poolLifecycle) {

--- a/src/routes/config.js
+++ b/src/routes/config.js
@@ -10,7 +10,7 @@
  */
 
 const express = require('express');
-const { RepoSettingsRepository, ReviewRepository, queryOne } = require('../database');
+const { RepoSettingsRepository, ReviewRepository, PRMetadataRepository, queryOne } = require('../database');
 const {
   getAllProvidersInfo,
   testProviderAvailability,
@@ -21,12 +21,12 @@ const {
   modelMatches
 } = require('../ai');
 const { normalizeRepository } = require('../utils/paths');
+const { resolvePreflightBinding } = require('../utils/host-resolution');
 const {
   isRunningViaNpx,
   getGitHubToken,
   getDefaultProvider,
   getDefaultModel,
-  resolveHostBinding,
   resolveBindingRepositoryFromPR,
   getSummaryEnabled,
   getSummaryAutoGenerate,
@@ -82,10 +82,11 @@ router.get('/runtime-config.js', (req, res) => {
  *   - has_global_github_token: always present. True iff `getGitHubToken(config)`
  *     resolves a token from the top-level config / env (no repo context).
  *   - has_github_token: present ONLY when both ?owner and ?repo query
- *     parameters are supplied. True iff a token can be resolved for that
- *     specific repository via `resolveHostBinding(repo, config)` — this
- *     covers repo-scoped `token`, `token_command`, alt-host bindings, AND
- *     falls through to the global lookup. Callers that know which repo
+ *     parameters are supplied. True iff ANY usable binding for that specific
+ *     repository resolves a token (`resolvePreflightBinding`) — this covers
+ *     repo-scoped `token`, `token_command`, alt-host bindings, a DUAL repo whose
+ *     only credential is the alt-host token, AND falls through to the global
+ *     lookup. Callers that know which repo
  *     they're rendering should pass these params so that repo-scoped
  *     authentication is reflected accurately (e.g. for deciding whether
  *     to enable GitHub-comment dedup). When the params are absent, the
@@ -146,10 +147,14 @@ router.get('/api/config', (req, res) => {
   let hasRepoGithubToken = null;
   if (hasRepoContext) {
     const repository = `${owner}/${repo}`;
-    // resolveHostBinding already falls through to top-level config when
-    // no repo-scoped token is configured, so this is a true union of
-    // "repo-scoped binding works" OR "global token works".
-    hasRepoGithubToken = Boolean(resolveHostBinding(repository, config).token);
+    // "Has any usable binding" semantics. resolveHostBinding already falls
+    // through to top-level config when no repo-scoped token is configured, so
+    // the no-host lookup unions "repo-scoped binding works" OR "global token
+    // works". But for a DUAL repo the no-host lookup uses the github ambiguity
+    // binding, which misses a repo whose only credential is the alt-host token —
+    // resolvePreflightBinding additionally tries the alt candidate, so an
+    // alt-only dual repo reports true (matching what setup/probe will do).
+    hasRepoGithubToken = Boolean(resolvePreflightBinding(repository, config, undefined).token);
   }
 
   // Only return safe configuration values (not secrets like github_token)
@@ -301,8 +306,14 @@ router.get('/api/repos/:owner/:repo/settings', async (req, res) => {
  * `javascript:` URLs stripped). The url_template is NOT substituted here —
  * the frontend has the live PR/branch context, so it performs the
  * whitelisted substitution at render time.
+ *
+ * Optional `?number=<n>` query: the PR number the header is being rendered
+ * for. For a dual-host repo (`api_host` + `exclusive: false`) the link set
+ * depends on which system the PR lives on, so we look up the PR's stored host
+ * and resolve links against it. Omitted (Local mode, plain/exclusive repos)
+ * or an unknown PR → repo-level defaults, byte-identical to before.
  */
-router.get('/api/repos/:owner/:repo/links', (req, res) => {
+router.get('/api/repos/:owner/:repo/links', async (req, res) => {
   try {
     const { owner, repo } = req.params;
     const repository = normalizeRepository(owner, repo);
@@ -311,7 +322,21 @@ router.get('/api/repos/:owner/:repo/links', (req, res) => {
     // `repos[...]` entry serving many captured owner/repo via
     // url_pattern) surface the right link config.
     const bindingRepository = resolveBindingRepositoryFromPR(owner, repo, config);
-    const links = resolveRepoLinks(config, bindingRepository);
+
+    // Per-PR host awareness: when the caller names a PR, look up its stored
+    // host so a dual-host repo shows the correct link set (github links for a
+    // github-hosted PR, the external link for an alt-hosted one). A missing
+    // row leaves `host` undefined, which resolveRepoLinks treats as the
+    // repo-level default — so non-dual repos are unaffected regardless.
+    let host;
+    const prNumber = parseInt(req.query.number, 10);
+    if (Number.isInteger(prNumber) && prNumber > 0) {
+      const prMetadataRepo = new PRMetadataRepository(req.app.get('db'));
+      const storedHost = await prMetadataRepo.getPRHost(repository, prNumber);
+      if (storedHost !== undefined) host = storedHost;
+    }
+
+    const links = resolveRepoLinks(config, bindingRepository, host);
     res.json({ repository, links });
   } catch (error) {
     logger.error('Error resolving repo links:', error);

--- a/src/routes/external-comments.js
+++ b/src/routes/external-comments.js
@@ -20,6 +20,7 @@ const express = require('express');
 const {
   ExternalCommentRepository,
   ReviewRepository,
+  PRMetadataRepository,
   withTransaction
 } = require('../database');
 const { getAdapter } = require('../external');
@@ -135,6 +136,17 @@ async function executeSync({ db, config, review, source, _deps }) {
     );
   }
 
+  // Look up the PR's stored host so a DUAL repo's alt-hosted PR binds to the
+  // alt host (and its line-based anchoring path) rather than api.github.com.
+  // Pass the raw stored value through to the adapter, which applies the
+  // legacy-NULL convention against its resolved binding key. `undefined`
+  // (no row / unknown) preserves the two-arg ambiguity behaviour.
+  let storedHost;
+  if (Number.isInteger(review.pr_number)) {
+    const prMetadataRepo = new PRMetadataRepository(db);
+    storedHost = await prMetadataRepo.getPRHost(review.repository, review.pr_number);
+  }
+
   // Delegate credential resolution to the adapter so the route stays
   // source-agnostic and each adapter can name its own env var in errors.
   // Thread `review.repository` through so the adapter resolves the
@@ -145,7 +157,7 @@ async function executeSync({ db, config, review, source, _deps }) {
   // `isAltHost` reflects whether the resolved binding targets an alternate
   // Git host. Alt-hosts don't implement GitHub's deprecated `position`
   // field, so it drives line-based anchoring in `mapComment` below.
-  const { client, isAltHost } = adapter.resolveCredentials(config || {}, review.repository, _deps);
+  const { client, isAltHost } = adapter.resolveCredentials(config || {}, review.repository, _deps, { storedHost });
 
   const apiRows = await adapter.fetchComments({
     client,

--- a/src/routes/github-collections.js
+++ b/src/routes/github-collections.js
@@ -16,12 +16,15 @@
 const express = require('express');
 const { query, run, withTransaction } = require('../database');
 const { GitHubClient } = require('../github/client');
-const { getGitHubToken } = require('../config');
+const { getGitHubToken, resolveHostBinding } = require('../config');
 const logger = require('../utils/logger');
 
 const router = express.Router();
 
-const SELECT_COLUMNS = 'owner, repo, number, title, author, updated_at, html_url, state, fetched_at';
+// `host` is additive: NULL for github.com rows, the repo's `api_host` URL for
+// alt-host rows. Both GET and the refresh re-read echo it so the frontend can
+// open a PR against the system it actually lives on without re-probing.
+const SELECT_COLUMNS = 'owner, repo, number, title, author, updated_at, html_url, state, fetched_at, host';
 
 // Valid `org/team` slug: two non-empty segments of GitHub-allowed characters.
 // Used to guard against query injection when interpolating the team into the
@@ -40,11 +43,18 @@ const TEAM_SLUG_PATTERN = /^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/;
  * namespaced cache entry for a query whose results are identical to the
  * unfiltered view.
  */
+// Each definition also carries a `classifyAlt(pr, login, team)` predicate that
+// buckets a REST-listed alt-host PR into this collection. Alt-hosts generally
+// have no Search API, so the collection semantics that `buildQuery` expresses
+// as a github.com search string are re-expressed here as a local predicate
+// over the fields `client.listOpenPullRequests` returns. `pr.requested_teams`
+// holds team *slugs*; `team`, when set, is a validated `org/team` slug.
 const COLLECTIONS = [
   {
     name: 'review-requests',
     label: 'review requests',
-    buildQuery: (login) => `is:pr is:open archived:false user-review-requested:${login}`
+    buildQuery: (login) => `is:pr is:open archived:false user-review-requested:${login}`,
+    classifyAlt: (pr, login) => pr.requested_reviewers.includes(login)
   },
   {
     name: 'team-reviews',
@@ -63,14 +73,127 @@ const COLLECTIONS = [
         return `is:pr is:open archived:false team-review-requested:${team}`;
       }
       return `is:pr is:open archived:false review-requested:${login} -user-review-requested:${login}`;
+    },
+    // A specific `team` filters to PRs requesting that team's slug (the part
+    // after the slash, since REST `requested_teams` carries bare slugs, not
+    // `org/team`); the all-teams view keeps the same "exclude direct requests"
+    // rule as the github.com search so a directly-requested PR shows under
+    // review-requests, not here.
+    classifyAlt: (pr, login, team) => {
+      if (pr.requested_teams.length === 0) return false;
+      if (team) {
+        const slug = team.slice(team.indexOf('/') + 1);
+        return pr.requested_teams.includes(slug);
+      }
+      return !pr.requested_reviewers.includes(login);
     }
   },
   {
     name: 'my-prs',
     label: 'your pull requests',
-    buildQuery: (login) => `is:pr is:open archived:false author:${login}`
+    buildQuery: (login) => `is:pr is:open archived:false author:${login}`,
+    classifyAlt: (pr, login) => pr.author === login
   }
 ];
+
+/**
+ * Derive an `owner/repo` pair from a `config.repos` key. Alt-host config
+ * entries are keyed by the canonical `owner/repo`; monorepo-style entries can
+ * be keyed by something else and matched to PRs via `url_pattern`, but the
+ * collections sweep needs a concrete owner/repo to call `pulls.list`, so those
+ * keys are skipped rather than guessed at.
+ * @param {string} repoKey - A `config.repos` key.
+ * @returns {{ owner: string, repo: string }|null} Null when not owner/repo shaped.
+ */
+function ownerRepoFromKey(repoKey) {
+  if (typeof repoKey !== 'string') return null;
+  const parts = repoKey.split('/');
+  if (parts.length !== 2 || !parts[0] || !parts[1]) return null;
+  return { owner: parts[0], repo: parts[1] };
+}
+
+/**
+ * Sweep every alt-host repo in config for open PRs belonging to `collection`,
+ * classifying each with `def.classifyAlt`. Best-effort per host: a failure for
+ * one repo is captured in the returned `hosts` array and never thrown, so the
+ * github.com results already gathered by the caller are never lost. Rows are
+ * stamped with the repo's `api_host` string for the `host` column.
+ *
+ * `credentialedRepoCount` counts alt-host repos that resolved a non-empty
+ * token (i.e. could authenticate), regardless of whether the subsequent fetch
+ * then succeeded. The refresh route uses it to decide whether ANY source can
+ * authenticate before returning 401 on an install with no github.com token.
+ *
+ * @param {Object} config - Server config (from loadConfig()).
+ * @param {Object} def - The collection definition (needs `classifyAlt`).
+ * @param {string|null} team - Validated `org/team` filter, or null.
+ * @returns {Promise<{ rows: Array<Object>, hosts: Array<{host: string, repo: string, ok: boolean, error?: string}>, credentialedRepoCount: number }>}
+ */
+async function sweepAltHosts(config, def, team) {
+  const rows = [];
+  const hosts = [];
+  let credentialedRepoCount = 0;
+  const repos = (config && config.repos) || {};
+  if (typeof def.classifyAlt !== 'function') {
+    return { rows, hosts, credentialedRepoCount };
+  }
+
+  // One `GET /user` per (host, token) per refresh — multiple repos can share a
+  // host, and a login lookup per repo would be wasteful. Keyed by token too so
+  // distinct credentials on the same host resolve their own identity.
+  const loginCache = new Map();
+
+  for (const [repoKey, repoEntry] of Object.entries(repos)) {
+    if (!repoEntry || typeof repoEntry !== 'object') continue;
+    const apiHost = (typeof repoEntry.api_host === 'string' && repoEntry.api_host) ? repoEntry.api_host : null;
+    if (!apiHost) continue;
+
+    const ownerRepo = ownerRepoFromKey(repoKey);
+    if (!ownerRepo) {
+      logger.warn(`Collections: skipping alt-host repo "${repoKey}" (${apiHost}) — key is not an owner/repo pair, cannot derive a repo for pulls.list`);
+      hosts.push({ host: apiHost, repo: repoKey, ok: false, error: 'config key is not an owner/repo pair' });
+      continue;
+    }
+
+    try {
+      const binding = resolveHostBinding(repoKey, config, { host: apiHost });
+
+      // A repo with `api_host` but no repo-scoped token yields an empty-token
+      // binding. Probing anyway would 401 once per collection per refresh and
+      // spam error logs; surface it as a per-host status instead (debug, not
+      // error — it's a config gap, not a runtime failure).
+      if (!binding.token) {
+        logger.debug(`Collections: skipping alt-host repo "${repoKey}" (${apiHost}) — no repo-scoped credentials configured`);
+        hosts.push({ host: apiHost, repo: repoKey, ok: false, error: 'no credentials configured' });
+        continue;
+      }
+      credentialedRepoCount++;
+
+      const client = new GitHubClient(binding);
+
+      const loginKey = `${apiHost}\u0000${binding.token}`;
+      let login = loginCache.get(loginKey);
+      if (login === undefined) {
+        const user = await client.getAuthenticatedUser();
+        login = user.login;
+        loginCache.set(loginKey, login);
+      }
+
+      const prs = await client.listOpenPullRequests(ownerRepo.owner, ownerRepo.repo);
+      for (const pr of prs) {
+        if (def.classifyAlt(pr, login, team)) {
+          rows.push({ ...pr, host: apiHost });
+        }
+      }
+      hosts.push({ host: apiHost, repo: repoKey, ok: true });
+    } catch (error) {
+      logger.error(`Collections: alt-host refresh failed for ${repoKey} (${apiHost}): ${error.message}`);
+      hosts.push({ host: apiHost, repo: repoKey, ok: false, error: error.message });
+    }
+  }
+
+  return { rows, hosts, credentialedRepoCount };
+}
 
 /**
  * Derive the cache storage key for a collection, namespacing by team so a
@@ -161,17 +284,40 @@ function registerCollection(def) {
       }
 
       const config = req.app.get('config');
+      const db = req.app.get('db');
+
+      // The dashboard has two independent PR sources: the github.com search
+      // (top-level token) and the per-repo alt-host sweep. Treat them
+      // independently so an alt-host-only install (repo-scoped alt credentials,
+      // NO global github token) can still refresh. A missing github token skips
+      // ONLY the github branch; a per-source status is recorded instead.
       // Cross-repo search on github.com — no per-repo binding applies here.
       // Explicit `undefined` repository selects the no-repo (top-level) path.
       const githubToken = getGitHubToken(config, undefined);
-      if (!githubToken) {
-        return res.status(401).json({ success: false, error: 'GitHub token not configured' });
+      const sourceStatuses = [];
+      let prs = [];
+      if (githubToken) {
+        const client = new GitHubClient(githubToken);
+        const user = await client.getAuthenticatedUser();
+        prs = await client.searchPullRequests(buildQuery(user.login, { team }));
+      } else {
+        // host:null, repo:null identifies the github.com cross-repo source
+        // (mirrors the NULL-host = github.com convention used for cache rows).
+        sourceStatuses.push({ host: null, repo: null, ok: false, error: 'no github.com token configured' });
       }
 
-      const db = req.app.get('db');
-      const client = new GitHubClient(githubToken);
-      const user = await client.getAuthenticatedUser();
-      const prs = await client.searchPullRequests(buildQuery(user.login, { team }));
+      // Alt-host repos (both exclusive and dual) have no Search API, so sweep
+      // them via REST and classify locally. Best-effort: a failing host is
+      // reported in `hosts` and never aborts the github.com rows below. Done
+      // BEFORE the transaction so a slow alt host doesn't hold a write lock.
+      const { rows: altRows, hosts, credentialedRepoCount } = await sweepAltHosts(config, def, team);
+
+      // Only 401 when NO source can authenticate at all: no github token AND no
+      // alt-host repo with credentials. If either can authenticate, proceed and
+      // report the unavailable source in the response.
+      if (!githubToken && credentialedRepoCount === 0) {
+        return res.status(401).json({ success: false, error: 'GitHub token not configured' });
+      }
 
       // Namespace the cache so a filtered view never clobbers the all-teams
       // cache. Every distinct team string the user tries creates its own cached
@@ -179,18 +325,34 @@ function registerCollection(def) {
       // home-page feature.
       const key = cacheKey(name, team);
       await withTransaction(db, async () => {
+        // DELETE-then-INSERT clears prior github AND alt rows for this key, so a
+        // retry re-derives the whole view rather than duplicating. github rows
+        // stamp host NULL; alt rows carry their api_host string.
         await run(db, 'DELETE FROM github_pr_cache WHERE collection = ?', [key]);
         for (const pr of prs) {
           await run(db,
-            'INSERT INTO github_pr_cache (owner, repo, number, title, author, updated_at, html_url, state, collection) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)',
-            [pr.owner, pr.repo, pr.number, pr.title, pr.author, pr.updated_at, pr.html_url, pr.state, key]
+            'INSERT INTO github_pr_cache (owner, repo, number, title, author, updated_at, html_url, state, collection, host) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+            [pr.owner, pr.repo, pr.number, pr.title, pr.author, pr.updated_at, pr.html_url, pr.state, key, null]
+          );
+        }
+        for (const pr of altRows) {
+          await run(db,
+            'INSERT INTO github_pr_cache (owner, repo, number, title, author, updated_at, html_url, state, collection, host) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+            [pr.owner, pr.repo, pr.number, pr.title, pr.author, pr.updated_at, pr.html_url, pr.state, key, pr.host]
           );
         }
       });
 
       const rows = await getCachedRows(db, key);
       const fetchedAt = rows.length > 0 ? rows[0].fetched_at : null;
-      res.json({ success: true, prs: rows, fetched_at: fetchedAt });
+      // `hosts` is additive; omit it entirely when every source is healthy (no
+      // alt-host repos and a working github token) so the github-only happy-path
+      // response shape is byte-identical to before. A skipped github source or
+      // any alt-host status makes it appear.
+      const allStatuses = sourceStatuses.concat(hosts);
+      const payload = { success: true, prs: rows, fetched_at: fetchedAt };
+      if (allStatuses.length > 0) payload.hosts = allStatuses;
+      res.json(payload);
     } catch (error) {
       if (error.status === 401 || error.status === 403) {
         return res.status(401).json({ success: false, error: 'GitHub token is invalid or expired' });

--- a/src/routes/pr.js
+++ b/src/routes/pr.js
@@ -27,6 +27,7 @@ const { v4: uuidv4 } = require('uuid');
 const fs = require('fs').promises;
 const path = require('path');
 const { resolveHostBinding, resolveBindingRepositoryFromPR, getWorktreeDisplayName, resolveLoadSkills, buildCouncilProviderOverrides, getRepoSkipBulkFetch, getSummaryEnabled, getTourEnabled } = require('../config');
+const { storedHostToOption, isDualHostRepo } = require('../utils/host-resolution');
 const { resolveHostName } = require('../links/repo-links');
 const { backgroundQueue } = require('../ai/background-queue');
 const logger = require('../utils/logger');
@@ -130,12 +131,12 @@ module.exports._attachHunkHashes = attachHunkHashes;
  *
  * @param {import('express').Request} req
  * @param {string} repository - "owner/repo" identifier
- * @returns {{ binding: {apiHost: string|null, token: string, features: Object, source: string}, token: string }|null}
+ * @returns {Promise<{ binding: {apiHost: string|null, host: string|null, token: string, features: Object, source: string}, token: string, bindingRepository: string }|null>}
  *   `null` when no token can be resolved AND the repo is github.com (so
  *   callers can fall through to optional behaviour). Throws for alt-host
- *   misconfiguration.
+ *   misconfiguration and for a stale stored host that no longer matches config.
  */
-function resolveBindingForRequest(req, repository) {
+async function resolveBindingForRequest(req, repository) {
   const config = req.app.get('config') || {};
   // `repository` here is the PR-identity `${owner}/${repo}`. For
   // monorepo-style configs the binding-key in `config.repos` can differ;
@@ -143,7 +144,23 @@ function resolveBindingForRequest(req, repository) {
   // the host binding so per-repo tokens/api_host/features apply.
   const [owner, repo] = String(repository).split('/');
   const bindingRepository = resolveBindingRepositoryFromPR(owner, repo, config);
-  const binding = resolveHostBinding(bindingRepository, config);
+
+  // PR-aware host resolution. Every caller is an `/:owner/:repo/:number` route,
+  // so a per-PR host may already be stored. When a pr_metadata row exists, bind
+  // to its stored host (github for NULL, the api_host string for an alt host);
+  // when no row exists, fall back to the ambiguity rule (two-arg resolve). A
+  // stale stored host (config changed) makes resolveHostBinding throw — that
+  // surfaces to the route's error handler as a clear failure rather than a
+  // silent bind to a dead host.
+  const prNumber = parseInt(req.params && req.params.number, 10);
+  let hostOptions;
+  if (Number.isInteger(prNumber) && prNumber > 0) {
+    const prMetadataRepo = new PRMetadataRepository(req.app.get('db'));
+    const storedHost = await prMetadataRepo.getPRHost(repository, prNumber);
+    // Apply the legacy-NULL back-compat convention (see storedHostToOption).
+    hostOptions = storedHostToOption(config, bindingRepository, storedHost);
+  }
+  const binding = resolveHostBinding(bindingRepository, config, hostOptions || {});
   if (binding.token) {
     return { binding, token: binding.token, bindingRepository };
   }
@@ -343,7 +360,7 @@ router.get('/api/pr/:owner/:repo/:number', async (req, res) => {
     {
       let resolved = null;
       try {
-        resolved = resolveBindingForRequest(req, repository);
+        resolved = await resolveBindingForRequest(req, repository);
       } catch (configErr) {
         // Alt-host repo with no token configured — surface the message
         // but don't fail the GET (draft info is supplementary).
@@ -383,7 +400,7 @@ router.get('/api/pr/:owner/:repo/:number', async (req, res) => {
     {
       let resolved = null;
       try {
-        resolved = resolveBindingForRequest(req, repository);
+        resolved = await resolveBindingForRequest(req, repository);
       } catch (configErr) {
         logger.warn(configErr.message);
       }
@@ -542,7 +559,7 @@ router.post('/api/pr/:owner/:repo/:number/refresh', async (req, res) => {
     // Resolve host binding for this repo (validates alt-host token presence).
     let binding;
     try {
-      const resolved = resolveBindingForRequest(req, repository);
+      const resolved = await resolveBindingForRequest(req, repository);
       if (!resolved) {
         return res.status(401).json({ error: 'GitHub token not configured' });
       }
@@ -653,7 +670,7 @@ router.post('/api/pr/:owner/:repo/:number/refresh', async (req, res) => {
     {
       let resolved = null;
       try {
-        resolved = resolveBindingForRequest(req, repository);
+        resolved = await resolveBindingForRequest(req, repository);
       } catch (configErr) {
         logger.warn(configErr.message);
       }
@@ -915,7 +932,7 @@ router.get('/api/pr/:owner/:repo/:number/check-stale', async (req, res) => {
     // Fetch current PR from GitHub
     let binding;
     try {
-      const resolved = resolveBindingForRequest(req, repository);
+      const resolved = await resolveBindingForRequest(req, repository);
       if (!resolved) {
         return res.json({ isStale: null, error: 'GitHub token not configured' });
       }
@@ -987,7 +1004,7 @@ router.get('/api/pr/:owner/:repo/:number/github-drafts', async (req, res) => {
     // Initialize GitHub client and check for pending drafts on GitHub
     let binding;
     try {
-      const resolved = resolveBindingForRequest(req, repository);
+      const resolved = await resolveBindingForRequest(req, repository);
       if (!resolved) {
         return res.status(500).json({
           error: 'GitHub token not configured. Please check your ~/.pair-review/config.json'
@@ -1467,7 +1484,7 @@ router.post('/api/pr/:owner/:repo/:number/submit-review', async (req, res) => {
     // Resolve host binding (repo-aware: alt-host repos require their own token).
     let binding;
     try {
-      const resolved = resolveBindingForRequest(req, repository);
+      const resolved = await resolveBindingForRequest(req, repository);
       if (!resolved) {
         return res.status(500).json({
           error: 'GitHub token not configured. Please check your ~/.pair-review/config.json'
@@ -1747,9 +1764,12 @@ router.post('/api/pr/:owner/:repo/:number/submit-review', async (req, res) => {
       // Send success response after all database operations complete.
       // Use the configured remote-host display name (e.g. "Meteorite")
       // instead of the literal "GitHub". Resolve via the binding repository
-      // so monorepo url_pattern configs map to the right repos[...] entry.
+      // so monorepo url_pattern configs map to the right repos[...] entry, and
+      // pass the PR's resolved host (`binding.host`: null=github, api_host
+      // string=alt) so a dual-host repo names the system this PR was submitted
+      // to rather than its repo-level default.
       const cfg = req.app.get('config') || {};
-      const hostName = resolveHostName(cfg, resolveBindingRepositoryFromPR(owner, repo, cfg));
+      const hostName = resolveHostName(cfg, resolveBindingRepositoryFromPR(owner, repo, cfg), binding.host);
       res.json({
         success: true,
         message: `${event === 'DRAFT' ? 'Draft review created' : 'Review submitted'} successfully ${event === 'DRAFT' ? 'on' : 'to'} ${hostName}`,
@@ -1946,11 +1966,28 @@ router.post('/api/parse-pr-url', (req, res) => {
   const result = parser.parsePRUrl(url);
 
   if (result) {
+    // Report whether the resolved repo is DUAL (github + alt-host). A github URL
+    // (host === null) for a dual repo must be forwarded to setup as an explicit
+    // github pick (the "github" sentinel) so it does not probe alt-first; for a
+    // plain or exclusive repo the client omits host (no probe / avoids the
+    // exclusive-null throw). Resolve the binding key first (url_pattern match
+    // supplies it; otherwise derive from owner/repo).
+    const safeConfig = config || {};
+    const bindingRepository = result.bindingRepository
+      || resolveBindingRepositoryFromPR(result.owner, result.repo, safeConfig);
     return res.json({
       valid: true,
       owner: result.owner,
       repo: result.repo,
-      prNumber: result.number
+      prNumber: result.number,
+      // `host` tells the setup call which system the PR lives on: `null` =
+      // github.com (a github/graphite URL), an api_host URL string = that alt
+      // host (a `url_pattern` match), or absent when the parser could not tell.
+      // `bindingRepository` is the matched `repos[...]` config key (may differ
+      // from owner/repo for monorepo-style url_pattern configs).
+      host: result.host,
+      bindingRepository: result.bindingRepository,
+      isDualHost: isDualHostRepo(safeConfig, bindingRepository)
     });
   }
 
@@ -2067,7 +2104,7 @@ async function launchPrCouncilAnalysis(req, {
   // Build a GitHubClient for analyzer-side dedup pre-fetch (PR mode only).
   let councilGithubClient;
   try {
-    const resolved = resolveBindingForRequest(req, repository);
+    const resolved = await resolveBindingForRequest(req, repository);
     councilGithubClient = resolved ? new GitHubClient(resolved.binding) : undefined;
   } catch (configErr) {
     logger.warn(`Skipping GitHub dedup pre-fetch (council): ${configErr.message}`);
@@ -2190,7 +2227,7 @@ router.post('/api/pr/:owner/:repo/:number/analyses', async (req, res) => {
     // for github.com repos we fall back to the server-startup cached token.
     let analyzerGithubClient;
     try {
-      const resolved = resolveBindingForRequest(req, repository);
+      const resolved = await resolveBindingForRequest(req, repository);
       analyzerGithubClient = resolved ? new GitHubClient(resolved.binding) : undefined;
     } catch (configErr) {
       // Alt-host misconfiguration — skip dedup pre-fetch with a clear log.
@@ -2709,7 +2746,7 @@ router.get('/api/pr/:owner/:repo/:number/share', async (req, res) => {
     // an alt-host's `getAuthenticatedUser` resolves the user on that host.
     let sharedBy = null;
     try {
-      const resolved = resolveBindingForRequest(req, repository);
+      const resolved = await resolveBindingForRequest(req, repository);
       if (resolved) {
         const githubClient = new GitHubClient(resolved.binding);
         const user = await githubClient.getAuthenticatedUser();
@@ -2843,7 +2880,7 @@ router.get('/api/pr/:owner/:repo/:number/stack-info', async (req, res) => {
 
     let binding;
     try {
-      const resolved = resolveBindingForRequest(req, repository);
+      const resolved = await resolveBindingForRequest(req, repository);
       if (!resolved) {
         return res.json({ stack: [] });
       }

--- a/src/routes/setup.js
+++ b/src/routes/setup.js
@@ -15,7 +15,8 @@ const crypto = require('crypto');
 const { activeSetups, broadcastSetupProgress } = require('./shared');
 const { setupPRReview } = require('../setup/pr-setup');
 const { setupLocalReview } = require('../setup/local-setup');
-const { getGitHubToken, expandPath, resolveBindingRepositoryFromPR } = require('../config');
+const { expandPath, resolveBindingRepositoryFromPR } = require('../config');
+const { resolvePreflightBinding } = require('../utils/host-resolution');
 const { queryOne, ReviewRepository } = require('../database');
 const { normalizeRepository } = require('../utils/paths');
 const { rejectUrlLikeLocalReviewPath } = require('../utils/local-path-input');
@@ -60,18 +61,38 @@ router.post('/api/setup/pr/:owner/:repo/:number', async (req, res) => {
       return res.status(400).json({ error: 'Invalid owner, repo, or PR number' });
     }
 
+    // Optional per-PR host override. Contract: `null` = github.com, an api_host
+    // URL string = that alt host, absent/undefined = unknown (server derives via
+    // stored host or a probe). A dashboard row (alt-host PR) and a URL paste both
+    // send this so setup binds to the right system without probing. Reject other
+    // shapes; the "must match the repo's api_host" check is enforced downstream
+    // by resolveHostBinding (a mismatch surfaces as a setup error).
+    const bodyHost = req.body ? req.body.host : undefined;
+    if (bodyHost !== undefined && bodyHost !== null && typeof bodyHost !== 'string') {
+      return res.status(400).json({ error: 'Invalid host: expected null or an api_host URL string' });
+    }
+
     const db = req.app.get('db');
     const config = req.app.get('config');
 
-    // GitHub token is required for PR setup. Resolve the binding key
-    // first so monorepo-style `repos[...]` entries (matched via
-    // `url_pattern` named captures) supply their per-repo token even when
-    // the captured owner/repo differs from the config key.
+    // GitHub token is required for PR setup. Resolve the binding key first so
+    // monorepo-style `repos[...]` entries (matched via `url_pattern` named
+    // captures) supply their per-repo token even when the captured owner/repo
+    // differs from the config key.
     const repositoryForToken = resolveBindingRepositoryFromPR(owner, repo, config);
-    const githubToken = getGitHubToken(config, repositoryForToken);
-    if (!githubToken) {
+    // Preflight the credential. resolvePreflightBinding gates on ANY usable
+    // binding — including a dual repo's alt-only token or a token pinned by an
+    // explicit body host — so an alt-host setup isn't falsely 401'd.
+    const preflightBinding = resolvePreflightBinding(repositoryForToken, config, bodyHost);
+    if (!preflightBinding.token) {
       return res.status(401).json({ error: 'GitHub token not configured' });
     }
+    // Split the two roles: the gate above accepts an alt token, but only a
+    // github.com token may be forwarded downstream as the github FALLBACK.
+    // resolvePrHostBinding can drop `githubToken` into a github.com client on the
+    // 404 probe fallback (clientArgFor's github-flavored branch), so an alt token
+    // must NEVER reach it — the CLI (main.js) applies the identical guard.
+    const githubToken = preflightBinding.apiHost === null ? preflightBinding.token : '';
 
     // Concurrency guard: if a setup is already running for this PR, return its ID
     const setupKey = `pr:${owner}/${repo}/${prNumber}`;
@@ -149,6 +170,7 @@ router.post('/api/setup/pr/:owner/:repo/:number', async (req, res) => {
           githubToken,
           bindingRepository: repositoryForToken,
           config,
+          host: bodyHost,
           poolLifecycle: req.app.get('poolLifecycle'),
           restoreMetadata,
           onProgress: (progress) => {

--- a/src/routes/stack-analysis.js
+++ b/src/routes/stack-analysis.js
@@ -20,6 +20,7 @@ const { mergeInstructions } = require('../utils/instructions');
 const { GitWorktreeManager } = require('../git/worktree');
 const { GitHubClient } = require('../github/client');
 const { getGitHubToken, resolveHostBinding, resolveBindingRepositoryFromPR, resolveRepoOptions, resolveLoadSkills, buildCouncilProviderOverrides } = require('../config');
+const { storedHostToOption } = require('../utils/host-resolution');
 const { setupStackPR } = require('../setup/stack-setup');
 const Analyzer = require('../ai/analyzer');
 const { getProviderClass, createProvider } = require('../ai/provider');
@@ -253,7 +254,14 @@ async function executeStackAnalysis(params) {
     // monorepo-style `url_pattern` configs (one `repos[...]` entry serves many
     // captured owner/repo pairs). The PR identity is still used for DB rows and
     // worktree identity.
-    const stackBinding = deps.resolveHostBinding(bindingRepository, config);
+    // Resolve the stack binding from the MAIN (trigger) PR's stored host so every
+    // sibling is fetched from — and later stamped with — the same host. Stacks
+    // don't span systems, so a dual repo's alt-hosted stack must not fall back to
+    // github via the two-arg ambiguity rule. `storedHostToOption` applies the
+    // legacy-NULL convention; `undefined` (no row) preserves the ambiguity rule.
+    const mainStoredHost = await new PRMetadataRepository(db).getPRHost(repository, triggerPRNumber);
+    const stackHostOption = storedHostToOption(config, bindingRepository, mainStoredHost);
+    const stackBinding = deps.resolveHostBinding(bindingRepository, config, stackHostOption || {});
     const githubToken = stackBinding.token;
     const prDataMap = new Map();
     if (githubToken) {

--- a/src/server.js
+++ b/src/server.js
@@ -1,8 +1,8 @@
 // Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
 const express = require('express');
 const path = require('path');
-const { loadConfig, getGitHubToken, resolveDbName, warnIfDevModeWithoutDbName } = require('./config');
-const { initializeDatabase, getDatabaseStatus, queryOne, run } = require('./database');
+const { loadConfig, getGitHubToken, resolveDbName, warnIfDevModeWithoutDbName, getRepoConfig, resolveBindingRepositoryFromPR, isExclusiveAltHost } = require('./config');
+const { initializeDatabase, getDatabaseStatus, queryOne, run, PRMetadataRepository } = require('./database');
 const { normalizeRepository } = require('./utils/paths');
 const { applyConfigOverrides, checkAllProviders } = require('./ai');
 const { checkAllChatProviders } = require('./chat/chat-providers');
@@ -25,6 +25,69 @@ function applyEnvOverrides(config) {
     config.single_port = false;
   }
   return config;
+}
+
+/**
+ * Apply an explicit `?host` correction from the /pr fast path.
+ *
+ * Dashboard clicks and pasted URLs can carry `?host` to say which system a PR
+ * lives on. When the PR already has metadata + a worktree, the route serves
+ * pr.html directly (no setup), so this is the only place that consumes the
+ * hint on the fast path. It is a LABEL correction only — the no-collision
+ * assumption means a same-numbered PR is the same logical PR, so no re-fetch.
+ *
+ * Sentinel mapping mirrors setup.html: `'github'` → null (github.com), any
+ * other non-empty string → an alt `api_host` URL, absent/empty → no-op. The
+ * target is validated against config so a stale link can't stamp a host the
+ * repo isn't configured for (which `resolveHostBinding` would later reject);
+ * on any mismatch we warn and ignore rather than break the page load.
+ *
+ * @param {Object} db - Database handle
+ * @param {Object} config - Loaded config
+ * @param {string} owner - URL owner segment
+ * @param {string} repo - URL repo segment
+ * @param {string} repository - Normalized `owner/repo` used as the pr_metadata key
+ * @param {number} prNumber - PR number
+ * @param {*} rawHost - `req.query.host` (already URL-decoded by Express)
+ * @returns {Promise<void>}
+ */
+async function applyHostQueryCorrection(db, config, owner, repo, repository, prNumber, rawHost) {
+  if (rawHost === undefined || rawHost === null || rawHost === '') return;
+  if (typeof rawHost !== 'string') return;
+
+  const targetHost = rawHost === 'github' ? null : rawHost;
+
+  // Resolve the repo's config entry (handles monorepo-style keys matched via
+  // url_pattern) to learn its configured api_host.
+  const bindingRepo = resolveBindingRepositoryFromPR(owner, repo, config);
+  const repoConfig = getRepoConfig(config, bindingRepo);
+  const configuredApiHost = (repoConfig && typeof repoConfig.api_host === 'string' && repoConfig.api_host)
+    ? repoConfig.api_host
+    : null;
+
+  if (targetHost !== null) {
+    // A string host must match this repo's configured api_host exactly.
+    if (targetHost !== configuredApiHost) {
+      logger.warn(`Ignoring ?host correction for ${repository} #${prNumber}: "${targetHost}" does not match configured api_host (${configuredApiHost || 'none'})`);
+      return;
+    }
+  } else if (isExclusiveAltHost(repoConfig)) {
+    // The github sentinel is meaningless for an exclusive alt-host repo (it has
+    // no github.com presence); stamping null would break binding resolution.
+    logger.warn(`Ignoring ?host=github correction for ${repository} #${prNumber}: repo is an exclusive alt-host repo with no github.com presence`);
+    return;
+  }
+
+  const prMetadataRepo = new PRMetadataRepository(db);
+  const stored = await prMetadataRepo.getPRHost(repository, prNumber);
+  // Fast path only runs when a row exists, so `stored` is null or a string.
+  // Skip the write when it already matches (avoids a needless updated_at bump).
+  if (stored === targetHost) return;
+
+  const changed = await prMetadataRepo.updatePRHost(repository, prNumber, targetHost);
+  if (changed) {
+    logger.info(`Corrected stored host for ${repository} #${prNumber} to ${targetHost === null ? 'github.com' : targetHost} via ?host`);
+  }
 }
 
 /**
@@ -276,6 +339,14 @@ async function startServer(sharedDb = null, sharedPoolLifecycle = null) {
           if (worktree) {
             // Update last_accessed_at so the recent reviews list reflects actual access
             run(db, 'UPDATE pr_metadata SET last_accessed_at = ? WHERE id = ?', [new Date().toISOString(), existing.id]).catch(err => logger.warn(`Failed to update last_accessed_at: ${err.message}`));
+            // Persist an explicit ?host correction BEFORE serving so pr.html's
+            // first data fetch resolves the binding against the corrected host.
+            // Never let a bad hint break the page — the helper swallows and warns.
+            try {
+              await applyHostQueryCorrection(db, config, owner, repo, repository, prNumber, req.query.host);
+            } catch (err) {
+              logger.warn(`Failed to apply ?host correction for ${repository} #${prNumber}: ${err.message}`);
+            }
             res.sendFile(path.join(__dirname, '..', 'public', 'pr.html'));
           } else {
             logger.info(`PR metadata exists but no worktree for ${repository} #${prNumber}, serving setup page`);
@@ -521,4 +592,4 @@ if (require.main === module) {
   startServer();
 }
 
-module.exports = { startServer, applyEnvOverrides };
+module.exports = { startServer, applyEnvOverrides, applyHostQueryCorrection };

--- a/src/setup/pr-setup.js
+++ b/src/setup/pr-setup.js
@@ -11,13 +11,14 @@
  *   - setupPRReview: full orchestrator that wires the above together
  */
 
-const { run, queryOne, WorktreeRepository, RepoSettingsRepository, ReviewRepository } = require('../database');
+const { run, queryOne, WorktreeRepository, RepoSettingsRepository, ReviewRepository, PRMetadataRepository } = require('../database');
 const { GitWorktreeManager, MISSING_COMMIT_ERROR_CODE } = require('../git/worktree');
 const { WorktreePoolLifecycle } = require('../git/worktree-pool-lifecycle');
 const { GitHubClient } = require('../github/client');
 const { normalizeRepository } = require('../utils/paths');
 const { findMainGitRoot } = require('../local-review');
-const { getConfigDir, getRepoPath, resolveRepoOptions, resolvePoolConfig, getRepoResetScript, resolveHostBinding, resolveBindingRepositoryFromPR, DEFAULT_CHECKOUT_TIMEOUT_MS } = require('../config');
+const { getConfigDir, getRepoPath, resolveRepoOptions, resolvePoolConfig, getRepoResetScript, resolveHostBinding, resolveBindingRepositoryFromPR, getRepoConfig, DEFAULT_CHECKOUT_TIMEOUT_MS } = require('../config');
+const { storedHostToOption, isDualHostRepoConfig } = require('../utils/host-resolution');
 const logger = require('../utils/logger');
 const { fireReviewStartedHook } = require('../hooks/payloads');
 const simpleGit = require('simple-git');
@@ -38,14 +39,74 @@ const path = require('path');
  * @param {string} worktreePath - Worktree (or checkout) path
  * @param {Object} [options] - Optional settings
  * @param {boolean} [options.skipWorktreeRecord] - Skip creating a worktree DB record
+ * @param {string|null} [options.host] - Per-PR host binding to stamp. When
+ *   omitted (`undefined`), the host column is left untouched on UPDATE and
+ *   written as NULL on INSERT. `null` (github.com) or an api_host URL string is
+ *   written on both the UPDATE and INSERT arms — this is the self-healing step
+ *   that stamps the host actually used to fetch the PR.
  */
 async function storePRData(db, prInfo, prData, diff, changedFiles, worktreePath, options = {}) {
   const repository = normalizeRepository(prInfo.owner, prInfo.repo);
+  // `undefined` means "caller doesn't know the host" — don't disturb any stored
+  // value on UPDATE and default to NULL (github.com) on INSERT. `null` or a URL
+  // string is an explicit host the caller wants persisted on both arms.
+  const writeHost = options.host !== undefined;
+  const hostValue = options.host;
 
   // Begin transaction for atomic database operations
   await run(db, 'BEGIN TRANSACTION');
 
   try {
+    // Look up any existing row FIRST — before any mutation — so the cross-host
+    // collision guard below can reject cleanly (no partial write to roll back).
+    const existingPR = await queryOne(db, `
+      SELECT id, host, pr_data FROM pr_metadata WHERE pr_number = ? AND repository = ? COLLATE NOCASE
+    `, [prInfo.number, repository]);
+
+    // Cross-host collision guard.
+    //
+    // INVARIANT: a given (repository, pr_number) identifies exactly ONE pull
+    // request across ALL hosts. This is the confirmed plan assumption
+    // (plans/per-pr-host-resolution.md, "Assumption (confirmed)") — PR numbers do
+    // NOT collide between github.com and an alt host for the same repo — and it
+    // is why durable identity stays keyed UNIQUE(pr_number, repository) with no
+    // host column and the /pr/:owner/:repo/:number URL scheme is unchanged.
+    //
+    // If that assumption is ever violated (two DIFFERENT PRs share a number on
+    // two hosts), the UPDATE arm below would silently overwrite the first PR's
+    // pr_data and re-point its reviews/worktrees at the second. Detect it: when
+    // this fetch's host differs from the stored row's host, the API id must
+    // match. Same id → same logical PR, the host difference is the intended
+    // self-heal relabel → proceed. Different id → genuine cross-host duplicate →
+    // refuse rather than corrupt the wrong PR. Unparseable stored id → proceed
+    // but warn (can't prove either way; nothing to compare against).
+    if (existingPR && writeHost && existingPR.host !== hostValue) {
+      const incomingId = prData.id ?? prData.node_id ?? null;
+      let storedId = null;
+      try {
+        const storedData = existingPR.pr_data ? JSON.parse(existingPR.pr_data) : null;
+        if (storedData) storedId = storedData.id ?? storedData.node_id ?? null;
+      } catch {
+        storedId = null; // unparseable → treated as "unknown" below
+      }
+      const storedHostLabel = existingPR.host === null ? 'github.com' : existingPR.host;
+      const incomingHostLabel = hostValue === null ? 'github.com' : hostValue;
+      if (storedId === null) {
+        logger.warn(
+          `storePRData: stored pr_metadata for ${repository} #${prInfo.number} has no parseable API id; ` +
+          `proceeding with host relabel (${storedHostLabel} -> ${incomingHostLabel})`
+        );
+      } else if (incomingId !== null && String(storedId) !== String(incomingId)) {
+        throw new Error(
+          `Cross-host PR conflict for ${repository} #${prInfo.number}: a DIFFERENT pull request with this ` +
+          `number is already stored on ${storedHostLabel}, but this fetch came from ${incomingHostLabel}. ` +
+          `pair-review assumes pull request numbers do not collide across hosts for a repository ` +
+          `(see plans/per-pr-host-resolution.md); reviewing two different PRs that share number ` +
+          `#${prInfo.number} on different hosts is not supported.`
+        );
+      }
+    }
+
     // Store or update worktree record (skip when using --use-checkout,
     // since the path is the user's working directory, not a managed worktree)
     if (!options.skipWorktreeRecord) {
@@ -67,19 +128,16 @@ async function storePRData(db, prInfo, prData, diff, changedFiles, worktreePath,
       fetched_at: new Date().toISOString()
     };
 
-    // First check if PR metadata exists
-    const existingPR = await queryOne(db, `
-      SELECT id FROM pr_metadata WHERE pr_number = ? AND repository = ? COLLATE NOCASE
-    `, [prInfo.number, repository]);
-
     const now = new Date().toISOString();
 
     if (existingPR) {
-      // Update existing PR metadata (preserves ID)
+      // Update existing PR metadata (preserves ID). The host column is only
+      // touched when the caller supplies one, so a plain re-fetch that doesn't
+      // know the host leaves any previously stamped value intact.
       await run(db, `
         UPDATE pr_metadata
         SET title = ?, description = ?, author = ?,
-            base_branch = ?, head_branch = ?, pr_data = ?,
+            base_branch = ?, head_branch = ?, pr_data = ?${writeHost ? ', host = ?' : ''},
             updated_at = CURRENT_TIMESTAMP, last_accessed_at = ?
         WHERE id = ?
       `, [
@@ -89,16 +147,18 @@ async function storePRData(db, prInfo, prData, diff, changedFiles, worktreePath,
         prData.base_branch,
         prData.head_branch,
         JSON.stringify(extendedPRData),
+        ...(writeHost ? [hostValue] : []),
         now,
         existingPR.id
       ]);
       logger.info(`Updated existing PR metadata (ID: ${existingPR.id})`);
     } else {
-      // Insert new PR metadata
+      // Insert new PR metadata. When no host is supplied the column is omitted
+      // and defaults to NULL (github.com).
       const result = await run(db, `
         INSERT INTO pr_metadata
-        (pr_number, repository, title, description, author, base_branch, head_branch, pr_data, last_accessed_at)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        (pr_number, repository, title, description, author, base_branch, head_branch, pr_data${writeHost ? ', host' : ''}, last_accessed_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?${writeHost ? ', ?' : ''}, ?)
       `, [
         prInfo.number,
         repository,
@@ -108,6 +168,7 @@ async function storePRData(db, prInfo, prData, diff, changedFiles, worktreePath,
         prData.base_branch,
         prData.head_branch,
         JSON.stringify(extendedPRData),
+        ...(writeHost ? [hostValue] : []),
         now
       ]);
       logger.info(`Created new PR metadata (ID: ${result.lastID})`);
@@ -170,6 +231,122 @@ async function storePRData(db, prInfo, prData, diff, changedFiles, worktreePath,
     await run(db, 'ROLLBACK');
     logger.error('Error storing PR data:', error);
     throw new Error(`Failed to store PR data: ${error.message}`);
+  }
+}
+
+/**
+ * Resolve the per-PR host binding and fetch the PR, applying the host
+ * precedence used by every PR-setup entry point (web setup route + CLI):
+ *
+ *   1. explicit `host` (URL paste / request body): `undefined` = unknown,
+ *      `null` = github.com, `'<url>'` = an alt host. When defined,
+ *      `resolveHostBinding` validates it and throws on a stale/mismatched host.
+ *   2. stored `pr_metadata.host` (a row exists → `getPRHost !== undefined`).
+ *   3. ambiguity rule. For a DUAL repo (`api_host` + `exclusive: false`) whose
+ *      host is still unknown, PROBE: fetch from the alt host first and, ONLY on
+ *      a 404, fall back to github.com. Any non-404 error (auth, network, 5xx)
+ *      fails loudly WITHOUT falling back — a silent fallback could fetch a
+ *      same-numbered PR from the wrong system and stamp the wrong host.
+ *      Exclusive alt-host and plain github repos resolve to a single binding
+ *      with no probe (byte-identical to pre-dual behaviour).
+ *
+ * The chosen binding carries a `host` echo field (null for github.com, the
+ * api_host string for an alt host) that callers persist via `storePRData` — the
+ * self-healing step that stamps the host actually used.
+ *
+ * @param {Object} params
+ * @param {Object} params.db - Database instance (for the stored-host lookup)
+ * @param {Object} params.config - Application config
+ * @param {string} params.bindingRepository - `repos[...]` config-lookup key
+ * @param {string} params.owner
+ * @param {string} params.repo
+ * @param {number} params.prNumber
+ * @param {string|null|undefined} params.host - explicit host override (see above)
+ * @param {string} [params.githubToken] - fallback token when the chosen binding
+ *   resolves none (legacy github.com behaviour)
+ * @param {Object} [params.deps] - `{ GitHubClient }` override for tests
+ * @returns {Promise<{ binding: Object, prData: Object, githubClient: Object }>}
+ */
+async function resolvePrHostBinding({ db, config, bindingRepository, owner, repo, prNumber, host, githubToken, deps = {} }) {
+  const Client = deps.GitHubClient || GitHubClient;
+  const repository = normalizeRepository(owner, repo);
+  const repoConfig = getRepoConfig(config, bindingRepository);
+  const configuredApiHost = (repoConfig && typeof repoConfig.api_host === 'string' && repoConfig.api_host)
+    ? repoConfig.api_host
+    : null;
+  // A dual repo has an api_host but is not exclusive — its PRs may live on
+  // github.com OR the alt host, so an unknown host must be probed.
+  const isDual = isDualHostRepoConfig(repoConfig);
+
+  // Build the argument for `new Client(...)` from a resolved binding. A binding
+  // with a token is used as-is. A github-flavored binding (apiHost === null) with
+  // no token may fall back to the caller's github.com token (legacy behaviour).
+  // An ALT-flavored binding with no token must NOT fall back to `githubToken` —
+  // that would point Octokit at api.github.com while the caller records the
+  // result as the alt host (stamping a same-numbered github PR as alt). Guard on
+  // host flavor, not token truthiness: surface a clear missing-credential error.
+  const clientArgFor = (binding) => {
+    if (binding.token) return binding;
+    if (binding.apiHost === null) return githubToken;
+    throw new Error(
+      `No token configured for alt host ${binding.apiHost} (repo ${bindingRepository}). ` +
+      `Configure repos["${bindingRepository}"].token or token_command.`
+    );
+  };
+
+  // Apply host precedence to decide whether we know the host up front.
+  let effectiveHost;
+  let hostKnown = false;
+  if (host !== undefined) {
+    effectiveHost = host;
+    hostKnown = true;
+  } else {
+    const prMetadataRepo = new PRMetadataRepository(db);
+    const storedHost = await prMetadataRepo.getPRHost(repository, prNumber);
+    // storedHostToOption applies the legacy-NULL convention: `undefined` means
+    // "host unknown" (leave hostKnown false → ambiguity/probe path), while a
+    // returned option object pins the host.
+    const storedOption = storedHostToOption(config, bindingRepository, storedHost);
+    if (storedOption !== undefined) {
+      effectiveHost = storedOption.host;
+      hostKnown = true;
+    }
+  }
+
+  // Fixed-binding path: host is known, OR the repo can only live on one host
+  // (plain github / exclusive alt) so the ambiguity rule is unambiguous.
+  if (hostKnown || !isDual) {
+    const binding = resolveHostBinding(bindingRepository, config, hostKnown ? { host: effectiveHost } : {});
+    const client = new Client(clientArgFor(binding));
+    const repoExists = await client.repositoryExists(owner, repo);
+    if (!repoExists) {
+      throw new Error(`Repository ${owner}/${repo} not found`);
+    }
+    const prData = await client.fetchPullRequest(owner, repo, prNumber);
+    return { binding, prData, githubClient: client };
+  }
+
+  // Probe path: dual repo, host unknown. Try the alt host first. `clientArgFor`
+  // errors clearly if the alt binding has no token rather than silently probing
+  // github.com disguised as the alt host.
+  const altBinding = resolveHostBinding(bindingRepository, config, { host: configuredApiHost });
+  const altClient = new Client(clientArgFor(altBinding));
+  try {
+    const prData = await altClient.fetchPullRequest(owner, repo, prNumber);
+    logger.info(`PR #${prNumber} (${repository}) resolved to alt host ${configuredApiHost}`);
+    return { binding: altBinding, prData, githubClient: altClient };
+  } catch (altErr) {
+    if (altErr && altErr.status === 404) {
+      logger.info(`PR #${prNumber} (${repository}) not found on alt host ${configuredApiHost}; falling back to github.com`);
+      const githubBinding = resolveHostBinding(bindingRepository, config, { host: null });
+      const githubClient = new Client(clientArgFor(githubBinding));
+      const prData = await githubClient.fetchPullRequest(owner, repo, prNumber);
+      return { binding: githubBinding, prData, githubClient };
+    }
+    // Auth/network/5xx on the alt host — do NOT fall back to github.com.
+    throw new Error(
+      `Failed to fetch PR #${prNumber} from alt host ${configuredApiHost}: ${altErr.message}`
+    );
   }
 }
 
@@ -419,30 +596,30 @@ function isShaNotFoundError(err) {
  * @param {Object} [params.config] - Application config (for monorepo path lookup)
  * @param {import('../git/worktree-pool-lifecycle').WorktreePoolLifecycle} [params.poolLifecycle] - Shared pool lifecycle instance (avoids creating a fresh singleton)
  * @param {Object} [params.restoreMetadata] - Stored PR data for restore mode (skips GitHub fetch + diff)
+ * @param {string|null} [params.host] - Explicit per-PR host override (URL paste /
+ *   dashboard row): `null` = github.com, an api_host URL string = that alt host,
+ *   omitted (`undefined`) = unknown (derive from stored host / probe).
  * @param {Function} [params.onProgress] - Optional progress callback
  * @returns {Promise<{ reviewUrl: string, title: string }>}
  */
-async function setupPRReview({ db, owner, repo, prNumber, githubToken, bindingRepository: externalBindingRepository, config, onProgress, poolLifecycle: externalPoolLifecycle, restoreMetadata }) {
+async function setupPRReview({ db, owner, repo, prNumber, githubToken, bindingRepository: externalBindingRepository, config, host, onProgress, poolLifecycle: externalPoolLifecycle, restoreMetadata }) {
   const repository = normalizeRepository(owner, repo);
   const progress = onProgress || (() => {});
 
-  // Resolve the per-repo host binding so alt-host setups talk to the
-  // configured `api_host`. Use `resolveBindingRepositoryFromPR` so
-  // monorepo-style configs (one `repos[...]` entry serving many
-  // captured owner/repo) find the right binding. Fall back to the bare
-  // token shape if no config is available (legacy invocation path) or
-  // the binding resolved no token (callers in this case already
-  // pre-resolved it).
+  // Resolve the config-lookup key. Use `resolveBindingRepositoryFromPR` so
+  // monorepo-style configs (one `repos[...]` entry serving many captured
+  // owner/repo) find the right binding. Fall back to the PR identity when no
+  // config is available (legacy invocation path).
   const bindingRepository = externalBindingRepository
     || (config ? resolveBindingRepositoryFromPR(owner, repo, config) : repository);
-  const setupBinding = config ? resolveHostBinding(bindingRepository, config) : null;
-  const clientArg = (setupBinding && setupBinding.token)
-    ? setupBinding
-    : githubToken;
 
   const isRestore = !!(restoreMetadata && restoreMetadata.head_sha);
   let prData;
   let githubClient = null;
+  // Host actually used to fetch — persisted by storePRData (self-healing). Left
+  // undefined for restore mode and the legacy (no-config) path so those flows
+  // leave any previously-stamped host untouched.
+  let stampHost;
 
   if (isRestore) {
     prData = restoreMetadata;
@@ -450,21 +627,33 @@ async function setupPRReview({ db, owner, repo, prNumber, githubToken, bindingRe
     progress({ step: 'fetch', status: 'completed', message: 'Using stored PR data.' });
   } else {
     // ------------------------------------------------------------------
-    // Step: verify - Verify repository access
+    // Step: verify + fetch - Resolve the per-PR host binding, verify access,
+    // and fetch PR data. `resolvePrHostBinding` applies host precedence
+    // (explicit host → stored host → ambiguity/probe) and, for a dual repo
+    // whose host is unknown, probes the alt host first (404 → github.com).
     // ------------------------------------------------------------------
     progress({ step: 'verify', status: 'running', message: 'Verifying repository access...' });
-    githubClient = new GitHubClient(clientArg);
-    const repoExists = await githubClient.repositoryExists(owner, repo);
-    if (!repoExists) {
-      throw new Error(`Repository ${owner}/${repo} not found`);
+    // Pair the 'fetch' step's completed event (below) with a running event and
+    // restore the spinner message; resolvePrHostBinding does the actual fetch.
+    progress({ step: 'fetch', status: 'running', message: 'Fetching pull request data from GitHub...' });
+    if (config) {
+      const resolved = await resolvePrHostBinding({
+        db, config, bindingRepository, owner, repo, prNumber, host, githubToken
+      });
+      githubClient = resolved.githubClient;
+      prData = resolved.prData;
+      stampHost = resolved.binding.host;
+    } else {
+      // Legacy path: no config, so bind directly with the supplied token and
+      // do not track a host.
+      githubClient = new GitHubClient(githubToken);
+      const repoExists = await githubClient.repositoryExists(owner, repo);
+      if (!repoExists) {
+        throw new Error(`Repository ${owner}/${repo} not found`);
+      }
+      prData = await githubClient.fetchPullRequest(owner, repo, prNumber);
     }
     progress({ step: 'verify', status: 'completed', message: 'Repository access verified.' });
-
-    // ------------------------------------------------------------------
-    // Step: fetch - Fetch PR data from GitHub
-    // ------------------------------------------------------------------
-    progress({ step: 'fetch', status: 'running', message: 'Fetching pull request data from GitHub...' });
-    prData = await githubClient.fetchPullRequest(owner, repo, prNumber);
     progress({ step: 'fetch', status: 'completed', message: 'Pull request data fetched.' });
   }
 
@@ -624,7 +813,9 @@ async function setupPRReview({ db, owner, repo, prNumber, githubToken, bindingRe
   // Step: store - Persist PR data and register repository location
   // ------------------------------------------------------------------
   progress({ step: 'store', status: 'running', message: 'Storing pull request data...' });
-  const { isNewReview, reviewId } = await storePRData(db, prInfo, prData, diff, changedFiles, worktreePath);
+  const { isNewReview, reviewId } = await storePRData(db, prInfo, prData, diff, changedFiles, worktreePath, {
+    host: stampHost
+  });
 
   // Persist review→worktree mapping in DB for pool usage tracking
   if (poolWorktreeId) {
@@ -662,8 +853,15 @@ async function setupPRReview({ db, owner, repo, prNumber, githubToken, bindingRe
     // fall back to a full fresh setup.
     if (isRestore && isShaNotFoundError(err)) {
       logger.warn(`Restore to stored SHA failed, falling back to fresh setup: ${err.message}`);
-      // Retry without restoreMetadata.
-      return setupPRReview({ db, owner, repo, prNumber, githubToken, config, onProgress, poolLifecycle: externalPoolLifecycle });
+      // Retry without restoreMetadata. Forward the explicit `host` and
+      // `bindingRepository` so the fresh fetch binds the SAME host the caller
+      // requested — re-deriving them here could bind a different host (probe a
+      // dual repo, or pick the wrong monorepo binding key).
+      return setupPRReview({
+        db, owner, repo, prNumber, githubToken,
+        bindingRepository: externalBindingRepository,
+        config, host, onProgress, poolLifecycle: externalPoolLifecycle
+      });
     }
 
     // Release the pool worktree so it doesn't stay permanently in_use.
@@ -684,4 +882,4 @@ async function setupPRReview({ db, owner, repo, prNumber, githubToken, bindingRe
   }
 }
 
-module.exports = { setupPRReview, storePRData, registerRepositoryLocation, findRepositoryPath, isShaNotFoundError };
+module.exports = { setupPRReview, storePRData, resolvePrHostBinding, registerRepositoryLocation, findRepositoryPath, isShaNotFoundError };

--- a/src/setup/stack-setup.js
+++ b/src/setup/stack-setup.js
@@ -90,9 +90,14 @@ async function setupStackPR({ db, owner, repo, prNumber, githubToken, binding, b
   // 5. Get changed files with stats
   const changedFiles = await worktreeManager.getChangedFiles(worktreePath, prData);
 
-  // 6. Store via storePRData (creates/updates pr_metadata, reviews, worktrees records)
+  // 6. Store via storePRData (creates/updates pr_metadata, reviews, worktrees records).
+  // Stamp the host of the binding used to fetch this stack PR (null for
+  // github.com, the api_host string for an alt host) so per-PR host resolution
+  // self-heals across the stack. Omitted when only a bare token was supplied.
   const prInfo = { owner, repo, number: prNumber };
-  const { isNewReview, reviewId } = await storePRData(db, prInfo, prData, diff, changedFiles, worktreePath);
+  const { isNewReview, reviewId } = await storePRData(db, prInfo, prData, diff, changedFiles, worktreePath, {
+    host: binding ? binding.host : undefined
+  });
 
   logger.info(`Stack PR #${prNumber} setup complete (reviewId: ${reviewId}, new: ${isNewReview})`);
 

--- a/src/single-port.js
+++ b/src/single-port.js
@@ -6,6 +6,7 @@ const { PRArgumentParser } = require('./github/parser');
 const logger = require('./utils/logger');
 const { rejectUrlLikeLocalReviewPath } = require('./utils/local-path-input');
 const { normalizeRepository } = require('./utils/paths');
+const { isDualHostRepo, hostSetupParamValue } = require('./utils/host-resolution');
 const { buildInteractiveAnalysisConfig } = require('./interactive-analysis-config');
 const { version: packageVersion } = require('../package.json');
 
@@ -169,6 +170,9 @@ function storeAnalysisConfigRemote(port, analysisConfig, _deps) {
  *   the resolved provider/model or council snapshot PLUS custom instructions). When
  *   present it supersedes `councilId` — the id already carries the council selection,
  *   mirroring the cold-start precedence in handlePullRequest/handleLocalReview.
+ * @param {string} [context.host] - Setup `?host=` value (alt api_host string or the
+ *   'github' sentinel) so a pasted alt URL binds directly instead of re-probing.
+ *   Already resolved by the caller via `hostSetupParamValue`; omitted when null.
  * @returns {string} Full URL
  */
 function buildDelegationUrl(port, mode, context = {}) {
@@ -182,6 +186,8 @@ function buildDelegationUrl(port, mode, context = {}) {
     } else if (context.councilId) {
       query.push(`council=${encodeURIComponent(context.councilId)}`);
     }
+    // Thread the pasted URL's host so setup binds it directly (cold-start parity).
+    if (context.host) query.push(`host=${encodeURIComponent(context.host)}`);
     if (query.length) url += `?${query.join('&')}`;
     return url;
   }
@@ -292,7 +298,12 @@ async function attemptDelegation(config, flags, prArgs, _deps, options = {}) {
     const prInfo = await parsePRArgsForDelegation(prArgs, config, _deps);
     const repository = normalizeRepository(prInfo.owner, prInfo.repo);
     const analysisConfigId = await handoffAnalysisConfigId(repository);
-    url = buildDelegationUrl(port, 'pr', { ...prInfo, analyze, councilId, analysisConfigId });
+    // Thread the parsed host so a pasted alt URL binds directly (no re-probe) —
+    // same mapping as the cold-start handlePullRequest path. bindingRepository
+    // (from a url_pattern match) is the config key that determines dual-ness.
+    const bindingRepository = prInfo.bindingRepository || repository;
+    const host = hostSetupParamValue(prInfo.host, isDualHostRepo(config, bindingRepository));
+    url = buildDelegationUrl(port, 'pr', { ...prInfo, analyze, councilId, analysisConfigId, host });
   } else {
     url = buildDelegationUrl(port, 'server');
   }

--- a/src/utils/host-resolution.js
+++ b/src/utils/host-resolution.js
@@ -1,0 +1,157 @@
+// Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+/**
+ * Shared per-PR host resolution helpers for dual (github.com + alt-host) repos.
+ *
+ * A single source of truth for the "legacy NULL" back-compat convention that
+ * translates a stored `pr_metadata.host` value into the `options` argument for
+ * `resolveHostBinding`. Multiple entry points need this exact mapping
+ * (PR-mode routes, PR setup, external-comment sync, stack analysis); keeping it
+ * here stops the copies from drifting.
+ */
+
+const { getRepoConfig, isExclusiveAltHost, resolveHostBinding } = require('../config');
+
+/**
+ * Translate a stored `pr_metadata.host` value into the `options` object for
+ * `resolveHostBinding`, applying the legacy-NULL back-compat convention:
+ *
+ *   - `undefined` (no pr_metadata row) → `undefined` (ambiguity rule; caller
+ *     should pass `{}` / omit the option to `resolveHostBinding`).
+ *   - `null` on an EXCLUSIVE alt-host repo → `undefined`. A legacy NULL row
+ *     predates host stamping and that repo has no github.com presence, so
+ *     `{ host: null }` would throw. Falling back to the ambiguity rule binds
+ *     to its alt host exactly as before this feature.
+ *   - `null` on a plain or dual repo → `{ host: null }` (github.com).
+ *   - a URL string → `{ host: '<url>' }` (that alt host).
+ *
+ * @param {Object} config - Application config
+ * @param {string} bindingRepository - `repos[...]` config-lookup key
+ * @param {string|null|undefined} storedHost - Value from `getPRHost`
+ * @returns {{ host: string|null }|undefined} The `resolveHostBinding` option,
+ *   or `undefined` to signal "use the ambiguity rule".
+ */
+function storedHostToOption(config, bindingRepository, storedHost) {
+  if (storedHost === undefined) return undefined;
+  if (storedHost === null && isExclusiveAltHost(getRepoConfig(config, bindingRepository))) {
+    return undefined;
+  }
+  return { host: storedHost };
+}
+
+/**
+ * A DUAL repo has an `api_host` configured but is NOT exclusive — its PRs may
+ * live on github.com OR the alt host, so a host-unknown setup must probe.
+ * Exclusive alt-host repos and plain github repos are NOT dual.
+ *
+ * This is the `repoConfig`-shaped predicate; callers that hold a `repos[...]`
+ * entry directly (e.g. repo-links, pr-setup) use it, while `isDualHostRepo`
+ * resolves a binding key to its entry first.
+ *
+ * @param {Object|null|undefined} repoConfig - A single `repos[...]` entry
+ * @returns {boolean}
+ */
+function isDualHostRepoConfig(repoConfig) {
+  const apiHost = (repoConfig && typeof repoConfig.api_host === 'string' && repoConfig.api_host)
+    ? repoConfig.api_host
+    : null;
+  return apiHost !== null && isExclusiveAltHost(repoConfig) === false;
+}
+
+/**
+ * Binding-key-shaped variant of {@link isDualHostRepoConfig}: resolves the
+ * `repos[...]` entry for `bindingRepository` before applying the predicate.
+ *
+ * @param {Object} config - Application config
+ * @param {string} bindingRepository - `repos[...]` config-lookup key
+ * @returns {boolean}
+ */
+function isDualHostRepo(config, bindingRepository) {
+  return isDualHostRepoConfig(getRepoConfig(config, bindingRepository));
+}
+
+/**
+ * The configured `api_host` URL string for a binding key, or `null` when the
+ * repo has none (plain github). Used by credential preflights that need to
+ * resolve the alt-host binding as a second candidate.
+ *
+ * @param {Object} config - Application config
+ * @param {string} bindingRepository - `repos[...]` config-lookup key
+ * @returns {string|null}
+ */
+function getConfiguredApiHost(config, bindingRepository) {
+  const repoConfig = getRepoConfig(config, bindingRepository);
+  return (repoConfig && typeof repoConfig.api_host === 'string' && repoConfig.api_host)
+    ? repoConfig.api_host
+    : null;
+}
+
+/**
+ * Resolve the binding used for a credential PREFLIGHT (fail-fast gate before
+ * network work), tolerating a dual repo whose host is still unknown.
+ *
+ * The primary binding is resolved against `host` (undefined = unknown →
+ * ambiguity rule; null = github; api_host string = that alt host). When the
+ * host is unknown AND the repo is dual, the ambiguity rule yields the github.com
+ * binding — but the downstream probe (`resolvePrHostBinding`) tries the alt host
+ * first, so an alt-only repo token IS usable even though the github binding has
+ * none. In that case return the alt binding so the caller does not falsely
+ * reject; the caller only fails when NEITHER candidate has a token.
+ *
+ * Shared by the CLI (`src/main.js`) and the setup route (`src/routes/setup.js`).
+ *
+ * @param {string} bindingRepository - `repos[...]` config-lookup key
+ * @param {Object} config
+ * @param {string|null|undefined} host - explicit host (URL paste / body) or undefined
+ * @returns {{ apiHost: string|null, token: string }} A binding; empty `.token`
+ *   signals the caller to reject (missing credential).
+ */
+function resolvePreflightBinding(bindingRepository, config, host) {
+  const primary = resolveHostBinding(
+    bindingRepository,
+    config,
+    host !== undefined ? { host } : {}
+  );
+  if (primary.token) return primary;
+  if (host === undefined && isDualHostRepo(config, bindingRepository)) {
+    const apiHost = getConfiguredApiHost(config, bindingRepository);
+    if (apiHost) {
+      const alt = resolveHostBinding(bindingRepository, config, { host: apiHost });
+      if (alt.token) return alt;
+    }
+  }
+  return primary;
+}
+
+/**
+ * Map a parser/stored host to the VALUE for the setup `?host=` query param, or
+ * `null` to omit the param. Single source for the CLI cold-start, single-port
+ * delegation, and (mirrored) the web paste flow — so a pasted alt URL binds the
+ * alt host directly instead of re-probing at setup.
+ *
+ *   - alt api_host URL string → that string (setup binds the alt host)
+ *   - `null` on a DUAL repo   → the `'github'` sentinel (setup binds github.com,
+ *     no probe — avoids a loud failure if the alt host is down for a PR we KNOW
+ *     is on github)
+ *   - anything else (plain/exclusive repo, or unknown host) → `null` (omit; no
+ *     probe happens for those, and omitting avoids the exclusive-null throw)
+ *
+ * Callers append the value as `host=${encodeURIComponent(value)}`.
+ *
+ * @param {string|null|undefined} host - parser/stored host
+ * @param {boolean} isDual - whether the repo is dual (github + alt-host)
+ * @returns {string|null} the param value, or null to omit
+ */
+function hostSetupParamValue(host, isDual) {
+  if (typeof host === 'string' && host) return host;
+  if (host === null && isDual) return 'github';
+  return null;
+}
+
+module.exports = {
+  storedHostToOption,
+  isDualHostRepo,
+  isDualHostRepoConfig,
+  getConfiguredApiHost,
+  resolvePreflightBinding,
+  hostSetupParamValue,
+};

--- a/tests/e2e/repo-links.spec.js
+++ b/tests/e2e/repo-links.spec.js
@@ -11,7 +11,9 @@
  *
  * The /api/repos/:owner/:repo/links endpoint is intercepted at the
  * Playwright network layer so the test does not depend on the test
- * server having `repos` configured.
+ * server having `repos` configured. The route glob ends in `links**`
+ * (not just `links`) because PR mode appends a `?number=<n>` query so the
+ * server can resolve the link set against the PR's host for dual-host repos.
  */
 
 import { test, expect } from './fixtures.js';
@@ -23,7 +25,7 @@ test.describe('Repo Links UI', () => {
     // owner/repo match what the page is showing.
     let fetchedUrl = null;
 
-    await page.route('**/api/repos/*/*/links', (route) => {
+    await page.route('**/api/repos/*/*/links**', (route) => {
       fetchedUrl = route.request().url();
       route.fulfill({
         status: 200,
@@ -74,7 +76,7 @@ test.describe('Repo Links UI', () => {
   });
 
   test('hides the github link without removing other header buttons', async ({ page }) => {
-    await page.route('**/api/repos/*/*/links', (route) => {
+    await page.route('**/api/repos/*/*/links**', (route) => {
       route.fulfill({
         status: 200,
         contentType: 'application/json',
@@ -97,7 +99,7 @@ test.describe('Repo Links UI', () => {
   });
 
   test('preserves default behaviour when the API returns the empty config', async ({ page }) => {
-    await page.route('**/api/repos/*/*/links', (route) => {
+    await page.route('**/api/repos/*/*/links**', (route) => {
       route.fulfill({
         status: 200,
         contentType: 'application/json',
@@ -118,7 +120,7 @@ test.describe('Repo Links UI', () => {
   });
 
   test('drops the external link when the URL template lacks a required placeholder', async ({ page }) => {
-    await page.route('**/api/repos/*/*/links', (route) => {
+    await page.route('**/api/repos/*/*/links**', (route) => {
       route.fulfill({
         status: 200,
         contentType: 'application/json',

--- a/tests/integration/database.test.js
+++ b/tests/integration/database.test.js
@@ -3552,3 +3552,327 @@ describe('Migration 49 - is_file_level on external_comments', () => {
     expect(CURRENT_SCHEMA_VERSION).toBeGreaterThanOrEqual(49);
   });
 });
+
+describe('Migration 50 - host column on pr_metadata and github_pr_cache', () => {
+  let db;
+  const Database = require('better-sqlite3');
+
+  // Pre-50 shape: pr_metadata and github_pr_cache WITHOUT the host column.
+  function createPreMigration50Database() {
+    const testDb = new Database(':memory:');
+    testDb.exec(`
+      CREATE TABLE pr_metadata (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        pr_number INTEGER NOT NULL,
+        repository TEXT NOT NULL,
+        title TEXT,
+        pr_data TEXT,
+        last_ai_run_id TEXT,
+        last_accessed_at TEXT,
+        UNIQUE(pr_number, repository)
+      )
+    `);
+    testDb.exec(`
+      CREATE TABLE github_pr_cache (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        owner TEXT NOT NULL,
+        repo TEXT NOT NULL,
+        number INTEGER NOT NULL,
+        collection TEXT NOT NULL,
+        fetched_at DATETIME DEFAULT CURRENT_TIMESTAMP
+      )
+    `);
+    testDb.pragma('user_version = 49');
+    return testDb;
+  }
+
+  function columnNames(testDb, table) {
+    return testDb.prepare(`PRAGMA table_info(${table})`).all().map(c => c.name);
+  }
+
+  afterEach(() => {
+    if (db) { db.close(); db = null; }
+  });
+
+  it('adds the host column to both tables', () => {
+    db = createPreMigration50Database();
+    expect(columnNames(db, 'pr_metadata')).not.toContain('host');
+    expect(columnNames(db, 'github_pr_cache')).not.toContain('host');
+
+    MIGRATIONS[50](db);
+
+    expect(columnNames(db, 'pr_metadata')).toContain('host');
+    expect(columnNames(db, 'github_pr_cache')).toContain('host');
+  });
+
+  it('leaves existing rows with NULL host (no backfill)', () => {
+    db = createPreMigration50Database();
+    db.prepare("INSERT INTO pr_metadata (pr_number, repository, title) VALUES (1, 'o/r', 't')").run();
+
+    MIGRATIONS[50](db);
+
+    const row = db.prepare('SELECT host FROM pr_metadata WHERE pr_number = 1').get();
+    expect(row.host).toBeNull();
+  });
+
+  it('is idempotent — running twice does not throw or duplicate the column', () => {
+    db = createPreMigration50Database();
+    MIGRATIONS[50](db);
+    expect(() => MIGRATIONS[50](db)).not.toThrow();
+    expect(columnNames(db, 'pr_metadata').filter(n => n === 'host')).toHaveLength(1);
+    expect(columnNames(db, 'github_pr_cache').filter(n => n === 'host')).toHaveLength(1);
+  });
+
+  it('does not throw when a target table is absent', () => {
+    const testDb = new Database(':memory:');
+    testDb.pragma('user_version = 49');
+    expect(() => MIGRATIONS[50](testDb)).not.toThrow();
+    testDb.close();
+  });
+
+  it('a fresh database (full schema) already has the host columns', async () => {
+    db = await createTestDatabase();
+    expect((await query(db, 'PRAGMA table_info(pr_metadata)')).map(c => c.name)).toContain('host');
+    expect((await query(db, 'PRAGMA table_info(github_pr_cache)')).map(c => c.name)).toContain('host');
+  });
+
+  it('CURRENT_SCHEMA_VERSION reaches 50', () => {
+    const { CURRENT_SCHEMA_VERSION } = require('../../src/database');
+    expect(CURRENT_SCHEMA_VERSION).toBeGreaterThanOrEqual(50);
+  });
+});
+
+// ============================================================================
+// PRMetadataRepository.getPRHost Tests
+// ============================================================================
+
+describe('PRMetadataRepository.getPRHost', () => {
+  let db;
+  let prMetadataRepo;
+  const { PRMetadataRepository } = database;
+
+  beforeEach(async () => {
+    db = await createTestDatabase();
+    prMetadataRepo = new PRMetadataRepository(db);
+  });
+
+  afterEach(async () => {
+    if (db) {
+      await closeTestDatabase(db);
+    }
+  });
+
+  it('returns undefined when no pr_metadata row exists', async () => {
+    const host = await prMetadataRepo.getPRHost('owner/repo', 123);
+    expect(host).toBeUndefined();
+  });
+
+  it('returns null when the row exists but host is unset (github.com)', async () => {
+    await run(db, `INSERT INTO pr_metadata (pr_number, repository, title) VALUES (?, ?, ?)`, [123, 'owner/repo', 't']);
+    const host = await prMetadataRepo.getPRHost('owner/repo', 123);
+    expect(host).toBeNull();
+  });
+
+  it('returns the stored api_host URL string when set', async () => {
+    await run(db, `INSERT INTO pr_metadata (pr_number, repository, title, host) VALUES (?, ?, ?, ?)`,
+      [123, 'owner/repo', 't', 'https://ghe.example.com/api/v3']);
+    const host = await prMetadataRepo.getPRHost('owner/repo', 123);
+    expect(host).toBe('https://ghe.example.com/api/v3');
+  });
+
+  it('matches the repository case-insensitively (COLLATE NOCASE)', async () => {
+    await run(db, `INSERT INTO pr_metadata (pr_number, repository, title, host) VALUES (?, ?, ?, ?)`,
+      [123, 'Owner/Repo', 't', 'https://ghe.example.com/api/v3']);
+    const host = await prMetadataRepo.getPRHost('owner/repo', 123);
+    expect(host).toBe('https://ghe.example.com/api/v3');
+  });
+
+  it('distinguishes PRs by number within the same repository', async () => {
+    await run(db, `INSERT INTO pr_metadata (pr_number, repository, title, host) VALUES (?, ?, ?, ?)`,
+      [1, 'owner/repo', 't', 'https://ghe.example.com/api/v3']);
+    await run(db, `INSERT INTO pr_metadata (pr_number, repository, title) VALUES (?, ?, ?)`,
+      [2, 'owner/repo', 't']);
+
+    expect(await prMetadataRepo.getPRHost('owner/repo', 1)).toBe('https://ghe.example.com/api/v3');
+    expect(await prMetadataRepo.getPRHost('owner/repo', 2)).toBeNull();
+    expect(await prMetadataRepo.getPRHost('owner/repo', 3)).toBeUndefined();
+  });
+});
+
+// ============================================================================
+// PRMetadataRepository.updatePRHost Tests
+// ============================================================================
+
+describe('PRMetadataRepository.updatePRHost', () => {
+  let db;
+  let prMetadataRepo;
+  const { PRMetadataRepository } = database;
+
+  beforeEach(async () => {
+    db = await createTestDatabase();
+    prMetadataRepo = new PRMetadataRepository(db);
+  });
+
+  afterEach(async () => {
+    if (db) {
+      await closeTestDatabase(db);
+    }
+  });
+
+  it('updates host from a URL string to null (github.com)', async () => {
+    await run(db, `INSERT INTO pr_metadata (pr_number, repository, title, host) VALUES (?, ?, ?, ?)`,
+      [123, 'owner/repo', 't', 'https://ghe.example.com/api/v3']);
+
+    const changed = await prMetadataRepo.updatePRHost('owner/repo', 123, null);
+    expect(changed).toBe(true);
+    expect(await prMetadataRepo.getPRHost('owner/repo', 123)).toBeNull();
+  });
+
+  it('updates host from null to a URL string', async () => {
+    await run(db, `INSERT INTO pr_metadata (pr_number, repository, title) VALUES (?, ?, ?)`,
+      [123, 'owner/repo', 't']);
+    expect(await prMetadataRepo.getPRHost('owner/repo', 123)).toBeNull();
+
+    const changed = await prMetadataRepo.updatePRHost('owner/repo', 123, 'https://ghe.example.com/api/v3');
+    expect(changed).toBe(true);
+    expect(await prMetadataRepo.getPRHost('owner/repo', 123)).toBe('https://ghe.example.com/api/v3');
+  });
+
+  it('matches the repository case-insensitively (COLLATE NOCASE)', async () => {
+    await run(db, `INSERT INTO pr_metadata (pr_number, repository, title) VALUES (?, ?, ?)`,
+      [123, 'Owner/Repo', 't']);
+
+    const changed = await prMetadataRepo.updatePRHost('owner/repo', 123, 'https://ghe.example.com/api/v3');
+    expect(changed).toBe(true);
+    expect(await prMetadataRepo.getPRHost('Owner/Repo', 123)).toBe('https://ghe.example.com/api/v3');
+  });
+
+  it('is a no-op (returns false) when no matching row exists', async () => {
+    const changed = await prMetadataRepo.updatePRHost('owner/repo', 999, 'https://ghe.example.com/api/v3');
+    expect(changed).toBe(false);
+  });
+
+  it('leaves other columns untouched', async () => {
+    await run(db, `INSERT INTO pr_metadata (pr_number, repository, title, pr_data) VALUES (?, ?, ?, ?)`,
+      [123, 'owner/repo', 'Original title', '{"key":"value"}']);
+
+    await prMetadataRepo.updatePRHost('owner/repo', 123, 'https://ghe.example.com/api/v3');
+
+    const row = await queryOne(db,
+      'SELECT title, pr_data, host FROM pr_metadata WHERE pr_number = ? AND repository = ? COLLATE NOCASE',
+      [123, 'owner/repo']);
+    expect(row.title).toBe('Original title');
+    expect(row.pr_data).toBe('{"key":"value"}');
+    expect(row.host).toBe('https://ghe.example.com/api/v3');
+  });
+});
+
+describe('Migration 51 - widen idx_github_pr_cache_unique with host', () => {
+  let db;
+  const Database = require('better-sqlite3');
+
+  // Pre-51 shape: github_pr_cache WITH the host column (migration 50 already
+  // ran) but the OLD 4-column unique index.
+  function createPreMigration51Database() {
+    const testDb = new Database(':memory:');
+    testDb.exec(`
+      CREATE TABLE github_pr_cache (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        owner TEXT NOT NULL,
+        repo TEXT NOT NULL,
+        number INTEGER NOT NULL,
+        collection TEXT NOT NULL,
+        host TEXT,
+        fetched_at DATETIME DEFAULT CURRENT_TIMESTAMP
+      )
+    `);
+    testDb.exec('CREATE UNIQUE INDEX idx_github_pr_cache_unique ON github_pr_cache(collection, owner, repo, number)');
+    testDb.pragma('user_version = 50');
+    return testDb;
+  }
+
+  // Columns participating in the named index, in order.
+  function indexColumns(testDb, indexName) {
+    return testDb.prepare(`PRAGMA index_info(${indexName})`).all().map(r => r.name);
+  }
+
+  afterEach(() => {
+    if (db) { db.close(); db = null; }
+  });
+
+  it('rebuilds the unique index to include host', () => {
+    db = createPreMigration51Database();
+    expect(indexColumns(db, 'idx_github_pr_cache_unique')).toEqual(['collection', 'owner', 'repo', 'number']);
+
+    MIGRATIONS[51](db);
+
+    expect(indexColumns(db, 'idx_github_pr_cache_unique')).toEqual(['collection', 'owner', 'repo', 'number', 'host']);
+  });
+
+  it('is idempotent — running twice keeps the same index shape', () => {
+    db = createPreMigration51Database();
+    MIGRATIONS[51](db);
+    expect(() => MIGRATIONS[51](db)).not.toThrow();
+    expect(indexColumns(db, 'idx_github_pr_cache_unique')).toEqual(['collection', 'owner', 'repo', 'number', 'host']);
+  });
+
+  it('does not throw when github_pr_cache is absent', () => {
+    const testDb = new Database(':memory:');
+    testDb.pragma('user_version = 50');
+    expect(() => MIGRATIONS[51](testDb)).not.toThrow();
+    testDb.close();
+  });
+
+  it('a fresh database (full schema) already has host in the unique index', async () => {
+    db = await createTestDatabase();
+    const cols = (await query(db, 'PRAGMA index_info(idx_github_pr_cache_unique)')).map(r => r.name);
+    expect(cols).toEqual(['collection', 'owner', 'repo', 'number', 'host']);
+  });
+
+  it('CURRENT_SCHEMA_VERSION reaches 51', () => {
+    const { CURRENT_SCHEMA_VERSION } = require('../../src/database');
+    expect(CURRENT_SCHEMA_VERSION).toBeGreaterThanOrEqual(51);
+  });
+
+  // Regression for the actual failure: a github row (host NULL) and an alt-host
+  // row (host = api_host URL) sharing the same (collection, owner, repo, number)
+  // must coexist. Under the old 4-column index the second insert threw and the
+  // collections refresh rolled back the whole transaction, showing zero PRs.
+  it('lets github (host NULL) and alt-host rows with the same collection/owner/repo/number coexist', async () => {
+    db = await createTestDatabase();
+
+    await run(db, `
+      INSERT INTO github_pr_cache (owner, repo, number, collection, host)
+      VALUES ('owner', 'repo', 5, 'my-prs', NULL)
+    `);
+
+    // Same (collection, owner, repo, number), different host — must NOT throw.
+    await run(db, `
+      INSERT INTO github_pr_cache (owner, repo, number, collection, host)
+      VALUES ('owner', 'repo', 5, 'my-prs', 'https://alt.example/api/v3')
+    `);
+
+    const rows = await query(db, `
+      SELECT host FROM github_pr_cache
+      WHERE collection = 'my-prs' AND owner = 'owner' AND repo = 'repo' AND number = 5
+      ORDER BY host
+    `);
+    expect(rows.map(r => r.host)).toEqual([null, 'https://alt.example/api/v3']);
+  });
+
+  it('still rejects a duplicate row with the same host (same collection/owner/repo/number/host)', async () => {
+    db = await createTestDatabase();
+
+    await run(db, `
+      INSERT INTO github_pr_cache (owner, repo, number, collection, host)
+      VALUES ('owner', 'repo', 7, 'my-prs', 'https://alt.example/api/v3')
+    `);
+
+    await expect(
+      run(db, `
+        INSERT INTO github_pr_cache (owner, repo, number, collection, host)
+        VALUES ('owner', 'repo', 7, 'my-prs', 'https://alt.example/api/v3')
+      `)
+    ).rejects.toThrow(/UNIQUE/i);
+  });
+});

--- a/tests/integration/external-comments-sync.test.js
+++ b/tests/integration/external-comments-sync.test.js
@@ -230,6 +230,72 @@ describe('POST /api/reviews/:reviewId/external-comments/sync', () => {
     expect(stored[0].body).toBe('after edit');
   });
 
+  // --- Dual-repo (github + alt-host) per-PR host binding ---
+
+  // Build an app whose config marks owner/repo as a DUAL repo (api_host +
+  // exclusive:false). The real resolveHostBinding runs; only the client is faked.
+  function createDualApp(db, FakeGitHubClient) {
+    const app = express();
+    app.use(express.json());
+    app.set('db', db);
+    app.set('config', {
+      github_token: 'gh-tok',
+      repos: {
+        'owner/repo': { api_host: 'https://alt.example/api/v3', exclusive: false, token: 'alt-tok' }
+      }
+    });
+    app.set('externalCommentsDeps', { GitHubClient: FakeGitHubClient });
+    app.use('/', externalCommentsRoutes);
+    return app;
+  }
+
+  it('dual repo with stored alt host: binds the alt host and uses line-based anchoring', async () => {
+    // A stored alt host must resolve the alt binding. Proof is behavioural:
+    // the alt path keeps a valid `line` even when `position` is null, whereas
+    // github.com would null it and mark the row outdated.
+    db.prepare('INSERT INTO pr_metadata (pr_number, repository, host) VALUES (?, ?, ?)')
+      .run(42, 'owner/repo', 'https://alt.example/api/v3');
+
+    const { FakeGitHubClient, calls } = makeFakeClient([
+      makeApiRow({ id: 501, position: null, line: 10, original_line: 10 })
+    ]);
+
+    const server = await startServer(createDualApp(db, FakeGitHubClient));
+    const res = await request(server)
+      .post(`/api/reviews/${reviewId}/external-comments/sync`)
+      .query({ source: 'github' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.count).toBe(1);
+    // Client was built from the alt binding (apiHost carried on the binding object).
+    expect(calls).toHaveLength(1);
+
+    const row = db.prepare('SELECT * FROM external_comments WHERE review_id = ? AND external_id = ?').get(reviewId, '501');
+    // Alt-host line-based anchoring: line kept, not marked outdated.
+    expect(row.is_outdated).toBe(0);
+    expect(row.line_end).toBe(10);
+  });
+
+  it('dual repo with stored NULL host: binds github.com and uses position-based anchoring', async () => {
+    db.prepare('INSERT INTO pr_metadata (pr_number, repository, host) VALUES (?, ?, ?)')
+      .run(42, 'owner/repo', null);
+
+    const { FakeGitHubClient } = makeFakeClient([
+      makeApiRow({ id: 502, position: null, line: 10, original_line: 10 })
+    ]);
+
+    const server = await startServer(createDualApp(db, FakeGitHubClient));
+    const res = await request(server)
+      .post(`/api/reviews/${reviewId}/external-comments/sync`)
+      .query({ source: 'github' });
+
+    expect(res.status).toBe(200);
+    const row = db.prepare('SELECT * FROM external_comments WHERE review_id = ? AND external_id = ?').get(reviewId, '502');
+    // github.com position-based anchoring: null position → outdated, line nulled.
+    expect(row.is_outdated).toBe(1);
+    expect(row.line_end).toBe(null);
+  });
+
   it('outdated comment: position=null but original_position set → upserted with is_outdated=1', async () => {
     const rows = [
       makeApiRow({

--- a/tests/integration/github-collections.test.js
+++ b/tests/integration/github-collections.test.js
@@ -8,6 +8,15 @@ import { listenOnLoopback, closeServer } from '../utils/loopback-server';
 const { GitHubClient } = require('../../src/github/client');
 const configModule = require('../../src/config');
 const { run, query } = require('../../src/database');
+const logger = require('../../src/utils/logger');
+
+// Capture the real getAuthenticatedUser before spying. The alt-host sweep and
+// the github.com search share the same prototype, so alt-host tests mock this
+// with an implementation that delegates the alt client (apiHost set) to the
+// REAL octokit call — hitting a loopback alt host — while the github.com client
+// (apiHost null) stays mocked. `listOpenPullRequests` is intentionally NOT
+// spied so the alt client exercises the real REST path against the loopback.
+const realGetAuthenticatedUser = GitHubClient.prototype.getAuthenticatedUser;
 
 // Spy on config module to prevent writing to user's real config
 vi.spyOn(configModule, 'getGitHubToken');
@@ -774,6 +783,351 @@ describe('GitHub Collections Routes', () => {
 
       expect(res.status).toBe(500);
       expect(res.body.success).toBe(false);
+    });
+  });
+
+  // ==========================================================================
+  // Alt-host sweep — refresh lists PRs from configured api_host repos too
+  // ==========================================================================
+
+  describe('alt-host sweep on refresh', () => {
+    let altServer;
+    let apiHost;
+
+    // Alt-host PR fixtures (REST `pulls.list` shape). Classification:
+    //   #101 authored by altuser        → my-prs
+    //   #102 requests reviewer altuser   → review-requests
+    //   #103 requests team platform only → team-reviews (all-teams)
+    const ALT_PULLS = [
+      {
+        number: 101, title: 'Alt my PR', state: 'open',
+        updated_at: '2025-04-01T10:00:00Z',
+        html_url: 'https://althost.example/altorg/altrepo/pull/101',
+        user: { login: 'altuser' }, requested_reviewers: [], requested_teams: []
+      },
+      {
+        number: 102, title: 'Alt review request', state: 'open',
+        updated_at: '2025-04-02T10:00:00Z',
+        html_url: 'https://althost.example/altorg/altrepo/pull/102',
+        user: { login: 'someoneelse' },
+        requested_reviewers: [{ login: 'altuser' }], requested_teams: []
+      },
+      {
+        number: 103, title: 'Alt team request', state: 'open',
+        updated_at: '2025-04-03T10:00:00Z',
+        html_url: 'https://althost.example/altorg/altrepo/pull/103',
+        user: { login: 'other' },
+        requested_reviewers: [], requested_teams: [{ slug: 'platform' }]
+      }
+    ];
+
+    /**
+     * Stand up a loopback HTTP server that speaks the alt-host REST subset the
+     * sweep needs (`GET /user`, `GET /repos/:owner/:repo/pulls`). Handlers are
+     * overridable to simulate failures.
+     */
+    async function startAltHost({ user, pulls, userStatus, pullsStatus } = {}) {
+      const altApp = express();
+      altApp.get('/user', (req, res) => {
+        if (userStatus && userStatus >= 400) return res.status(userStatus).json({ message: 'alt /user failed' });
+        res.json(user || { login: 'altuser' });
+      });
+      altApp.get('/repos/:owner/:repo/pulls', (req, res) => {
+        if (pullsStatus && pullsStatus >= 400) return res.status(pullsStatus).json({ message: 'alt pulls failed' });
+        res.json(pulls || ALT_PULLS);
+      });
+      altServer = await listenOnLoopback(altApp);
+      apiHost = `http://127.0.0.1:${altServer.address().port}`;
+      return apiHost;
+    }
+
+    /**
+     * Replace the outer no-repos app/server with one whose config has an
+     * alt-host repo pointing at the loopback alt host.
+     */
+    async function useAltRepo(repoOverrides = {}) {
+      await closeServer(server);
+      const repos = {
+        'altorg/altrepo': { api_host: apiHost, token: 'alt-token', exclusive: false, ...repoOverrides }
+      };
+      app = createTestApp(db, { github_token: 'test-token', port: 7247, theme: 'light', repos });
+      server = await listenOnLoopback(app);
+    }
+
+    /** Wire the github.com client mocks (search + identity branch by apiHost). */
+    function mockGithub(githubLogin, githubPrs) {
+      configModule.getGitHubToken.mockReturnValue('test-token');
+      GitHubClient.prototype.searchPullRequests.mockResolvedValue(githubPrs);
+      GitHubClient.prototype.getAuthenticatedUser.mockImplementation(function () {
+        // Alt client (apiHost set) hits the real loopback; github client is mocked.
+        if (this.apiHost) return realGetAuthenticatedUser.call(this);
+        return Promise.resolve({ login: githubLogin, name: 'GH User', avatar_url: '' });
+      });
+    }
+
+    afterEach(async () => {
+      await closeServer(altServer);
+      altServer = null;
+    });
+
+    it('contributes alt-host rows (host stamped) alongside github rows (host NULL)', async () => {
+      await startAltHost();
+      await useAltRepo();
+      mockGithub('ghuser', [
+        {
+          owner: 'gh-org', repo: 'gh-repo', number: 5,
+          title: 'GitHub my PR', author: 'ghuser',
+          updated_at: '2025-03-01T12:00:00Z',
+          html_url: 'https://github.com/gh-org/gh-repo/pull/5', state: 'open'
+        }
+      ]);
+
+      const res = await request(server).post('/api/github/my-prs/refresh');
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+
+      // github row stamped NULL, alt row #101 (authored by altuser) stamped host.
+      const githubRow = res.body.prs.find(p => p.number === 5);
+      const altRow = res.body.prs.find(p => p.number === 101);
+      expect(githubRow).toBeTruthy();
+      expect(githubRow.host).toBeNull();
+      expect(altRow).toBeTruthy();
+      expect(altRow.host).toBe(apiHost);
+      expect(altRow.owner).toBe('altorg');
+      expect(altRow.repo).toBe('altrepo');
+      expect(altRow.author).toBe('altuser');
+
+      // Only the my-prs alt PR is included; the review/team ones are not.
+      expect(res.body.prs.some(p => p.number === 102 || p.number === 103)).toBe(false);
+
+      // Per-host status reported, additive and honest.
+      expect(res.body.hosts).toEqual([{ host: apiHost, repo: 'altorg/altrepo', ok: true }]);
+
+      // Persisted with host column.
+      const dbRows = await query(db, "SELECT number, host FROM github_pr_cache WHERE collection = 'my-prs' ORDER BY number", []);
+      expect(dbRows).toEqual([
+        { number: 5, host: null },
+        { number: 101, host: apiHost }
+      ]);
+    });
+
+    it('classifies review-requests by requested_reviewers on the alt host', async () => {
+      await startAltHost();
+      await useAltRepo();
+      mockGithub('ghuser', []);
+
+      const res = await request(server).post('/api/github/review-requests/refresh');
+
+      expect(res.status).toBe(200);
+      const numbers = res.body.prs.map(p => p.number).sort();
+      expect(numbers).toEqual([102]); // only the PR requesting altuser as reviewer
+      expect(res.body.prs[0].host).toBe(apiHost);
+    });
+
+    it('classifies team-reviews by requested_teams (all-teams view)', async () => {
+      await startAltHost();
+      await useAltRepo();
+      mockGithub('ghuser', []);
+
+      const res = await request(server).post('/api/github/team-reviews/refresh');
+
+      expect(res.status).toBe(200);
+      const numbers = res.body.prs.map(p => p.number).sort();
+      expect(numbers).toEqual([103]); // only the team-requested PR
+    });
+
+    it('keeps github rows intact and reports the error when an alt host fails', async () => {
+      await startAltHost({ pullsStatus: 500 });
+      await useAltRepo();
+      mockGithub('ghuser', [
+        {
+          owner: 'gh-org', repo: 'gh-repo', number: 7,
+          title: 'GitHub PR', author: 'ghuser',
+          updated_at: '2025-03-02T12:00:00Z',
+          html_url: 'https://github.com/gh-org/gh-repo/pull/7', state: 'open'
+        }
+      ]);
+
+      const res = await request(server).post('/api/github/my-prs/refresh');
+
+      // github.com refresh still succeeds with its rows.
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.prs).toHaveLength(1);
+      expect(res.body.prs[0].number).toBe(7);
+      expect(res.body.prs[0].host).toBeNull();
+
+      // The alt host failure is surfaced, not swallowed.
+      expect(res.body.hosts).toHaveLength(1);
+      expect(res.body.hosts[0]).toMatchObject({ host: apiHost, repo: 'altorg/altrepo', ok: false });
+      expect(res.body.hosts[0].error).toBeTruthy();
+
+      // Cache holds only the github row.
+      const dbRows = await query(db, "SELECT number, host FROM github_pr_cache WHERE collection = 'my-prs'", []);
+      expect(dbRows).toEqual([{ number: 7, host: null }]);
+    });
+
+    it('a failing /user on the alt host does not break the github refresh', async () => {
+      await startAltHost({ userStatus: 500 });
+      await useAltRepo();
+      mockGithub('ghuser', []);
+
+      const res = await request(server).post('/api/github/my-prs/refresh');
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.hosts[0].ok).toBe(false);
+    });
+
+    it('retrying refresh does not duplicate alt-host rows', async () => {
+      await startAltHost();
+      await useAltRepo();
+      mockGithub('ghuser', []);
+
+      await request(server).post('/api/github/my-prs/refresh');
+      await request(server).post('/api/github/my-prs/refresh');
+
+      const dbRows = await query(db, "SELECT number, host FROM github_pr_cache WHERE collection = 'my-prs'", []);
+      expect(dbRows).toEqual([{ number: 101, host: apiHost }]);
+    });
+
+    it('GET returns the host column for cached rows', async () => {
+      await startAltHost();
+      await useAltRepo();
+      mockGithub('ghuser', []);
+
+      await request(server).post('/api/github/my-prs/refresh');
+      const res = await request(server).get('/api/github/my-prs');
+
+      expect(res.status).toBe(200);
+      expect(res.body.prs).toHaveLength(1);
+      expect(res.body.prs[0].host).toBe(apiHost);
+    });
+
+    it('refreshes an alt-host-only install with no github.com token (skips github branch)', async () => {
+      await startAltHost();
+      await useAltRepo(); // alt repo HAS a token ('alt-token')
+      // No top-level github token — alt-host-only install.
+      configModule.getGitHubToken.mockReturnValue(null);
+      GitHubClient.prototype.getAuthenticatedUser.mockImplementation(function () {
+        if (this.apiHost) return realGetAuthenticatedUser.call(this);
+        return Promise.resolve({ login: 'ghuser', name: 'GH User', avatar_url: '' });
+      });
+
+      const res = await request(server).post('/api/github/my-prs/refresh');
+
+      expect(res.status).toBe(200);
+      // Alt rows still written (PR #101 authored by altuser → my-prs).
+      expect(res.body.prs.some(p => p.number === 101 && p.host === apiHost)).toBe(true);
+      // github.com search never ran without a token.
+      expect(GitHubClient.prototype.searchPullRequests).not.toHaveBeenCalled();
+      // Both sources reported: github skipped, alt host ok.
+      expect(res.body.hosts).toContainEqual({ host: null, repo: null, ok: false, error: 'no github.com token configured' });
+      expect(res.body.hosts).toContainEqual({ host: apiHost, repo: 'altorg/altrepo', ok: true });
+
+      // Persisted alt row present; no github rows.
+      const dbRows = await query(db, "SELECT number, host FROM github_pr_cache WHERE collection = 'my-prs'", []);
+      expect(dbRows).toEqual([{ number: 101, host: apiHost }]);
+    });
+
+    it('returns 401 when NO source can authenticate (no github token, token-less alt repo)', async () => {
+      await closeServer(server);
+      app = createTestApp(db, {
+        port: 7247, theme: 'light',
+        // Alt repo with api_host but no credentials, and no top-level github token.
+        repos: { 'altorg/altrepo': { api_host: 'https://althost.example/api/v3', exclusive: false } }
+      });
+      server = await listenOnLoopback(app);
+      configModule.getGitHubToken.mockReturnValue(null);
+
+      const res = await request(server).post('/api/github/my-prs/refresh');
+
+      expect(res.status).toBe(401);
+      expect(res.body.success).toBe(false);
+      expect(res.body.error).toContain('token not configured');
+      // No probe attempted against the token-less repo.
+      expect(GitHubClient.prototype.getAuthenticatedUser).not.toHaveBeenCalled();
+    });
+
+    it('omits the hosts field for a healthy github-only install (backward compatible)', async () => {
+      // Default outer app has a github token and no repos.
+      configModule.getGitHubToken.mockReturnValue('test-token');
+      GitHubClient.prototype.getAuthenticatedUser.mockResolvedValue({ login: 'ghuser', name: '', avatar_url: '' });
+      GitHubClient.prototype.searchPullRequests.mockResolvedValue([]);
+
+      const res = await request(server).post('/api/github/my-prs/refresh');
+
+      expect(res.status).toBe(200);
+      expect(res.body).not.toHaveProperty('hosts');
+    });
+
+    it('reports a token-less alt repo without probing or error-logging', async () => {
+      // Repo has api_host but no repo-scoped credentials → empty-token binding.
+      // The sweep must NOT construct a client or probe (which would 401 and
+      // spam error logs); it reports a per-host status at debug level instead.
+      await closeServer(server);
+      const missingCredHost = 'https://althost.example/api/v3';
+      app = createTestApp(db, {
+        github_token: 'test-token', port: 7247, theme: 'light',
+        repos: { 'altorg/altrepo': { api_host: missingCredHost, exclusive: false } }
+      });
+      server = await listenOnLoopback(app);
+      mockGithub('ghuser', [
+        {
+          owner: 'gh-org', repo: 'gh-repo', number: 11,
+          title: 'GitHub PR', author: 'ghuser',
+          updated_at: '2025-03-04T12:00:00Z',
+          html_url: 'https://github.com/gh-org/gh-repo/pull/11', state: 'open'
+        }
+      ]);
+      const errorSpy = vi.spyOn(logger, 'error');
+
+      const res = await request(server).post('/api/github/my-prs/refresh');
+
+      expect(res.status).toBe(200);
+      // github rows intact.
+      expect(res.body.prs).toHaveLength(1);
+      expect(res.body.prs[0].number).toBe(11);
+      // Per-host status surfaced with the config-gap reason.
+      expect(res.body.hosts).toEqual([
+        { host: missingCredHost, repo: 'altorg/altrepo', ok: false, error: 'no credentials configured' }
+      ]);
+      // No probe happened: getAuthenticatedUser called once (github only), and
+      // no error-level log for a mere config gap.
+      expect(GitHubClient.prototype.getAuthenticatedUser).toHaveBeenCalledTimes(1);
+      expect(errorSpy).not.toHaveBeenCalled();
+
+      errorSpy.mockRestore();
+    });
+
+    it('skips a non-owner/repo config key and reports it without crashing', async () => {
+      await startAltHost();
+      await closeServer(server);
+      // A monorepo-style key that is not `owner/repo`; the sweep cannot derive
+      // a repo for pulls.list, so it must be skipped (not crash the refresh).
+      app = createTestApp(db, {
+        github_token: 'test-token', port: 7247, theme: 'light',
+        repos: { 'weird-monorepo-key': { api_host: apiHost, token: 'alt-token', exclusive: false } }
+      });
+      server = await listenOnLoopback(app);
+      mockGithub('ghuser', [
+        {
+          owner: 'gh-org', repo: 'gh-repo', number: 9,
+          title: 'GitHub PR', author: 'ghuser',
+          updated_at: '2025-03-03T12:00:00Z',
+          html_url: 'https://github.com/gh-org/gh-repo/pull/9', state: 'open'
+        }
+      ]);
+
+      const res = await request(server).post('/api/github/my-prs/refresh');
+
+      expect(res.status).toBe(200);
+      expect(res.body.prs).toHaveLength(1);
+      expect(res.body.prs[0].number).toBe(9);
+      expect(res.body.hosts).toHaveLength(1);
+      expect(res.body.hosts[0]).toMatchObject({ host: apiHost, repo: 'weird-monorepo-key', ok: false });
+      expect(res.body.hosts[0].error).toMatch(/owner\/repo/);
     });
   });
 });

--- a/tests/integration/pr-host-correction.test.js
+++ b/tests/integration/pr-host-correction.test.js
@@ -1,0 +1,110 @@
+// Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+/**
+ * Tests for the /pr fast-path `?host` correction helper (src/server.js).
+ *
+ * The /pr/:owner/:repo/:number route serves pr.html directly when a PR already
+ * has metadata + a worktree, so `applyHostQueryCorrection` is the only place
+ * that consumes an explicit `?host` hint on that fast path. It maps the sentinel
+ * ('github' → null, other string → alt api_host, absent → no-op), validates
+ * against config, and persists a corrected host via PRMetadataRepository.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { createTestDatabase, closeTestDatabase } from '../utils/schema';
+
+const { applyHostQueryCorrection } = require('../../src/server');
+const { run, PRMetadataRepository } = require('../../src/database');
+const logger = require('../../src/utils/logger');
+
+const API_HOST = 'https://althost.example/api/v3';
+const REPOSITORY = 'altorg/altrepo';
+const PR_NUMBER = 42;
+
+/** Config with a dual (non-exclusive) alt-host repo. */
+function dualConfig() {
+  return { repos: { [REPOSITORY]: { api_host: API_HOST, token: 'alt-token', exclusive: false } } };
+}
+
+/** Config with an exclusive alt-host repo (no github.com presence). */
+function exclusiveConfig() {
+  return { repos: { [REPOSITORY]: { api_host: API_HOST, token: 'alt-token' } } };
+}
+
+async function seedPR(db, host) {
+  await run(db,
+    'INSERT INTO pr_metadata (pr_number, repository, host) VALUES (?, ?, ?)',
+    [PR_NUMBER, REPOSITORY, host]
+  );
+}
+
+async function storedHost(db) {
+  return new PRMetadataRepository(db).getPRHost(REPOSITORY, PR_NUMBER);
+}
+
+describe('applyHostQueryCorrection (/pr fast path ?host)', () => {
+  let db;
+
+  beforeEach(() => {
+    db = createTestDatabase();
+  });
+
+  afterEach(() => {
+    if (db) closeTestDatabase(db);
+    vi.restoreAllMocks();
+  });
+
+  it('stamps a matching alt host onto a legacy NULL row', async () => {
+    await seedPR(db, null);
+
+    await applyHostQueryCorrection(db, dualConfig(), 'altorg', 'altrepo', REPOSITORY, PR_NUMBER, API_HOST);
+
+    expect(await storedHost(db)).toBe(API_HOST);
+  });
+
+  it('nulls the host for the github sentinel on a dual repo', async () => {
+    await seedPR(db, API_HOST);
+
+    await applyHostQueryCorrection(db, dualConfig(), 'altorg', 'altrepo', REPOSITORY, PR_NUMBER, 'github');
+
+    expect(await storedHost(db)).toBeNull();
+  });
+
+  it('warns and ignores a host that does not match the configured api_host', async () => {
+    await seedPR(db, null);
+    const warnSpy = vi.spyOn(logger, 'warn');
+
+    await applyHostQueryCorrection(db, dualConfig(), 'altorg', 'altrepo', REPOSITORY, PR_NUMBER, 'https://evil.example/api');
+
+    expect(warnSpy).toHaveBeenCalled();
+    expect(await storedHost(db)).toBeNull(); // untouched
+  });
+
+  it('warns and ignores the github sentinel for an exclusive alt-host repo', async () => {
+    await seedPR(db, API_HOST);
+    const warnSpy = vi.spyOn(logger, 'warn');
+
+    await applyHostQueryCorrection(db, exclusiveConfig(), 'altorg', 'altrepo', REPOSITORY, PR_NUMBER, 'github');
+
+    expect(warnSpy).toHaveBeenCalled();
+    expect(await storedHost(db)).toBe(API_HOST); // untouched
+  });
+
+  it('does nothing when no host query param is present', async () => {
+    await seedPR(db, null);
+    const warnSpy = vi.spyOn(logger, 'warn');
+
+    await applyHostQueryCorrection(db, dualConfig(), 'altorg', 'altrepo', REPOSITORY, PR_NUMBER, undefined);
+
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(await storedHost(db)).toBeNull();
+  });
+
+  it('skips the write when the stored host already matches', async () => {
+    await seedPR(db, API_HOST);
+    const updateSpy = vi.spyOn(PRMetadataRepository.prototype, 'updatePRHost');
+
+    await applyHostQueryCorrection(db, dualConfig(), 'altorg', 'altrepo', REPOSITORY, PR_NUMBER, API_HOST);
+
+    expect(updateSpy).not.toHaveBeenCalled();
+    expect(await storedHost(db)).toBe(API_HOST);
+  });
+});

--- a/tests/integration/pr-setup-host-resolution.test.js
+++ b/tests/integration/pr-setup-host-resolution.test.js
@@ -1,0 +1,203 @@
+// Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+/**
+ * Per-PR host resolution for dual (github + alt-host) repos.
+ *
+ * Exercises `resolvePrHostBinding` — the shared primitive used by every PR
+ * setup entry point (web setup route + CLI) — across the precedence matrix
+ * (explicit host > stored pr_metadata host > ambiguity/probe) and the probe
+ * error taxonomy (alt 200 → alt, alt 404 → github fallback, alt 401 → loud
+ * failure with NO fallback).
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+const { createTestDatabase, closeTestDatabase } = require('../utils/schema');
+const { run } = require('../../src/database');
+const { resolvePrHostBinding } = require('../../src/setup/pr-setup');
+const { GitHubApiError } = require('../../src/github/errors');
+
+const ALT_HOST = 'https://alt.example/api/v3';
+
+// A GitHubClient stand-in injected via `deps.GitHubClient`. Records every
+// construction so tests can assert which hosts were contacted (and, for the
+// no-fallback case, that a second host was NOT).
+function makeFakeClient(fetchBehaviour) {
+  const constructions = [];
+  class FakeClient {
+    constructor(arg) {
+      // `arg` is a binding object (has `.apiHost`) or a bare token string.
+      this.apiHost = (arg && typeof arg === 'object') ? arg.apiHost : null;
+      constructions.push({ apiHost: this.apiHost });
+    }
+    async repositoryExists() { return true; }
+    async fetchPullRequest(owner, repo, prNumber) {
+      return fetchBehaviour(this.apiHost, { owner, repo, prNumber });
+    }
+  }
+  return { FakeClient, constructions };
+}
+
+function insertPRHost(db, repository, prNumber, host) {
+  // `host === undefined` inserts no row; `null` / string writes the column.
+  return run(db, `INSERT INTO pr_metadata (pr_number, repository, host) VALUES (?, ?, ?)`,
+    [prNumber, repository, host === undefined ? null : host]);
+}
+
+const dualConfig = {
+  github_token: 'gh-tok',
+  repos: {
+    'acme/widgets': { api_host: ALT_HOST, exclusive: false, token: 'alt-tok' }
+  }
+};
+const exclusiveConfig = {
+  github_token: 'gh-tok',
+  repos: {
+    'acme/widgets': { api_host: ALT_HOST, token: 'alt-tok' }
+  }
+};
+const plainConfig = { github_token: 'gh-tok', repos: {} };
+
+const base = { bindingRepository: 'acme/widgets', owner: 'acme', repo: 'widgets', prNumber: 42, githubToken: 'gh-tok' };
+
+describe('resolvePrHostBinding — precedence + probe', () => {
+  let db;
+  beforeEach(() => { db = createTestDatabase(); });
+  afterEach(() => { if (db) closeTestDatabase(db); });
+
+  it('explicit host (alt url) binds to the alt host with no probe', async () => {
+    const { FakeClient, constructions } = makeFakeClient(() => ({ number: 42, title: 'x' }));
+    const { binding, prData } = await resolvePrHostBinding({
+      db, config: dualConfig, ...base, host: ALT_HOST, deps: { GitHubClient: FakeClient }
+    });
+    expect(binding.host).toBe(ALT_HOST);
+    expect(binding.apiHost).toBe(ALT_HOST);
+    expect(prData.number).toBe(42);
+    expect(constructions).toEqual([{ apiHost: ALT_HOST }]); // single client, no probe
+  });
+
+  it('explicit host null binds to github.com (dual repo)', async () => {
+    const { FakeClient, constructions } = makeFakeClient(() => ({ number: 42 }));
+    const { binding } = await resolvePrHostBinding({
+      db, config: dualConfig, ...base, host: null, deps: { GitHubClient: FakeClient }
+    });
+    expect(binding.host).toBe(null);
+    expect(binding.apiHost).toBe(null);
+    expect(constructions).toEqual([{ apiHost: null }]);
+  });
+
+  it('stored alt host wins when no explicit host is given', async () => {
+    await insertPRHost(db, 'acme/widgets', 42, ALT_HOST);
+    const { FakeClient, constructions } = makeFakeClient(() => ({ number: 42 }));
+    const { binding } = await resolvePrHostBinding({
+      db, config: dualConfig, ...base, host: undefined, deps: { GitHubClient: FakeClient }
+    });
+    expect(binding.host).toBe(ALT_HOST);
+    expect(constructions).toEqual([{ apiHost: ALT_HOST }]); // no probe
+  });
+
+  it('stored NULL host (dual repo) binds to github.com', async () => {
+    await insertPRHost(db, 'acme/widgets', 42, null);
+    const { FakeClient, constructions } = makeFakeClient(() => ({ number: 42 }));
+    const { binding } = await resolvePrHostBinding({
+      db, config: dualConfig, ...base, host: undefined, deps: { GitHubClient: FakeClient }
+    });
+    expect(binding.host).toBe(null);
+    expect(constructions).toEqual([{ apiHost: null }]);
+  });
+
+  it('probes the alt host first and binds there on success (dual, unknown)', async () => {
+    const { FakeClient, constructions } = makeFakeClient((apiHost) => {
+      if (apiHost === ALT_HOST) return { number: 42, title: 'on-alt' };
+      throw new Error('github should not be contacted');
+    });
+    const { binding, prData } = await resolvePrHostBinding({
+      db, config: dualConfig, ...base, host: undefined, deps: { GitHubClient: FakeClient }
+    });
+    expect(binding.host).toBe(ALT_HOST);
+    expect(prData.title).toBe('on-alt');
+    expect(constructions).toEqual([{ apiHost: ALT_HOST }]);
+  });
+
+  it('falls back to github.com when the alt host returns 404', async () => {
+    const { FakeClient, constructions } = makeFakeClient((apiHost) => {
+      if (apiHost === ALT_HOST) throw new GitHubApiError('Pull request #42 not found', 404);
+      return { number: 42, title: 'on-github' };
+    });
+    const { binding, prData } = await resolvePrHostBinding({
+      db, config: dualConfig, ...base, host: undefined, deps: { GitHubClient: FakeClient }
+    });
+    expect(binding.host).toBe(null);
+    expect(prData.title).toBe('on-github');
+    expect(constructions).toEqual([{ apiHost: ALT_HOST }, { apiHost: null }]); // probed alt, then github
+  });
+
+  it('does NOT fall back on a 401 from the alt host (fails loudly)', async () => {
+    const { FakeClient, constructions } = makeFakeClient((apiHost) => {
+      if (apiHost === ALT_HOST) throw new GitHubApiError('auth failed', 401);
+      return { number: 42, title: 'wrong-pr' };
+    });
+    await expect(resolvePrHostBinding({
+      db, config: dualConfig, ...base, host: undefined, deps: { GitHubClient: FakeClient }
+    })).rejects.toThrow(/alt\.example/);
+    // github.com must never be contacted — that could fetch a same-numbered PR.
+    expect(constructions).toEqual([{ apiHost: ALT_HOST }]);
+  });
+
+  it('probe with a token-less alt binding fails loudly and does NOT probe github disguised as alt', async () => {
+    // Dual repo whose alt host has NO configured token. The probe must not fall
+    // back to the github token (which would hit api.github.com while recording
+    // the result as the alt host). It must surface a clear missing-credential
+    // error naming the alt host, and never construct a client.
+    const dualNoAltToken = {
+      github_token: 'gh-tok',
+      repos: { 'acme/widgets': { api_host: ALT_HOST, exclusive: false } }
+    };
+    const { FakeClient, constructions } = makeFakeClient(() => ({ number: 42, title: 'should-not-fetch' }));
+
+    await expect(resolvePrHostBinding({
+      db, config: dualNoAltToken, ...base, host: undefined, deps: { GitHubClient: FakeClient }
+    })).rejects.toThrow(/No token configured for alt host .*alt\.example/);
+    // clientArgFor throws before any client is constructed — github never contacted.
+    expect(constructions).toEqual([]);
+  });
+
+  it('explicit alt host with a token-less alt binding errors instead of retargeting github', async () => {
+    const dualNoAltToken = {
+      github_token: 'gh-tok',
+      repos: { 'acme/widgets': { api_host: ALT_HOST, exclusive: false } }
+    };
+    const { FakeClient, constructions } = makeFakeClient(() => ({ number: 42 }));
+
+    await expect(resolvePrHostBinding({
+      db, config: dualNoAltToken, ...base, host: ALT_HOST, deps: { GitHubClient: FakeClient }
+    })).rejects.toThrow(/No token configured for alt host/);
+    expect(constructions).toEqual([]);
+  });
+
+  it('plain github repo never probes (single github binding)', async () => {
+    const { FakeClient, constructions } = makeFakeClient(() => ({ number: 42 }));
+    const { binding } = await resolvePrHostBinding({
+      db, config: plainConfig, ...base, host: undefined, deps: { GitHubClient: FakeClient }
+    });
+    expect(binding.host).toBe(null);
+    expect(constructions).toEqual([{ apiHost: null }]);
+  });
+
+  it('exclusive alt-host repo binds to the alt host with no probe', async () => {
+    const { FakeClient, constructions } = makeFakeClient(() => ({ number: 42 }));
+    const { binding } = await resolvePrHostBinding({
+      db, config: exclusiveConfig, ...base, host: undefined, deps: { GitHubClient: FakeClient }
+    });
+    expect(binding.host).toBe(ALT_HOST);
+    expect(constructions).toEqual([{ apiHost: ALT_HOST }]);
+  });
+
+  it('legacy NULL stored host on an exclusive repo derives the alt host (no throw)', async () => {
+    await insertPRHost(db, 'acme/widgets', 42, null);
+    const { FakeClient, constructions } = makeFakeClient(() => ({ number: 42 }));
+    const { binding } = await resolvePrHostBinding({
+      db, config: exclusiveConfig, ...base, host: undefined, deps: { GitHubClient: FakeClient }
+    });
+    expect(binding.host).toBe(ALT_HOST);
+    expect(constructions).toEqual([{ apiHost: ALT_HOST }]);
+  });
+});

--- a/tests/integration/pr-setup.test.js
+++ b/tests/integration/pr-setup.test.js
@@ -581,6 +581,102 @@ describe('storePRData returns isNewReview flag', () => {
 });
 
 // ============================================================================
+// storePRData - host column stamping (per-PR host resolution)
+// ============================================================================
+// The host column records which system a PR lives on (NULL = github.com,
+// otherwise the configured api_host URL). storePRData self-heals the stored
+// host when the caller knows it, but must not disturb it on a plain re-fetch.
+
+describe('storePRData host stamping', () => {
+  let db;
+
+  const prInfo = { owner: 'owner', repo: 'repo', number: 77 };
+  const prData = {
+    title: 'Host PR',
+    body: 'Description',
+    author: 'octocat',
+    base_branch: 'main',
+    head_branch: 'feature',
+  };
+  const diff = '--- a/file.js\n+++ b/file.js\n@@ -1 +1 @@\n-old\n+new';
+  const changedFiles = [{ file: 'file.js', insertions: 1, deletions: 1, changes: 2 }];
+  const worktreePath = '/tmp/wt/pr-77';
+
+  async function readHost() {
+    const row = await queryOne(
+      db,
+      'SELECT host FROM pr_metadata WHERE pr_number = ? AND repository = ? COLLATE NOCASE',
+      [prInfo.number, 'owner/repo']
+    );
+    return row ? row.host : undefined;
+  }
+
+  beforeEach(async () => {
+    db = await createTestDatabase();
+    vi.clearAllMocks();
+    hookRunnerModule.fireHooks.mockImplementation(() => {});
+  });
+
+  afterEach(async () => {
+    if (db) {
+      await closeTestDatabase(db);
+    }
+  });
+
+  it('writes NULL host on INSERT when host is omitted', async () => {
+    await storePRData(db, prInfo, prData, diff, changedFiles, worktreePath, {
+      skipWorktreeRecord: true
+    });
+    expect(await readHost()).toBeNull();
+  });
+
+  it('writes an api_host URL string on INSERT when host is provided', async () => {
+    await storePRData(db, prInfo, prData, diff, changedFiles, worktreePath, {
+      skipWorktreeRecord: true,
+      host: 'https://ghe.example.com/api/v3'
+    });
+    expect(await readHost()).toBe('https://ghe.example.com/api/v3');
+  });
+
+  it('writes explicit null host (github.com) on INSERT', async () => {
+    await storePRData(db, prInfo, prData, diff, changedFiles, worktreePath, {
+      skipWorktreeRecord: true,
+      host: null
+    });
+    expect(await readHost()).toBeNull();
+  });
+
+  it('stamps host on UPDATE when a host is provided', async () => {
+    // First insert with NULL host, then re-fetch with a known alt host.
+    await storePRData(db, prInfo, prData, diff, changedFiles, worktreePath, {
+      skipWorktreeRecord: true
+    });
+    expect(await readHost()).toBeNull();
+
+    await storePRData(db, prInfo, prData, diff, changedFiles, worktreePath, {
+      skipWorktreeRecord: true,
+      host: 'https://ghe.example.com/api/v3'
+    });
+    expect(await readHost()).toBe('https://ghe.example.com/api/v3');
+  });
+
+  it('leaves a previously stamped host untouched on UPDATE when host is omitted', async () => {
+    // Seed a stamped host, then re-fetch without a host (host undefined).
+    await storePRData(db, prInfo, prData, diff, changedFiles, worktreePath, {
+      skipWorktreeRecord: true,
+      host: 'https://ghe.example.com/api/v3'
+    });
+    expect(await readHost()).toBe('https://ghe.example.com/api/v3');
+
+    await storePRData(db, prInfo, prData, diff, changedFiles, worktreePath, {
+      skipWorktreeRecord: true
+    });
+    // The stored host must survive an ordinary re-fetch that doesn't know it.
+    expect(await readHost()).toBe('https://ghe.example.com/api/v3');
+  });
+});
+
+// ============================================================================
 // Pool-enabled PR setup (setupPRReview with poolSize > 0)
 // ============================================================================
 // These tests exercise the pool code path inside setupPRReview, verifying that
@@ -1069,6 +1165,52 @@ describe('restore mode (setupPRReview with restoreMetadata)', () => {
     expect(GitHubClient.prototype.fetchPullRequest).toHaveBeenCalledOnce();
 
     expect(result.reviewUrl).toBe('/pr/owner/repo/42');
+  });
+
+  it('SHA-miss restore fallback forwards the explicit host to the fresh retry (FINDING E)', async () => {
+    const ALT = 'https://alt.example/api/v3';
+    // DUAL repo: with host forwarded (null = github) the fresh fetch binds
+    // github and stamps host=null. If the recursion DROPPED host, the dual repo
+    // would probe alt-first (mocked fetch succeeds) and stamp ALT instead — so
+    // the stamped host proves the explicit host survived the retry.
+    const dualConfig = {
+      github_token: githubToken,
+      monorepos: {},
+      repos: { 'owner/repo': { api_host: ALT, exclusive: false, token: 'alt-tok' } }
+    };
+    worktreePoolLifecycleModule.WorktreePoolLifecycle.prototype.acquireForPR
+      .mockRejectedValueOnce(new Error('pathspec \'head111\' did not match any file(s) known to git'))
+      .mockResolvedValueOnce({ worktreePath: poolWorktreePath, worktreeId: poolWorktreeId });
+
+    await setupPRReview({
+      db, owner, repo, prNumber, githubToken, config: dualConfig,
+      restoreMetadata: mockRestoreMetadata,
+      host: null,
+    });
+
+    const row = await queryOne(db, 'SELECT host FROM pr_metadata WHERE pr_number = ? AND repository = ? COLLATE NOCASE', [prNumber, repository]);
+    expect(row.host).toBe(null);
+  });
+
+  it('SHA-miss restore fallback forwards bindingRepository to the fresh retry (FINDING E)', async () => {
+    // Pass an explicit bindingRepository that differs from the PR identity. The
+    // retry must reuse it (not re-derive owner/repo), so every resolvePoolConfig
+    // call — including the retry's — receives the forwarded key.
+    worktreePoolLifecycleModule.WorktreePoolLifecycle.prototype.acquireForPR
+      .mockRejectedValueOnce(new Error('pathspec \'head111\' did not match any file(s) known to git'))
+      .mockResolvedValueOnce({ worktreePath: poolWorktreePath, worktreeId: poolWorktreeId });
+
+    await setupPRReview({
+      db, owner, repo, prNumber, githubToken, config: testConfig,
+      bindingRepository: 'custom-binding-key',
+      restoreMetadata: mockRestoreMetadata,
+    });
+
+    const poolConfigCalls = configModule.resolvePoolConfig.mock.calls;
+    expect(poolConfigCalls.length).toBeGreaterThanOrEqual(2); // restore attempt + retry
+    for (const call of poolConfigCalls) {
+      expect(call[1]).toBe('custom-binding-key');
+    }
   });
 
   it('should NOT fall back for non-SHA errors in restore mode', async () => {

--- a/tests/integration/resolve-binding-for-request.test.js
+++ b/tests/integration/resolve-binding-for-request.test.js
@@ -1,0 +1,80 @@
+// Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+/**
+ * `resolveBindingForRequest` (PR-mode route chokepoint) is PR-aware: it reads
+ * the stored `pr_metadata.host` for the request's PR and binds accordingly,
+ * falling back to the ambiguity rule when no row exists and surfacing a stale
+ * stored host as a throw.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+const { createTestDatabase, closeTestDatabase } = require('../utils/schema');
+const { run } = require('../../src/database');
+const prRoutes = require('../../src/routes/pr');
+const { resolveBindingForRequest } = prRoutes._internals;
+
+const ALT_HOST = 'https://alt.example/api/v3';
+
+function makeReq(db, config, number) {
+  const store = { db, config, githubToken: 'startup-tok' };
+  return { app: { get: (k) => store[k] }, params: { number: String(number) } };
+}
+
+const dualConfig = {
+  github_token: 'gh-tok',
+  repos: { 'acme/widgets': { api_host: ALT_HOST, exclusive: false, token: 'alt-tok' } }
+};
+const exclusiveConfig = {
+  github_token: 'gh-tok',
+  repos: { 'acme/widgets': { api_host: ALT_HOST, token: 'alt-tok' } }
+};
+
+describe('resolveBindingForRequest — per-PR host', () => {
+  let db;
+  let savedEnvToken;
+  beforeEach(() => {
+    db = createTestDatabase();
+    // Deterministic token resolution: GITHUB_TOKEN would short-circuit the chain.
+    savedEnvToken = process.env.GITHUB_TOKEN;
+    delete process.env.GITHUB_TOKEN;
+  });
+  afterEach(() => {
+    if (savedEnvToken !== undefined) process.env.GITHUB_TOKEN = savedEnvToken;
+    if (db) closeTestDatabase(db);
+  });
+
+  it('no stored row → ambiguity rule (dual repo → github binding)', async () => {
+    const resolved = await resolveBindingForRequest(makeReq(db, dualConfig, 42), 'acme/widgets');
+    expect(resolved.binding.apiHost).toBe(null);
+    expect(resolved.binding.host).toBe(null);
+    expect(resolved.token).toBe('gh-tok');
+  });
+
+  it('stored alt host → alt binding with the repo-scoped token', async () => {
+    await run(db, 'INSERT INTO pr_metadata (pr_number, repository, host) VALUES (?, ?, ?)', [42, 'acme/widgets', ALT_HOST]);
+    const resolved = await resolveBindingForRequest(makeReq(db, dualConfig, 42), 'acme/widgets');
+    expect(resolved.binding.apiHost).toBe(ALT_HOST);
+    expect(resolved.binding.host).toBe(ALT_HOST);
+    expect(resolved.token).toBe('alt-tok');
+  });
+
+  it('stored NULL host (dual repo) → github binding', async () => {
+    await run(db, 'INSERT INTO pr_metadata (pr_number, repository, host) VALUES (?, ?, ?)', [42, 'acme/widgets', null]);
+    const resolved = await resolveBindingForRequest(makeReq(db, dualConfig, 42), 'acme/widgets');
+    expect(resolved.binding.apiHost).toBe(null);
+    expect(resolved.token).toBe('gh-tok');
+  });
+
+  it('legacy NULL host on an exclusive repo → derives the alt binding (no throw)', async () => {
+    await run(db, 'INSERT INTO pr_metadata (pr_number, repository, host) VALUES (?, ?, ?)', [42, 'acme/widgets', null]);
+    const resolved = await resolveBindingForRequest(makeReq(db, exclusiveConfig, 42), 'acme/widgets');
+    expect(resolved.binding.apiHost).toBe(ALT_HOST);
+    expect(resolved.token).toBe('alt-tok');
+  });
+
+  it('stale stored host (no longer matches config) throws a targeted error', async () => {
+    await run(db, 'INSERT INTO pr_metadata (pr_number, repository, host) VALUES (?, ?, ?)', [42, 'acme/widgets', 'https://old.example/api/v3']);
+    await expect(
+      resolveBindingForRequest(makeReq(db, dualConfig, 42), 'acme/widgets')
+    ).rejects.toThrow(/stored host no longer matches config/);
+  });
+});

--- a/tests/integration/routes.test.js
+++ b/tests/integration/routes.test.js
@@ -288,6 +288,68 @@ describe('PR Management Endpoints', () => {
     applyDefaultMocks();
   });
 
+  describe('POST /api/parse-pr-url', () => {
+    it('returns host: null for a github.com URL', async () => {
+      const response = await request(server)
+        .post('/api/parse-pr-url')
+        .send({ url: 'https://github.com/owner/repo/pull/123' });
+
+      expect(response.status).toBe(200);
+      expect(response.body).toMatchObject({
+        valid: true, owner: 'owner', repo: 'repo', prNumber: 123, host: null,
+        isDualHost: false
+      });
+    });
+
+    it('returns the matched api_host and bindingRepository for a url_pattern match (exclusive → not dual)', async () => {
+      app.set('config', {
+        repos: {
+          'acme/widgets': {
+            api_host: 'https://althost.example/api/v3',
+            url_pattern: '^https://althost\\.example/(?<owner>[^/]+)/(?<repo>[^/]+)/pull/(?<number>[0-9]+)'
+          }
+        }
+      });
+
+      const response = await request(server)
+        .post('/api/parse-pr-url')
+        .send({ url: 'https://althost.example/acme/widgets/pull/42' });
+
+      expect(response.status).toBe(200);
+      expect(response.body).toMatchObject({
+        valid: true, owner: 'acme', repo: 'widgets', prNumber: 42,
+        host: 'https://althost.example/api/v3', bindingRepository: 'acme/widgets',
+        // api_host with no `exclusive` key → exclusive:true → NOT dual.
+        isDualHost: false
+      });
+    });
+
+    it('flags isDualHost:true for a github URL that resolves to a DUAL repo', async () => {
+      app.set('config', {
+        github_token: 'gh-tok',
+        repos: {
+          'acme/widgets': {
+            api_host: 'https://althost.example/api/v3',
+            exclusive: false,
+            token: 'alt-tok'
+          }
+        }
+      });
+
+      const response = await request(server)
+        .post('/api/parse-pr-url')
+        .send({ url: 'https://github.com/acme/widgets/pull/42' });
+
+      expect(response.status).toBe(200);
+      expect(response.body).toMatchObject({
+        valid: true, owner: 'acme', repo: 'widgets', prNumber: 42,
+        // github URL → host null, but the repo is dual so the client sends the
+        // "github" sentinel to avoid an alt-first probe.
+        host: null, isDualHost: true
+      });
+    });
+  });
+
   describe('GET /api/pr/:owner/:repo/:number', () => {
     it('should return 400 for invalid PR number', async () => {
       const response = await request(server)
@@ -3553,6 +3615,41 @@ describe('Config Endpoints', () => {
         expect(response.body.has_github_token).toBe(false);
       });
 
+      it('returns has_github_token=true for a DUAL repo whose only credential is the alt-host token (FINDING 4)', async () => {
+        // github ambiguity binding has no token, but the alt binding does. The
+        // flag must report "any usable binding", so this is authenticated.
+        app.set('config', {
+          theme: 'light',
+          // No global github_token; dual repo with alt-only token.
+          repos: {
+            'foo/bar': { api_host: 'https://alt.example/api/v3', exclusive: false, token: 'alt-only-token' }
+          }
+        });
+
+        const response = await request(server)
+          .get('/api/config')
+          .query({ owner: 'foo', repo: 'bar' });
+
+        expect(response.status).toBe(200);
+        expect(response.body.has_global_github_token).toBe(false);
+        expect(response.body.has_github_token).toBe(true);
+      });
+
+      it('returns has_github_token=false for a DUAL repo with no token on either host', async () => {
+        app.set('config', {
+          theme: 'light',
+          repos: {
+            'foo/bar': { api_host: 'https://alt.example/api/v3', exclusive: false }
+          }
+        });
+
+        const response = await request(server)
+          .get('/api/config')
+          .query({ owner: 'foo', repo: 'bar' });
+
+        expect(response.body.has_github_token).toBe(false);
+      });
+
       it('treats missing repo param (only owner supplied) as the no-repo case', async () => {
         app.set('config', {
           theme: 'light',
@@ -4030,6 +4127,78 @@ describe('Repo Links Endpoint', () => {
       expect(res.status).toBe(200);
       expect(res.body.links.external).not.toBeNull();
       expect(res.body.links.external.icon).toBeNull();
+    });
+  });
+
+  describe('GET /api/repos/:owner/:repo/links?number= (dual-host per-PR host)', () => {
+    const ALT_HOST = 'https://alt.example/api/v3';
+
+    // A dual-host repo: api_host + exclusive:false, with an external link but
+    // no explicit github/graphite:false so the per-host default is observable.
+    function configureDualRepo() {
+      app.set('config', {
+        ...app.get('config'),
+        repos: {
+          'dual/repo': {
+            api_host: ALT_HOST,
+            exclusive: false,
+            links: {
+              external: {
+                name: 'Meteorite',
+                label: 'Open on Meteorite',
+                url_template: 'https://meteorite.example/{owner}/{repo}/pull/{number}',
+              },
+            },
+          },
+        },
+      });
+    }
+
+    async function seedPR(prNumber, host) {
+      await run(db, `
+        INSERT INTO pr_metadata (pr_number, repository, title, host)
+        VALUES (?, 'dual/repo', 'Dual PR', ?)
+      `, [prNumber, host]);
+    }
+
+    it('github-hosted PR (stored host NULL) hides external, keeps github', async () => {
+      configureDualRepo();
+      await seedPR(7, null);
+      const res = await request(server).get('/api/repos/dual/repo/links?number=7');
+      expect(res.status).toBe(200);
+      expect(res.body.links.external).toBeNull();
+      expect(res.body.links.github).toBe(true);
+      expect(res.body.links.graphite).toBe(true);
+    });
+
+    it('alt-hosted PR (stored host = api_host) shows external, hides github/graphite', async () => {
+      configureDualRepo();
+      await seedPR(8, ALT_HOST);
+      const res = await request(server).get('/api/repos/dual/repo/links?number=8');
+      expect(res.status).toBe(200);
+      expect(res.body.links.external).not.toBeNull();
+      expect(res.body.links.external.name).toBe('Meteorite');
+      expect(res.body.links.github).toBe(false);
+      expect(res.body.links.graphite).toBe(false);
+    });
+
+    it('no number query falls back to repo-level defaults', async () => {
+      configureDualRepo();
+      const res = await request(server).get('/api/repos/dual/repo/links');
+      expect(res.status).toBe(200);
+      // Unknown host → today's behaviour: external present, github/graphite kept.
+      expect(res.body.links.external).not.toBeNull();
+      expect(res.body.links.github).toBe(true);
+      expect(res.body.links.graphite).toBe(true);
+    });
+
+    it('unknown PR number (no row) falls back to repo-level defaults', async () => {
+      configureDualRepo();
+      const res = await request(server).get('/api/repos/dual/repo/links?number=999');
+      expect(res.status).toBe(200);
+      expect(res.body.links.external).not.toBeNull();
+      expect(res.body.links.github).toBe(true);
+      expect(res.body.links.graphite).toBe(true);
     });
   });
 });

--- a/tests/integration/setup-routes.test.js
+++ b/tests/integration/setup-routes.test.js
@@ -228,10 +228,110 @@ describe('POST /api/setup/pr/:owner/:repo/:number', () => {
     expect(callArgs.restoreMetadata).toBeNull();
   });
 
-  it('resolves binding key for monorepo url_pattern config and feeds it to getGitHubToken', async () => {
+  it('passes a body host through to setupPRReview', async () => {
+    // The repo must actually declare this api_host — the credential gate now
+    // resolves the token against the body host, which validates it against config.
+    const app = createApp(db, {
+      repos: { 'owner/repo': { api_host: 'https://althost.example/api/v3', exclusive: false, token: 'alt-tok' } }
+    });
+    server = await listenOnLoopback(app);
+    const res = await request(server)
+      .post('/api/setup/pr/owner/repo/42')
+      .send({ host: 'https://althost.example/api/v3' });
+
+    expect(res.status).toBe(200);
+    expect(prSetupModule.setupPRReview).toHaveBeenCalledOnce();
+    expect(prSetupModule.setupPRReview.mock.calls[0][0].host).toBe('https://althost.example/api/v3');
+  });
+
+  it('passes an explicit body host of null through to setupPRReview', async () => {
+    const app = createApp(db);
+    server = await listenOnLoopback(app);
+    const res = await request(server)
+      .post('/api/setup/pr/owner/repo/42')
+      .send({ host: null });
+
+    expect(res.status).toBe(200);
+    expect(prSetupModule.setupPRReview.mock.calls[0][0].host).toBe(null);
+  });
+
+  it('leaves host undefined when no body host is supplied', async () => {
+    const app = createApp(db);
+    server = await listenOnLoopback(app);
+    const res = await request(server).post('/api/setup/pr/owner/repo/42');
+
+    expect(res.status).toBe(200);
+    expect(prSetupModule.setupPRReview.mock.calls[0][0].host).toBeUndefined();
+  });
+
+  it('rejects an invalid host shape with 400 and does not start setup', async () => {
+    const app = createApp(db);
+    server = await listenOnLoopback(app);
+    const res = await request(server)
+      .post('/api/setup/pr/owner/repo/42')
+      .send({ host: 123 });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/Invalid host/);
+    expect(prSetupModule.setupPRReview).not.toHaveBeenCalled();
+  });
+
+  // FINDING 3: the credential gate must not falsely 401 a dual repo whose only
+  // credential is the alt-host token. getGitHubToken (no host) returns empty for
+  // such a repo; the route re-resolves via resolvePreflightBinding before 401ing.
+  describe('dual-repo alt-only credential gate', () => {
+    let savedEnvToken;
+    const dualAltOnly = {
+      repos: { 'owner/repo': { api_host: 'https://alt.example/api/v3', exclusive: false, token: 'alt-tok' } }
+    };
+
+    beforeEach(() => {
+      // getGitHubToken (no host) resolves the github ambiguity binding → empty
+      // for an alt-only dual repo. Force that so the extended path is exercised.
+      configModule.getGitHubToken.mockReturnValue('');
+      savedEnvToken = process.env.GITHUB_TOKEN;
+      delete process.env.GITHUB_TOKEN; // else the github chain short-circuits
+    });
+    afterEach(() => {
+      if (savedEnvToken !== undefined) process.env.GITHUB_TOKEN = savedEnvToken;
+    });
+
+    it('alt bodyHost + alt-only token → passes the gate (no 401)', async () => {
+      const app = createApp(db, dualAltOnly);
+      server = await listenOnLoopback(app);
+      const res = await request(server)
+        .post('/api/setup/pr/owner/repo/42')
+        .send({ host: 'https://alt.example/api/v3' });
+
+      expect(res.status).toBe(200);
+      expect(prSetupModule.setupPRReview).toHaveBeenCalledOnce();
+    });
+
+    it('no host + dual repo + alt-only token → passes the gate to the probe (no 401)', async () => {
+      const app = createApp(db, dualAltOnly);
+      server = await listenOnLoopback(app);
+      const res = await request(server).post('/api/setup/pr/owner/repo/42');
+
+      expect(res.status).toBe(200);
+      expect(prSetupModule.setupPRReview).toHaveBeenCalledOnce();
+    });
+
+    it('no host + dual repo + NO token → still 401s', async () => {
+      const app = createApp(db, {
+        repos: { 'owner/repo': { api_host: 'https://alt.example/api/v3', exclusive: false } }
+      });
+      server = await listenOnLoopback(app);
+      const res = await request(server).post('/api/setup/pr/owner/repo/42');
+
+      expect(res.status).toBe(401);
+      expect(prSetupModule.setupPRReview).not.toHaveBeenCalled();
+    });
+  });
+
+  it('resolves the binding key for a monorepo url_pattern config and feeds it downstream', async () => {
     // Config has one `repos[...]` entry whose url_pattern captures
-    // many owner/repo pairs. The route must call getGitHubToken with
-    // the BINDING KEY ("acme-monorepo"), not the captured "acme/widget-a".
+    // many owner/repo pairs. The route must resolve the token against the
+    // BINDING KEY ("acme-monorepo"), not the captured "acme/widget-a".
     const monorepoConfig = {
       repos: {
         'acme-monorepo': {
@@ -247,11 +347,11 @@ describe('POST /api/setup/pr/:owner/:repo/:number', () => {
     server = await listenOnLoopback(app);
     const res = await request(server).post('/api/setup/pr/acme/widget-a/7');
 
+    // The gate resolves the alt token for the binding key (not 401), and the
+    // binding key is threaded to setupPRReview for downstream config lookups
+    // (path, pool, reset_script). bindingRepository being the key (not the
+    // captured PR identity) is the invariant this test protects.
     expect(res.status).toBe(200);
-    expect(configModule.getGitHubToken).toHaveBeenCalledWith(monorepoConfig, 'acme-monorepo');
-
-    // setupPRReview also receives the binding key so downstream config
-    // lookups (path, pool, reset_script) hit the right entry.
     expect(prSetupModule.setupPRReview).toHaveBeenCalledOnce();
     const callArgs = prSetupModule.setupPRReview.mock.calls[0][0];
     expect(callArgs.bindingRepository).toBe('acme-monorepo');
@@ -265,7 +365,6 @@ describe('POST /api/setup/pr/:owner/:repo/:number', () => {
 
     expect(res.status).toBe(200);
     // Binding key = "alice/tool" (the PR identity) when nothing matched.
-    expect(configModule.getGitHubToken).toHaveBeenCalledWith(plainConfig, 'alice/tool');
     const callArgs = prSetupModule.setupPRReview.mock.calls[0][0];
     expect(callArgs.bindingRepository).toBe('alice/tool');
   });

--- a/tests/integration/store-prdata-collision.test.js
+++ b/tests/integration/store-prdata-collision.test.js
@@ -1,0 +1,127 @@
+// Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+/**
+ * FINDING A — cross-host collision guard in storePRData.
+ *
+ * pr_metadata/reviews/worktrees are keyed UNIQUE(pr_number, repository) with no
+ * host column (the plan's confirmed no-collision assumption). storePRData's
+ * UPDATE arm must therefore detect the pathological case — two DIFFERENT PRs
+ * sharing a number on two hosts — and REJECT it rather than overwrite the wrong
+ * PR. Same-id host relabel is the intended self-heal and proceeds.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+const { createTestDatabase, closeTestDatabase } = require('../utils/schema');
+const { run, queryOne } = require('../../src/database');
+const { storePRData } = require('../../src/setup/pr-setup');
+const logger = require('../../src/utils/logger');
+
+const REPO = 'acme/widgets';
+const ALT = 'https://alt.example/api/v3';
+
+function prData({ node_id, title = 'PR', headBranch = 'feature' }) {
+  return {
+    node_id,
+    title,
+    body: 'body',
+    author: 'alice',
+    base_branch: 'main',
+    head_branch: headBranch,
+    head_sha: 'sha-head',
+    base_sha: 'sha-base',
+  };
+}
+
+async function seedRow(db, { host, node_id }) {
+  await run(db,
+    `INSERT INTO pr_metadata (pr_number, repository, title, pr_data, host) VALUES (?, ?, ?, ?, ?)`,
+    [42, REPO, 'Seeded', JSON.stringify({ node_id, head_sha: 'sha-head' }), host]
+  );
+}
+
+describe('storePRData — cross-host collision guard', () => {
+  let db;
+  beforeEach(() => { db = createTestDatabase(); });
+  afterEach(() => { if (db) closeTestDatabase(db); });
+
+  it('same API id + different host → proceeds and restamps the host (self-heal)', async () => {
+    await seedRow(db, { host: ALT, node_id: 'NODE_SAME' });
+
+    await storePRData(
+      db, { owner: 'acme', repo: 'widgets', number: 42 },
+      prData({ node_id: 'NODE_SAME', title: 'Updated' }),
+      'diff', [], '/tmp/wt', { host: null } // relabel alt -> github
+    );
+
+    const row = await queryOne(db, 'SELECT host, title FROM pr_metadata WHERE pr_number = 42 AND repository = ?', [REPO]);
+    expect(row.host).toBe(null);       // restamped to github
+    expect(row.title).toBe('Updated'); // row updated
+  });
+
+  it('different API id + different host → throws and leaves the row unmodified', async () => {
+    await seedRow(db, { host: null, node_id: 'NODE_GITHUB' });
+
+    await expect(storePRData(
+      db, { owner: 'acme', repo: 'widgets', number: 42 },
+      prData({ node_id: 'NODE_ALT', title: 'Should not land' }),
+      'diff', [], '/tmp/wt', { host: ALT }
+    )).rejects.toThrow(/Cross-host PR conflict for acme\/widgets #42/);
+
+    // No partial write: host, title, pr_data all unchanged; no worktree row.
+    const row = await queryOne(db, 'SELECT host, title, pr_data FROM pr_metadata WHERE pr_number = 42 AND repository = ?', [REPO]);
+    expect(row.host).toBe(null);
+    expect(row.title).toBe('Seeded');
+    expect(JSON.parse(row.pr_data).node_id).toBe('NODE_GITHUB');
+    const wt = await queryOne(db, 'SELECT id FROM worktrees WHERE pr_number = 42 AND repository = ?', [REPO]);
+    expect(wt).toBeFalsy();
+  });
+
+  it('stored row with no parseable id + different host → warns and proceeds', async () => {
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+    // Seed a row whose pr_data has no id/node_id.
+    await run(db,
+      `INSERT INTO pr_metadata (pr_number, repository, title, pr_data, host) VALUES (?, ?, ?, ?, ?)`,
+      [42, REPO, 'Seeded', JSON.stringify({ head_sha: 'sha' }), null]
+    );
+
+    await storePRData(
+      db, { owner: 'acme', repo: 'widgets', number: 42 },
+      prData({ node_id: 'NODE_ALT' }),
+      'diff', [], '/tmp/wt', { host: ALT }
+    );
+
+    const row = await queryOne(db, 'SELECT host FROM pr_metadata WHERE pr_number = 42 AND repository = ?', [REPO]);
+    expect(row.host).toBe(ALT); // proceeded with the relabel
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringMatching(/no parseable API id/));
+    warnSpy.mockRestore();
+  });
+
+  it('same host (no relabel) → no guard, normal update', async () => {
+    await seedRow(db, { host: null, node_id: 'NODE_GITHUB' });
+
+    // Different id but SAME host (null) — guard does not fire (host unchanged).
+    await storePRData(
+      db, { owner: 'acme', repo: 'widgets', number: 42 },
+      prData({ node_id: 'NODE_DIFFERENT', title: 'Same-host update' }),
+      'diff', [], '/tmp/wt', { host: null }
+    );
+
+    const row = await queryOne(db, 'SELECT host, title FROM pr_metadata WHERE pr_number = 42 AND repository = ?', [REPO]);
+    expect(row.host).toBe(null);
+    expect(row.title).toBe('Same-host update');
+  });
+
+  it('incoming host undefined (host unknown) → no guard even if stored host is set', async () => {
+    await seedRow(db, { host: ALT, node_id: 'NODE_ALT' });
+
+    // No host option → writeHost false → guard skipped; host column untouched.
+    await storePRData(
+      db, { owner: 'acme', repo: 'widgets', number: 42 },
+      prData({ node_id: 'NODE_OTHER', title: 'Host-unknown update' }),
+      'diff', [], '/tmp/wt', {}
+    );
+
+    const row = await queryOne(db, 'SELECT host, title FROM pr_metadata WHERE pr_number = 42 AND repository = ?', [REPO]);
+    expect(row.host).toBe(ALT);   // untouched
+    expect(row.title).toBe('Host-unknown update');
+  });
+});

--- a/tests/unit/config.test.js
+++ b/tests/unit/config.test.js
@@ -5,7 +5,7 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 const childProcess = require('child_process');
-const { deepMerge, getGitHubToken, expandPath, resolveDbName, warnIfDevModeWithoutDbName, loadConfig, shouldSkipUpdateNotifier, _resetTokenCache, getRepoConfig, getRepoPath, getRepoCheckoutScript, getRepoWorktreeDirectory, getRepoWorktreeNameTemplate, getRepoCheckoutTimeout, resolveRepoOptions, getRepoResetScript, getRepoSkipBulkFetch, getRepoPoolSize, getRepoPoolFetchInterval, resolvePoolConfig, getWorktreeDisplayName, getConfigDir, getRepoLoadSkills, resolveLoadSkills, buildCouncilProviderOverrides, getSummaryProvider, getSummaryModel, getTourProvider, getTourModel, getSummaryEnabled, getSummaryAutoGenerate, getTourEnabled, getTourAutoGenerate, resolveHostBinding, invalidateTokenCache, validateRepoConfig, matchRepoByUrl, resolveBindingRepositoryFromPR } = require('../../src/config');
+const { deepMerge, getGitHubToken, expandPath, resolveDbName, warnIfDevModeWithoutDbName, loadConfig, shouldSkipUpdateNotifier, _resetTokenCache, getRepoConfig, getRepoPath, getRepoCheckoutScript, getRepoWorktreeDirectory, getRepoWorktreeNameTemplate, getRepoCheckoutTimeout, resolveRepoOptions, getRepoResetScript, getRepoSkipBulkFetch, getRepoPoolSize, getRepoPoolFetchInterval, resolvePoolConfig, getWorktreeDisplayName, getConfigDir, getRepoLoadSkills, resolveLoadSkills, buildCouncilProviderOverrides, getSummaryProvider, getSummaryModel, getTourProvider, getTourModel, getSummaryEnabled, getSummaryAutoGenerate, getTourEnabled, getTourAutoGenerate, resolveHostBinding, isExclusiveAltHost, invalidateTokenCache, validateRepoConfig, matchRepoByUrl, resolveBindingRepositoryFromPR } = require('../../src/config');
 
 describe('config.js', () => {
   describe('getGitHubToken', () => {
@@ -2614,6 +2614,285 @@ describe('config.js', () => {
     });
   });
 
+  describe('isExclusiveAltHost', () => {
+    it('returns false for null/undefined/non-object', () => {
+      expect(isExclusiveAltHost(null)).toBe(false);
+      expect(isExclusiveAltHost(undefined)).toBe(false);
+      expect(isExclusiveAltHost('nope')).toBe(false);
+    });
+
+    it('returns false for a repo with no api_host (plain github repo)', () => {
+      expect(isExclusiveAltHost({ path: '/x' })).toBe(false);
+      expect(isExclusiveAltHost({ api_host: '' })).toBe(false);
+      // exclusive is meaningless without api_host and must not flip the result
+      expect(isExclusiveAltHost({ exclusive: true })).toBe(false);
+    });
+
+    it('returns true for an api_host repo with exclusive omitted (default)', () => {
+      expect(isExclusiveAltHost({ api_host: 'https://althost.example/api/v3' })).toBe(true);
+    });
+
+    it('returns true for an api_host repo with exclusive: true', () => {
+      expect(isExclusiveAltHost({ api_host: 'https://althost.example/api/v3', exclusive: true })).toBe(true);
+    });
+
+    it('returns false for a dual repo (api_host + exclusive: false)', () => {
+      expect(isExclusiveAltHost({ api_host: 'https://althost.example/api/v3', exclusive: false })).toBe(false);
+    });
+  });
+
+  describe('resolveHostBinding per-PR host override', () => {
+    const ALT = 'https://althost.example/api/v3';
+    let originalEnv;
+    let execSyncSpy;
+    let warnSpy;
+    let debugSpy;
+
+    beforeEach(() => {
+      originalEnv = process.env.GITHUB_TOKEN;
+      delete process.env.GITHUB_TOKEN;
+      _resetTokenCache();
+      execSyncSpy = vi.spyOn(childProcess, 'execSync');
+      const logger = require('../../src/utils/logger');
+      warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+      debugSpy = vi.spyOn(logger, 'debug').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      if (originalEnv !== undefined) {
+        process.env.GITHUB_TOKEN = originalEnv;
+      } else {
+        delete process.env.GITHUB_TOKEN;
+      }
+      _resetTokenCache();
+      execSyncSpy.mockRestore();
+      warnSpy.mockRestore();
+      debugSpy.mockRestore();
+    });
+
+    const plainConfig = () => ({
+      github_token: 'top-gh',
+      repos: { 'owner/plain': { path: '/x' } }
+    });
+    const exclusiveExplicitConfig = () => ({
+      github_token: 'top-gh',
+      repos: { 'owner/alt': { api_host: ALT, exclusive: true, token: 'alt-token' } }
+    });
+    const exclusiveOmittedConfig = () => ({
+      github_token: 'top-gh',
+      repos: { 'owner/alt': { api_host: ALT, token: 'alt-token' } }
+    });
+    const dualConfig = () => ({
+      github_token: 'top-gh',
+      repos: {
+        'owner/dual': {
+          api_host: ALT,
+          exclusive: false,
+          token: 'alt-token',
+          features: { pending_review_comments: 'host', stack_walker: 'rest' }
+        }
+      }
+    });
+
+    describe('options.host === undefined (legacy + ambiguity rule)', () => {
+      it('plain repo (two-arg) → github binding, unchanged behaviour', () => {
+        const binding = resolveHostBinding('owner/plain', plainConfig());
+        expect(binding.apiHost).toBeNull();
+        expect(binding.host).toBeNull();
+        expect(binding.token).toBe('top-gh');
+        expect(binding.source).toBe('config:github_token');
+        expect(binding.features.stack_walker).toBe('graphql');
+      });
+
+      it('exclusive alt repo (explicit true, two-arg) → alt binding', () => {
+        const binding = resolveHostBinding('owner/alt', exclusiveExplicitConfig());
+        expect(binding.apiHost).toBe(ALT);
+        expect(binding.host).toBe(ALT);
+        expect(binding.token).toBe('alt-token');
+        expect(binding.source).toBe('repo:token');
+        expect(binding.features.stack_walker).toBe('rest');
+      });
+
+      it('REGRESSION: api_host repo with no exclusive key (two-arg) behaves exactly as before → alt binding', () => {
+        const binding = resolveHostBinding('owner/alt', exclusiveOmittedConfig());
+        expect(binding.apiHost).toBe(ALT);
+        expect(binding.host).toBe(ALT);
+        expect(binding.token).toBe('alt-token');
+        expect(binding.source).toBe('repo:token');
+        expect(binding.features.pending_review_comments).toBe('host');
+      });
+
+      it('dual repo (two-arg) → github binding (top-level token, github features)', () => {
+        const binding = resolveHostBinding('owner/dual', dualConfig());
+        expect(binding.apiHost).toBeNull();
+        expect(binding.host).toBeNull();
+        // top-level github_token, NOT the repo-scoped alt token
+        expect(binding.token).toBe('top-gh');
+        expect(binding.source).toBe('config:github_token');
+        // repo's explicit features (host/rest) do NOT apply to the github binding
+        expect(binding.features.pending_review_comments).toBe('graphql');
+        expect(binding.features.stack_walker).toBe('graphql');
+      });
+
+      it('explicit host: undefined is treated the same as no options', () => {
+        const binding = resolveHostBinding('owner/dual', dualConfig(), { host: undefined });
+        expect(binding.apiHost).toBeNull();
+        expect(binding.token).toBe('top-gh');
+      });
+    });
+
+    describe('options.host === null (force github binding)', () => {
+      it('plain repo → github binding', () => {
+        const binding = resolveHostBinding('owner/plain', plainConfig(), { host: null });
+        expect(binding.apiHost).toBeNull();
+        expect(binding.host).toBeNull();
+        expect(binding.token).toBe('top-gh');
+      });
+
+      it('dual repo → github binding (top-level token, github features)', () => {
+        const binding = resolveHostBinding('owner/dual', dualConfig(), { host: null });
+        expect(binding.apiHost).toBeNull();
+        expect(binding.host).toBeNull();
+        expect(binding.token).toBe('top-gh');
+        expect(binding.features.pending_review_comments).toBe('graphql');
+      });
+
+      it('throws for an exclusive alt repo (explicit true)', () => {
+        expect(() => resolveHostBinding('owner/alt', exclusiveExplicitConfig(), { host: null }))
+          .toThrow(/exclusive alt-host repo .* has no github\.com presence.*host=null.*caller bug/);
+      });
+
+      it('throws for an exclusive alt repo (exclusive omitted)', () => {
+        expect(() => resolveHostBinding('owner/alt', exclusiveOmittedConfig(), { host: null }))
+          .toThrow(/exclusive alt-host repo/);
+      });
+    });
+
+    describe('options.host === matching url (force alt binding)', () => {
+      it('exclusive alt repo → alt binding', () => {
+        const binding = resolveHostBinding('owner/alt', exclusiveExplicitConfig(), { host: ALT });
+        expect(binding.apiHost).toBe(ALT);
+        expect(binding.host).toBe(ALT);
+        expect(binding.token).toBe('alt-token');
+        expect(binding.source).toBe('repo:token');
+      });
+
+      it('dual repo → alt binding (repo token + repo features)', () => {
+        const binding = resolveHostBinding('owner/dual', dualConfig(), { host: ALT });
+        expect(binding.apiHost).toBe(ALT);
+        expect(binding.host).toBe(ALT);
+        expect(binding.token).toBe('alt-token');
+        expect(binding.source).toBe('repo:token');
+        expect(binding.features.pending_review_comments).toBe('host');
+        expect(binding.features.stack_walker).toBe('rest');
+      });
+    });
+
+    describe('options.host === stale url (throws)', () => {
+      it('throws for a dual repo when the requested host no longer matches config', () => {
+        expect(() => resolveHostBinding('owner/dual', dualConfig(), { host: 'https://old.example/api/v3' }))
+          .toThrow(/does not match its configured api_host \("https:\/\/althost\.example\/api\/v3"\).*re-open the PR from a URL/);
+      });
+
+      it('throws for a plain repo asked for any alt host (config has no api_host)', () => {
+        expect(() => resolveHostBinding('owner/plain', plainConfig(), { host: ALT }))
+          .toThrow(/does not match its configured api_host \(none\)/);
+      });
+
+      it('throws for an exclusive alt repo when the requested host is stale', () => {
+        expect(() => resolveHostBinding('owner/alt', exclusiveExplicitConfig(), { host: 'https://old.example/api/v3' }))
+          .toThrow(/does not match its configured api_host/);
+      });
+    });
+
+    describe('token selection per binding for dual repos', () => {
+      it('github binding does NOT fall back to the repo-scoped alt token', () => {
+        // Dual repo with ONLY a repo token and no github credentials at all.
+        const config = {
+          repos: { 'owner/dual': { api_host: ALT, exclusive: false, token: 'alt-token' } }
+        };
+        const binding = resolveHostBinding('owner/dual', config, { host: null });
+        expect(binding.token).toBe('');
+        expect(binding.source).toBe('none');
+      });
+
+      it('github binding uses the top-level github chain (env → github_token → github_token_command)', () => {
+        // env wins
+        process.env.GITHUB_TOKEN = 'env-token';
+        let binding = resolveHostBinding('owner/dual', dualConfig(), { host: null });
+        expect(binding.token).toBe('env-token');
+        expect(binding.source).toBe('env:GITHUB_TOKEN');
+        delete process.env.GITHUB_TOKEN;
+
+        // github_token next
+        binding = resolveHostBinding('owner/dual', dualConfig(), { host: null });
+        expect(binding.token).toBe('top-gh');
+        expect(binding.source).toBe('config:github_token');
+
+        // github_token_command last
+        _resetTokenCache();
+        execSyncSpy.mockReturnValueOnce('top-cmd\n');
+        binding = resolveHostBinding('owner/dual', {
+          github_token_command: 'gh auth token',
+          repos: { 'owner/dual': { api_host: ALT, exclusive: false, token: 'alt-token' } }
+        }, { host: null });
+        expect(binding.token).toBe('top-cmd');
+        expect(binding.source).toBe('config:github_token_command');
+      });
+
+      it('alt binding uses the repo-scoped token, never the github chain', () => {
+        process.env.GITHUB_TOKEN = 'env-token';
+        const binding = resolveHostBinding('owner/dual', dualConfig(), { host: ALT });
+        expect(binding.token).toBe('alt-token');
+        expect(binding.source).toBe('repo:token');
+      });
+    });
+
+    describe('features per binding for dual repos', () => {
+      it('github binding resolves plain github defaults, ignoring the repo features block', () => {
+        const binding = resolveHostBinding('owner/dual', dualConfig(), { host: null });
+        expect(binding.features.pending_review_check).toBe('graphql');
+        expect(binding.features.stack_walker).toBe('graphql');
+        expect(binding.features.review_lifecycle).toBe('graphql');
+        expect(binding.features.pending_review_comments).toBe('graphql');
+      });
+
+      it('alt binding applies the repo features block on top of alt-host defaults', () => {
+        const binding = resolveHostBinding('owner/dual', dualConfig(), { host: ALT });
+        expect(binding.features.pending_review_check).toBe('rest');
+        expect(binding.features.stack_walker).toBe('rest');
+        expect(binding.features.review_lifecycle).toBe('rest');
+        expect(binding.features.pending_review_comments).toBe('host');
+      });
+    });
+
+    describe('refresh preserves the binding flavor', () => {
+      it('an alt binding refresh re-resolves the alt host, not the github chain', () => {
+        // Dual repo: alt uses repo token_command, github would use the top-level
+        // command. A two-arg re-resolve would pick github (ambiguity rule); the
+        // refresh must re-resolve the SAME alt flavor.
+        const config = {
+          github_token_command: 'echo GITHUB',
+          repos: {
+            'owner/dual': { api_host: ALT, exclusive: false, token_command: 'echo ALT' }
+          }
+        };
+        execSyncSpy.mockReturnValueOnce('alt-first\n');
+        const binding = resolveHostBinding('owner/dual', config, { host: ALT });
+        expect(binding.token).toBe('alt-first');
+        expect(binding.source).toBe('repo:token_command');
+
+        execSyncSpy.mockReturnValueOnce('alt-second\n');
+        const fresh = binding.refresh();
+        expect(fresh).toBe('alt-second');
+        // The alt command was re-run (2 calls total); the github command was
+        // never invoked.
+        expect(execSyncSpy).toHaveBeenCalledTimes(2);
+        expect(execSyncSpy).not.toHaveBeenCalledWith('echo GITHUB', expect.anything());
+      });
+    });
+  });
+
   describe('validateRepoConfig', () => {
     it('does not throw on the happy path (no repos, or repos without alt-host config)', () => {
       expect(() => validateRepoConfig({})).not.toThrow();
@@ -2629,6 +2908,76 @@ describe('config.js', () => {
           }
         }
       })).not.toThrow();
+    });
+
+    describe('exclusive flag', () => {
+      it('accepts a boolean exclusive alongside api_host', () => {
+        expect(() => validateRepoConfig({
+          repos: { 'owner/alt': { api_host: 'https://althost.example/api/v3', exclusive: true } }
+        })).not.toThrow();
+        expect(() => validateRepoConfig({
+          repos: { 'owner/alt': { api_host: 'https://althost.example/api/v3', exclusive: false } }
+        })).not.toThrow();
+      });
+
+      it('throws when exclusive is not a boolean', () => {
+        expect(() => validateRepoConfig({
+          repos: { 'owner/alt': { api_host: 'https://althost.example/api/v3', exclusive: 'yes' } }
+        })).toThrow(/repos\["owner\/alt"\]\.exclusive must be a boolean/);
+      });
+
+      it('throws when exclusive is present without api_host', () => {
+        expect(() => validateRepoConfig({
+          repos: { 'owner/repo': { exclusive: false } }
+        })).toThrow(/repos\["owner\/repo"\]\.exclusive is only valid when api_host is set/);
+        expect(() => validateRepoConfig({
+          repos: { 'owner/repo': { exclusive: true } }
+        })).toThrow(/repos\["owner\/repo"\]\.exclusive is only valid when api_host is set/);
+      });
+    });
+
+    describe('over-broad url_pattern warning (FINDING B)', () => {
+      let warnSpy;
+      beforeEach(() => {
+        const logger = require('../../src/utils/logger');
+        warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+      });
+      afterEach(() => warnSpy.mockRestore());
+
+      it('warns when an api_host url_pattern also matches canonical github.com/Graphite URLs', () => {
+        validateRepoConfig({
+          repos: {
+            'owner/alt': {
+              api_host: 'https://althost.example/api/v3',
+              url_pattern: '/(?<owner>[^/]+)/(?<repo>[^/]+)/pull/(?<number>[0-9]+)'
+            }
+          }
+        });
+        expect(warnSpy).toHaveBeenCalledWith(expect.stringMatching(/also matches canonical github\.com \/ Graphite URLs/));
+      });
+
+      it('does not warn for an anchored alt-host url_pattern', () => {
+        validateRepoConfig({
+          repos: {
+            'owner/alt': {
+              api_host: 'https://althost.example/api/v3',
+              url_pattern: '^https://althost\\.example/(?<owner>[^/]+)/(?<repo>[^/]+)/pull/(?<number>[0-9]+)'
+            }
+          }
+        });
+        expect(warnSpy).not.toHaveBeenCalled();
+      });
+
+      it('does not warn for a url_pattern on a repo without api_host', () => {
+        validateRepoConfig({
+          repos: {
+            'owner/repo': {
+              url_pattern: '/(?<owner>[^/]+)/(?<repo>[^/]+)/pull/(?<number>[0-9]+)'
+            }
+          }
+        });
+        expect(warnSpy).not.toHaveBeenCalled();
+      });
     });
 
     it('throws when api_host is set and a feature requests graphql', () => {

--- a/tests/unit/external/github-adapter.test.js
+++ b/tests/unit/external/github-adapter.test.js
@@ -195,11 +195,59 @@ describe('github-adapter', () => {
       );
 
       expect(resolveBindingRepositoryFromPR).toHaveBeenCalledWith('OctoCat', 'Hello-World', { repos: {} });
-      expect(resolveHostBinding).toHaveBeenCalledWith('monorepo/key', { repos: {} });
+      // Third arg is the resolved host option; with no storedHost it is {} (ambiguity).
+      expect(resolveHostBinding).toHaveBeenCalledWith('monorepo/key', { repos: {} }, {});
       expect(FakeGitHubClient).toHaveBeenCalledWith(fakeBinding);
       expect(result.client.binding).toBe(fakeBinding);
       // fakeBinding.apiHost is set → alt-host.
       expect(result.isAltHost).toBe(true);
+    });
+
+    it('dual repo: a stored alt host pins the alt binding (options.storedHost = api_host)', () => {
+      // Dual repo (api_host + exclusive:false). A stored alt host must resolve
+      // the ALT binding (and isAltHost=true → line-based anchoring), not the
+      // two-arg github ambiguity binding.
+      const FakeGitHubClient = vi.fn(function (binding) { this.binding = binding; });
+      const config = {
+        github_token: 'gh-tok',
+        repos: {
+          'acme/widgets': { api_host: 'https://alt.example/api/v3', exclusive: false, token: 'alt-tok' }
+        }
+      };
+
+      const result = githubAdapter.resolveCredentials(
+        config,
+        'acme/widgets',
+        { GitHubClient: FakeGitHubClient },
+        { storedHost: 'https://alt.example/api/v3' }
+      );
+
+      const binding = FakeGitHubClient.mock.calls[0][0];
+      expect(binding.apiHost).toBe('https://alt.example/api/v3');
+      expect(binding.token).toBe('alt-tok');
+      expect(result.isAltHost).toBe(true);
+    });
+
+    it('dual repo: a stored NULL host binds github.com (options.storedHost = null)', () => {
+      const FakeGitHubClient = vi.fn(function (binding) { this.binding = binding; });
+      const config = {
+        github_token: 'gh-tok',
+        repos: {
+          'acme/widgets': { api_host: 'https://alt.example/api/v3', exclusive: false, token: 'alt-tok' }
+        }
+      };
+
+      const result = githubAdapter.resolveCredentials(
+        config,
+        'acme/widgets',
+        { GitHubClient: FakeGitHubClient },
+        { storedHost: null }
+      );
+
+      const binding = FakeGitHubClient.mock.calls[0][0];
+      expect(binding.apiHost).toBe(null);
+      expect(binding.token).toBe('gh-tok');
+      expect(result.isAltHost).toBe(false);
     });
 
     it('binding-aware: alt-host repo with no token throws GitHubApiError(status=401) mentioning repo-scoped token', () => {

--- a/tests/unit/github-client.test.js
+++ b/tests/unit/github-client.test.js
@@ -2262,6 +2262,85 @@ describe('GitHubClient', () => {
     });
   });
 
+  describe('listOpenPullRequests', () => {
+    it('should paginate rest.pulls.list for open PRs with owner/repo', async () => {
+      const client = new GitHubClient('test-token');
+      const mockPaginate = vi.fn().mockResolvedValue([]);
+      client.octokit.paginate = mockPaginate;
+
+      await client.listOpenPullRequests('acme', 'widget');
+
+      expect(mockPaginate).toHaveBeenCalledWith(
+        client.octokit.rest.pulls.list,
+        { owner: 'acme', repo: 'widget', state: 'open', per_page: 100 }
+      );
+    });
+
+    it('should map PR items to display + classification fields', async () => {
+      const client = new GitHubClient('test-token');
+      client.octokit.paginate = vi.fn().mockResolvedValue([
+        {
+          number: 12,
+          title: 'Add feature',
+          user: { login: 'alice' },
+          updated_at: '2025-04-01T10:00:00Z',
+          html_url: 'https://althost.example/acme/widget/pull/12',
+          state: 'open',
+          requested_reviewers: [{ login: 'bob' }, { login: 'carol' }],
+          requested_teams: [{ slug: 'platform' }, { slug: 'infra' }]
+        }
+      ]);
+
+      const result = await client.listOpenPullRequests('acme', 'widget');
+
+      expect(result).toEqual([
+        {
+          owner: 'acme',
+          repo: 'widget',
+          number: 12,
+          title: 'Add feature',
+          author: 'alice',
+          updated_at: '2025-04-01T10:00:00Z',
+          html_url: 'https://althost.example/acme/widget/pull/12',
+          state: 'open',
+          requested_reviewers: ['bob', 'carol'],
+          requested_teams: ['platform', 'infra']
+        }
+      ]);
+    });
+
+    it('should tolerate null user and missing reviewer/team arrays', async () => {
+      const client = new GitHubClient('test-token');
+      client.octokit.paginate = vi.fn().mockResolvedValue([
+        {
+          number: 3,
+          title: 'Ghost PR',
+          user: null,
+          updated_at: '2025-01-01T00:00:00Z',
+          html_url: 'https://althost.example/acme/widget/pull/3',
+          state: 'open'
+          // requested_reviewers / requested_teams absent
+        }
+      ]);
+
+      const result = await client.listOpenPullRequests('acme', 'widget');
+
+      expect(result[0].author).toBeNull();
+      expect(result[0].requested_reviewers).toEqual([]);
+      expect(result[0].requested_teams).toEqual([]);
+    });
+
+    it('should propagate API errors', async () => {
+      const client = new GitHubClient('test-token');
+      const apiError = new Error('Not Implemented');
+      apiError.status = 501;
+      client.octokit.paginate = vi.fn().mockRejectedValue(apiError);
+
+      await expect(client.listOpenPullRequests('acme', 'widget'))
+        .rejects.toThrow('Not Implemented');
+    });
+  });
+
   describe('getAuthenticatedUser', () => {
     it('should call octokit.rest.users.getAuthenticated() and return mapped data', async () => {
       const client = new GitHubClient('test-token');

--- a/tests/unit/host-resolution.test.js
+++ b/tests/unit/host-resolution.test.js
@@ -1,0 +1,122 @@
+// Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+/**
+ * Unit tests for the shared per-PR host resolution helpers.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+const { storedHostToOption, isDualHostRepo, getConfiguredApiHost, resolvePreflightBinding, hostSetupParamValue } = require('../../src/utils/host-resolution');
+
+const ALT = 'https://alt.example/api/v3';
+const dualConfig = { repos: { 'acme/widgets': { api_host: ALT, exclusive: false, token: 't' } } };
+const exclusiveConfig = { repos: { 'acme/widgets': { api_host: ALT, token: 't' } } };
+const plainConfig = { repos: {} };
+
+describe('storedHostToOption', () => {
+  it('undefined (no row) → undefined (ambiguity)', () => {
+    expect(storedHostToOption(dualConfig, 'acme/widgets', undefined)).toBeUndefined();
+  });
+
+  it('a URL string → { host: <url> }', () => {
+    expect(storedHostToOption(dualConfig, 'acme/widgets', ALT)).toEqual({ host: ALT });
+  });
+
+  it('null on a dual repo → { host: null } (github)', () => {
+    expect(storedHostToOption(dualConfig, 'acme/widgets', null)).toEqual({ host: null });
+  });
+
+  it('null on a plain repo → { host: null } (github)', () => {
+    expect(storedHostToOption(plainConfig, 'acme/widgets', null)).toEqual({ host: null });
+  });
+
+  it('null on an EXCLUSIVE alt-host repo → undefined (legacy NULL derives alt)', () => {
+    expect(storedHostToOption(exclusiveConfig, 'acme/widgets', null)).toBeUndefined();
+  });
+});
+
+describe('isDualHostRepo', () => {
+  it('true only for api_host + exclusive:false', () => {
+    expect(isDualHostRepo(dualConfig, 'acme/widgets')).toBe(true);
+  });
+
+  it('false for an exclusive alt-host repo (api_host, no exclusive key)', () => {
+    expect(isDualHostRepo(exclusiveConfig, 'acme/widgets')).toBe(false);
+  });
+
+  it('false for a plain github repo (no api_host)', () => {
+    expect(isDualHostRepo(plainConfig, 'acme/widgets')).toBe(false);
+  });
+
+  it('false for an unknown repo key', () => {
+    expect(isDualHostRepo(dualConfig, 'nobody/here')).toBe(false);
+  });
+});
+
+describe('getConfiguredApiHost', () => {
+  it('returns the api_host for a dual/exclusive repo, null otherwise', () => {
+    expect(getConfiguredApiHost(dualConfig, 'acme/widgets')).toBe(ALT);
+    expect(getConfiguredApiHost(exclusiveConfig, 'acme/widgets')).toBe(ALT);
+    expect(getConfiguredApiHost(plainConfig, 'acme/widgets')).toBe(null);
+  });
+});
+
+describe('hostSetupParamValue (FINDING C)', () => {
+  it('alt api_host string → that string', () => {
+    expect(hostSetupParamValue(ALT, false)).toBe(ALT);
+    expect(hostSetupParamValue(ALT, true)).toBe(ALT);
+  });
+  it('null on a dual repo → github sentinel', () => {
+    expect(hostSetupParamValue(null, true)).toBe('github');
+  });
+  it('null on a non-dual repo → null (omit)', () => {
+    expect(hostSetupParamValue(null, false)).toBe(null);
+  });
+  it('undefined (unknown) → null (omit)', () => {
+    expect(hostSetupParamValue(undefined, true)).toBe(null);
+    expect(hostSetupParamValue(undefined, false)).toBe(null);
+  });
+});
+
+describe('resolvePreflightBinding (FINDING 2/3/4)', () => {
+  let savedEnvToken;
+  beforeEach(() => {
+    // Deterministic: GITHUB_TOKEN would short-circuit the github chain.
+    savedEnvToken = process.env.GITHUB_TOKEN;
+    delete process.env.GITHUB_TOKEN;
+  });
+  afterEach(() => {
+    if (savedEnvToken !== undefined) process.env.GITHUB_TOKEN = savedEnvToken;
+  });
+
+  const altOnly = { repos: { 'acme/widgets': { api_host: ALT, exclusive: false, token: 'alt-tok' } } };
+  const githubOnly = { github_token: 'gh-tok', repos: { 'acme/widgets': { api_host: ALT, exclusive: false } } };
+  const neither = { repos: { 'acme/widgets': { api_host: ALT, exclusive: false } } };
+  const plainWithToken = { github_token: 'gh-tok', repos: {} };
+
+  it('dual repo, alt-only token, host unknown → returns the alt binding token (no false reject)', () => {
+    const b = resolvePreflightBinding('acme/widgets', altOnly, undefined);
+    expect(b.token).toBe('alt-tok');
+    expect(b.apiHost).toBe(ALT);
+  });
+
+  it('dual repo, github-only token, host unknown → returns the github binding token', () => {
+    const b = resolvePreflightBinding('acme/widgets', githubOnly, undefined);
+    expect(b.token).toBe('gh-tok');
+    expect(b.apiHost).toBe(null);
+  });
+
+  it('dual repo, neither token, host unknown → empty token (caller rejects)', () => {
+    expect(resolvePreflightBinding('acme/widgets', neither, undefined).token).toBe('');
+  });
+
+  it('explicit alt bodyHost → resolves the alt binding token', () => {
+    const b = resolvePreflightBinding('acme/widgets', altOnly, ALT);
+    expect(b.token).toBe('alt-tok');
+    expect(b.apiHost).toBe(ALT);
+  });
+
+  it('plain repo with a github token is unchanged', () => {
+    const b = resolvePreflightBinding('acme/widgets', plainWithToken, undefined);
+    expect(b.token).toBe('gh-tok');
+    expect(b.apiHost).toBe(null);
+  });
+});

--- a/tests/unit/index-open-analyze-buttons.test.js
+++ b/tests/unit/index-open-analyze-buttons.test.js
@@ -221,6 +221,8 @@ function setupGlobals() {
 // ---------------------------------------------------------------------------
 
 describe('Index page Open/Analyze buttons', () => {
+  let indexModule;
+
   beforeEach(async () => {
     setupGlobals();
 
@@ -229,8 +231,10 @@ describe('Index page Open/Analyze buttons', () => {
     delete require.cache[modulePath];
 
     // Load the actual production IIFE — this registers the document click
-    // handler and the DOMContentLoaded listener (but does NOT trigger it)
-    require('../../public/js/index.js');
+    // handler and the DOMContentLoaded listener (but does NOT trigger it).
+    // The IIFE also exposes its internal bulk-open helpers on module.exports
+    // under Vitest so they can be tested directly.
+    indexModule = require('../../public/js/index.js');
 
     // Trigger DOMContentLoaded so that form submit and analyze-button click
     // handlers are registered on the elements.
@@ -293,6 +297,55 @@ describe('Index page Open/Analyze buttons', () => {
     expect(global.window.location.href).toBe('/pr/testowner/testrepo/42');
   });
 
+  // Helper: mock parse-pr-url with custom host / isDualHost fields.
+  function mockFetchParsePR(extra) {
+    global.fetch = vi.fn((url) => {
+      if (typeof url === 'string' && url.includes('/api/parse-pr-url')) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({
+            valid: true, owner: 'testowner', repo: 'testrepo', prNumber: 42, ...extra,
+          }),
+        });
+      }
+      return Promise.resolve({ ok: false });
+    });
+  }
+
+  // ─── FIX 2: host sentinel forwarding on the paste flow ───────────────────
+
+  it('paste of an alt-host URL forwards the api_host as ?host=', async () => {
+    const form = elementsById['start-review-form'];
+    elementsById['pr-url-input'].value = 'https://althost.example/testowner/testrepo/pull/42';
+    mockFetchParsePR({ host: 'https://althost.example/api/v3', isDualHost: false });
+
+    await form._listeners.submit[0]({ preventDefault: vi.fn() });
+
+    expect(global.window.location.href).toBe(
+      '/pr/testowner/testrepo/42?host=' + encodeURIComponent('https://althost.example/api/v3')
+    );
+  });
+
+  it('paste of a github URL for a DUAL repo forwards the "github" sentinel', async () => {
+    const form = elementsById['start-review-form'];
+    elementsById['pr-url-input'].value = 'https://github.com/testowner/testrepo/pull/42';
+    mockFetchParsePR({ host: null, isDualHost: true });
+
+    await form._listeners.submit[0]({ preventDefault: vi.fn() });
+
+    expect(global.window.location.href).toBe('/pr/testowner/testrepo/42?host=github');
+  });
+
+  it('paste of a github URL for a plain repo omits the host param', async () => {
+    const form = elementsById['start-review-form'];
+    elementsById['pr-url-input'].value = 'https://github.com/testowner/testrepo/pull/42';
+    mockFetchParsePR({ host: null, isDualHost: false });
+
+    await form._listeners.submit[0]({ preventDefault: vi.fn() });
+
+    expect(global.window.location.href).toBe('/pr/testowner/testrepo/42');
+  });
+
   // ─── Test 2: PR Analyze button navigates with analyze param ──────────────
 
   it('PR Analyze button navigates with analyze param', async () => {
@@ -323,6 +376,112 @@ describe('Index page Open/Analyze buttons', () => {
     await submitHandler({ preventDefault: vi.fn() });
 
     expect(global.window.location.href).toBe('/local?path=%2Ftmp%2Fmyproject');
+  });
+
+  // ─── Collection row click: alt-host PR threads host into the PR route ─────
+
+  it('alt-host collection row click navigates to the PR route with a host query param', () => {
+    const clickHandlers = documentListeners['click'] || [];
+    expect(clickHandlers.length).toBeGreaterThan(0);
+
+    const apiHost = 'https://althost.example/api/v3';
+    const row = {
+      dataset: {
+        host: apiHost,
+        owner: 'altorg',
+        repo: 'altrepo',
+        number: '77',
+        prUrl: 'https://althost.example/altorg/altrepo/pull/77',
+      },
+      // Not in selection mode.
+      closest: vi.fn(() => null),
+    };
+    const target = {
+      // Row matches only the collection-pr-row selector; not a link/select cell.
+      closest: vi.fn((sel) => (sel === '.collection-pr-row' ? row : null)),
+    };
+
+    clickHandlers.forEach((fn) => fn({ target, preventDefault: vi.fn() }));
+
+    expect(global.window.location.href).toBe(
+      '/pr/altorg/altrepo/77?host=' + encodeURIComponent(apiHost)
+    );
+  });
+
+  it('github collection row click does NOT navigate directly (falls back to the parse flow)', () => {
+    const clickHandlers = documentListeners['click'] || [];
+
+    const row = {
+      // No `host` — a github.com row.
+      dataset: {
+        owner: 'gh-org',
+        repo: 'gh-repo',
+        number: '5',
+        prUrl: 'https://github.com/gh-org/gh-repo/pull/5',
+      },
+      closest: vi.fn(() => null),
+    };
+    const target = {
+      closest: vi.fn((sel) => (sel === '.collection-pr-row' ? row : null)),
+    };
+
+    clickHandlers.forEach((fn) => fn({ target, preventDefault: vi.fn() }));
+
+    // The direct host-carrying navigation must not fire for github rows; the
+    // existing parse-and-submit path owns them and does not set href here.
+    expect(global.window.location.href).not.toContain('?host=');
+  });
+
+  // ─── Bulk open/analyze: alt host threaded into every built PR URL ─────────
+
+  it('buildReviewUrlsFromRows appends encoded host for alt-host rows', () => {
+    const apiHost = 'https://althost.example/api/v3';
+    const urls = indexModule.buildReviewUrlsFromRows(
+      [{ owner: 'altorg', repo: 'altrepo', number: '77', host: apiHost }],
+      ''
+    );
+    expect(urls).toEqual(['/pr/altorg/altrepo/77?host=' + encodeURIComponent(apiHost)]);
+  });
+
+  it('buildReviewUrlsFromRows preserves analyze params and adds host with &', () => {
+    const apiHost = 'https://althost.example/api/v3';
+    const urls = indexModule.buildReviewUrlsFromRows(
+      [{ owner: 'altorg', repo: 'altrepo', number: '77', host: apiHost }],
+      '?analyze=true&analysisConfigId=cfg1'
+    );
+    expect(urls).toEqual([
+      '/pr/altorg/altrepo/77?analyze=true&analysisConfigId=cfg1&host=' + encodeURIComponent(apiHost)
+    ]);
+  });
+
+  it('buildReviewUrlsFromRows adds no host param for github.com rows', () => {
+    const urls = indexModule.buildReviewUrlsFromRows(
+      [{ owner: 'gh-org', repo: 'gh-repo', number: '5' }], // no host
+      '?analyze=true'
+    );
+    expect(urls).toEqual(['/pr/gh-org/gh-repo/5?analyze=true']);
+    expect(urls[0]).not.toContain('host=');
+  });
+
+  it('getSelectedCollectionRows carries data-host from selected rows', () => {
+    const apiHost = 'https://althost.example/api/v3';
+    const fakeTbody = {
+      querySelectorAll: vi.fn(() => [
+        { dataset: { prUrl: 'u-alt', owner: 'altorg', repo: 'altrepo', number: '77', host: apiHost } },
+        { dataset: { prUrl: 'u-gh', owner: 'gh-org', repo: 'gh-repo', number: '5' } }
+      ])
+    };
+    const origGet = global.document.getElementById;
+    global.document.getElementById = vi.fn(() => fakeTbody);
+    try {
+      const rows = indexModule.getSelectedCollectionRows(new Set(['u-alt', 'u-gh']), 'my-prs-tbody');
+      expect(rows).toEqual([
+        { owner: 'altorg', repo: 'altrepo', number: '77', prUrl: 'u-alt', host: apiHost },
+        { owner: 'gh-org', repo: 'gh-repo', number: '5', prUrl: 'u-gh', host: undefined }
+      ]);
+    } finally {
+      global.document.getElementById = origGet;
+    }
   });
 
   it('Local Open button rejects URL input without navigating', async () => {

--- a/tests/unit/main-token-resolution.test.js
+++ b/tests/unit/main-token-resolution.test.js
@@ -36,7 +36,9 @@ describe('main.js — handlePullRequest token-resolution ordering', () => {
     const body = src.slice(fnStart, nextFnStart === -1 ? undefined : nextFnStart);
 
     const parsePosition = body.indexOf('parser.parsePRArguments');
-    const bindingPosition = body.indexOf('resolveHostBinding(');
+    // Token/binding resolution now goes through the shared preflight helper,
+    // which tolerates dual repos whose host is unknown (alt-only token).
+    const bindingPosition = body.indexOf('resolvePreflightBinding(');
     expect(parsePosition).toBeGreaterThan(-1);
     expect(bindingPosition).toBeGreaterThan(-1);
 

--- a/tests/unit/parser.test.js
+++ b/tests/unit/parser.test.js
@@ -19,17 +19,17 @@ describe('PRArgumentParser', () => {
   describe('parseGitHubURL', () => {
     it('should parse standard GitHub PR URL', () => {
       const result = parser.parseGitHubURL('https://github.com/owner/repo/pull/123');
-      expect(result).toEqual({ owner: 'owner', repo: 'repo', number: 123 });
+      expect(result).toEqual({ owner: 'owner', repo: 'repo', number: 123, host: null });
     });
 
     it('should parse GitHub PR URL with trailing segments', () => {
       const result = parser.parseGitHubURL('https://github.com/owner/repo/pull/456/files');
-      expect(result).toEqual({ owner: 'owner', repo: 'repo', number: 456 });
+      expect(result).toEqual({ owner: 'owner', repo: 'repo', number: 456, host: null });
     });
 
     it('should parse GitHub PR URL with commits tab', () => {
       const result = parser.parseGitHubURL('https://github.com/owner/repo/pull/789/commits');
-      expect(result).toEqual({ owner: 'owner', repo: 'repo', number: 789 });
+      expect(result).toEqual({ owner: 'owner', repo: 'repo', number: 789, host: null });
     });
 
     it('should throw error for invalid GitHub URL', () => {
@@ -44,47 +44,47 @@ describe('PRArgumentParser', () => {
   describe('parsePRUrl', () => {
     it('should parse GitHub URL with protocol', () => {
       const result = parser.parsePRUrl('https://github.com/owner/repo/pull/123');
-      expect(result).toEqual({ owner: 'owner', repo: 'repo', number: 123 });
+      expect(result).toEqual({ owner: 'owner', repo: 'repo', number: 123, host: null });
     });
 
     it('should parse GitHub URL without protocol', () => {
       const result = parser.parsePRUrl('github.com/owner/repo/pull/456');
-      expect(result).toEqual({ owner: 'owner', repo: 'repo', number: 456 });
+      expect(result).toEqual({ owner: 'owner', repo: 'repo', number: 456, host: null });
     });
 
     it('should parse Graphite .dev URL with protocol', () => {
       const result = parser.parsePRUrl('https://app.graphite.dev/github/pr/shop/world/337891');
-      expect(result).toEqual({ owner: 'shop', repo: 'world', number: 337891 });
+      expect(result).toEqual({ owner: 'shop', repo: 'world', number: 337891, host: null });
     });
 
     it('should parse Graphite .com URL with protocol', () => {
       const result = parser.parsePRUrl('https://app.graphite.com/github/pr/shop/world/337891');
-      expect(result).toEqual({ owner: 'shop', repo: 'world', number: 337891 });
+      expect(result).toEqual({ owner: 'shop', repo: 'world', number: 337891, host: null });
     });
 
     it('should parse Graphite /pull/ URL with protocol', () => {
       const result = parser.parsePRUrl('https://app.graphite.com/github/shop/world/pull/540063');
-      expect(result).toEqual({ owner: 'shop', repo: 'world', number: 540063 });
+      expect(result).toEqual({ owner: 'shop', repo: 'world', number: 540063, host: null });
     });
 
     it('should parse Graphite /pull/ URL without protocol', () => {
       const result = parser.parsePRUrl('app.graphite.com/github/shop/world/pull/540063');
-      expect(result).toEqual({ owner: 'shop', repo: 'world', number: 540063 });
+      expect(result).toEqual({ owner: 'shop', repo: 'world', number: 540063, host: null });
     });
 
     it('should parse Graphite .dev URL without protocol', () => {
       const result = parser.parsePRUrl('app.graphite.dev/github/pr/shop/world/337891');
-      expect(result).toEqual({ owner: 'shop', repo: 'world', number: 337891 });
+      expect(result).toEqual({ owner: 'shop', repo: 'world', number: 337891, host: null });
     });
 
     it('should parse Graphite .com URL without protocol', () => {
       const result = parser.parsePRUrl('app.graphite.com/github/pr/shop/world/337891');
-      expect(result).toEqual({ owner: 'shop', repo: 'world', number: 337891 });
+      expect(result).toEqual({ owner: 'shop', repo: 'world', number: 337891, host: null });
     });
 
     it('should handle whitespace around URL', () => {
       const result = parser.parsePRUrl('  https://github.com/owner/repo/pull/789  ');
-      expect(result).toEqual({ owner: 'owner', repo: 'repo', number: 789 });
+      expect(result).toEqual({ owner: 'owner', repo: 'repo', number: 789, host: null });
     });
 
     it('should return null for invalid URL', () => {
@@ -107,9 +107,11 @@ describe('PRArgumentParser', () => {
       expect(parser.parsePRUrl(123)).toBeNull();
     });
 
-    it('should parse pair-review:// protocol URL', () => {
+    it('should parse pair-review:// protocol URL (host undefined — no host in the scheme)', () => {
       const result = parser.parsePRUrl('pair-review://pr/owner/repo/123');
       expect(result).toEqual({ owner: 'owner', repo: 'repo', number: 123 });
+      // Not github-only and no host in the path → undefined so it probes/derives.
+      expect(result.host).toBeUndefined();
     });
 
     it('should return null for invalid pair-review:// protocol URL', () => {
@@ -120,32 +122,32 @@ describe('PRArgumentParser', () => {
   describe('parseGraphiteURL', () => {
     it('should parse Graphite URL with .dev domain', () => {
       const result = parser.parseGraphiteURL('https://app.graphite.dev/github/pr/shop/world/337891');
-      expect(result).toEqual({ owner: 'shop', repo: 'world', number: 337891 });
+      expect(result).toEqual({ owner: 'shop', repo: 'world', number: 337891, host: null });
     });
 
     it('should parse Graphite URL with .com domain', () => {
       const result = parser.parseGraphiteURL('https://app.graphite.com/github/pr/shop/world/337891');
-      expect(result).toEqual({ owner: 'shop', repo: 'world', number: 337891 });
+      expect(result).toEqual({ owner: 'shop', repo: 'world', number: 337891, host: null });
     });
 
     it('should parse Graphite URL with encoded title segment', () => {
       const result = parser.parseGraphiteURL('https://app.graphite.com/github/pr/shop/world/338808/%5BConveyor%5D-Minor-update-to-audit-release-cycle-help');
-      expect(result).toEqual({ owner: 'shop', repo: 'world', number: 338808 });
+      expect(result).toEqual({ owner: 'shop', repo: 'world', number: 338808, host: null });
     });
 
     it('should parse Graphite URL with plain title segment', () => {
       const result = parser.parseGraphiteURL('https://app.graphite.dev/github/pr/my-org/my-repo/12345/fix-bug-in-parser');
-      expect(result).toEqual({ owner: 'my-org', repo: 'my-repo', number: 12345 });
+      expect(result).toEqual({ owner: 'my-org', repo: 'my-repo', number: 12345, host: null });
     });
 
     it('should parse Graphite URL with query parameters', () => {
       const result = parser.parseGraphiteURL('https://app.graphite.com/github/pr/my-org/my-repo/123?ref=gt-pasteable-stack');
-      expect(result).toEqual({ owner: 'my-org', repo: 'my-repo', number: 123 });
+      expect(result).toEqual({ owner: 'my-org', repo: 'my-repo', number: 123, host: null });
     });
 
     it('should handle org/repo with hyphens', () => {
       const result = parser.parseGraphiteURL('https://app.graphite.dev/github/pr/my-cool-org/my-cool-repo/999');
-      expect(result).toEqual({ owner: 'my-cool-org', repo: 'my-cool-repo', number: 999 });
+      expect(result).toEqual({ owner: 'my-cool-org', repo: 'my-cool-repo', number: 999, host: null });
     });
 
     it('should throw error for invalid Graphite URL missing PR number', () => {
@@ -166,29 +168,30 @@ describe('PRArgumentParser', () => {
 
     it('should parse Graphite /pull/ URL with .com domain', () => {
       const result = parser.parseGraphiteURL('https://app.graphite.com/github/shop/world/pull/540063');
-      expect(result).toEqual({ owner: 'shop', repo: 'world', number: 540063 });
+      expect(result).toEqual({ owner: 'shop', repo: 'world', number: 540063, host: null });
     });
 
     it('should parse Graphite /pull/ URL with .dev domain', () => {
       const result = parser.parseGraphiteURL('https://app.graphite.dev/github/shop/world/pull/540063');
-      expect(result).toEqual({ owner: 'shop', repo: 'world', number: 540063 });
+      expect(result).toEqual({ owner: 'shop', repo: 'world', number: 540063, host: null });
     });
 
     it('should parse Graphite /pull/ URL with title segment', () => {
       const result = parser.parseGraphiteURL('https://app.graphite.com/github/shop/world/pull/540063/fix-something');
-      expect(result).toEqual({ owner: 'shop', repo: 'world', number: 540063 });
+      expect(result).toEqual({ owner: 'shop', repo: 'world', number: 540063, host: null });
     });
 
     it('should parse Graphite /pull/ URL with query parameters', () => {
       const result = parser.parseGraphiteURL('https://app.graphite.com/github/shop/world/pull/540063?ref=gt-pasteable-stack');
-      expect(result).toEqual({ owner: 'shop', repo: 'world', number: 540063 });
+      expect(result).toEqual({ owner: 'shop', repo: 'world', number: 540063, host: null });
     });
   });
 
   describe('parseProtocolURL', () => {
-    it('should parse valid pair-review:// PR URL', () => {
+    it('should parse valid pair-review:// PR URL (host undefined)', () => {
       const result = parser.parseProtocolURL('pair-review://pr/owner/repo/123');
       expect(result).toEqual({ owner: 'owner', repo: 'repo', number: 123 });
+      expect(result.host).toBeUndefined();
     });
 
     it('should parse protocol URL with trailing path', () => {
@@ -217,27 +220,27 @@ describe('PRArgumentParser', () => {
   describe('parsePRArguments', () => {
     it('should parse GitHub URL', async () => {
       const result = await parser.parsePRArguments(['https://github.com/owner/repo/pull/123']);
-      expect(result).toEqual({ owner: 'owner', repo: 'repo', number: 123 });
+      expect(result).toEqual({ owner: 'owner', repo: 'repo', number: 123, host: null });
     });
 
     it('should parse Graphite .dev URL', async () => {
       const result = await parser.parsePRArguments(['https://app.graphite.dev/github/pr/shop/world/337891']);
-      expect(result).toEqual({ owner: 'shop', repo: 'world', number: 337891 });
+      expect(result).toEqual({ owner: 'shop', repo: 'world', number: 337891, host: null });
     });
 
     it('should parse Graphite .com URL', async () => {
       const result = await parser.parsePRArguments(['https://app.graphite.com/github/pr/shop/world/337891']);
-      expect(result).toEqual({ owner: 'shop', repo: 'world', number: 337891 });
+      expect(result).toEqual({ owner: 'shop', repo: 'world', number: 337891, host: null });
     });
 
     it('should parse Graphite URL with title', async () => {
       const result = await parser.parsePRArguments(['https://app.graphite.com/github/pr/shop/world/338808/%5BConveyor%5D-Minor-update-to-audit-release-cycle-help']);
-      expect(result).toEqual({ owner: 'shop', repo: 'world', number: 338808 });
+      expect(result).toEqual({ owner: 'shop', repo: 'world', number: 338808, host: null });
     });
 
     it('should parse Graphite /pull/ URL', async () => {
       const result = await parser.parsePRArguments(['https://app.graphite.com/github/shop/world/pull/540063']);
-      expect(result).toEqual({ owner: 'shop', repo: 'world', number: 540063 });
+      expect(result).toEqual({ owner: 'shop', repo: 'world', number: 540063, host: null });
     });
 
     it('should parse PR number and fetch repo from git remote', async () => {
@@ -261,6 +264,7 @@ describe('PRArgumentParser', () => {
     it('should parse pair-review:// protocol URL', async () => {
       const result = await parser.parsePRArguments(['pair-review://pr/facebook/react/12345']);
       expect(result).toEqual({ owner: 'facebook', repo: 'react', number: 12345 });
+      expect(result.host).toBeUndefined();
     });
   });
 
@@ -277,7 +281,7 @@ describe('PRArgumentParser', () => {
       const result = await configuredParser.parsePRArguments([
         'https://althost.example/acme/widgets/pull/42'
       ]);
-      expect(result).toEqual({ owner: 'acme', repo: 'widgets', number: 42, bindingRepository: 'acme/widgets' });
+      expect(result).toEqual({ owner: 'acme', repo: 'widgets', number: 42, bindingRepository: 'acme/widgets', host: null });
     });
 
     it('should still resolve github.com URLs via parseGitHubURL when config has no matching pattern', async () => {
@@ -292,7 +296,7 @@ describe('PRArgumentParser', () => {
       const result = await configuredParser.parsePRArguments([
         'https://github.com/octocat/Hello-World/pull/7'
       ]);
-      expect(result).toEqual({ owner: 'octocat', repo: 'Hello-World', number: 7 });
+      expect(result).toEqual({ owner: 'octocat', repo: 'Hello-World', number: 7, host: null });
     });
 
     it('should prefer matchRepoByUrl over parseGitHubURL when both could match', async () => {
@@ -310,7 +314,7 @@ describe('PRArgumentParser', () => {
       const result = await configuredParser.parsePRArguments([
         'https://github.com/some-other/repo/pull/9'
       ]);
-      expect(result).toEqual({ owner: 'acme', repo: 'widgets', number: 9, bindingRepository: 'acme/widgets' });
+      expect(result).toEqual({ owner: 'acme', repo: 'widgets', number: 9, bindingRepository: 'acme/widgets', host: null });
     });
 
     it('should fall back to GitHub parsing when url_pattern lacks a number', async () => {
@@ -327,7 +331,7 @@ describe('PRArgumentParser', () => {
       const result = await configuredParser.parsePRArguments([
         'https://github.com/octocat/Hello-World/pull/11'
       ]);
-      expect(result).toEqual({ owner: 'octocat', repo: 'Hello-World', number: 11 });
+      expect(result).toEqual({ owner: 'octocat', repo: 'Hello-World', number: 11, host: null });
     });
 
     it('parsePRUrl should respect url_pattern when called directly', () => {
@@ -342,7 +346,77 @@ describe('PRArgumentParser', () => {
       const result = configuredParser.parsePRUrl(
         'https://althost.example/acme/widgets/pull/123'
       );
-      expect(result).toEqual({ owner: 'acme', repo: 'widgets', number: 123, bindingRepository: 'acme/widgets' });
+      expect(result).toEqual({ owner: 'acme', repo: 'widgets', number: 123, bindingRepository: 'acme/widgets', host: null });
+    });
+
+    it('should carry the matched repo api_host as host on a url_pattern match', () => {
+      const config = {
+        repos: {
+          'acme/widgets': {
+            api_host: 'https://althost.example/api/v3',
+            url_pattern: '^https://althost\\.example/(?<owner>[^/]+)/(?<repo>[^/]+)/pull/(?<number>[0-9]+)'
+          }
+        }
+      };
+      const configuredParser = new PRArgumentParser(config);
+      const result = configuredParser.parsePRUrl('https://althost.example/acme/widgets/pull/42');
+      expect(result).toEqual({
+        owner: 'acme', repo: 'widgets', number: 42,
+        bindingRepository: 'acme/widgets',
+        host: 'https://althost.example/api/v3'
+      });
+    });
+
+    it('does NOT let an over-broad api_host url_pattern hijack a canonical github.com URL (FINDING B)', () => {
+      const config = {
+        repos: {
+          'acme/widgets': {
+            api_host: 'https://althost.example/api/v3',
+            // Over-broad / unanchored — also matches github.com URLs.
+            url_pattern: '/(?<owner>[^/]+)/(?<repo>[^/]+)/pull/(?<number>[0-9]+)'
+          }
+        }
+      };
+      const p = new PRArgumentParser(config);
+      const result = p.parsePRUrl('https://github.com/real-owner/real-repo/pull/9');
+      // Discarded the alt match; fell through to the real github parser.
+      expect(result.host).toBe(null);
+      expect(result.owner).toBe('real-owner');
+      expect(result.repo).toBe('real-repo');
+      expect(result.number).toBe(9);
+      expect(result.bindingRepository).toBeUndefined();
+    });
+
+    it('does NOT let an over-broad api_host url_pattern hijack a canonical Graphite URL', () => {
+      const config = {
+        repos: {
+          'acme/widgets': {
+            api_host: 'https://althost.example/api/v3',
+            url_pattern: '/(?<owner>[^/]+)/(?<repo>[^/]+)/(?<number>[0-9]+)'
+          }
+        }
+      };
+      const p = new PRArgumentParser(config);
+      const result = p.parsePRUrl('https://app.graphite.dev/github/pr/gorg/grepo/55');
+      expect(result.host).toBe(null);
+      expect(result.owner).toBe('gorg');
+      expect(result.repo).toBe('grepo');
+      expect(result.number).toBe(55);
+    });
+
+    it('an anchored alt-host url_pattern is unaffected by the guard (still binds the alt host)', () => {
+      const config = {
+        repos: {
+          'acme/widgets': {
+            api_host: 'https://althost.example/api/v3',
+            url_pattern: '^https://althost\\.example/(?<owner>[^/]+)/(?<repo>[^/]+)/pull/(?<number>[0-9]+)'
+          }
+        }
+      };
+      const p = new PRArgumentParser(config);
+      const result = p.parsePRUrl('https://althost.example/acme/widgets/pull/42');
+      expect(result.host).toBe('https://althost.example/api/v3');
+      expect(result.bindingRepository).toBe('acme/widgets');
     });
 
     it('should ignore url_pattern when constructed without a config', () => {
@@ -367,7 +441,7 @@ describe('PRArgumentParser', () => {
       // Named groups (teamA/projB) win over the repo key (default/repo)
       // for the PR identity, but bindingRepository still points at the
       // matched config entry so host bindings resolve correctly.
-      expect(result).toEqual({ owner: 'teamA', repo: 'projB', number: 5, bindingRepository: 'default/repo' });
+      expect(result).toEqual({ owner: 'teamA', repo: 'projB', number: 5, bindingRepository: 'default/repo', host: null });
     });
   });
 
@@ -574,6 +648,7 @@ describe('PRArgumentParser', () => {
       };
 
       const result = await configuredParser.parsePRArguments(['42']);
+      // Bare number via git remote leaves host undefined (probe/derive later).
       expect(result).toEqual({ owner: 'team', repo: 'widget', number: 42 });
     });
 

--- a/tests/unit/pr-setup-binding-repo.test.js
+++ b/tests/unit/pr-setup-binding-repo.test.js
@@ -40,10 +40,12 @@ describe('src/routes/setup.js — token preflight uses binding key', () => {
     expect(src).toMatch(/resolveBindingRepositoryFromPR/);
   });
 
-  it('resolves the binding key before calling getGitHubToken', () => {
+  it('resolves the binding key before resolving the preflight token', () => {
     const src = readSource('src/routes/setup.js');
     const bindingPos = src.indexOf('resolveBindingRepositoryFromPR(owner, repo, config)');
-    const tokenPos = src.indexOf('getGitHubToken(config, repositoryForToken)');
+    // Token resolution now goes through resolvePreflightBinding (which tolerates
+    // a dual repo's alt-only token) keyed on the resolved binding repository.
+    const tokenPos = src.indexOf('resolvePreflightBinding(repositoryForToken, config, bodyHost)');
     expect(bindingPos).toBeGreaterThan(-1);
     expect(tokenPos).toBeGreaterThan(-1);
     expect(bindingPos).toBeLessThan(tokenPos);

--- a/tests/unit/repo-links-frontend.test.js
+++ b/tests/unit/repo-links-frontend.test.js
@@ -147,4 +147,20 @@ describe('frontend host accessors (hostName / externalUrl / externalIcon)', () =
     expect(RepoLinks.hostName()).toBe('Meteorite');   // name still works
     expect(RepoLinks.externalUrl()).toBeNull();        // url substitution fails
   });
+
+  it('passes the PR number as a query param so the server resolves per-PR host', async () => {
+    mockLinks({ external: null, github: true, graphite: true });
+    await RepoLinks.fetchAndApplyRepoLinks('acme', 'widget', {
+      owner: 'acme', repo: 'widget', number: 42
+    });
+    expect(global.fetch).toHaveBeenCalledWith('/api/repos/acme/widget/links?number=42');
+  });
+
+  it('omits the number query when no PR number is known (Local mode)', async () => {
+    mockLinks({ external: null, github: true, graphite: true });
+    await RepoLinks.fetchAndApplyRepoLinks('acme', 'widget', {
+      owner: 'acme', repo: 'widget'
+    });
+    expect(global.fetch).toHaveBeenCalledWith('/api/repos/acme/widget/links');
+  });
 });

--- a/tests/unit/repo-links.test.js
+++ b/tests/unit/repo-links.test.js
@@ -405,3 +405,165 @@ describe('resolveHostName', () => {
     expect(resolveHostName({ repos: {} }, 'acme/widget')).toBe('GitHub');
   });
 });
+
+// ---------------------------------------------------------------------------
+// Per-PR host awareness (dual-host repos). The `host` arg is: null = github,
+// an api_host URL string = the alt host, undefined = unknown / not applicable.
+// Only dual repos (`api_host` + `exclusive: false`) react to it; plain and
+// exclusive repos render byte-identically regardless of the arg.
+// ---------------------------------------------------------------------------
+describe('resolveRepoLinks host-awareness', () => {
+  const ALT_HOST = 'https://alt.example/api/v3';
+
+  // A full links block (external + explicit github/graphite hidden) as a
+  // dual-host repo would realistically configure it.
+  const LINKS = {
+    external: {
+      name: 'Meteorite',
+      label: 'Open on Meteorite',
+      url_template: 'https://meteorite.example/{owner}/{repo}/pull/{number}',
+    },
+    github: false,
+    graphite: false,
+  };
+
+  const plainConfig = { repos: { 'acme/widget': { links: LINKS } } };
+  const exclusiveConfig = {
+    repos: { 'acme/widget': { api_host: ALT_HOST, links: LINKS } },
+  };
+  const dualConfig = {
+    repos: { 'acme/widget': { api_host: ALT_HOST, exclusive: false, links: LINKS } },
+  };
+
+  describe('back-compat: non-dual repos ignore the host arg', () => {
+    it('plain repo renders identically for null / alt / omitted host', () => {
+      const base = resolveRepoLinks(plainConfig, 'acme/widget');
+      expect(resolveRepoLinks(plainConfig, 'acme/widget', null)).toEqual(base);
+      expect(resolveRepoLinks(plainConfig, 'acme/widget', ALT_HOST)).toEqual(base);
+    });
+
+    it('exclusive alt-host repo renders identically for null / alt / omitted host', () => {
+      const base = resolveRepoLinks(exclusiveConfig, 'acme/widget');
+      // Exclusive repo: external shown, github/graphite hidden by explicit config.
+      expect(base.external).not.toBeNull();
+      expect(base.github).toBe(false);
+      expect(base.graphite).toBe(false);
+      // The host arg must not change anything — including host=null, which
+      // would THROW in resolveHostBinding but must be inert for links.
+      expect(resolveRepoLinks(exclusiveConfig, 'acme/widget', null)).toEqual(base);
+      expect(resolveRepoLinks(exclusiveConfig, 'acme/widget', ALT_HOST)).toEqual(base);
+    });
+  });
+
+  describe('dual repo: github-hosted PR (host = null)', () => {
+    it('hides the external link and keeps the github link', () => {
+      const result = resolveRepoLinks(dualConfig, 'acme/widget', null);
+      expect(result.external).toBeNull();
+      // Explicit links.github:false is an alt-host override authored for the
+      // alt side; on a github PR the default github link is kept... but an
+      // EXPLICIT false still hides. Here LINKS sets github:false, so it hides.
+      expect(result.github).toBe(false);
+      expect(result.graphite).toBe(false);
+    });
+
+    it('keeps github/graphite when no explicit override hides them', () => {
+      const cfg = {
+        repos: {
+          'acme/widget': {
+            api_host: ALT_HOST,
+            exclusive: false,
+            links: {
+              external: {
+                name: 'Meteorite',
+                label: 'Open on Meteorite',
+                url_template: 'https://meteorite.example/{owner}/{repo}/pull/{number}',
+              },
+            },
+          },
+        },
+      };
+      const result = resolveRepoLinks(cfg, 'acme/widget', null);
+      expect(result.external).toBeNull();
+      expect(result.github).toBe(true);
+      expect(result.graphite).toBe(true);
+    });
+  });
+
+  describe('dual repo: alt-hosted PR (host = api_host string)', () => {
+    it('shows the external link and hides github/graphite', () => {
+      const result = resolveRepoLinks(dualConfig, 'acme/widget', ALT_HOST);
+      expect(result.external).not.toBeNull();
+      expect(result.external.name).toBe('Meteorite');
+      expect(result.github).toBe(false);
+      expect(result.graphite).toBe(false);
+    });
+
+    it('hides github/graphite even without explicit links.github/graphite:false', () => {
+      const cfg = {
+        repos: {
+          'acme/widget': {
+            api_host: ALT_HOST,
+            exclusive: false,
+            links: {
+              external: {
+                name: 'Meteorite',
+                label: 'Open on Meteorite',
+                url_template: 'https://meteorite.example/{owner}/{repo}/pull/{number}',
+              },
+            },
+          },
+        },
+      };
+      const result = resolveRepoLinks(cfg, 'acme/widget', ALT_HOST);
+      expect(result.external).not.toBeNull();
+      expect(result.github).toBe(false);
+      expect(result.graphite).toBe(false);
+    });
+  });
+
+  describe('dual repo: unknown host (omitted arg)', () => {
+    it('falls back to repo-level defaults (today\'s behaviour)', () => {
+      const result = resolveRepoLinks(dualConfig, 'acme/widget');
+      // No host known → no per-host flip; external present, explicit
+      // github/graphite:false honoured.
+      expect(result.external).not.toBeNull();
+      expect(result.github).toBe(false);
+      expect(result.graphite).toBe(false);
+    });
+  });
+});
+
+describe('resolveHostName host-awareness', () => {
+  const ALT_HOST = 'https://alt.example/api/v3';
+  const LINKS = {
+    external: {
+      name: 'Meteorite',
+      label: 'Open on Meteorite',
+      url_template: 'https://meteorite.example/{owner}/{repo}/pull/{number}',
+    },
+  };
+  const dualConfig = {
+    repos: { 'acme/widget': { api_host: ALT_HOST, exclusive: false, links: LINKS } },
+  };
+  const exclusiveConfig = {
+    repos: { 'acme/widget': { api_host: ALT_HOST, links: LINKS } },
+  };
+
+  it('dual repo + github-hosted PR reports "GitHub"', () => {
+    expect(resolveHostName(dualConfig, 'acme/widget', null)).toBe('GitHub');
+  });
+
+  it('dual repo + alt-hosted PR reports the external name', () => {
+    expect(resolveHostName(dualConfig, 'acme/widget', ALT_HOST)).toBe('Meteorite');
+  });
+
+  it('dual repo + unknown host reports the external name (repo default)', () => {
+    expect(resolveHostName(dualConfig, 'acme/widget')).toBe('Meteorite');
+  });
+
+  it('exclusive repo ignores the host arg (always the external name)', () => {
+    expect(resolveHostName(exclusiveConfig, 'acme/widget', null)).toBe('Meteorite');
+    expect(resolveHostName(exclusiveConfig, 'acme/widget', ALT_HOST)).toBe('Meteorite');
+    expect(resolveHostName(exclusiveConfig, 'acme/widget')).toBe('Meteorite');
+  });
+});

--- a/tests/unit/route-bindings.test.js
+++ b/tests/unit/route-bindings.test.js
@@ -56,10 +56,15 @@ describe('PR-mode route call sites use host bindings (alt-host safety)', () => {
     expect(directReads).toBeLessThanOrEqual(1); // only inside resolveBindingForRequest
   });
 
-  it('src/main.js — performHeadlessReview resolves a binding before client construction', () => {
+  it('src/main.js — headless PR paths resolve a per-PR host binding before fetching', () => {
     const src = readSource('src/main.js');
-    expect(src).toMatch(/resolveHostBinding\(/);
-    expect(src).toMatch(/new GitHubClient\(headlessBinding\)/);
+    // Preflight resolves a binding (tolerating dual repos with an alt-only token)
+    // for the fail-fast credential check...
+    expect(src).toMatch(/resolvePreflightBinding\(/);
+    // ...and the fetch routes through the shared host-aware helper (which
+    // constructs the GitHubClient from the chosen binding, never a bare token).
+    expect(src).toMatch(/resolvePrHostBinding\(/);
+    expect(src).not.toMatch(/new GitHubClient\(githubToken\)/);
   });
 
   it('src/setup/pr-setup.js — setupPRReview routes through a host binding', () => {
@@ -79,7 +84,8 @@ describe('PR-mode route call sites use host bindings (alt-host safety)', () => {
     // configs where the config key differs from `${owner}/${repo}`), then
     // pass that key into `resolveHostBinding`.
     expect(src).toMatch(/resolveBindingRepositoryFromPR\(owner, repo, config\)/);
-    expect(src).toMatch(/resolveHostBinding\(bindingRepository, config\)/);
+    // Now host-aware: the third arg pins the main PR's stored host for the stack.
+    expect(src).toMatch(/resolveHostBinding\(bindingRepository, config, stackHostOption \|\| \{\}\)/);
     expect(src).toMatch(/new deps\.GitHubClient\(stackBinding\)/);
   });
 

--- a/tests/unit/single-port.test.js
+++ b/tests/unit/single-port.test.js
@@ -263,6 +263,25 @@ describe('buildDelegationUrl', () => {
     expect(url).toBe('http://localhost:7247/pr/acme/widgets/42?analyze=true&analysisConfigId=a%20b%2Fc');
   });
 
+  it('appends an alt-host value as an encoded host param (FINDING C)', () => {
+    const url = buildDelegationUrl(7247, 'pr', {
+      owner: 'acme', repo: 'widgets', number: 42, host: 'https://althost.example/api/v3'
+    });
+    expect(url).toBe('http://localhost:7247/pr/acme/widgets/42?host=https%3A%2F%2Falthost.example%2Fapi%2Fv3');
+  });
+
+  it('appends the github sentinel host param', () => {
+    const url = buildDelegationUrl(7247, 'pr', {
+      owner: 'acme', repo: 'widgets', number: 42, host: 'github'
+    });
+    expect(url).toBe('http://localhost:7247/pr/acme/widgets/42?host=github');
+  });
+
+  it('omits the host param when context.host is absent', () => {
+    const url = buildDelegationUrl(7247, 'pr', { owner: 'acme', repo: 'widgets', number: 42 });
+    expect(url).toBe('http://localhost:7247/pr/acme/widgets/42');
+  });
+
   it('builds server landing URL', () => {
     const url = buildDelegationUrl(7247, 'server');
     expect(url).toBe('http://localhost:7247/');
@@ -420,6 +439,38 @@ describe('attemptDelegation', () => {
     const result = await attemptDelegation(baseConfig, {}, [], deps);
     expect(result).toBe(true);
     expect(deps.open).toHaveBeenCalledWith('http://localhost:7247/');
+  });
+
+  it('threads an alt host into the delegated PR URL (FINDING C)', async () => {
+    class AltParser {
+      async parsePRArguments() {
+        return { owner: 'acme', repo: 'widgets', number: 42, host: 'https://alt.example/api/v3', bindingRepository: 'acme/widgets' };
+      }
+    }
+    const deps = createMockDeps({ PRArgumentParser: AltParser });
+    const config = { port: 7247, single_port: true, repos: { 'acme/widgets': { api_host: 'https://alt.example/api/v3', exclusive: false, token: 't' } } };
+    await attemptDelegation(config, {}, ['https://alt.example/acme/widgets/pull/42'], deps);
+    expect(deps.open).toHaveBeenCalledWith(expect.stringContaining('host=https%3A%2F%2Falt.example%2Fapi%2Fv3'));
+  });
+
+  it('threads the github sentinel for a dual repo opened via a github URL', async () => {
+    class GithubDualParser {
+      async parsePRArguments() { return { owner: 'acme', repo: 'widgets', number: 42, host: null }; }
+    }
+    const deps = createMockDeps({ PRArgumentParser: GithubDualParser });
+    const config = { port: 7247, single_port: true, repos: { 'acme/widgets': { api_host: 'https://alt.example/api/v3', exclusive: false, token: 't' } } };
+    await attemptDelegation(config, {}, ['https://github.com/acme/widgets/pull/42'], deps);
+    expect(deps.open).toHaveBeenCalledWith(expect.stringContaining('host=github'));
+  });
+
+  it('omits the host param for a plain github repo', async () => {
+    class PlainParser {
+      async parsePRArguments() { return { owner: 'a', repo: 'b', number: 1, host: null }; }
+    }
+    const deps = createMockDeps({ PRArgumentParser: PlainParser });
+    const config = { port: 7247, single_port: true, repos: {} };
+    await attemptDelegation(config, {}, ['https://github.com/a/b/pull/1'], deps);
+    expect(deps.open.mock.calls[0][0]).not.toContain('host=');
   });
 
   it('appends ?analyze=true when flags.ai is set for PR mode', async () => {

--- a/tests/unit/stack-analysis-binding-repo.test.js
+++ b/tests/unit/stack-analysis-binding-repo.test.js
@@ -63,6 +63,7 @@ vi.spyOn(databaseModule.PRMetadataRepository.prototype, 'getByPR').mockResolvedV
   description: ''
 });
 vi.spyOn(databaseModule.PRMetadataRepository.prototype, 'updateLastAiRunId').mockResolvedValue(undefined);
+  vi.spyOn(databaseModule.PRMetadataRepository.prototype, 'getPRHost').mockResolvedValue(undefined);
 vi.spyOn(databaseModule.ReviewRepository.prototype, 'getOrCreate').mockResolvedValue({ review: { id: 1 } });
 vi.spyOn(databaseModule.ReviewRepository.prototype, 'upsertSummary').mockResolvedValue(undefined);
 vi.spyOn(databaseModule.RepoSettingsRepository.prototype, 'getRepoSettings').mockResolvedValue(null);
@@ -239,6 +240,7 @@ describe('executeStackAnalysis — bindingRepository resolution', () => {
       description: ''
     });
     vi.spyOn(databaseModule.PRMetadataRepository.prototype, 'updateLastAiRunId').mockResolvedValue(undefined);
+  vi.spyOn(databaseModule.PRMetadataRepository.prototype, 'getPRHost').mockResolvedValue(undefined);
     vi.spyOn(databaseModule.ReviewRepository.prototype, 'getOrCreate').mockResolvedValue({ review: { id: 1 } });
     vi.spyOn(databaseModule.RepoSettingsRepository.prototype, 'getRepoSettings').mockResolvedValue(null);
     vi.spyOn(databaseModule.AnalysisRunRepository.prototype, 'create').mockResolvedValue(undefined);
@@ -279,8 +281,9 @@ describe('executeStackAnalysis — bindingRepository resolution', () => {
 
     // The binding lookup MUST use the resolved config key, not the PR identity.
     expect(deps.resolveBindingRepositoryFromPR).toHaveBeenCalledWith('acme', 'widget-a', config);
-    expect(resolveHostBinding).toHaveBeenCalledWith('acme-monorepo', config);
-    expect(resolveHostBinding).not.toHaveBeenCalledWith('acme/widget-a', config);
+    // Third arg is the main PR's host option; no stored host → {} (ambiguity).
+    expect(resolveHostBinding).toHaveBeenCalledWith('acme-monorepo', config, {});
+    expect(resolveHostBinding).not.toHaveBeenCalledWith('acme/widget-a', config, {});
 
     // The monorepo token should reach the GitHubClient via the binding.
     const ghClientArgs = deps.GitHubClient.mock.calls.map(c => c[0]);
@@ -313,8 +316,39 @@ describe('executeStackAnalysis — bindingRepository resolution', () => {
 
     expect(deps.resolveBindingRepositoryFromPR).toHaveBeenCalledWith('acme', 'widget-a', config);
     // The real resolver lowercases the fallback, so the key passed to
-    // resolveHostBinding is the lowercased PR identity.
-    expect(resolveHostBinding).toHaveBeenCalledWith('acme/widget-a', config);
+    // resolveHostBinding is the lowercased PR identity (third arg = {} ambiguity).
+    expect(resolveHostBinding).toHaveBeenCalledWith('acme/widget-a', config, {});
+  });
+
+  it('stack binding follows the MAIN PR stored host (dual repo alt-hosted stack)', async () => {
+    // Dual repo whose trigger PR lives on the alt host. The stack binding must
+    // resolve with { host: <alt> } so siblings are fetched from and stamped
+    // with the alt host, not the two-arg github ambiguity binding.
+    const config = {
+      github_token: 'gh-tok',
+      repos: {
+        'acme/widget-a': { api_host: 'https://alt.example/api/v3', exclusive: false, token: 'alt-tok' }
+      }
+    };
+    // Trigger PR (#10) is stored on the alt host.
+    vi.spyOn(databaseModule.PRMetadataRepository.prototype, 'getPRHost')
+      .mockResolvedValue('https://alt.example/api/v3');
+
+    const resolveHostBinding = vi.fn().mockReturnValue({
+      apiHost: 'https://alt.example/api/v3', host: 'https://alt.example/api/v3',
+      token: 'alt-tok', features: {}, source: 'config:repos[acme/widget-a].token',
+    });
+    const deps = createMockDeps({ resolveHostBinding });
+    const params = createDefaultParams(deps, { config });
+    initActiveState(params.stackAnalysisId, params.prNumbers);
+
+    await executeStackAnalysis(params);
+
+    // Binding resolved with the main PR's stored alt host.
+    expect(resolveHostBinding).toHaveBeenCalledWith('acme/widget-a', config, { host: 'https://alt.example/api/v3' });
+    // setupStackPR receives that binding, so stack-setup stamps binding.host (alt).
+    const setupArgs = deps.setupStackPR.mock.calls[0][0];
+    expect(setupArgs.binding.host).toBe('https://alt.example/api/v3');
   });
 
   it('setupStackPR plumbing: invoked with bindingRepository set to the resolved binding key', async () => {

--- a/tests/unit/stack-orchestrator.test.js
+++ b/tests/unit/stack-orchestrator.test.js
@@ -56,6 +56,7 @@ vi.spyOn(databaseModule.PRMetadataRepository.prototype, 'getByPR').mockResolvedV
   description: ''
 });
 vi.spyOn(databaseModule.PRMetadataRepository.prototype, 'updateLastAiRunId').mockResolvedValue(undefined);
+  vi.spyOn(databaseModule.PRMetadataRepository.prototype, 'getPRHost').mockResolvedValue(undefined);
 vi.spyOn(databaseModule.ReviewRepository.prototype, 'getOrCreate').mockResolvedValue({ review: { id: 1 } });
 vi.spyOn(databaseModule.ReviewRepository.prototype, 'upsertSummary').mockResolvedValue(undefined);
 vi.spyOn(databaseModule.RepoSettingsRepository.prototype, 'getRepoSettings').mockResolvedValue(null);
@@ -196,6 +197,7 @@ describe('executeStackAnalysis', () => {
       description: ''
     });
     vi.spyOn(databaseModule.PRMetadataRepository.prototype, 'updateLastAiRunId').mockResolvedValue(undefined);
+  vi.spyOn(databaseModule.PRMetadataRepository.prototype, 'getPRHost').mockResolvedValue(undefined);
     vi.spyOn(databaseModule.ReviewRepository.prototype, 'getOrCreate').mockResolvedValue({ review: { id: 1 } });
     vi.spyOn(databaseModule.RepoSettingsRepository.prototype, 'getRepoSettings').mockResolvedValue(null);
     vi.spyOn(databaseModule.AnalysisRunRepository.prototype, 'create').mockResolvedValue(undefined);

--- a/tests/unit/stack-setup.test.js
+++ b/tests/unit/stack-setup.test.js
@@ -148,8 +148,20 @@ describe('setupStackPR', () => {
       fakePRData,
       diff,
       changedFiles,
-      '/tmp/worktree/test-repo'
+      '/tmp/worktree/test-repo',
+      // No binding is passed in these params, so no host is stamped.
+      { host: undefined }
     );
+  });
+
+  it('stamps the binding host on storePRData when a binding is supplied', async () => {
+    await setupStackPR({
+      ...defaultParams(),
+      binding: { apiHost: 'https://alt.example/api/v3', host: 'https://alt.example/api/v3', token: 'alt-tok', features: {} }
+    });
+
+    const call = mockStorePRData.mock.calls[0];
+    expect(call[6]).toEqual({ host: 'https://alt.example/api/v3' });
   });
 
   it('handles already-existing PR records (isNew is false)', async () => {

--- a/tests/unit/wiring/local-host-binding.test.js
+++ b/tests/unit/wiring/local-host-binding.test.js
@@ -1,0 +1,277 @@
+// Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+/**
+ * Local-mode host-binding wiring tests (Phase 7: per-PR host resolution).
+ *
+ * Local mode has no PR identity, so it always calls the two-argument form of
+ * resolveHostBinding(repository, config) for best-effort branch enrichment.
+ * The two-arg form applies the "ambiguity rule":
+ *   - DUAL repo (api_host + exclusive:false)  → github binding (host === null,
+ *     top-level github.com token). The repo's alt-host token/features do NOT
+ *     apply to this binding.
+ *   - EXCLUSIVE alt-host repo (api_host, no exclusive key) → alt binding
+ *     (host === api_host, repo-scoped token) — unchanged from today.
+ *
+ * These tests assert the binding actually fed into branch enrichment at both
+ * local-mode entry points (CLAUDE.md "CLI vs Web UI entry points"):
+ *   1. setupLocalReviewSession()      — the CLI seam (local-review.js:802)
+ *   2. POST /api/local/start          — the web UI seam (routes/local.js:501)
+ * and that the ambiguity rule never throws on a local path (local mode passes
+ * no host override, so the new host-mismatch throws in resolveHostBinding
+ * cannot fire here).
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import os from 'os';
+import path from 'path';
+import fs from 'fs/promises';
+import { createTestDatabase, closeTestDatabase } from '../../utils/schema';
+import { listenOnLoopback, closeServer } from '../../utils/loopback-server';
+
+const localReviewModule = require('../../../src/local-review');
+const configModule = require('../../../src/config');
+const baseBranchModule = require('../../../src/git/base-branch');
+const summaryGenerator = require('../../../src/ai/summary-generator');
+const tourGenerator = require('../../../src/ai/tour-generator');
+const stackWalkerModule = require('../../../src/github/stack-walker');
+const { localReviewDiffs } = require('../../../src/routes/shared');
+
+const ALT_HOST = 'https://alt.example.com/api/v3';
+
+// A DUAL repo: alt host present but not exclusive. The repo-scoped token is an
+// alt-host credential; the top-level github_token is the github.com credential.
+function dualRepoConfig() {
+  return {
+    port: 7247,
+    github_token: 'GH_TOKEN',
+    repos: {
+      'owner/repo': {
+        path: '/mock/repo',
+        api_host: ALT_HOST,
+        exclusive: false,
+        token: 'ALT_TOKEN'
+      }
+    }
+  };
+}
+
+// An EXCLUSIVE alt-host repo: api_host with no `exclusive` key (defaults to
+// exclusive). Today's behaviour — every PR (and enrichment) uses the alt host.
+function exclusiveRepoConfig() {
+  return {
+    port: 7247,
+    github_token: 'GH_TOKEN',
+    repos: {
+      'owner/repo': {
+        path: '/mock/repo',
+        api_host: ALT_HOST,
+        token: 'ALT_TOKEN'
+      }
+    }
+  };
+}
+
+describe('local-mode host binding (ambiguity rule)', () => {
+  let db;
+  let savedGithubTokenEnv;
+
+  beforeEach(() => {
+    db = createTestDatabase();
+
+    // GITHUB_TOKEN would short-circuit the github binding's token resolution
+    // ahead of config.github_token; unset it so the assertions are stable.
+    savedGithubTokenEnv = process.env.GITHUB_TOKEN;
+    delete process.env.GITHUB_TOKEN;
+
+    // Stub git-touching helpers so no real repo is required. All of these are
+    // invoked via module.exports (or an inline require) by both entry points,
+    // so vi.spyOn on the module is observable at call time.
+    vi.spyOn(localReviewModule, 'findGitRoot').mockResolvedValue('/mock/repo');
+    vi.spyOn(localReviewModule, 'getHeadSha').mockResolvedValue('abc123def456');
+    vi.spyOn(localReviewModule, 'getRepositoryName').mockResolvedValue('owner/repo');
+    vi.spyOn(localReviewModule, 'getCurrentBranch').mockResolvedValue('feature-branch');
+    vi.spyOn(localReviewModule, 'findMainGitRoot').mockResolvedValue('/mock/repo');
+    vi.spyOn(localReviewModule, 'generateScopedDiff').mockResolvedValue({
+      diff: '',
+      stats: { trackedChanges: 0, untrackedFiles: 0, stagedChanges: 0, unstagedChanges: 0 },
+      mergeBaseSha: null
+    });
+    vi.spyOn(localReviewModule, 'computeScopedDigest').mockResolvedValue('digest123');
+
+    // Cut off the deepest git/network step. detectAndBuildBranchInfo inline
+    // requires detectBaseBranch per call, so this spy is reliably wired even
+    // when the route runs the real detectAndBuildBranchInfo — keeping the
+    // route tests off the network (no real PR probe).
+    vi.spyOn(baseBranchModule, 'detectBaseBranch').mockResolvedValue(null);
+
+    // Background provider jobs are irrelevant here; keep them inert.
+    vi.spyOn(summaryGenerator, 'kickOffSummaryJob').mockReturnValue(null);
+    vi.spyOn(tourGenerator, 'kickOffTourJob').mockReturnValue(null);
+    vi.spyOn(stackWalkerModule, 'walkPRStack').mockResolvedValue(null);
+  });
+
+  afterEach(() => {
+    localReviewDiffs.clear();
+    vi.restoreAllMocks();
+    if (savedGithubTokenEnv === undefined) {
+      delete process.env.GITHUB_TOKEN;
+    } else {
+      process.env.GITHUB_TOKEN = savedGithubTokenEnv;
+    }
+    closeTestDatabase(db);
+  });
+
+  /**
+   * Captures the `hostBinding` (and `githubToken`) that a local entry point
+   * feeds into branch enrichment by spying detectAndBuildBranchInfo — both
+   * entry points call it with { repository, hostBinding, githubToken, ... }.
+   */
+  function captureEnrichmentBinding() {
+    const captured = {};
+    vi.spyOn(localReviewModule, 'detectAndBuildBranchInfo').mockImplementation(async (repoPath, branch, options = {}) => {
+      captured.repoPath = repoPath;
+      captured.branch = branch;
+      captured.hostBinding = options.hostBinding;
+      captured.githubToken = options.githubToken;
+      return null;
+    });
+    return captured;
+  }
+
+  describe('CLI seam: setupLocalReviewSession()', () => {
+    it('DUAL repo → github binding (host null, top-level github token)', async () => {
+      const captured = captureEnrichmentBinding();
+
+      const result = await localReviewModule.setupLocalReviewSession({
+        db,
+        config: dualRepoConfig(),
+        repoPath: '/mock/repo',
+        flags: {},
+        startBackgroundJobs: false
+      });
+
+      expect(result.sessionId).toBeDefined();
+      expect(captured.hostBinding).toBeTruthy();
+      // github flavor: no alt api host, host echo null.
+      expect(captured.hostBinding.apiHost).toBeNull();
+      expect(captured.hostBinding.host).toBeNull();
+      // Top-level github.com credential, not the repo-scoped alt token.
+      expect(captured.hostBinding.token).toBe('GH_TOKEN');
+      expect(captured.hostBinding.source).toBe('config:github_token');
+      // The fallback token passed alongside must agree with the binding.
+      expect(captured.githubToken).toBe('GH_TOKEN');
+    });
+
+    it('EXCLUSIVE alt-host repo → alt binding (host api_host, repo token) — unchanged', async () => {
+      const captured = captureEnrichmentBinding();
+
+      const result = await localReviewModule.setupLocalReviewSession({
+        db,
+        config: exclusiveRepoConfig(),
+        repoPath: '/mock/repo',
+        flags: {},
+        startBackgroundJobs: false
+      });
+
+      expect(result.sessionId).toBeDefined();
+      expect(captured.hostBinding).toBeTruthy();
+      expect(captured.hostBinding.apiHost).toBe(ALT_HOST);
+      expect(captured.hostBinding.host).toBe(ALT_HOST);
+      expect(captured.hostBinding.token).toBe('ALT_TOKEN');
+      expect(captured.hostBinding.source).toBe('repo:token');
+    });
+
+    it('does not throw for a dual repo on the local path (no host override is passed)', async () => {
+      captureEnrichmentBinding();
+      await expect(localReviewModule.setupLocalReviewSession({
+        db,
+        config: dualRepoConfig(),
+        repoPath: '/mock/repo',
+        flags: {},
+        startBackgroundJobs: false
+      })).resolves.toBeTruthy();
+    });
+  });
+
+  describe('web UI seam: POST /api/local/start', () => {
+    let app;
+    let server;
+    let tmpDir;
+
+    // The start handler destructures detectAndBuildBranchInfo at module load
+    // (routes/local.js), so a module-export spy on it is only reliably wired on
+    // the first require. It resolves the binding through an inline
+    // require('../config') per request, so wrapping resolveHostBinding is the
+    // stable capture point across multiple route tests.
+    function captureViaResolveHostBinding() {
+      const captured = {};
+      const real = configModule.resolveHostBinding;
+      vi.spyOn(configModule, 'resolveHostBinding').mockImplementation((repository, config, options) => {
+        const binding = real(repository, config, options);
+        captured.repository = repository;
+        captured.options = options;
+        captured.hostBinding = binding;
+        return binding;
+      });
+      return captured;
+    }
+
+    async function mountRouter(config) {
+      app = express();
+      app.use(express.json());
+      app.set('db', db);
+      app.set('config', config);
+      const localRouter = require('../../../src/routes/local');
+      app.use(localRouter);
+      server = await listenOnLoopback(app);
+    }
+
+    beforeEach(async () => {
+      // POST /api/local/start fs.stat()s the request path before spied helpers
+      // run, so it must be a real, existing directory (per-file mkdtemp).
+      tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'pr-local-host-'));
+    });
+
+    afterEach(async () => {
+      if (server) await closeServer(server);
+      server = undefined;
+      if (tmpDir) await fs.rm(tmpDir, { recursive: true, force: true });
+    });
+
+    it('DUAL repo → github binding (host null, top-level token), request succeeds', async () => {
+      const captured = captureViaResolveHostBinding();
+      await mountRouter(dualRepoConfig());
+
+      const res = await request(server)
+        .post('/api/local/start')
+        .send({ path: tmpDir });
+
+      expect(res.status).toBe(200);
+      expect(captured.repository).toBe('owner/repo');
+      // Best-effort enrichment passes no host override → ambiguity rule applies.
+      expect(captured.options).toBeUndefined();
+      expect(captured.hostBinding).toBeTruthy();
+      expect(captured.hostBinding.apiHost).toBeNull();
+      expect(captured.hostBinding.host).toBeNull();
+      expect(captured.hostBinding.token).toBe('GH_TOKEN');
+      expect(captured.hostBinding.source).toBe('config:github_token');
+    });
+
+    it('EXCLUSIVE alt-host repo → alt binding (host api_host, repo token) — unchanged', async () => {
+      const captured = captureViaResolveHostBinding();
+      await mountRouter(exclusiveRepoConfig());
+
+      const res = await request(server)
+        .post('/api/local/start')
+        .send({ path: tmpDir });
+
+      expect(res.status).toBe(200);
+      expect(captured.hostBinding).toBeTruthy();
+      expect(captured.hostBinding.apiHost).toBe(ALT_HOST);
+      expect(captured.hostBinding.host).toBe(ALT_HOST);
+      expect(captured.hostBinding.token).toBe('ALT_TOKEN');
+      expect(captured.hostBinding.source).toBe('repo:token');
+    });
+  });
+});

--- a/tests/utils/schema.js
+++ b/tests/utils/schema.js
@@ -91,6 +91,7 @@ const SCHEMA_SQL = {
       pr_data TEXT,
       last_ai_run_id TEXT,
       last_accessed_at TEXT,
+      host TEXT,
       UNIQUE(pr_number, repository)
     )
   `,
@@ -280,6 +281,7 @@ const SCHEMA_SQL = {
       html_url TEXT,
       state TEXT DEFAULT 'open',
       collection TEXT NOT NULL,
+      host TEXT,
       fetched_at DATETIME DEFAULT CURRENT_TIMESTAMP
     )
   `,
@@ -368,8 +370,11 @@ const INDEX_SQL = [
   'CREATE INDEX IF NOT EXISTS idx_context_files_review ON context_files(review_id)',
   // Hunk summaries indexes
   'CREATE INDEX IF NOT EXISTS idx_hunk_summaries_review ON hunk_summaries(review_id)',
-  // GitHub PR cache indexes
-  'CREATE UNIQUE INDEX IF NOT EXISTS idx_github_pr_cache_unique ON github_pr_cache(collection, owner, repo, number)',
+  // GitHub PR cache indexes. `host` is part of the unique key so a dual-host
+  // repo can cache the same (collection, owner, repo, number) from github.com
+  // (host NULL) and its alt host without colliding. Must match production
+  // src/database.js (widened by migration 51).
+  'CREATE UNIQUE INDEX IF NOT EXISTS idx_github_pr_cache_unique ON github_pr_cache(collection, owner, repo, number, host)',
   // Worktree pool indexes
   'CREATE INDEX IF NOT EXISTS idx_worktree_pool_repo ON worktree_pool(repository)',
   'CREATE INDEX IF NOT EXISTS idx_worktree_pool_status ON worktree_pool(repository, status)',


### PR DESCRIPTION
## Summary

A repo configured with `api_host` currently binds **every** PR to the alternate host. Real migrations are mixed: some PRs still live on GitHub/Graphite while newer ones exist only on the alt host. This PR resolves the host **per PR** instead of per repo.

Design doc: `plans/per-pr-host-resolution.md`. User docs: `docs/alt-host.md` ("Dual-Host Repositories").

### Config
- New per-repo boolean `exclusive` (only valid with `api_host`). Omitted/`true` = today's behavior, alt host only. `false` = dual repo.
- Dual repos bind github.com with the top-level credential chain and GraphQL feature defaults; repo-scoped `token`/`features` remain alt-host-only.

### Storage
- Migration v50: `host TEXT` on `pr_metadata` and `github_pr_cache` (`NULL` = github.com, else the api_host URL). No backfill — legacy NULL rows resolve via config and are re-stamped on next fetch (self-healing).
- Migration v51: cache unique index widened to `(collection, owner, repo, number, host)` so same-numbered rows from both hosts coexist.

### Resolution
- `resolveHostBinding(repository, config, { host })` with a `host` echo field; the legacy-NULL convention and credential preflight live in one place (`src/utils/host-resolution.js`).
- `resolveBindingForRequest` reads the stored host, so all PR-mode routes, review submission, external-comments sync, stack analysis, and header links follow the PR's actual host.

### Host derivation (confidence order)
1. **Pasted URL** — the matched `url_pattern` pins the alt host; canonical github/graphite URLs pin github (an over-broad pattern cannot hijack a canonical URL; config load warns about such patterns). Carried through web paste, CLI cold start, and single-port delegation, including a `?host=github` sentinel for known-github PRs on dual repos.
2. **Dashboard collections** — refresh sweeps each configured alt host (`pulls.list` + local classification; alt hosts lack the Search API), stamps each cached row, degrades best-effort per source (alt-host-only installs work without a global github token).
3. **Setup-time probe** — bare numbers on dual repos probe alt-first; only a 404 falls back to github. Auth/network errors fail loudly rather than fetching the wrong system's same-numbered PR.

### Safety
- `storePRData` guards cross-host number collisions (API id comparison) per the plan's documented no-collision assumption — a genuine collision throws before mutating instead of silently attaching reviews/worktrees to the wrong PR; the legitimate host-relabel self-heal still proceeds.
- Alt-scoped tokens never reach a github.com client (CLI and web parity).
- Local mode is unaffected: bindings stay best-effort enrichment (dual repos enrich via github).
- Plain github repos and existing exclusive alt-host configs behave identically to before.

## Review history
Two review rounds (17 findings total, incl. two Critical: the cache unique index and durable-identity collision handling) were addressed in this branch with regression tests for each.

## Test plan
- [x] Full unit + integration suite: 250 files / 8,437 tests pass
- [x] Playwright E2E: 335 pass, 1 skipped
- [x] Regression: `api_host` repos without `exclusive` behave byte-identically (existing alt-host suites)
- Changeset included (`minor`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)