### PR TITLE
Add GPT-5.6 Codex model variants

### DIFF
--- a/.changeset/add-gpt-5-6-codex-models.md
+++ b/.changeset/add-gpt-5-6-codex-models.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Add GPT-5.6 Sol, Terra, and Luna reasoning-effort variants to the Codex provider model picker.

--- a/src/ai/codex-provider.js
+++ b/src/ai/codex-provider.js
@@ -21,14 +21,18 @@ const BIN_DIR = path.join(__dirname, '..', '..', 'bin');
 /**
  * Codex model definitions with tier mappings
  *
- * Based on OpenAI Codex Models guide (developers.openai.com/codex/models)
+ * Based on OpenAI's GPT-5.6 launch and Models guide
+ * (openai.com/index/gpt-5-6 and developers.openai.com/api/docs/models)
+ * - gpt-5.6-sol: Flagship frontier model for complex professional work
+ * - gpt-5.6-terra: Balances intelligence and cost for everyday work
+ * - gpt-5.6-luna: Fast, affordable model for cost-sensitive, high-volume work
  * - gpt-5.4-nano: Cheapest model ($0.20/$1.25 per MTok), good for surface scans
  * - gpt-5.4-mini: Fast with 400k context ($0.75/$4.50 per MTok)
  * - gpt-5.3-codex: Industry-leading coding model for complex engineering tasks
- * - gpt-5.4 / gpt-5.5: Exposed only via -high / -xhigh reasoning variants so the
- *   selected effort level is always explicit.
+ * - GPT-5.6, gpt-5.4, and gpt-5.5 models are exposed only through the requested
+ *   explicit reasoning-effort variants.
  *
- * Reasoning-effort variants (-high / -xhigh) use `cli_model` to pass the base
+ * Reasoning-effort variants (-high / -xhigh / -max) use `cli_model` to pass the base
  * model ID to `codex exec -m` and add `-c model_reasoning_effort="..."` via
  * extra_args so Codex picks up the effort level through its config override.
  *
@@ -36,16 +40,60 @@ const BIN_DIR = path.join(__dirname, '..', '..', 'bin');
  */
 const CODEX_MODELS = [
   {
+    id: 'gpt-5.6-sol-high',
+    cli_model: 'gpt-5.6-sol',
+    extra_args: ['-c', 'model_reasoning_effort="high"'],
+    name: 'GPT-5.6 Sol High',
+    tier: 'thorough',
+    tagline: 'Frontier Review',
+    description: 'OpenAI flagship and best coding model yet, with high reasoning effort for demanding PR reviews, complex professional work, and cross-file analysis.',
+    badge: 'Recommended',
+    badgeClass: 'badge-recommended',
+    default: true
+  },
+  {
+    id: 'gpt-5.6-sol-xhigh',
+    cli_model: 'gpt-5.6-sol',
+    extra_args: ['-c', 'model_reasoning_effort="xhigh"'],
+    name: 'GPT-5.6 Sol XHigh',
+    tier: 'thorough',
+    tagline: 'Frontier Depth',
+    description: 'GPT-5.6 Sol with extra-high reasoning effort for difficult architectural reviews, subtle regressions, and security-sensitive changes.',
+    badge: 'Extra High',
+    badgeClass: 'badge-power'
+  },
+  {
+    id: 'gpt-5.6-terra-xhigh',
+    cli_model: 'gpt-5.6-terra',
+    extra_args: ['-c', 'model_reasoning_effort="xhigh"'],
+    name: 'GPT-5.6 Terra XHigh',
+    tier: 'balanced',
+    tagline: 'Intelligence & Value',
+    description: 'GPT-5.6 balanced model with extra-high reasoning effort, combining strong intelligence and lower cost for careful everyday PR reviews.',
+    badge: 'Best Balance',
+    badgeClass: 'badge-balanced'
+  },
+  {
+    id: 'gpt-5.6-luna-max',
+    cli_model: 'gpt-5.6-luna',
+    extra_args: ['-c', 'model_reasoning_effort="max"'],
+    name: 'GPT-5.6 Luna Max',
+    tier: 'balanced',
+    tagline: 'High-Volume Value',
+    description: 'GPT-5.6 fastest, most cost-efficient model with max reasoning effort for high-volume reviews and broad codebase scans.',
+    badge: 'Lowest Cost',
+    badgeClass: 'badge-speed'
+  },
+  {
     id: 'gpt-5.5-high',
     cli_model: 'gpt-5.5',
     extra_args: ['-c', 'model_reasoning_effort="high"'],
     name: 'GPT-5.5 High',
     tier: 'thorough',
-    tagline: 'Latest Deep',
-    description: 'Latest-generation GPT model with high reasoning effort for demanding PR reviews, strong code understanding, and careful cross-file analysis.',
-    badge: 'Recommended',
-    badgeClass: 'badge-recommended',
-    default: true
+    tagline: 'Previous Flagship',
+    description: 'Previous-generation GPT model with high reasoning effort for demanding PR reviews, strong code understanding, and careful cross-file analysis.',
+    badge: 'Previous Gen',
+    badgeClass: 'badge-power'
   },
   {
     id: 'gpt-5.5-xhigh',
@@ -122,7 +170,7 @@ class CodexProvider extends AIProvider {
    * @param {Object} configOverrides.env - Additional environment variables
    * @param {Object[]} configOverrides.models - Custom model definitions
    */
-  constructor(model = 'gpt-5.5-high', configOverrides = {}) {
+  constructor(model = 'gpt-5.6-sol-high', configOverrides = {}) {
     super(model);
 
     // Command precedence: ENV > config > default
@@ -845,7 +893,7 @@ class CodexProvider extends AIProvider {
   }
 
   static getDefaultModel() {
-    return 'gpt-5.5-high';
+    return 'gpt-5.6-sol-high';
   }
 
   static getInstallInstructions() {

--- a/tests/unit/codex-provider.test.js
+++ b/tests/unit/codex-provider.test.js
@@ -53,23 +53,27 @@ describe('CodexProvider', () => {
       expect(CodexProvider.getProviderId()).toBe('codex');
     });
 
-    it('should return gpt-5.5-high as default model', () => {
-      expect(CodexProvider.getDefaultModel()).toBe('gpt-5.5-high');
+    it('should return gpt-5.6-sol-high as default model', () => {
+      expect(CodexProvider.getDefaultModel()).toBe('gpt-5.6-sol-high');
     });
 
     it('should return array of models with expected structure', () => {
       const models = CodexProvider.getModels();
       expect(Array.isArray(models)).toBe(true);
-      expect(models.length).toBe(7);
+      expect(models.length).toBe(11);
 
       // Check that we have the expected model IDs
       const modelIds = models.map(m => m.id);
       expect(modelIds.slice(0, 4)).toEqual([
-        'gpt-5.5-high',
-        'gpt-5.5-xhigh',
-        'gpt-5.4-high',
-        'gpt-5.4-xhigh',
+        'gpt-5.6-sol-high',
+        'gpt-5.6-sol-xhigh',
+        'gpt-5.6-terra-xhigh',
+        'gpt-5.6-luna-max'
       ]);
+      expect(modelIds).toContain('gpt-5.6-sol-high');
+      expect(modelIds).toContain('gpt-5.6-sol-xhigh');
+      expect(modelIds).toContain('gpt-5.6-terra-xhigh');
+      expect(modelIds).toContain('gpt-5.6-luna-max');
       expect(modelIds).toContain('gpt-5.4-nano');
       expect(modelIds).toContain('gpt-5.4-mini');
       expect(modelIds).toContain('gpt-5.3-codex');
@@ -77,22 +81,25 @@ describe('CodexProvider', () => {
       expect(modelIds).toContain('gpt-5.4-xhigh');
       expect(modelIds).toContain('gpt-5.5-high');
       expect(modelIds).toContain('gpt-5.5-xhigh');
-      // Bare gpt-5.4 / gpt-5.5 (unspecified reasoning effort) are not
-      // exposed as picker entries — users pick an explicit -high / -xhigh
-      // variant. `gpt-5.4` is kept as an alias of gpt-5.4-high so previously
+      // Bare GPT-5.6 / gpt-5.4 / gpt-5.5 (unspecified reasoning effort) are not
+      // exposed as picker entries — users pick an explicit reasoning variant
+      // instead. `gpt-5.4` is kept as an alias of gpt-5.4-high so previously
       // saved results/councils still resolve.
       expect(modelIds).not.toContain('gpt-5.4');
       expect(modelIds).not.toContain('gpt-5.5');
+      expect(modelIds).not.toContain('gpt-5.6-sol');
+      expect(modelIds).not.toContain('gpt-5.6-terra');
+      expect(modelIds).not.toContain('gpt-5.6-luna');
 
       const high54 = models.find(m => m.id === 'gpt-5.4-high');
       expect(high54.aliases).toContain('gpt-5.4');
       expect(high54.badge).toBe('Previous Gen');
 
-      // Check model structure — default is now gpt-5.5-high (explicit reasoning)
+      // Check model structure — default is GPT-5.6 Sol with explicit high reasoning
       const defaultModel = models.find(m => m.default === true);
       expect(defaultModel).toMatchObject({
-        id: 'gpt-5.5-high',
-        name: 'GPT-5.5 High',
+        id: 'gpt-5.6-sol-high',
+        name: 'GPT-5.6 Sol High',
         tier: 'thorough',
         default: true
       });
@@ -103,17 +110,21 @@ describe('CodexProvider', () => {
     it('reasoning-effort variants should declare cli_model and -c reasoning effort', () => {
       const models = CodexProvider.getModels();
       const variants = [
-        { id: 'gpt-5.4-high', cliModel: 'gpt-5.4', effort: 'high' },
-        { id: 'gpt-5.4-xhigh', cliModel: 'gpt-5.4', effort: 'xhigh' },
-        { id: 'gpt-5.5-high', cliModel: 'gpt-5.5', effort: 'high' },
-        { id: 'gpt-5.5-xhigh', cliModel: 'gpt-5.5', effort: 'xhigh' }
+        { id: 'gpt-5.6-sol-high', cliModel: 'gpt-5.6-sol', effort: 'high', tier: 'thorough' },
+        { id: 'gpt-5.6-sol-xhigh', cliModel: 'gpt-5.6-sol', effort: 'xhigh', tier: 'thorough' },
+        { id: 'gpt-5.6-terra-xhigh', cliModel: 'gpt-5.6-terra', effort: 'xhigh', tier: 'balanced' },
+        { id: 'gpt-5.6-luna-max', cliModel: 'gpt-5.6-luna', effort: 'max', tier: 'balanced' },
+        { id: 'gpt-5.4-high', cliModel: 'gpt-5.4', effort: 'high', tier: 'thorough' },
+        { id: 'gpt-5.4-xhigh', cliModel: 'gpt-5.4', effort: 'xhigh', tier: 'thorough' },
+        { id: 'gpt-5.5-high', cliModel: 'gpt-5.5', effort: 'high', tier: 'thorough' },
+        { id: 'gpt-5.5-xhigh', cliModel: 'gpt-5.5', effort: 'xhigh', tier: 'thorough' }
       ];
       for (const v of variants) {
         const model = models.find(m => m.id === v.id);
         expect(model, `missing model ${v.id}`).toBeDefined();
         expect(model.cli_model).toBe(v.cliModel);
         expect(model.extra_args).toEqual(['-c', `model_reasoning_effort="${v.effort}"`]);
-        expect(model.tier).toBe('thorough');
+        expect(model.tier).toBe(v.tier);
       }
     });
 
@@ -127,7 +138,7 @@ describe('CodexProvider', () => {
   describe('constructor', () => {
     it('should create instance with default model', () => {
       const provider = new CodexProvider();
-      expect(provider.model).toBe('gpt-5.5-high');
+      expect(provider.model).toBe('gpt-5.6-sol-high');
     });
 
     it('should create instance with specified model', () => {
@@ -230,6 +241,19 @@ describe('CodexProvider', () => {
         const mIdx = provider.args.indexOf('-m');
         expect(provider.args[mIdx + 1]).toBe('gpt-5.5');
         expect(provider.args).toContain('model_reasoning_effort="xhigh"');
+      });
+
+      it.each([
+        ['gpt-5.6-sol-high', 'gpt-5.6-sol', 'high'],
+        ['gpt-5.6-sol-xhigh', 'gpt-5.6-sol', 'xhigh'],
+        ['gpt-5.6-terra-xhigh', 'gpt-5.6-terra', 'xhigh'],
+        ['gpt-5.6-luna-max', 'gpt-5.6-luna', 'max']
+      ])('should resolve %s to base model %s with %s reasoning effort', (modelId, cliModel, effort) => {
+        const provider = new CodexProvider(modelId);
+        const mIdx = provider.args.indexOf('-m');
+        expect(provider.args[mIdx + 1]).toBe(cliModel);
+        expect(provider.args).not.toContain(modelId);
+        expect(provider.args).toContain(`model_reasoning_effort="${effort}"`);
       });
 
       it('should place stdin marker `-` AFTER reasoning extra_args in non-shell mode', () => {


### PR DESCRIPTION
## Summary

- add GPT-5.6 Sol high and xhigh Codex variants
- add GPT-5.6 Terra xhigh and Luna max balanced variants
- make GPT-5.6 Sol high the Codex default and refresh model metadata
- add provider mapping tests and a changeset

## Testing

- full test suite: 8,672 tests passed
- focused Codex provider suite: 84 tests passed
- Terra xhigh CLI mapping smoke check passed
- git diff --check passed