### PR TITLE
feat: add --scope and --base CLI options for local reviews

### DIFF
--- a/.changeset/local-scope-cli-flags.md
+++ b/.changeset/local-scope-cli-flags.md
@@ -1,0 +1,18 @@
+---
+"@in-the-loop-labs/pair-review": minor
+---
+
+Add `--scope` and `--base` CLI options for local reviews. `--scope <start>..<end>`
+sets which changes a local review covers, using the same scope model as the web
+UI — the ordered stops `branch`, `staged`, `unstaged`, `untracked`, restricted to
+the six contiguous ranges that include `unstaged` (default `unstaged..untracked`).
+`branch..*` scopes diff from the merge-base with the base branch, and `--base
+<branch>` overrides base-branch auto-detection (Graphite state → GitHub PR base →
+origin default branch → main/master). Both flags are local-mode only. An explicit
+`--scope` is persisted on the review session, so reopening the review in the web UI
+shows the same scope.
+
+The `pair-loop` skill is updated to use `--scope branch..untracked` when the loop
+commits work between rounds (or the reviewed work already spans commits on a
+branch), so each review round covers the whole branch instead of an empty working
+tree.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
   - [AI-Guided Review](#3-ai-guided-review-when-youre-accountable)
 - [Quick Start](#quick-start)
 - [Command Line Interface](#command-line-interface)
+  - [Local review scope](#local-review-scope)
   - [Headless analysis mode](#headless-analysis-mode)
 - [Configuration](#configuration)
   - [Environment Variables](#environment-variables)
@@ -89,7 +90,8 @@ Compared to giving feedback in chat, this feels like moving from a machete to a 
 
 **Tips:**
 - Stage previous changes in git, then only review new modifications in the next round
-- Local mode only shows unstaged changes and untracked files (opinionated by design)
+- By default local mode reviews unstaged changes and untracked files; adjust the range with `--scope` (or the web UI scope selector) — e.g. `branch..untracked` to cover the whole branch (see [Local review scope](#local-review-scope))
+
 ### 2. Meta-Review: Judging AI Suggestions
 
 **When to use:** You're not going to read every line of code. Let AI be your reader.
@@ -203,6 +205,8 @@ pair-review --local [path]
 | `-d`, `--debug` | Enable verbose debug logging for troubleshooting |
 | `-h`, `--help` | Show help message with full CLI documentation |
 | `-l`, `--local [path]` | Review local uncommitted changes. Optional path defaults to current directory |
+| `--scope <start>..<end>` | **Local mode only.** Set the diff range a local review covers. Stops (in order): `branch`, `staged`, `unstaged`, `untracked`. Six valid ranges (contiguous, must include `unstaged`); default `unstaged..untracked`. `branch..*` diffs from the merge-base with the base branch. See [Local review scope](#local-review-scope). |
+| `--base <branch>` | **Local mode only.** With a `branch..*` scope, override base-branch auto-detection. Errors if used without a branch-start scope. |
 | `--model <name>` | Override the AI model for any provider. Model availability depends on provider configuration. |
 | `--provider <name>` | Override the AI provider. Applies to headless modes (`--ai-draft` / `--ai-review`) **and** to browser-driven auto-analysis (`--ai`), where it overrides the repo/app default the browser would otherwise use — including across single-port delegation to an already-running server. Defaults to the repo/app default provider (`claude`). Pair with `--model` when the model belongs to a non-default provider (e.g. `--provider codex --model gpt-5.5`). |
 | `--register` | Register `pair-review://` URL scheme handler (macOS only) |
@@ -242,6 +246,44 @@ pair-review --register --command "node bin/pair-review.js"  # Custom command
 > global config default. This applies to `--headless`, the submit modes, and the
 > web UI's default **Analyze** action, so `--council`/`--model` are optional when
 > a repo default is configured.
+
+### Local review scope
+
+`--scope <start>..<end>` sets which changes a **local** review covers (it has
+no effect on PR reviews). The scope walks four ordered stops — `branch` →
+`staged` → `unstaged` → `untracked` — and a range must be contiguous and always
+include `unstaged`, since the AI models read files from the working tree and the
+diff must cover that state. That leaves six valid ranges:
+
+| Scope | Covers |
+|-------|--------|
+| `branch..unstaged` | All tracked changes since the base branch (committed + staged + unstaged); no new files |
+| `branch..untracked` | Everything since the base branch, including new files |
+| `staged..unstaged` | Staged changes plus working-tree edits vs `HEAD`; no new files |
+| `staged..untracked` | Staged changes, working-tree edits, and new files |
+| `unstaged..unstaged` | Only unstaged working-tree edits (staged changes treated as already reviewed) |
+| `unstaged..untracked` | Unstaged working-tree edits plus new files (**default**) |
+
+A scope ending at `untracked` includes new (untracked) files automatically — no
+`git add -N` needed. `branch..*` diffs from the merge-base with the base branch.
+
+`--base <branch>` overrides base-branch auto-detection for a `branch..*` scope.
+Detection order when `--base` is omitted: Graphite stack state (only when
+`enable_graphite: true` is set in `~/.pair-review/config.json`) → GitHub PR base →
+`origin`'s default branch → `main`/`master`. `--base` errors if used without a
+branch-start scope.
+
+Both flags are **local-mode only**: they error when given a PR argument and do
+**not** imply `--local`. An explicit `--scope` is persisted on the review
+session, so opening the web UI for that review later shows the same scope.
+
+```bash
+# Review everything on this branch since it diverged from the trunk, plus new files
+pair-review --local --scope branch..untracked
+
+# Same, but against an explicit base branch (stacked branches / non-default trunk)
+pair-review --local --scope branch..untracked --base develop
+```
 
 ### Headless analysis mode
 
@@ -800,7 +842,10 @@ Templates typically include `{description}` to render the suggestion body.
 
 ### Local Mode
 
-Review **unstaged**, uncommitted changes before creating a PR:
+Review your uncommitted changes before creating a PR — by default the unstaged
+working-tree edits plus untracked files, with the range adjustable via `--scope`
+(or the web UI scope selector), e.g. `branch..untracked` to cover the whole
+branch (see [Local review scope](#local-review-scope)):
 
 ```bash
 pair-review --local

--- a/plugin-pair-loop/skills/loop/SKILL.md
+++ b/plugin-pair-loop/skills/loop/SKILL.md
@@ -49,8 +49,10 @@ These are not judgment calls:
 3. **Sequence strictly: fix → write triage back → then run the next round.**
 4. **One review at a time.** Never run two reviews concurrently for the same
    repo.
-5. **Do not commit or push.** Leave changes in the working tree. `git add -N`
-   (intent-to-add) any new files so they appear in diffs.
+5. **Do not commit or push.** Leave changes in the working tree. New
+   (untracked) files are included automatically whenever the review scope ends
+   at `untracked` — which the default scope (`unstaged..untracked`) does — so
+   no `git add -N` (intent-to-add) is needed.
 6. **Report failures faithfully.** A failed run (`"ok": false`, non-zero
    exit) is reported as what it is — never papered over as "no findings".
 
@@ -73,11 +75,20 @@ These are not judgment calls:
 ## Running a review round
 
 ```bash
-pair-review --local --headless --json --council <handle> --instructions "<round instructions>"
+pair-review --local --headless --json --council <handle> [--scope <range>] --instructions "<round instructions>"
 ```
 
 - Run from `REPO_ROOT`. `--local` with no path uses the current directory.
 - Omit `--council` to use the repo's default council.
+- **Scope (`--scope`).** By default a local review covers only uncommitted
+  working-tree changes plus new files (`unstaged..untracked`). That is right
+  only while all the work under review stays uncommitted. If the work under
+  review already spans commits on a branch, a clean working tree would review as
+  **empty** — pass
+  `--scope branch..untracked` so every round covers the whole branch
+  (everything since the base branch) plus the working tree and new files. Add
+  `--base <branch>` when the base branch is not auto-detected (a non-default
+  trunk, or a stacked branch). `--scope`/`--base` are local-mode only.
 - **Be patient — council reviews routinely take 15–40 minutes.** Individual
   council voices have their own internal timeouts; trust the CLI to finish.
   Run the command in the background (or with a timeout of at least 45
@@ -203,6 +214,8 @@ and requires a GitHub token in `~/.pair-review/config.json`. The review's
 checkout lives in a pair-review worktree — your fixes belong in whatever
 checkout the user asked you to work in; do not edit the pool worktree.
 Write-back and the review URL work the same way via `run.review_id`.
+`--scope`/`--base` do not apply here — they are local-mode only; a PR review
+always covers the PR's full diff.
 
 ## Reporting
 

--- a/public/setup.html
+++ b/public/setup.html
@@ -612,6 +612,14 @@
                     context.path = params.get('path');
                 }
             }
+            // Forward a delegated --scope/--base selection (the CLI carries them
+            // on the /local?path=... URL when delegating to a running server).
+            // The server re-validates; this only relays the request.
+            if (mode === 'local') {
+                const scopeParams = new URLSearchParams(window.location.search);
+                if (scopeParams.get('scope')) context.scope = scopeParams.get('scope');
+                if (scopeParams.get('base')) context.base = scopeParams.get('base');
+            }
 
             const steps = mode === 'local' ? LOCAL_STEPS : PR_STEPS;
             const stepStates = {};
@@ -752,7 +760,10 @@
                     var fetchOptions = { method: 'POST' };
                     if (mode === 'local') {
                         fetchOptions.headers = { 'Content-Type': 'application/json' };
-                        fetchOptions.body = JSON.stringify({ path: context.path });
+                        var localBody = { path: context.path };
+                        if (context.scope) localBody.scope = context.scope;
+                        if (context.base) localBody.base = context.base;
+                        fetchOptions.body = JSON.stringify(localBody);
                     } else if (mode === 'pr') {
                         // A `host` query param (set when opening a PR from a dashboard
                         // collection row or a pasted URL) tells setup which system the

--- a/src/local-review.js
+++ b/src/local-review.js
@@ -11,7 +11,7 @@ const { fireHooks, hasHooks } = require('./hooks/hook-runner');
 const { buildReviewStartedPayload, buildReviewLoadedPayload, getCachedUser } = require('./hooks/payloads');
 
 const execAsync = promisify(exec);
-const { STOPS, scopeIncludes, includesBranch, DEFAULT_SCOPE, scopeLabel, reviewScope } = require('./local-scope');
+const { STOPS, scopeIncludes, includesBranch, DEFAULT_SCOPE, scopeLabel, reviewScope, parseScopeArg } = require('./local-scope');
 const { initializeDatabase, ReviewRepository, RepoSettingsRepository } = require('./database');
 const { resolveCouncilHandle } = require('./councils/resolve-council');
 const { prepareInteractiveAnalysisConfig } = require('./interactive-analysis-config');
@@ -21,6 +21,10 @@ const summaryGenerator = require('./ai/summary-generator');
 const tourGenerator = require('./ai/tour-generator');
 const { getShaAbbrevLength } = require('./git/sha-abbrev');
 const { GIT_DIFF_FLAGS, GIT_DIFF_FLAGS_ARRAY } = require('./git/diff-flags');
+// Namespace import (not destructured) so detectBaseBranch is resolved off the
+// module object at call time — this keeps it interceptable by vi.spyOn on the
+// base-branch module in tests, unlike a destructured binding captured at load.
+const baseBranchModule = require('./git/base-branch');
 const open = (...args) => process.env.PAIR_REVIEW_NO_OPEN ? Promise.resolve() : import('open').then(({ default: open }) => open(...args));
 
 // Design note: This module uses execSync for git commands despite async function signatures.
@@ -695,6 +699,112 @@ async function generateLocalDiff(repoPath, options = {}) {
 }
 
 /**
+ * Resolve the effective scope and base branch for a local review session,
+ * applying an explicit `--scope`/`--base` (or delegated query) override on top
+ * of the persisted/default scope.
+ *
+ * Shared by the CLI seam (setupLocalReviewSession) and the web setup seam
+ * (src/setup/local-setup.js) so a scoped launch behaves identically whether it
+ * cold-starts a server or is delegated to a running one. Callers MUST have
+ * validated flags.scope/flags.base first (parseScopeArg + branch-name regex +
+ * "base requires branch scope"); an invalid flags.scope is treated as "no
+ * override" here rather than throwing.
+ *
+ * Precedence — scope: explicit override > persisted review scope > DEFAULT_SCOPE.
+ * Precedence — base: explicit --base > persisted local_base_branch >
+ * detectBaseBranch. The base is nulled for any non-branch scope so a stale value
+ * from a previously branch-scoped session never leaks into the diff/persist/return.
+ *
+ * @param {Object} params
+ * @param {Object|null} params.existingReview - Persisted review row, or null for a fresh session
+ * @param {Object} [params.flags] - { scope?, base? }
+ * @param {string} params.repoPath
+ * @param {string} params.branch - Current branch name
+ * @param {string} params.repository - owner/repo (for host binding / PR base lookup)
+ * @param {Object} params.config
+ * @returns {Promise<{scopeStart: string, scopeEnd: string, baseBranch: string|null, scopeOverridden: boolean}>}
+ */
+async function resolveScopeAndBase({ existingReview, flags = {}, repoPath, branch, repository, config }) {
+  const scopeOverride = flags.scope ? parseScopeArg(flags.scope) : null;
+  let scopeStart, scopeEnd;
+  if (scopeOverride) {
+    ({ start: scopeStart, end: scopeEnd } = scopeOverride);
+  } else if (existingReview) {
+    ({ start: scopeStart, end: scopeEnd } = reviewScope(existingReview));
+  } else {
+    ({ start: scopeStart, end: scopeEnd } = DEFAULT_SCOPE);
+  }
+
+  let baseBranch = existingReview?.local_base_branch || null;
+  if (scopeOverride && includesBranch(scopeStart)) {
+    if (flags.base) {
+      baseBranch = flags.base;
+    } else if (!baseBranch) {
+      const branchBinding = repository ? resolveHostBinding(repository, config) : null;
+      const token = branchBinding?.token || getGitHubToken(config);
+      const detection = await baseBranchModule.detectBaseBranch(repoPath, branch, {
+        repository,
+        enableGraphite: config?.enable_graphite === true,
+        _deps: (token || branchBinding) ? {
+          getGitHubToken: () => token || '',
+          getHostBinding: () => branchBinding || null
+        } : undefined
+      });
+      if (!detection) {
+        throw new Error(
+          `Could not detect a base branch for scope '${scopeStart}..${scopeEnd}'. ` +
+          'Pass --base <branch> to specify one explicitly.'
+        );
+      }
+      baseBranch = detection.baseBranch;
+    }
+  }
+
+  // A non-branch scope has no base branch. Drop any value seeded from a
+  // previously branch-scoped session so the stale base never reaches the diff,
+  // the persisted row, or the returned session — matching the web set-scope
+  // route, which persists null when leaving branch scope.
+  if (!includesBranch(scopeStart)) {
+    baseBranch = null;
+  }
+
+  return { scopeStart, scopeEnd, baseBranch, scopeOverridden: !!scopeOverride };
+}
+
+/**
+ * Persist an explicitly-overridden scope (and its resolved base) and auto-name
+ * the review when a branch scope is newly applied to an unnamed review. Call
+ * ONLY after generateScopedDiff succeeds, so a scope whose diff fails (e.g. a
+ * bad --base) never sticks. Shared by the CLI and web setup seams. Caller gates
+ * this on `scopeOverridden` — it always writes when invoked.
+ *
+ * @param {Object} params
+ * @param {Object} params.reviewRepo - ReviewRepository instance
+ * @param {number} params.sessionId
+ * @param {Object|null} params.existingReview
+ * @param {string} params.scopeStart
+ * @param {string} params.scopeEnd
+ * @param {string|null} params.baseBranch
+ * @param {string} params.branch - Current branch (stored as head branch for branch scopes)
+ * @param {string} params.repoPath
+ */
+async function persistScopeSelection({ reviewRepo, sessionId, existingReview, scopeStart, scopeEnd, baseBranch, branch, repoPath }) {
+  await reviewRepo.updateLocalScope(sessionId, scopeStart, scopeEnd, baseBranch, branch);
+
+  // Keep CLI and web set-scope in sync: when a branch scope is newly applied to
+  // an as-yet-unnamed review, auto-name it from the first commit subject.
+  // Mirrors routes/local.js set-scope. A fresh session has no existing review,
+  // which counts as both unnamed and previously non-branch.
+  const oldScopeStart = existingReview ? reviewScope(existingReview).start : DEFAULT_SCOPE.start;
+  if (!existingReview?.name && includesBranch(scopeStart) && !includesBranch(oldScopeStart) && baseBranch) {
+    const firstSubject = await module.exports.getFirstCommitSubject(repoPath, baseBranch);
+    if (firstSubject) {
+      await reviewRepo.updateReview(sessionId, { name: firstSubject.slice(0, 200) });
+    }
+  }
+}
+
+/**
  * Set up a local review session: resolve git state, persist the diff,
  * and enqueue the background summary job. Caller is responsible for
  * starting the server and opening the browser.
@@ -777,7 +887,11 @@ async function setupLocalReviewSession({ db, config, repoPath, flags = {}, start
     console.log(`Created new review session (ID: ${sessionId})`);
   }
 
-  const { start: scopeStart, end: scopeEnd } = existingReview ? reviewScope(existingReview) : DEFAULT_SCOPE;
+  // Resolve scope + base (explicit --scope/--base override > persisted > default)
+  // via the shared helper so the CLI and delegated web-setup seam stay identical.
+  const { scopeStart, scopeEnd, baseBranch, scopeOverridden } = await resolveScopeAndBase({
+    existingReview, flags, repoPath, branch, repository, config
+  });
 
   const hookEvent = existingReview ? 'review.loaded' : 'review.started';
   if (hasHooks(hookEvent, config)) {
@@ -790,10 +904,19 @@ async function setupLocalReviewSession({ db, config, repoPath, flags = {}, start
       fireHooks(hookEvent, payload, config);
     }).catch(err => { logger.warn(`Review hook failed: ${err.message}`); });
   }
-  const baseBranch = existingReview?.local_base_branch || null;
 
   console.log(`Generating diff for scope: ${scopeLabel(scopeStart, scopeEnd)}...`);
   const { diff, stats } = await module.exports.generateScopedDiff(repoPath, scopeStart, scopeEnd, baseBranch);
+
+  // Persist an explicitly-requested scope (and its resolved base) so the web UI
+  // later opens with the same scope. Only after generateScopedDiff succeeds, so a
+  // scope whose diff fails (e.g. a bad --base) never sticks. Never touch persisted
+  // scope when no override was supplied.
+  if (scopeOverridden) {
+    await persistScopeSelection({
+      reviewRepo, sessionId, existingReview, scopeStart, scopeEnd, baseBranch, branch, repoPath
+    });
+  }
 
   let branchInfo = null;
   if (!includesBranch(scopeStart)) {
@@ -1090,14 +1213,13 @@ async function detectAndBuildBranchInfo(repoPath, branch, options = {}) {
   if (untrackedFiles && untrackedFiles.length > 0) return null;
 
   try {
-    const { detectBaseBranch } = require('./git/base-branch');
     const depsOverride = githubToken || hostBinding
       ? {
           getGitHubToken: () => githubToken || '',
           getHostBinding: () => hostBinding || null
         }
       : undefined;
-    const detection = await detectBaseBranch(repoPath, branch, {
+    const detection = await baseBranchModule.detectBaseBranch(repoPath, branch, {
       repository,
       enableGraphite,
       _deps: depsOverride
@@ -1122,6 +1244,8 @@ async function detectAndBuildBranchInfo(repoPath, branch, options = {}) {
 module.exports = {
   handleLocalReview,
   setupLocalReviewSession,
+  resolveScopeAndBase,
+  persistScopeSelection,
   findGitRoot,
   findMainGitRoot,
   getHeadSha,

--- a/src/local-scope.js
+++ b/src/local-scope.js
@@ -15,6 +15,42 @@ function isValidScope(start, end) {
   return si !== -1 && ei !== -1 && si <= ei && si <= UNSTAGED_INDEX && ei >= UNSTAGED_INDEX;
 }
 
+/**
+ * The full set of valid scope ranges, formatted as `start..end` strings.
+ * Computed from STOPS + isValidScope so it stays the single source of truth.
+ * Ordered by STOPS position (branch-first).
+ * @type {string[]}
+ */
+const VALID_SCOPE_RANGES = (() => {
+  const ranges = [];
+  for (const start of STOPS) {
+    for (const end of STOPS) {
+      if (isValidScope(start, end)) ranges.push(`${start}..${end}`);
+    }
+  }
+  return ranges;
+})();
+
+/**
+ * Parse a `--scope` CLI argument of the form `<start>..<end>` into a scope
+ * object. Splits on `..`, trims each side, and delegates validation to
+ * isValidScope (the single source of truth). Single tokens, missing `..`,
+ * unknown stops, non-contiguous ranges, ranges excluding 'unstaged', and
+ * reversed ranges all return null.
+ *
+ * @param {string} value - Raw CLI value (e.g. 'branch..untracked')
+ * @returns {{ start: string, end: string }|null} Parsed scope, or null if invalid
+ */
+function parseScopeArg(value) {
+  if (typeof value !== 'string') return null;
+  const parts = value.split('..');
+  if (parts.length !== 2) return null;
+  const start = parts[0].trim();
+  const end = parts[1].trim();
+  if (!isValidScope(start, end)) return null;
+  return { start, end };
+}
+
 function normalizeScope(start, end) {
   if (isValidScope(start, end)) return { start, end };
   const si = STOPS.indexOf(start);
@@ -130,7 +166,9 @@ function scopeGitHints(start, end, baseBranch) {
 const LocalScope = {
   STOPS,
   DEFAULT_SCOPE,
+  VALID_SCOPE_RANGES,
   isValidScope,
+  parseScopeArg,
   normalizeScope,
   reviewScope,
   scopeIncludes,

--- a/src/main.js
+++ b/src/main.js
@@ -20,7 +20,7 @@ const { resolveReviewConfig } = require('./review-config');
 const { redirectConsoleToStderr } = require('./mcp-stdio');
 const { getChangedFiles } = require('./routes/executable-analysis');
 const { safeParseJson } = require('./utils/safe-parse-json');
-const { includesBranch } = require('./local-scope');
+const { includesBranch, parseScopeArg, VALID_SCOPE_RANGES } = require('./local-scope');
 const { storePRData, resolvePrHostBinding, registerRepositoryLocation, findRepositoryPath } = require('./setup/pr-setup');
 const { isDualHostRepo, resolvePreflightBinding, hostSetupParamValue } = require('./utils/host-resolution');
 const { fireReviewStartedHook } = require('./hooks/payloads');
@@ -191,6 +191,21 @@ OPTIONS:
     -h, --help              Show this help message and exit
     -l, --local [path]      Review local uncommitted changes
                             Optional path defaults to current directory
+    --scope <start>..<end>  (Local mode only) Set the diff scope for the review.
+                            Stops, in order: branch, staged, unstaged, untracked.
+                            The range must include 'unstaged'. Valid ranges:
+                              branch..unstaged     committed+staged+unstaged vs merge-base
+                              branch..untracked    everything vs merge-base (incl. untracked)
+                              staged..unstaged     staged + unstaged vs HEAD
+                              staged..untracked    staged + unstaged + untracked vs HEAD
+                              unstaged..unstaged   only unstaged working-tree changes
+                              unstaged..untracked  unstaged + untracked (the default)
+                            Requires --local; cannot be used with a PR. The chosen
+                            scope is persisted so the web UI opens with it too.
+    --base <branch>         (Local mode only) Override base-branch detection for a
+                            branch-relative scope. Requires --scope starting at
+                            'branch' (e.g. --scope branch..untracked). Defaults to
+                            the persisted, then auto-detected, base branch.
     --mcp                   Start as an MCP stdio server for AI coding agents.
                             The web UI also starts for the human reviewer.
     --model <name>          Override the AI model. Claude Code is the default provider.
@@ -224,6 +239,9 @@ EXAMPLES:
     pair-review 123                    # Review PR #123 in current repo
     pair-review https://github.com/owner/repo/pull/456
     pair-review --local                # Review uncommitted local changes
+    pair-review --local --scope branch..untracked   # Review whole branch vs merge-base
+    pair-review --local --scope staged..unstaged    # Review staged + unstaged changes
+    pair-review --local --scope branch..untracked --base develop   # Branch scope vs develop
     pair-review 123 --ai               # Auto-run AI analysis
     pair-review --ai-review            # CI mode: auto-detect PR, submit review
     pair-review 123 --ai-draft --council security-review  # Headless council draft
@@ -495,6 +513,25 @@ function parseArgs(args) {
       } else {
         throw new Error('--council flag requires a council handle (e.g., --council my-council)');
       }
+    } else if (arg === '--scope') {
+      // Next argument is a scope range like `unstaged..untracked`. A range
+      // won't legitimately start with '-', so apply the same missing-value
+      // guard as --model. Range validity is checked later in main().
+      if (i + 1 < args.length && !args[i + 1].startsWith('-')) {
+        flags.scope = args[i + 1];
+        i++; // Skip next argument since we consumed it
+      } else {
+        throw new Error('--scope flag requires a range value (e.g., --scope unstaged..untracked)');
+      }
+    } else if (arg === '--base') {
+      // Next argument is a base branch name. A branch name won't legitimately
+      // start with '-', so apply the same guard as --model.
+      if (i + 1 < args.length && !args[i + 1].startsWith('-')) {
+        flags.base = args[i + 1];
+        i++; // Skip next argument since we consumed it
+      } else {
+        throw new Error('--base flag requires a branch name (e.g., --base main)');
+      }
     } else if (arg === '--list-councils') {
       flags.listCouncils = true;
     } else if (arg === '-l' || arg === '--local') {
@@ -718,6 +755,39 @@ AI PROVIDERS:
     if (flags.headless && prArgs.length === 0 && !flags.local) {
       throw new Error('--headless flag requires a pull request number/URL or --local to run analysis.');
     }
+    // --scope and --base are local-review diff controls. They require --local
+    // and cannot be combined with a PR positional. They do NOT imply --local
+    // (explicit flags only — no magic mode switching).
+    if (flags.scope || flags.base) {
+      if (prArgs.length > 0) {
+        throw new Error('--scope/--base apply to local reviews only; they cannot be combined with a pull request number/URL.');
+      }
+      if (!flags.local) {
+        throw new Error('--scope/--base require --local (they set the diff scope for a local review).');
+      }
+    }
+    // Validate the --scope range against the six accepted local-review scopes.
+    let parsedScopeFlag = null;
+    if (flags.scope) {
+      parsedScopeFlag = parseScopeArg(flags.scope);
+      if (!parsedScopeFlag) {
+        throw new Error(
+          `Invalid --scope value "${flags.scope}". Valid ranges are: ${VALID_SCOPE_RANGES.join(', ')}. ` +
+          "The range must be two stops joined by '..' and must include 'unstaged'."
+        );
+      }
+    }
+    // --base overrides base-branch detection and only applies to a
+    // branch-relative scope (one that starts at 'branch').
+    if (flags.base) {
+      if (!parsedScopeFlag || parsedScopeFlag.start !== 'branch') {
+        throw new Error("--base requires --scope with a branch-relative range (starting at 'branch', e.g. --scope branch..untracked).");
+      }
+      // Same validation the set-scope route uses to prevent shell injection.
+      if (!/^[\w.\-/]+$/.test(flags.base)) {
+        throw new Error(`Invalid --base branch name "${flags.base}".`);
+      }
+    }
     // --instructions[-file] only takes effect in a mode that actually runs
     // analysis. Plain interactive mode never auto-analyzes, so reject the
     // orphaned case with a clear message rather than silently dropping the text
@@ -816,6 +886,11 @@ AI PROVIDERS:
     // Skipped for: headless modes (no browser), single_port: false (dev mode).
     // --headless never delegates/opens a browser — it runs analysis locally and
     // reports to stdout/stderr.
+    //
+    // --scope/--base ARE delegated: attemptDelegation carries them on the local
+    // URL (buildDelegationUrl), the setup page relays them, and the setup route
+    // re-validates and applies them — so a scoped --local while a server is
+    // running lands at the requested scope instead of crashing on the busy port.
     if (config.single_port !== false && !flags.aiReview && !flags.aiDraft && !flags.headless) {
       // Carry --instructions across delegation. When an analyzing mode
       // (--ai/--council) ALSO supplies per-run instructions and a server is

--- a/src/routes/setup.js
+++ b/src/routes/setup.js
@@ -20,6 +20,7 @@ const { resolvePreflightBinding } = require('../utils/host-resolution');
 const { queryOne, ReviewRepository } = require('../database');
 const { normalizeRepository } = require('../utils/paths');
 const { rejectUrlLikeLocalReviewPath } = require('../utils/local-path-input');
+const { parseScopeArg, VALID_SCOPE_RANGES } = require('../local-scope');
 const logger = require('../utils/logger');
 
 const router = express.Router();
@@ -208,7 +209,7 @@ router.post('/api/setup/pr/:owner/:repo/:number', async (req, res) => {
  */
 router.post('/api/setup/local', async (req, res) => {
   try {
-    const { path: rawPath } = req.body;
+    const { path: rawPath, scope: rawScope, base: rawBase } = req.body;
 
     if (!rawPath) {
       return res.status(400).json({ error: 'Missing required field: path' });
@@ -218,6 +219,37 @@ router.post('/api/setup/local', async (req, res) => {
       rejectUrlLikeLocalReviewPath(rawPath);
     } catch (err) {
       return res.status(400).json({ error: err.message });
+    }
+
+    // Re-validate scope/base server-side — NEVER trust the delegated URL. Mirrors
+    // the CLI checks in main() so a delegated launch is held to the same contract.
+    let flags = {};
+    if (rawScope !== undefined && rawScope !== null && rawScope !== '') {
+      const parsed = parseScopeArg(rawScope);
+      if (!parsed) {
+        return res.status(400).json({
+          error: `Invalid scope value "${rawScope}". Valid ranges are: ${VALID_SCOPE_RANGES.join(', ')}. ` +
+            "The range must be two stops joined by '..' and must include 'unstaged'."
+        });
+      }
+      flags.scope = rawScope;
+      if (rawBase !== undefined && rawBase !== null && rawBase !== '') {
+        // --base only applies to a branch-relative scope, and must be a safe branch name.
+        if (parsed.start !== 'branch') {
+          return res.status(400).json({
+            error: "base requires a branch-relative scope (starting at 'branch', e.g. branch..untracked)."
+          });
+        }
+        if (!/^[\w.\-/]+$/.test(rawBase)) {
+          return res.status(400).json({ error: `Invalid base branch name "${rawBase}".` });
+        }
+        flags.base = rawBase;
+      }
+    } else if (rawBase !== undefined && rawBase !== null && rawBase !== '') {
+      // base without scope is meaningless (mirrors main()'s "base requires branch scope").
+      return res.status(400).json({
+        error: "base requires a branch-relative scope (starting at 'branch', e.g. branch..untracked)."
+      });
     }
 
     const targetPath = expandPath(rawPath);
@@ -238,6 +270,7 @@ router.post('/api/setup/local', async (req, res) => {
           db,
           targetPath,
           config: req.app.get('config') || {},
+          flags,
           onProgress: (progress) => {
             sendSetupEvent(setupId, 'step', progress);
           }

--- a/src/setup/local-setup.js
+++ b/src/setup/local-setup.js
@@ -1,10 +1,10 @@
 // Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
-const { findGitRoot, getHeadSha, getCurrentBranch, getRepositoryName, generateScopedDiff, generateLocalReviewId, computeScopedDigest, findMainGitRoot } = require('../local-review');
+const { findGitRoot, getHeadSha, getCurrentBranch, getRepositoryName, generateScopedDiff, generateLocalReviewId, computeScopedDigest, findMainGitRoot, resolveScopeAndBase, persistScopeSelection } = require('../local-review');
 const { ReviewRepository, RepoSettingsRepository } = require('../database');
 const { localReviewDiffs } = require('../routes/shared');
 const { fireHooks, hasHooks } = require('../hooks/hook-runner');
 const { buildReviewStartedPayload, buildReviewLoadedPayload, getCachedUser } = require('../hooks/payloads');
-const { STOPS, DEFAULT_SCOPE, reviewScope } = require('../local-scope');
+const { STOPS } = require('../local-scope');
 const logger = require('../utils/logger');
 const { LOCAL_REVIEW_PATH_URL_ERROR, rejectUrlLikeLocalReviewPath } = require('../utils/local-path-input');
 const path = require('path');
@@ -21,9 +21,12 @@ const fs = require('fs').promises;
  * @param {string} options.targetPath - Path to review (file or directory)
  * @param {Function} [options.onProgress] - Progress callback ({ step, status, message })
  * @param {Object} [options.config] - App config (for hooks)
+ * @param {Object} [options.flags] - Scope override { scope?, base? } forwarded from
+ *   a delegated `--scope`/`--base` launch. The route MUST have validated these
+ *   first. Absent flags leave scope resolution at persisted/default (unchanged).
  * @returns {Promise<Object>} Review session info
  */
-async function setupLocalReview({ db, targetPath, onProgress, config }) {
+async function setupLocalReview({ db, targetPath, onProgress, config, flags = {} }) {
   const progress = typeof onProgress === 'function'
     ? onProgress
     : () => {};
@@ -104,10 +107,14 @@ async function setupLocalReview({ db, targetPath, onProgress, config }) {
   }
 
   // ── Step: diff ──────────────────────────────────────────────────────
-  let diff, stats, digest;
+  // Resolve scope + base via the shared helper so a delegated --scope/--base
+  // launch is honored identically to the cold-start CLI path. With no override
+  // (flags absent) this yields the persisted/default scope — unchanged behavior.
+  let diff, stats, digest, scopeStart, scopeEnd, baseBranch, scopeOverridden;
   try {
-    const { start: scopeStart, end: scopeEnd } = existingReview ? reviewScope(existingReview) : DEFAULT_SCOPE;
-    const baseBranch = existingReview?.local_base_branch || null;
+    ({ scopeStart, scopeEnd, baseBranch, scopeOverridden } = await resolveScopeAndBase({
+      existingReview, flags, repoPath, branch, repository, config
+    }));
 
     progress({ step: 'diff', status: 'running', message: 'Generating diff for local changes...' });
 
@@ -146,6 +153,15 @@ async function setupLocalReview({ db, targetPath, onProgress, config }) {
       });
     }
 
+    // Persist an explicitly-overridden scope (and its resolved base) so the web
+    // UI opens this delegated session at the requested scope — only after the
+    // diff above succeeded. No-op when no override was supplied.
+    if (scopeOverridden) {
+      await persistScopeSelection({
+        reviewRepo: storeRepo, sessionId, existingReview, scopeStart, scopeEnd, baseBranch, branch, repoPath
+      });
+    }
+
     localReviewDiffs.set(sessionId, { diff, stats, digest });
 
     progress({ step: 'store', status: 'completed', message: `Review session ${sessionId} stored` });
@@ -159,7 +175,7 @@ async function setupLocalReview({ db, targetPath, onProgress, config }) {
   if (config && hasHooks(hookEvent, config)) {
     getCachedUser(config).then(user => {
       const builder = existingReview ? buildReviewLoadedPayload : buildReviewStartedPayload;
-      const { start: scopeStart, end: scopeEnd } = existingReview ? reviewScope(existingReview) : DEFAULT_SCOPE;
+      // Reflect the resolved (possibly overridden) scope, not just the persisted one.
       const si = STOPS.indexOf(scopeStart);
       const ei = STOPS.indexOf(scopeEnd);
       const scope = STOPS.slice(si, ei + 1);

--- a/src/single-port.js
+++ b/src/single-port.js
@@ -175,6 +175,9 @@ function storeAnalysisConfigRemote(port, analysisConfig, _deps) {
  *   Already resolved by the caller via `hostSetupParamValue`; omitted when null.
  * @param {string} [context.provider] - CLI provider override to carry to the running server
  * @param {string} [context.model] - CLI model override to carry to the running server
+ * @param {string} [context.scope] - Local-mode only: the `--scope` range to carry
+ *   to the delegated session (e.g. 'branch..untracked').
+ * @param {string} [context.base] - Local-mode only: the `--base` branch override.
  * @returns {string} Full URL
  */
 function buildDelegationUrl(port, mode, context = {}) {
@@ -224,6 +227,12 @@ function buildDelegationUrl(port, mode, context = {}) {
     // The `?path=` segment is always present, so the intent bundle appends with `&`.
     let url = `${base}/local?path=${encodeURIComponent(context.localPath)}`;
     if (query) url += `&${query}`;
+    // Carry the diff-scope selection so a delegated `--local --scope/--base` run
+    // lands at the requested scope instead of the server's default. The receiving
+    // setup page relays these and the server re-validates them. These keep
+    // encodeURIComponent to match the `path` param's wire format.
+    if (context.scope) url += `&scope=${encodeURIComponent(context.scope)}`;
+    if (context.base) url += `&base=${encodeURIComponent(context.base)}`;
     return url;
   }
   return `${base}/`;
@@ -323,7 +332,8 @@ async function attemptDelegation(config, flags, prArgs, _deps, options = {}) {
     const analysisConfigId = await handoffAnalysisConfigId(options.localRepository || null);
     url = buildDelegationUrl(port, 'local', {
       localPath: targetPath, analyze, councilId, analysisConfigId,
-      provider: flags.provider, model: flags.model
+      provider: flags.provider, model: flags.model,
+      scope: flags.scope || null, base: flags.base || null
     });
   } else if (prArgs.length > 0) {
     const prInfo = await parsePRArgsForDelegation(prArgs, config, _deps);

--- a/tests/e2e/local-start.spec.js
+++ b/tests/e2e/local-start.spec.js
@@ -19,4 +19,50 @@ test.describe('Local Review Start', () => {
     await expect(page).toHaveURL(currentUrl);
     await expect(error).toContainText('filesystem path');
   });
+
+  // The receiving end of single-port delegation: the CLI carries --scope/--base
+  // on /local?path=...; setup.html must relay them into the /api/setup/local POST.
+  // We intercept the POST (fulfilling it) so this exercises the real page code
+  // without needing a backend git repo.
+  test('forwards delegated scope and base into the setup POST body', async ({ page }) => {
+    let resolveBody;
+    const bodyPromise = new Promise((r) => { resolveBody = r; });
+    await page.route('**/api/setup/local', async (route) => {
+      resolveBody(route.request().postDataJSON());
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ existing: false, setupId: 'e2e-setup-id' })
+      });
+    });
+
+    const repoPath = '/tmp/e2e-scope-project';
+    await page.goto(`/local?path=${encodeURIComponent(repoPath)}&scope=branch..untracked&base=develop`);
+
+    const body = await bodyPromise;
+    expect(body.path).toBe(repoPath);
+    expect(body.scope).toBe('branch..untracked');
+    expect(body.base).toBe('develop');
+  });
+
+  test('omits scope/base from the setup POST when the URL has none', async ({ page }) => {
+    let resolveBody;
+    const bodyPromise = new Promise((r) => { resolveBody = r; });
+    await page.route('**/api/setup/local', async (route) => {
+      resolveBody(route.request().postDataJSON());
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ existing: false, setupId: 'e2e-setup-id' })
+      });
+    });
+
+    const repoPath = '/tmp/e2e-scope-project';
+    await page.goto(`/local?path=${encodeURIComponent(repoPath)}`);
+
+    const body = await bodyPromise;
+    expect(body.path).toBe(repoPath);
+    expect(body.scope).toBeUndefined();
+    expect(body.base).toBeUndefined();
+  });
 });

--- a/tests/e2e/test-server.js
+++ b/tests/e2e/test-server.js
@@ -325,6 +325,12 @@ async function startTestServer(port) {
   app.get('/', (req, res) => res.sendFile(path.join(publicDir, 'index.html')));
   app.get('/pr/:owner/:repo/:number', (req, res) => res.sendFile(path.join(publicDir, 'pr.html')));
   app.get('/settings/:owner/:repo', (req, res) => res.sendFile(path.join(publicDir, 'repo-settings.html')));
+  // Local review SETUP page (query-param form), mirrors production server.js. Serves
+  // setup.html so E2E can exercise the delegated /local?path=...&scope=... flow.
+  app.get('/local', (req, res) => {
+    if (!req.query.path) return res.redirect('/');
+    res.sendFile(path.join(publicDir, 'setup.html'));
+  });
   app.get('/local/:reviewId', (req, res) => res.sendFile(path.join(publicDir, 'local.html')));
   app.get('/health', (req, res) => res.json({ status: 'ok' }));
 

--- a/tests/integration/setup-local-scope.test.js
+++ b/tests/integration/setup-local-scope.test.js
@@ -1,0 +1,155 @@
+// Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+/**
+ * POST /api/setup/local scope/base handling (the delegated --scope/--base seam).
+ *
+ * This is the receiving end of single-port delegation: the CLI carries
+ * `--scope`/`--base` on the /local?path=... URL, the setup page relays them into
+ * this POST body, and the route re-validates + applies them via the shared
+ * scope-resolution helpers. Uses the REAL setupLocalReview against a per-test
+ * temp git repo (no mocking) so persistence is exercised end to end.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { execSync } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import express from 'express';
+import request from 'supertest';
+import { createTestDatabase, closeTestDatabase } from '../utils/schema';
+import { listenOnLoopback, closeServer } from '../utils/loopback-server';
+
+const setupRoutes = require('../../src/routes/setup');
+const { activeSetups } = require('../../src/routes/shared');
+
+function git(cwd, args) {
+  execSync(`git ${args}`, { cwd, stdio: ['pipe', 'pipe', 'pipe'] });
+}
+
+/** Build a temp repo on `feature` with a branch commit + unstaged + untracked changes. */
+function makeRepo() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'setup-scope-'));
+  git(dir, 'init -q -b main');
+  git(dir, 'config user.email t@t.com');
+  git(dir, 'config user.name t');
+  fs.writeFileSync(path.join(dir, 'a.txt'), 'l1\nl2\n');
+  git(dir, 'add a.txt');
+  git(dir, 'commit -qm init');
+  git(dir, 'checkout -q -b feature');
+  fs.writeFileSync(path.join(dir, 'a.txt'), 'l1\nl2\nl3\n');
+  git(dir, 'commit -qam "First feature commit subject"');
+  fs.writeFileSync(path.join(dir, 'a.txt'), 'l1\nl2\nl3\nunstaged\n');
+  fs.writeFileSync(path.join(dir, 'untracked.txt'), 'new\n');
+  return dir;
+}
+
+/** The single local review row (each test uses its own DB). */
+function localReviewRow(db) {
+  return db.prepare("SELECT * FROM reviews WHERE review_type = 'local'").get();
+}
+
+describe('POST /api/setup/local — scope/base', () => {
+  let db;
+  let server;
+  let repoDir;
+
+  beforeEach(async () => {
+    db = createTestDatabase();
+    activeSetups.clear();
+    repoDir = makeRepo();
+
+    const app = express();
+    app.use(express.json());
+    app.set('db', db);
+    app.set('config', {});
+    app.use(setupRoutes);
+    server = await listenOnLoopback(app);
+  });
+
+  afterEach(async () => {
+    await closeServer(server);
+    server = null;
+    activeSetups.clear();
+    closeTestDatabase(db);
+    if (repoDir) fs.rmSync(repoDir, { recursive: true, force: true });
+  });
+
+  it('applies and persists a branch scope with explicit base, auto-naming the review', async () => {
+    const res = await request(server)
+      .post('/api/setup/local')
+      .send({ path: repoDir, scope: 'branch..untracked', base: 'main' });
+    expect(res.status).toBe(200);
+    expect(res.body.setupId).toBeTruthy();
+
+    await vi.waitFor(() => {
+      const row = localReviewRow(db);
+      expect(row && row.local_scope_start).toBe('branch');
+    }, { timeout: 5000 });
+
+    const row = localReviewRow(db);
+    expect(row.local_scope_start).toBe('branch');
+    expect(row.local_scope_end).toBe('untracked');
+    expect(row.local_base_branch).toBe('main');
+    expect(row.local_head_branch).toBe('feature');
+    expect(row.local_mode).toBe('branch');
+    // Auto-named from the first commit subject on the branch.
+    expect(row.name).toBe('First feature commit subject');
+  });
+
+  it('leaves default scope untouched when no scope/base params are sent', async () => {
+    const res = await request(server)
+      .post('/api/setup/local')
+      .send({ path: repoDir });
+    expect(res.status).toBe(200);
+
+    await vi.waitFor(() => {
+      expect(localReviewRow(db)).toBeTruthy();
+    }, { timeout: 5000 });
+
+    const row = localReviewRow(db);
+    // Schema default scope, no branch base, no auto-name — byte-identical to before.
+    expect(row.local_scope_start).toBe('unstaged');
+    expect(row.local_scope_end).toBe('untracked');
+    expect(row.local_base_branch).toBeNull();
+    expect(row.name).toBeNull();
+  });
+
+  it('rejects an invalid scope with 400 and the valid-ranges message; no session created', async () => {
+    const res = await request(server)
+      .post('/api/setup/local')
+      .send({ path: repoDir, scope: 'branch..staged' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/Invalid scope value "branch\.\.staged"/);
+    expect(res.body.error).toMatch(/branch\.\.untracked/);
+    expect(res.body.error).toMatch(/must include 'unstaged'/);
+    // Validation happens before any setup work — nothing persisted.
+    expect(localReviewRow(db)).toBeUndefined();
+  });
+
+  it('rejects base with a non-branch scope (400)', async () => {
+    const res = await request(server)
+      .post('/api/setup/local')
+      .send({ path: repoDir, scope: 'unstaged..untracked', base: 'main' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/base requires a branch-relative scope/);
+    expect(localReviewRow(db)).toBeUndefined();
+  });
+
+  it('rejects base without any scope (400)', async () => {
+    const res = await request(server)
+      .post('/api/setup/local')
+      .send({ path: repoDir, base: 'main' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/base requires a branch-relative scope/);
+    expect(localReviewRow(db)).toBeUndefined();
+  });
+
+  it('rejects an unsafe base branch name (400)', async () => {
+    const res = await request(server)
+      .post('/api/setup/local')
+      .send({ path: repoDir, scope: 'branch..untracked', base: 'bad;rm -rf' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/Invalid base branch name/);
+    expect(localReviewRow(db)).toBeUndefined();
+  });
+});

--- a/tests/unit/local-review-scope.test.js
+++ b/tests/unit/local-review-scope.test.js
@@ -1,0 +1,286 @@
+// Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+/**
+ * setupLocalReviewSession scope/base precedence (CLI --scope / --base).
+ *
+ * Exercises the CLI seam directly (per CLAUDE.md "CLI vs Web UI entry points"):
+ * setupLocalReviewSession is the single function both CLI paths (headless and
+ * interactive) route through. Git side effects are stubbed via vi.spyOn on the
+ * module exports (vi.mock doesn't work for CommonJS require() under the forks
+ * pool). No real git, no network, no browser.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { createTestDatabase, closeTestDatabase } from '../utils/schema';
+
+const localReviewModule = require('../../src/local-review');
+const summaryGenerator = require('../../src/ai/summary-generator');
+const tourGenerator = require('../../src/ai/tour-generator');
+const { ReviewRepository } = require('../../src/database');
+const { localReviewDiffs } = require('../../src/routes/shared');
+// local-review.js uses a namespace import of this module and calls
+// baseBranchModule.detectBaseBranch(...), so a spy on this same cached object is
+// observed at call time (a destructured binding would not be).
+const baseBranchModule = require('../../src/git/base-branch');
+
+describe('setupLocalReviewSession scope/base precedence', () => {
+  let db;
+  const repoPath = '/mock/repo';
+  const config = { port: 7247 };
+
+  beforeEach(() => {
+    db = createTestDatabase();
+
+    vi.spyOn(localReviewModule, 'getHeadSha').mockResolvedValue('abc123def456');
+    vi.spyOn(localReviewModule, 'getRepositoryName').mockResolvedValue('owner/repo');
+    vi.spyOn(localReviewModule, 'getCurrentBranch').mockResolvedValue('feature');
+    vi.spyOn(localReviewModule, 'findMainGitRoot').mockResolvedValue('/mock/repo');
+    vi.spyOn(localReviewModule, 'generateScopedDiff').mockResolvedValue({
+      diff: 'diff --git a/file.js b/file.js\n--- a/file.js\n+++ b/file.js\n@@ -1 +1 @@\n-old\n+new',
+      stats: { trackedChanges: 1, untrackedFiles: 0, stagedChanges: 0, unstagedChanges: 1 },
+      mergeBaseSha: null
+    });
+    vi.spyOn(localReviewModule, 'computeScopedDigest').mockResolvedValue('digest123');
+    vi.spyOn(localReviewModule, 'detectAndBuildBranchInfo').mockResolvedValue(null);
+    vi.spyOn(localReviewModule, 'findMergeBase').mockResolvedValue('mergebase123');
+    // Background jobs are opted out per-call (startBackgroundJobs: false), but
+    // stub the kickoffs defensively so a stray call is a no-op, not a real job.
+    vi.spyOn(summaryGenerator, 'kickOffSummaryJob').mockReturnValue(null);
+    vi.spyOn(tourGenerator, 'kickOffTourJob').mockReturnValue(null);
+    // Safe defaults for the base-detection + auto-name seams; overridden per test.
+    // detectBaseBranch → null means "no base found"; getFirstCommitSubject → null
+    // means "no name to apply". Both are harmless no-ops unless a test exercises them.
+    vi.spyOn(baseBranchModule, 'detectBaseBranch').mockResolvedValue(null);
+    vi.spyOn(localReviewModule, 'getFirstCommitSubject').mockResolvedValue(null);
+  });
+
+  afterEach(() => {
+    closeTestDatabase(db);
+    localReviewDiffs.clear();
+    vi.restoreAllMocks();
+  });
+
+  const setup = (flags) =>
+    localReviewModule.setupLocalReviewSession({ db, config, repoPath, flags, startBackgroundJobs: false });
+
+  it('fresh review + --scope uses the flag scope and persists it', async () => {
+    const session = await setup({ scope: 'staged..untracked' });
+
+    expect(session.scopeStart).toBe('staged');
+    expect(session.scopeEnd).toBe('untracked');
+
+    const persisted = await new ReviewRepository(db).getLocalReviewById(session.sessionId);
+    expect(persisted.local_scope_start).toBe('staged');
+    expect(persisted.local_scope_end).toBe('untracked');
+    // Non-branch scope leaves head_branch/base cleared.
+    expect(persisted.local_head_branch).toBeNull();
+    expect(persisted.local_base_branch).toBeNull();
+  });
+
+  it('fresh review with no flag falls back to DEFAULT_SCOPE and does not persist a scope override', async () => {
+    const session = await setup({});
+
+    expect(session.scopeStart).toBe('unstaged');
+    expect(session.scopeEnd).toBe('untracked');
+
+    // The row keeps schema defaults (unstaged..untracked); no explicit override written.
+    const persisted = await new ReviewRepository(db).getLocalReviewById(session.sessionId);
+    expect(persisted.local_scope_start).toBe('unstaged');
+    expect(persisted.local_scope_end).toBe('untracked');
+  });
+
+  it('existing persisted scope is overridden by --scope, and the override persists', async () => {
+    // First run persists staged..untracked.
+    const first = await setup({ scope: 'staged..untracked' });
+    const reviewId = first.sessionId;
+
+    // Second run with a different --scope wins and rewrites the persisted scope.
+    const second = await setup({ scope: 'unstaged..unstaged' });
+    expect(second.sessionId).toBe(reviewId); // same session resumed
+    expect(second.scopeStart).toBe('unstaged');
+    expect(second.scopeEnd).toBe('unstaged');
+
+    const persisted = await new ReviewRepository(db).getLocalReviewById(reviewId);
+    expect(persisted.local_scope_start).toBe('unstaged');
+    expect(persisted.local_scope_end).toBe('unstaged');
+  });
+
+  it('existing persisted scope is used untouched when no --scope flag is passed', async () => {
+    // Persist staged..untracked via a first flagged run.
+    const first = await setup({ scope: 'staged..untracked' });
+    const reviewId = first.sessionId;
+
+    // Watch updateLocalScope from here on: a no-flag resume must NOT re-persist
+    // scope. (Spy set up after the first run so its persist isn't counted.)
+    const updateScopeSpy = vi.spyOn(ReviewRepository.prototype, 'updateLocalScope');
+
+    const second = await setup({});
+    expect(second.sessionId).toBe(reviewId);
+    expect(second.scopeStart).toBe('staged');
+    expect(second.scopeEnd).toBe('untracked');
+    expect(updateScopeSpy).not.toHaveBeenCalled();
+
+    const persisted = await new ReviewRepository(db).getLocalReviewById(reviewId);
+    expect(persisted.local_scope_start).toBe('staged');
+    expect(persisted.local_scope_end).toBe('untracked');
+  });
+
+  it('--base is persisted with a branch-relative --scope and used for the diff', async () => {
+    const session = await setup({ scope: 'branch..untracked', base: 'develop' });
+
+    expect(session.scopeStart).toBe('branch');
+    expect(session.scopeEnd).toBe('untracked');
+    expect(session.baseBranch).toBe('develop');
+
+    // generateScopedDiff receives the explicit base branch (no detection needed).
+    expect(localReviewModule.generateScopedDiff).toHaveBeenCalledWith(
+      repoPath, 'branch', 'untracked', 'develop'
+    );
+
+    const persisted = await new ReviewRepository(db).getLocalReviewById(session.sessionId);
+    expect(persisted.local_scope_start).toBe('branch');
+    expect(persisted.local_scope_end).toBe('untracked');
+    expect(persisted.local_base_branch).toBe('develop');
+    // Branch scope records the current branch as the head branch.
+    expect(persisted.local_head_branch).toBe('feature');
+    expect(persisted.local_mode).toBe('branch');
+  });
+
+  describe('base-branch precedence for branch scopes', () => {
+    it('(a) uses persisted local_base_branch without calling detectBaseBranch', async () => {
+      // Seed a persisted branch scope with base 'main' (explicit --base, no detection).
+      const first = await setup({ scope: 'branch..untracked', base: 'main' });
+      baseBranchModule.detectBaseBranch.mockClear();
+
+      // Resume with a branch scope and NO --base: the persisted base must be reused.
+      const second = await setup({ scope: 'branch..untracked' });
+      expect(second.sessionId).toBe(first.sessionId);
+      expect(second.baseBranch).toBe('main');
+      expect(baseBranchModule.detectBaseBranch).not.toHaveBeenCalled();
+
+      const persisted = await new ReviewRepository(db).getLocalReviewById(second.sessionId);
+      expect(persisted.local_base_branch).toBe('main');
+    });
+
+    it('(b) detects the base branch when none is persisted, then uses/persists it', async () => {
+      baseBranchModule.detectBaseBranch.mockResolvedValue({ baseBranch: 'main', source: 'github' });
+
+      const session = await setup({ scope: 'branch..untracked' });
+
+      expect(baseBranchModule.detectBaseBranch).toHaveBeenCalledTimes(1);
+      expect(session.baseBranch).toBe('main');
+      // Detected base flows into the diff...
+      expect(localReviewModule.generateScopedDiff).toHaveBeenCalledWith(
+        repoPath, 'branch', 'untracked', 'main'
+      );
+      // ...and is persisted.
+      const persisted = await new ReviewRepository(db).getLocalReviewById(session.sessionId);
+      expect(persisted.local_base_branch).toBe('main');
+    });
+
+    it('(c) rejects when detection finds no base branch', async () => {
+      baseBranchModule.detectBaseBranch.mockResolvedValue(null);
+
+      await expect(setup({ scope: 'branch..untracked' })).rejects.toThrow(
+        /Could not detect a base branch/
+      );
+    });
+
+    it('(d) explicit --base wins over a persisted base and persists', async () => {
+      const first = await setup({ scope: 'branch..untracked', base: 'develop' });
+      baseBranchModule.detectBaseBranch.mockClear();
+
+      const second = await setup({ scope: 'branch..untracked', base: 'main' });
+      expect(second.sessionId).toBe(first.sessionId);
+      expect(second.baseBranch).toBe('main');
+      expect(baseBranchModule.detectBaseBranch).not.toHaveBeenCalled();
+
+      const persisted = await new ReviewRepository(db).getLocalReviewById(second.sessionId);
+      expect(persisted.local_base_branch).toBe('main');
+    });
+  });
+
+  describe('stale base cleared when leaving branch scope (finding 3)', () => {
+    it('reopening a branch-scoped review with a non-branch --scope nulls the base everywhere', async () => {
+      // Persist a branch scope with base 'develop'.
+      const first = await setup({ scope: 'branch..untracked', base: 'develop' });
+      localReviewModule.generateScopedDiff.mockClear();
+
+      // Reopen with unstaged..untracked: the stale 'develop' base must be dropped.
+      const second = await setup({ scope: 'unstaged..untracked' });
+      expect(second.sessionId).toBe(first.sessionId);
+      expect(second.baseBranch).toBeNull();
+
+      // The diff generator must not receive the stale base.
+      expect(localReviewModule.generateScopedDiff).toHaveBeenCalledWith(
+        repoPath, 'unstaged', 'untracked', null
+      );
+
+      // The persisted row matches the web set-scope route: base null, mode uncommitted.
+      const persisted = await new ReviewRepository(db).getLocalReviewById(second.sessionId);
+      expect(persisted.local_scope_start).toBe('unstaged');
+      expect(persisted.local_scope_end).toBe('untracked');
+      expect(persisted.local_base_branch).toBeNull();
+      expect(persisted.local_head_branch).toBeNull();
+      expect(persisted.local_mode).toBe('uncommitted');
+    });
+  });
+
+  describe('auto-name on newly-applied branch scope (finding 4)', () => {
+    it('names a fresh, unnamed review from the first commit subject', async () => {
+      localReviewModule.getFirstCommitSubject.mockResolvedValue('Implement the widget');
+
+      const session = await setup({ scope: 'branch..untracked', base: 'main' });
+
+      expect(localReviewModule.getFirstCommitSubject).toHaveBeenCalledWith(repoPath, 'main');
+      const persisted = await new ReviewRepository(db).getLocalReviewById(session.sessionId);
+      expect(persisted.name).toBe('Implement the widget');
+    });
+
+    it('truncates a long commit subject to 200 characters', async () => {
+      const longSubject = 'x'.repeat(250);
+      localReviewModule.getFirstCommitSubject.mockResolvedValue(longSubject);
+
+      const session = await setup({ scope: 'branch..untracked', base: 'main' });
+
+      const persisted = await new ReviewRepository(db).getLocalReviewById(session.sessionId);
+      expect(persisted.name).toBe('x'.repeat(200));
+    });
+
+    it('does NOT auto-name when the review already has a name', async () => {
+      // Create an unnamed default-scope session, then give it a name.
+      const first = await setup({});
+      await new ReviewRepository(db).updateReview(first.sessionId, { name: 'Existing name' });
+      localReviewModule.getFirstCommitSubject.mockClear();
+      localReviewModule.getFirstCommitSubject.mockResolvedValue('Should not be used');
+
+      // Apply a branch scope: the name must be preserved, auto-name skipped.
+      await setup({ scope: 'branch..untracked', base: 'main' });
+
+      expect(localReviewModule.getFirstCommitSubject).not.toHaveBeenCalled();
+      const persisted = await new ReviewRepository(db).getLocalReviewById(first.sessionId);
+      expect(persisted.name).toBe('Existing name');
+    });
+
+    it('does NOT auto-name when the scope was already a branch scope', async () => {
+      // Seed a branch-scoped, unnamed review directly (bypass setup's own auto-name).
+      const reviewRepo = new ReviewRepository(db);
+      const id = await reviewRepo.upsertLocalReview({
+        localPath: repoPath,
+        localHeadSha: 'abc123def456',
+        repository: 'owner/repo',
+        localHeadBranch: 'feature'
+      });
+      await reviewRepo.updateLocalScope(id, 'branch', 'untracked', 'main', 'feature');
+      localReviewModule.getFirstCommitSubject.mockResolvedValue('Should not be used');
+
+      // Resume with another branch scope: oldScopeStart is already 'branch', so
+      // the "newly entered branch scope" guard is false and auto-name is skipped.
+      const session = await setup({ scope: 'branch..unstaged', base: 'main' });
+      expect(session.sessionId).toBe(id);
+      expect(localReviewModule.getFirstCommitSubject).not.toHaveBeenCalled();
+
+      const persisted = await reviewRepo.getLocalReviewById(id);
+      expect(persisted.name).toBeNull();
+    });
+  });
+});

--- a/tests/unit/local-scope.test.js
+++ b/tests/unit/local-scope.test.js
@@ -2,7 +2,7 @@
 import { describe, it, expect } from 'vitest';
 import LocalScope from '../../src/local-scope.js';
 
-const { STOPS, DEFAULT_SCOPE, isValidScope, normalizeScope, reviewScope, scopeIncludes, includesBranch, fromLegacyMode, scopeLabel, scopeGitHints } = LocalScope;
+const { STOPS, DEFAULT_SCOPE, VALID_SCOPE_RANGES, isValidScope, parseScopeArg, normalizeScope, reviewScope, scopeIncludes, includesBranch, fromLegacyMode, scopeLabel, scopeGitHints } = LocalScope;
 
 describe('LocalScope', () => {
   describe('STOPS', () => {
@@ -70,6 +70,89 @@ describe('LocalScope', () => {
     it('rejects null inputs', () => {
       expect(isValidScope(null, 'branch')).toBe(false);
       expect(isValidScope('branch', null)).toBe(false);
+    });
+  });
+
+  describe('VALID_SCOPE_RANGES', () => {
+    it('lists exactly the six accepted ranges, branch-first', () => {
+      expect(VALID_SCOPE_RANGES).toEqual([
+        'branch..unstaged',
+        'branch..untracked',
+        'staged..unstaged',
+        'staged..untracked',
+        'unstaged..unstaged',
+        'unstaged..untracked',
+      ]);
+    });
+
+    it('contains exactly the ranges isValidScope accepts', () => {
+      const derived = [];
+      for (const start of STOPS) {
+        for (const end of STOPS) {
+          if (isValidScope(start, end)) derived.push(`${start}..${end}`);
+        }
+      }
+      expect(VALID_SCOPE_RANGES).toEqual(derived);
+    });
+  });
+
+  describe('parseScopeArg', () => {
+    const validRanges = [
+      ['branch..unstaged', { start: 'branch', end: 'unstaged' }],
+      ['branch..untracked', { start: 'branch', end: 'untracked' }],
+      ['staged..unstaged', { start: 'staged', end: 'unstaged' }],
+      ['staged..untracked', { start: 'staged', end: 'untracked' }],
+      ['unstaged..unstaged', { start: 'unstaged', end: 'unstaged' }],
+      ['unstaged..untracked', { start: 'unstaged', end: 'untracked' }],
+    ];
+
+    it.each(validRanges)('parses valid range %s', (input, expected) => {
+      expect(parseScopeArg(input)).toEqual(expected);
+    });
+
+    it('trims surrounding whitespace on each stop', () => {
+      expect(parseScopeArg('  branch  ..  untracked  ')).toEqual({ start: 'branch', end: 'untracked' });
+    });
+
+    it('returns null for a single token (no "..")', () => {
+      expect(parseScopeArg('branch')).toBeNull();
+      expect(parseScopeArg('unstaged')).toBeNull();
+    });
+
+    it('returns null when the ".." separator is missing but stops are present', () => {
+      expect(parseScopeArg('branch untracked')).toBeNull();
+    });
+
+    it('returns null for three-part input (extra dots)', () => {
+      expect(parseScopeArg('branch...untracked')).toBeNull();
+      expect(parseScopeArg('branch..staged..untracked')).toBeNull();
+    });
+
+    it('returns null for a range that excludes unstaged', () => {
+      expect(parseScopeArg('branch..staged')).toBeNull();
+      expect(parseScopeArg('staged..staged')).toBeNull();
+    });
+
+    it('returns null for reversed order (start after end)', () => {
+      expect(parseScopeArg('untracked..unstaged')).toBeNull();
+      expect(parseScopeArg('unstaged..staged')).toBeNull();
+    });
+
+    it('returns null for unknown stop names', () => {
+      expect(parseScopeArg('bogus..untracked')).toBeNull();
+      expect(parseScopeArg('branch..bogus')).toBeNull();
+      expect(parseScopeArg('foo..bar')).toBeNull();
+    });
+
+    it('returns null for empty string', () => {
+      expect(parseScopeArg('')).toBeNull();
+    });
+
+    it('returns null for non-string input', () => {
+      expect(parseScopeArg(null)).toBeNull();
+      expect(parseScopeArg(undefined)).toBeNull();
+      expect(parseScopeArg(42)).toBeNull();
+      expect(parseScopeArg({ start: 'branch', end: 'untracked' })).toBeNull();
     });
   });
 

--- a/tests/unit/main.test.js
+++ b/tests/unit/main.test.js
@@ -386,6 +386,45 @@ describe('main.js parseArgs', () => {
       expect(() => parseArgs(['123', '--instructions-file', '--headless'])).toThrow('--instructions-file flag requires a file path');
     });
 
+    it('should parse --scope flag with a range value', () => {
+      const result = parseArgs(['--local', '--scope', 'branch..untracked']);
+      expect(result.flags.local).toBe(true);
+      expect(result.flags.scope).toBe('branch..untracked');
+      expect(result.prArgs).toEqual([]);
+    });
+
+    it('should throw error when --scope has no value', () => {
+      expect(() => parseArgs(['--local', '--scope'])).toThrow('--scope flag requires a range value');
+    });
+
+    it('should throw error when --scope is followed by another flag', () => {
+      expect(() => parseArgs(['--local', '--scope', '--headless'])).toThrow('--scope flag requires a range value');
+    });
+
+    it('should parse --base flag with a branch name', () => {
+      const result = parseArgs(['--local', '--scope', 'branch..untracked', '--base', 'develop']);
+      expect(result.flags.base).toBe('develop');
+      expect(result.flags.scope).toBe('branch..untracked');
+    });
+
+    it('should throw error when --base has no value', () => {
+      expect(() => parseArgs(['--local', '--base'])).toThrow('--base flag requires a branch name');
+    });
+
+    it('should throw error when --base is followed by another flag', () => {
+      expect(() => parseArgs(['--local', '--base', '--scope'])).toThrow('--base flag requires a branch name');
+    });
+
+    // parseArgs itself does not know that --scope requires --local or that
+    // --base requires a branch-relative --scope — those cross-flag rules live in
+    // main() and are covered by the "headless CLI smoke" spawn tests below. At
+    // the parseArgs layer the flags simply parse into the flags object.
+    it('parses --scope alongside a PR arg without erroring (main() rejects it)', () => {
+      const result = parseArgs(['123', '--scope', 'branch..untracked']);
+      expect(result.flags.scope).toBe('branch..untracked');
+      expect(result.prArgs).toEqual(['123']);
+    });
+
     it('should parse a full headless council invocation', () => {
       const result = parseArgs(['--local', '--headless', '--json', '--council', 'security', '--instructions', 'focus on auth']);
       expect(result.flags.local).toBe(true);
@@ -699,6 +738,45 @@ describe('headless CLI smoke (main()-level validations)', () => {
     const result = run(['123', '--instructions', 'focus on auth']);
     expect(result.status).not.toBe(0);
     expect(result.stderr + result.stdout).toMatch(/require a mode that runs analysis/);
+  });
+
+  it('--scope without --local exits non-zero with a clear message', () => {
+    const result = run(['--scope', 'branch..untracked']);
+    expect(result.status).not.toBe(0);
+    expect(result.stderr + result.stdout).toMatch(/--scope\/--base require --local/);
+  });
+
+  it('--scope with a PR positional exits non-zero with a clear message', () => {
+    const result = run(['123', '--scope', 'branch..untracked']);
+    expect(result.status).not.toBe(0);
+    expect(result.stderr + result.stdout).toMatch(/cannot be combined with a pull request/);
+  });
+
+  it('--scope with an invalid range lists the valid ranges', () => {
+    const result = run(['--local', '--scope', 'branch..staged']);
+    expect(result.status).not.toBe(0);
+    const out = result.stderr + result.stdout;
+    expect(out).toMatch(/Invalid --scope value "branch\.\.staged"/);
+    expect(out).toMatch(/branch\.\.untracked/);
+    expect(out).toMatch(/must include 'unstaged'/);
+  });
+
+  it('--base without a branch-relative --scope exits non-zero with a clear message', () => {
+    const result = run(['--local', '--scope', 'unstaged..untracked', '--base', 'main']);
+    expect(result.status).not.toBe(0);
+    expect(result.stderr + result.stdout).toMatch(/--base requires --scope with a branch-relative range/);
+  });
+
+  it('--base without any --scope exits non-zero (requires branch-relative scope)', () => {
+    const result = run(['--local', '--base', 'main']);
+    expect(result.status).not.toBe(0);
+    expect(result.stderr + result.stdout).toMatch(/--base requires --scope with a branch-relative range/);
+  });
+
+  it('--base with an invalid branch name is rejected', () => {
+    const result = run(['--local', '--scope', 'branch..untracked', '--base', 'bad;rm -rf']);
+    expect(result.status).not.toBe(0);
+    expect(result.stderr + result.stdout).toMatch(/Invalid --base branch name/);
   });
 
   // COVERAGE GAP (intentional): the full happy-path smoke — `--local --headless

--- a/tests/unit/single-port.test.js
+++ b/tests/unit/single-port.test.js
@@ -282,6 +282,47 @@ describe('buildDelegationUrl', () => {
     expect(url).toBe('http://localhost:7247/pr/acme/widgets/42');
   });
 
+  it('appends scope to local URL', () => {
+    const url = buildDelegationUrl(7247, 'local', { localPath: '/tmp/project', scope: 'branch..untracked' });
+    expect(url).toBe('http://localhost:7247/local?path=%2Ftmp%2Fproject&scope=branch..untracked');
+  });
+
+  it('appends scope and base to local URL', () => {
+    const url = buildDelegationUrl(7247, 'local', {
+      localPath: '/tmp/project', scope: 'branch..untracked', base: 'develop'
+    });
+    expect(url).toBe('http://localhost:7247/local?path=%2Ftmp%2Fproject&scope=branch..untracked&base=develop');
+  });
+
+  it('appends scope/base after analyze and analysisConfigId', () => {
+    const url = buildDelegationUrl(7247, 'local', {
+      localPath: '/tmp/project', analyze: true, analysisConfigId: 'cfg-9',
+      scope: 'staged..untracked', base: null
+    });
+    expect(url).toBe('http://localhost:7247/local?path=%2Ftmp%2Fproject&analyze=true&analysisConfigId=cfg-9&scope=staged..untracked');
+  });
+
+  it('url-encodes scope and base values', () => {
+    const url = buildDelegationUrl(7247, 'local', {
+      localPath: '/tmp/project', scope: 'branch..untracked', base: 'feature/x y'
+    });
+    expect(url).toBe('http://localhost:7247/local?path=%2Ftmp%2Fproject&scope=branch..untracked&base=feature%2Fx%20y');
+  });
+
+  it('omits scope/base when absent', () => {
+    const url = buildDelegationUrl(7247, 'local', { localPath: '/tmp/project' });
+    expect(url).toBe('http://localhost:7247/local?path=%2Ftmp%2Fproject');
+    expect(url).not.toContain('scope=');
+    expect(url).not.toContain('base=');
+  });
+
+  it('does not append scope/base to PR URLs', () => {
+    const url = buildDelegationUrl(7247, 'pr', {
+      owner: 'acme', repo: 'widgets', number: 42, scope: 'branch..untracked', base: 'develop'
+    });
+    expect(url).toBe('http://localhost:7247/pr/acme/widgets/42');
+  });
+
   it('builds server landing URL', () => {
     const url = buildDelegationUrl(7247, 'server');
     expect(url).toBe('http://localhost:7247/');
@@ -449,6 +490,29 @@ describe('attemptDelegation', () => {
     expect(deps.open).toHaveBeenCalledWith(
       expect.stringContaining('/local?path=')
     );
+  });
+
+  it('carries --scope and --base into the delegated local URL', async () => {
+    const deps = createMockDeps();
+    const result = await attemptDelegation(
+      baseConfig,
+      { local: true, localPath: '/tmp/project', scope: 'branch..untracked', base: 'develop' },
+      [],
+      deps
+    );
+    expect(result).toBe(true);
+    const openedUrl = deps.open.mock.calls[0][0];
+    expect(openedUrl).toContain('/local?path=');
+    expect(openedUrl).toContain('scope=branch..untracked');
+    expect(openedUrl).toContain('base=develop');
+  });
+
+  it('does not add scope/base to the delegated URL when absent', async () => {
+    const deps = createMockDeps();
+    await attemptDelegation(baseConfig, { local: true, localPath: '/tmp/project' }, [], deps);
+    const openedUrl = deps.open.mock.calls[0][0];
+    expect(openedUrl).not.toContain('scope=');
+    expect(openedUrl).not.toContain('base=');
   });
 
   it('rejects URL input for local mode before opening browser', async () => {


### PR DESCRIPTION
## Summary

Adds `--scope <start>..<end>` and `--base <branch>` CLI options so local reviews can be scoped from the command line, matching the web UI's scope model — the six contiguous ranges over `branch`/`staged`/`unstaged`/`untracked` that include `unstaged` (default `unstaged..untracked`).

```bash
pair-review --local --scope branch..untracked              # whole branch vs merge-base
pair-review --local --scope branch..untracked --base develop
pair-review --local --headless --json --scope branch..untracked   # pair-loop friendly
```

- **Single source of truth**: `parseScopeArg` / `VALID_SCOPE_RANGES` live in `src/local-scope.js` (shared with the browser); validation delegates to the existing `isValidScope`.
- **Shared semantics**: scope resolution and persistence are extracted into `resolveScopeAndBase` / `persistScopeSelection` in `src/local-review.js`, used by both the CLI path and the web setup path — explicit flag > persisted scope > default; base precedence `--base` > persisted > auto-detect (Graphite when enabled → GitHub PR base → origin default → main/master); persist only after `generateScopedDiff` succeeds; base nulled for non-branch scopes; auto-name on newly-branch scope (CLI/web parity).
- **Delegation threading**: a scoped `--local` while a server is already running carries `scope`/`base` through the delegation URL → `setup.html` → `POST /api/setup/local`, which re-validates server-side. Previously this scenario either silently dropped the flags or (with an interim guard) crashed on the busy port.
- **Constraints**: local-mode only (clear errors with a PR arg or without `--local`); `--base` requires a branch-relative scope; explicit `--scope` is persisted so the web UI reopens at the same scope.
- **pair-loop skill**: recommends `--scope branch..untracked` for branch-spanning work; removes the obsolete `git add -N` guidance (untracked files are included natively when the scope ends at `untracked`).
- README section, help text, and a `minor` changeset included.

## Test plan

- [x] Full unit/integration suite: 8668 passed (includes new suites: `local-review-scope.test.js` precedence/regression coverage, `setup-local-scope.test.js` driving the real setup route against a temp git repo)
- [x] Playwright E2E: 357 passed (includes new tests asserting the production `setup.html` forwards `scope`/`base` into the POST body)
- [x] Live delegation repro: server running + `pair-review --local --scope branch..untracked` delegates with scope carried (previously EADDRINUSE/silent drop)
- [x] CLI error paths smoke-tested: invalid range, missing `--local`, PR-arg conflict, `--base` without branch scope, missing values
- [x] Rebased on `origin/main` (#507 `--provider`, dual-host); suites re-run green after resolving delegation-URL and setup.html overlaps

🤖 Generated with [Claude Code](https://claude.com/claude-code)