### PR TITLE
Widen tour stops and always show full description

### DIFF
--- a/.changeset/wider-tour-stops-full-description.md
+++ b/.changeset/wider-tour-stops-full-description.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Widen tour stop annotations and always show the full description. Tour stops now span the diff width (matching full-width comments/suggestions) with their prose capped to a readable measure, instead of being narrowed to that measure as a whole card. The description is always shown in full — the truncation and "Show more" toggle have been removed.

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ public/js/vendor/pierre-diffs.js
 public/js/vendor/pierre-diffs.js.map
 public/js/vendor/pierre-diffs-worker.js
 public/js/vendor/pierre-diffs-worker.js.map
+.pair-loop/

--- a/public/css/pr.css
+++ b/public/css/pr.css
@@ -13180,9 +13180,10 @@ body.summaries-hidden .hunk-summary-row,
   border: 1px solid rgba(212, 167, 44, 0.55);
   border-left: 3px solid #d4a72c;
   border-radius: var(--radius-md, 6px);
-  /* Viewport overflow guard + readable prose measure on wide displays
-     (centered banner, matching .hunk-summary-annotation). */
-  max-width: min(calc(100vw - var(--sidebar-width, 0px) - var(--right-panel-group-width, 0px) - 64px), var(--annotation-prose-max, 80ch));
+  /* Span the available diff width, matching full-width comments/suggestions;
+     only the description prose below is capped to a readable measure. The
+     viewport guard keeps the card from overrunning the sidebar/right panel. */
+  max-width: calc(100vw - var(--sidebar-width, 0px) - var(--right-panel-group-width, 0px) - 64px);
   box-sizing: border-box;
   word-break: break-word;
   transition: box-shadow var(--transition-fast, 0.1s ease),
@@ -13229,84 +13230,17 @@ body.summaries-hidden .hunk-summary-row,
   line-height: 1.3;
 }
 
+/* The description is always shown in full — stops are short by design, so
+   there is no line-clamp or "Show more" toggle. The card spans the diff
+   width; capping the prose here (not the card) keeps it at a readable
+   measure, matching full-width comment/suggestion bodies. */
 .tour-annotation-description {
   margin: 0;
+  max-width: min(100%, var(--annotation-prose-max, 80ch));
   font-size: 13px;
   font-weight: 400;
   line-height: 1.45;
   opacity: 0.95;
-}
-
-/* Wrap around the description <p>. Collapsed state uses the WebKit
-   line-clamp triplet to cap visible content at ~3 lines; expanded state
-   removes the clamp so the full description shows. The wrapper (not the
-   inner <p>) carries the clamp so the JS overflow check has a stable
-   element to measure (`scrollHeight > clientHeight`). */
-.tour-annotation-description-wrap {
-  display: -webkit-box;
-  -webkit-box-orient: vertical;
-  -webkit-line-clamp: 3;
-  line-clamp: 3;
-  overflow: hidden;
-}
-
-.tour-annotation-description-wrap.expanded {
-  display: block;
-  -webkit-line-clamp: unset;
-  line-clamp: unset;
-  overflow: visible;
-}
-
-/* Footer holds only the "Show more"/"Show less" toggle when the
-   description overflows the line-clamp; otherwise it's an empty stub.
-   Chat about lives in the header now. */
-.tour-annotation-footer {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  margin-top: 4px;
-}
-
-.tour-annotation-footer:empty {
-  display: none;
-}
-
-/* "Show more" / "Show less" toggle. Styled as a borderless amber link
-   button so it reads as part of the tour annotation but doesn't compete
-   with the primary Chat about action. */
-.tour-annotation-show-more-btn {
-  appearance: none;
-  background: none;
-  border: 0;
-  padding: 2px 4px;
-  margin: 0;
-  font: inherit;
-  font-size: 12px;
-  font-weight: 600;
-  color: #7d5700;
-  cursor: pointer;
-  text-decoration: underline;
-  text-underline-offset: 2px;
-  border-radius: var(--radius-sm, 3px);
-}
-
-.tour-annotation-show-more-btn:hover {
-  color: #5b3f00;
-  background: rgba(255, 255, 255, 0.45);
-}
-
-.tour-annotation-show-more-btn:focus-visible {
-  outline: 2px solid #d4a72c;
-  outline-offset: 1px;
-}
-
-[data-theme="dark"] .tour-annotation-show-more-btn {
-  color: #e3b341;
-}
-
-[data-theme="dark"] .tour-annotation-show-more-btn:hover {
-  color: #f3c861;
-  background: rgba(187, 128, 9, 0.18);
 }
 
 /* The chat button on a tour-stop annotation reuses .ai-action / .ai-action-chat

--- a/public/js/modules/tour-renderer.js
+++ b/public/js/modules/tour-renderer.js
@@ -13,10 +13,10 @@
  *     still render as an HTML table. The stop mounts as a
  *     `<tr class="tour-annotation-row">` inserted immediately ABOVE the
  *     anchor row.
- * Both variants carry the SAME inner `.tour-annotation` card (title,
- * description, Prev/Next lives on the TourBar, Chat-about + Show-more here)
- * and the same `data-stop-index`, so page CSS and the navigator code are
- * agnostic to which path mounted them.
+ * Both variants carry the SAME inner `.tour-annotation` card (title, full
+ * description, Chat-about button; Prev/Next lives on the TourBar) and the
+ * same `data-stop-index`, so page CSS and the navigator code are agnostic to
+ * which path mounted them.
  *
  * Responsibilities:
  *   - Resolve a stop's anchor line by (file_path, side, [line_start, line_end])
@@ -109,12 +109,6 @@ class TourRenderer {
     // PR diff. Removed in unmountAll so the user's persistent context-files
     // list isn't polluted by transient tour state.
     this._autoAddedContextFileIds = new Set();
-    // Set<number> — stop indices whose description the user has expanded
-    // via "Show more". Survives unmount/remount within the same tour
-    // session (e.g. when the user scrolls past, then back to, the stop)
-    // so the description doesn't snap back to its clamped form. Cleared
-    // when setStops replaces the tour entirely.
-    this._expandedDescriptions = new Set();
     // Cache the user's motion preference at construction so scrollIntoView
     // honors it on every navigation. Reading matchMedia each call would
     // still work; caching just avoids the lookup.
@@ -139,10 +133,6 @@ class TourRenderer {
   setStops(stops) {
     this.unmountAll();
     this._stops = Array.isArray(stops) ? stops : [];
-    // A new stops list silently remaps indices; previously-expanded entries
-    // would point at the wrong descriptions. Reset rather than carry stale
-    // state across.
-    this._expandedDescriptions.clear();
     this._activeIndex = -1;
   }
 
@@ -425,7 +415,7 @@ class TourRenderer {
     this._ensureTourStopRendererRegistered();
     const id = this._pierreAnnotationId(index);
     // Record BEFORE adding so the renderer callback (fired synchronously by
-    // addAnnotation) can resolve active-stop / expanded state for this index.
+    // addAnnotation) can resolve the active-stop state for this index.
     this._pierreMounts.set(index, { filePath, side, id, anchorLine });
     if (typeof bridge.addAnnotation === 'function') {
       bridge.addAnnotation(filePath, {
@@ -562,13 +552,6 @@ class TourRenderer {
     const row = this._buildAnnotationRow(index, stop, anchorRow);
     anchorRow.parentNode.insertBefore(row, anchorRow);
     this._mounted.set(index, row);
-
-    // Now that the row is in the live DOM, measure the description and
-    // append a "Show more" toggle if it actually overflows the clamp.
-    // Defer one frame (rAF when available, microtask in jsdom) so the
-    // browser has time to apply layout to the just-inserted node before
-    // we read `scrollHeight`. The helper is idempotent against re-mounts.
-    this._scheduleOverflowCheck(index);
     return row;
   }
 
@@ -645,8 +628,7 @@ class TourRenderer {
    * PierreBridge (once). The callback receives (data, id, fileName) and
    * returns the annotation card element the bridge slots below the anchor
    * line. It is re-invoked on every file rerender, so it rebuilds the card
-   * from CURRENT state (active-stop + expanded-description) each time and
-   * re-schedules the overflow probe.
+   * from CURRENT state (active-stop) each time.
    */
   _ensureTourStopRendererRegistered() {
     if (this._tourStopRendererRegistered) return;
@@ -657,9 +639,6 @@ class TourRenderer {
       const stop = this._stops[index];
       if (!stop) return null;
       const row = this._buildAnnotationDiv(index, stop);
-      // The element isn't in the DOM yet (the bridge slots it after this
-      // returns); defer the overflow measurement to the next frame.
-      this._scheduleOverflowCheck(index);
       return row;
     });
     this._tourStopRendererRegistered = true;
@@ -891,8 +870,8 @@ class TourRenderer {
 
   /**
    * Build the shared `.tour-annotation` card (marker + Chat button, title,
-   * clamped description, Show-more footer) used by both the legacy `<tr>` and
-   * the pierre `<div>` wrappers.
+   * full description) used by both the legacy `<tr>` and the pierre `<div>`
+   * wrappers.
    * @param {number} index
    * @param {Object} stop
    * @returns {HTMLDivElement}
@@ -939,145 +918,19 @@ class TourRenderer {
     title.className = 'tour-annotation-title';
     title.textContent = stop.title || '';
 
-    // The wrapper carries the CSS line-clamp so we can measure overflow
-    // (scrollHeight > clientHeight) on the SAME element that hosts the clamp.
-    // The inner <p> stays so existing selectors (.tour-annotation-description)
-    // — including tests and the e2e spec — keep working.
-    const descriptionWrap = document.createElement('div');
-    descriptionWrap.className = 'tour-annotation-description-wrap';
-    if (this._expandedDescriptions.has(index)) {
-      descriptionWrap.classList.add('expanded');
-    }
-
+    // Descriptions are always shown in full — they are short by design, so
+    // there is no truncation or "Show more" toggle. The prose width is capped
+    // to a readable measure in CSS (.tour-annotation-description), matching
+    // full-width comment/suggestion bodies.
     const description = document.createElement('p');
     description.className = 'tour-annotation-description';
     description.textContent = stop.description || '';
-    descriptionWrap.appendChild(description);
 
     annotation.appendChild(header);
     annotation.appendChild(title);
-    annotation.appendChild(descriptionWrap);
-
-    // Footer is reserved for the "Show more"/"Show less" toggle that the
-    // overflow check appends when the description is clamped. Empty when
-    // the description fits inline.
-    const footer = document.createElement('div');
-    footer.className = 'tour-annotation-footer';
-    annotation.appendChild(footer);
+    annotation.appendChild(description);
 
     return annotation;
-  }
-
-  /**
-   * Defer one frame, then evaluate description overflow for `index`. Real
-   * browsers need a layout pass before `scrollHeight` is meaningful on a
-   * just-inserted node; jsdom returns 0 either way, which is fine — there
-   * is no real overflow to detect.
-   *
-   * Uses `requestAnimationFrame` when present (real browsers), otherwise
-   * falls back to a 0ms timer (jsdom). Tests that want to force the
-   * overflow path can stub `scrollHeight` / `clientHeight` on the wrapper
-   * and call `_evaluateDescriptionOverflow(index)` directly without
-   * waiting for the timer.
-   *
-   * @param {number} index
-   */
-  _scheduleOverflowCheck(index) {
-    const run = () => this._evaluateDescriptionOverflow(index);
-    if (typeof requestAnimationFrame === 'function') {
-      requestAnimationFrame(run);
-    } else if (typeof setTimeout === 'function') {
-      setTimeout(run, 0);
-    } else {
-      run();
-    }
-  }
-
-  /**
-   * Synchronously read the description wrapper's overflow state and, if
-   * it overflows the line-clamp, append a "Show more" toggle to the stop's
-   * footer. Idempotent — calling it twice on the same row does NOT add
-   * two buttons.
-   *
-   * Overflow check: `scrollHeight > clientHeight + 1`. The 1px fudge
-   * dampens sub-pixel rounding noise on retina displays.
-   *
-   * Exported (as a regular method) so tests can stub scrollHeight /
-   * clientHeight on the wrapper before triggering the check, sidestepping
-   * jsdom's zero-layout default.
-   *
-   * @param {number} index
-   */
-  _evaluateDescriptionOverflow(index) {
-    const row = this._resolveRow(index);
-    if (!row || !row.isConnected) return;
-    const wrap = row.querySelector('.tour-annotation-description-wrap');
-    if (!wrap) return;
-    const footer = row.querySelector('.tour-annotation-footer');
-    if (!footer) return;
-    // Idempotency guard — re-running after a remount must not add a
-    // second button.
-    if (footer.querySelector('.tour-annotation-show-more-btn')) return;
-    // Don't show the toggle when the user already expanded this stop;
-    // the wrapper has no overflow to detect in that state.
-    if (this._expandedDescriptions.has(index)) {
-      this._appendShowMoreButton(index, row, /* expanded */ true);
-      return;
-    }
-    const overflows = wrap.scrollHeight > wrap.clientHeight + 1;
-    if (!overflows) return;
-    this._appendShowMoreButton(index, row, /* expanded */ false);
-  }
-
-  /**
-   * Build and insert the "Show more"/"Show less" button into the stop's
-   * footer. The Chat about button now lives in the header, so the footer
-   * is dedicated to the show-more toggle.
-   *
-   * @param {number} index
-   * @param {HTMLElement} row
-   * @param {boolean} expanded
-   */
-  _appendShowMoreButton(index, row, expanded) {
-    const footer = row.querySelector('.tour-annotation-footer');
-    if (!footer) return;
-    const wrap = row.querySelector('.tour-annotation-description-wrap');
-    if (!wrap) return;
-    const btn = document.createElement('button');
-    btn.type = 'button';
-    btn.className = 'tour-annotation-show-more-btn';
-    btn.dataset.stopIndex = String(index);
-    btn.textContent = expanded ? 'Show less' : 'Show more';
-    btn.setAttribute('aria-expanded', expanded ? 'true' : 'false');
-    btn.addEventListener('click', (e) => {
-      e.stopPropagation();
-      this._toggleDescriptionExpansion(index);
-    });
-    footer.appendChild(btn);
-  }
-
-  /**
-   * Flip the expanded state for stop `index`: toggles the wrapper's
-   * `.expanded` class and the button label. Persists the index into
-   * `_expandedDescriptions` so a remount restores the expanded state.
-   *
-   * @param {number} index
-   */
-  _toggleDescriptionExpansion(index) {
-    const row = this._resolveRow(index);
-    if (!row) return;
-    const wrap = row.querySelector('.tour-annotation-description-wrap');
-    const btn = row.querySelector('.tour-annotation-show-more-btn');
-    if (!wrap || !btn) return;
-    const willExpand = !wrap.classList.contains('expanded');
-    wrap.classList.toggle('expanded', willExpand);
-    btn.textContent = willExpand ? 'Show less' : 'Show more';
-    btn.setAttribute('aria-expanded', willExpand ? 'true' : 'false');
-    if (willExpand) {
-      this._expandedDescriptions.add(index);
-    } else {
-      this._expandedDescriptions.delete(index);
-    }
   }
 
   /**

--- a/tests/e2e/tour.spec.js
+++ b/tests/e2e/tour.spec.js
@@ -225,16 +225,15 @@ for (const mode of MODES) {
       await expect(bar.locator('.tour-bar__progress')).toContainText('complete');
     });
 
-    test('long description shows a Show more toggle that expands and collapses', async ({ page }) => {
+    test('long description is shown in full with no Show more toggle', async ({ page }) => {
       await enableToursConfig(page);
-      // Build a stop with a deliberately long description so the
-      // line-clamp triggers the overflow probe. ~700 chars is well past
-      // what fits in the 3-line clamp at the annotation's font size.
+      // A deliberately long description: it must render in full — no
+      // truncation, line-clamp, or "Show more" toggle.
       const LONG_DESC =
         'This stop deserves a longer explanation because the surrounding code carries a lot of subtle invariants that only become visible when you read through every branch carefully and consider what would happen if a caller passes unexpected inputs. ' +
         'The reviewer should pay particular attention to the error-handling path, where a silent swallow could mask a real upstream bug. ' +
         'The change touches both the happy path and the rollback path, so make sure each is exercised by a test before approving. ' +
-        'Extra context follows so the description actually overflows the three-line clamp regardless of viewport width.';
+        'Extra context follows so the description is unmistakably longer than three lines at any viewport width.';
       const longStops = [
         {
           ...FIXED_STOPS[0],
@@ -245,6 +244,10 @@ for (const mode of MODES) {
       ];
       await mockTourEndpoint(page, longStops);
 
+      // A wide viewport so the diff column is comfortably wider than the
+      // capped prose measure — that gap is what the width assertions below
+      // discriminate on.
+      await page.setViewportSize({ width: 1600, height: 900 });
       await page.goto(mode.path);
       await waitForDiffToRender(page);
       await page.locator('#tour-toggle-btn').click();
@@ -252,24 +255,36 @@ for (const mode of MODES) {
       const stopRow = page.locator('.tour-annotation-row[data-stop-index="0"]');
       await expect(stopRow).toBeVisible();
 
-      const wrap = stopRow.locator('.tour-annotation-description-wrap');
-      const btn = stopRow.locator('.tour-annotation-show-more-btn');
+      const card = stopRow.locator('.tour-annotation');
+      const description = stopRow.locator('.tour-annotation-description');
+      await expect(description).toBeVisible();
+      // Full text is present verbatim.
+      await expect(description).toHaveText(LONG_DESC);
 
-      // The overflow probe runs on the next rAF after mount; allow Playwright's
-      // auto-waiting to find the button once it appears.
-      await expect(btn).toBeVisible();
-      await expect(btn).toHaveText('Show more');
-      await expect(wrap).not.toHaveClass(/expanded/);
+      // None of the old truncation machinery exists.
+      await expect(stopRow.locator('.tour-annotation-show-more-btn')).toHaveCount(0);
+      await expect(stopRow.locator('.tour-annotation-description-wrap')).toHaveCount(0);
 
-      // Expand.
-      await btn.click();
-      await expect(wrap).toHaveClass(/expanded/);
-      await expect(btn).toHaveText('Show less');
+      // The description is not clamped: its rendered height must exceed a
+      // single line, proving the full multi-line text is laid out.
+      const scrollH = await description.evaluate((el) => el.scrollHeight);
+      const clientH = await description.evaluate((el) => el.clientHeight);
+      expect(clientH).toBeGreaterThan(40); // several lines tall
+      expect(scrollH).toBeLessThanOrEqual(clientH + 1); // nothing hidden by overflow
 
-      // Collapse again.
-      await btn.click();
-      await expect(wrap).not.toHaveClass(/expanded/);
-      await expect(btn).toHaveText('Show more');
+      // Primary objective: the CARD spans the diff width while only the PROSE
+      // stays capped. Measure both. A regression that re-caps the whole card
+      // to the prose measure (the pre-change behavior) would collapse the
+      // card down to ~description width and fail these.
+      const cardW = await card.evaluate((el) => el.getBoundingClientRect().width);
+      const rowW = await stopRow.evaluate((el) => el.getBoundingClientRect().width);
+      const descW = await description.evaluate((el) => el.getBoundingClientRect().width);
+      // Card fills (most of) its row — it is NOT narrowed to a prose measure.
+      expect(cardW).toBeGreaterThan(rowW * 0.8);
+      // And the capped prose is meaningfully narrower than the wide card
+      // (padding alone is ~28px; require a real gap so an 80ch-wide card
+      // regression, where card ≈ prose, cannot pass).
+      expect(cardW - descW).toBeGreaterThan(120);
     });
 
     test('Escape exits the tour and restores normal view', async ({ page }) => {

--- a/tests/unit/tour-renderer.test.js
+++ b/tests/unit/tour-renderer.test.js
@@ -888,118 +888,48 @@ describe('TourRenderer', () => {
   // removed so the user can toggle each independently.
   // ----------------------------------------------------------------------
   // ----------------------------------------------------------------------
-  // "Show more" / "Show less" toggle for long descriptions.
-  //
-  // jsdom returns 0 for both scrollHeight and clientHeight (no layout
-  // engine), so the overflow check always returns false there. To force
-  // the overflow path in tests we stub `scrollHeight` / `clientHeight`
-  // on the wrapper element via `Object.defineProperty`, then call
-  // `_evaluateDescriptionOverflow` directly (bypassing the rAF defer
-  // that mountStop normally uses to wait for browser layout).
+  // Descriptions are always shown in full. There is no truncation, no
+  // line-clamp wrapper, and no "Show more" toggle — stops are short by
+  // design, so the full text renders inline. (The prose width is capped in
+  // CSS to a readable measure; that is not observable in jsdom.)
   // ----------------------------------------------------------------------
-  describe('show more / show less toggle', () => {
-    async function mountWithOverflow({ overflow, expanded } = { overflow: true }) {
-      buildDiff();
-      renderer.setStops([makeStop({ line_start: 11, description: 'long desc' })]);
-      if (expanded) {
-        renderer._expandedDescriptions.add(0);
-      }
-      const row = await renderer.mountStop(0);
-      const wrap = row.querySelector('.tour-annotation-description-wrap');
-      // Stub overflow geometry. jsdom returns 0 for both by default —
-      // defineProperty is the standard escape hatch for this exact case.
-      Object.defineProperty(wrap, 'scrollHeight', {
-        configurable: true,
-        value: overflow ? 200 : 30,
-      });
-      Object.defineProperty(wrap, 'clientHeight', {
-        configurable: true,
-        value: 60,
-      });
-      // Evaluate synchronously so we don't have to wait for the rAF
-      // scheduled inside mountStop.
-      renderer._evaluateDescriptionOverflow(0);
-      return { row, wrap };
-    }
+  describe('description always shows in full', () => {
+    const LONG_DESC =
+      'This stop deserves a longer explanation because the surrounding code ' +
+      'carries a lot of subtle invariants that only become visible when you ' +
+      'read through every branch carefully and consider unexpected inputs. ' +
+      'The reviewer should pay particular attention to the error-handling ' +
+      'path, where a silent swallow could mask a real upstream bug.';
 
-    it('wraps the description in a clamp container', async () => {
+    it('renders the full description text with no clamp wrapper', async () => {
       buildDiff();
-      renderer.setStops([makeStop({ line_start: 11 })]);
+      renderer.setStops([makeStop({ line_start: 11, description: LONG_DESC })]);
       const row = await renderer.mountStop(0);
-      const wrap = row.querySelector('.tour-annotation-description-wrap');
-      expect(wrap).toBeTruthy();
-      // Description <p> still exists inside the wrap for backwards
-      // compatibility with existing selectors.
-      const p = wrap.querySelector('.tour-annotation-description');
+      const p = row.querySelector('.tour-annotation-description');
       expect(p).toBeTruthy();
+      // Full text, verbatim — no truncation.
+      expect(p.textContent).toBe(LONG_DESC);
+      // The old clamp wrapper is gone; the <p> is a direct child of the card.
+      expect(row.querySelector('.tour-annotation-description-wrap')).toBeNull();
+      expect(p.parentElement.classList.contains('tour-annotation')).toBe(true);
     });
 
-    it('does NOT render a Show more button when the description fits', async () => {
-      const { row } = await mountWithOverflow({ overflow: false });
+    it('never renders a Show more button, even for a long description', async () => {
+      buildDiff();
+      renderer.setStops([makeStop({ line_start: 11, description: LONG_DESC })]);
+      const row = await renderer.mountStop(0);
       expect(row.querySelector('.tour-annotation-show-more-btn')).toBeNull();
+      // No leftover footer stub either.
+      expect(row.querySelector('.tour-annotation-footer')).toBeNull();
     });
 
-    it('renders a Show more button when the description overflows', async () => {
-      const { row } = await mountWithOverflow({ overflow: true });
-      const btn = row.querySelector('.tour-annotation-show-more-btn');
-      expect(btn).toBeTruthy();
-      expect(btn.textContent).toBe('Show more');
-      expect(btn.getAttribute('aria-expanded')).toBe('false');
-    });
-
-    it('clicking Show more flips to Show less and adds .expanded', async () => {
-      const { row, wrap } = await mountWithOverflow({ overflow: true });
-      const btn = row.querySelector('.tour-annotation-show-more-btn');
-      btn.click();
-      expect(wrap.classList.contains('expanded')).toBe(true);
-      expect(btn.textContent).toBe('Show less');
-      expect(btn.getAttribute('aria-expanded')).toBe('true');
-    });
-
-    it('clicking Show less reverses the expansion', async () => {
-      const { row, wrap } = await mountWithOverflow({ overflow: true });
-      const btn = row.querySelector('.tour-annotation-show-more-btn');
-      btn.click();
-      btn.click();
-      expect(wrap.classList.contains('expanded')).toBe(false);
-      expect(btn.textContent).toBe('Show more');
-      expect(btn.getAttribute('aria-expanded')).toBe('false');
-    });
-
-    it('a remount preserves the expanded state for the same stop index', async () => {
-      // First mount: expand.
-      const first = await mountWithOverflow({ overflow: true });
-      first.row.querySelector('.tour-annotation-show-more-btn').click();
-      expect(renderer._expandedDescriptions.has(0)).toBe(true);
-
-      // Unmount and re-mount the same index.
-      renderer.unmountStop(0);
-      const row2 = await renderer.mountStop(0);
-      const wrap2 = row2.querySelector('.tour-annotation-description-wrap');
-      // The wrap should be in expanded state immediately on re-mount
-      // (no need to wait for the overflow probe to fire).
-      expect(wrap2.classList.contains('expanded')).toBe(true);
-      // And calling the evaluator should append the toggle in its
-      // "Show less" form, not Show more.
-      renderer._evaluateDescriptionOverflow(0);
-      const btn2 = row2.querySelector('.tour-annotation-show-more-btn');
-      expect(btn2).toBeTruthy();
-      expect(btn2.textContent).toBe('Show less');
-    });
-
-    it('setStops resets _expandedDescriptions (indices remap to new stops)', async () => {
-      await mountWithOverflow({ overflow: true });
-      renderer._toggleDescriptionExpansion(0);
-      expect(renderer._expandedDescriptions.size).toBe(1);
-      renderer.setStops([makeStop({ line_start: 12 })]);
-      expect(renderer._expandedDescriptions.size).toBe(0);
-    });
-
-    it('overflow evaluation is idempotent (no duplicate buttons on re-call)', async () => {
-      const { row } = await mountWithOverflow({ overflow: true });
-      renderer._evaluateDescriptionOverflow(0);
-      renderer._evaluateDescriptionOverflow(0);
-      expect(row.querySelectorAll('.tour-annotation-show-more-btn')).toHaveLength(1);
+    it('drops the overflow/expansion machinery entirely', () => {
+      // These methods and state were removed with the Show-more feature.
+      expect(renderer._expandedDescriptions).toBeUndefined();
+      expect(renderer._evaluateDescriptionOverflow).toBeUndefined();
+      expect(renderer._appendShowMoreButton).toBeUndefined();
+      expect(renderer._toggleDescriptionExpansion).toBeUndefined();
+      expect(renderer._scheduleOverflowCheck).toBeUndefined();
     });
   });
 
@@ -1142,6 +1072,34 @@ describe('TourRenderer — pierre-rendered files (annotation path)', () => {
     // Tracked as a pierre mount, not a legacy one.
     expect(r._pierreMounts.has(0)).toBe(true);
     expect(r._pierreMounts.get(0).id).toBe('tour-stop-0');
+  });
+
+  it('renders the full description with no clamp/footer/Show-more on the pierre path', async () => {
+    // Parity insurance: `_buildAnnotationInner` is shared, but assert the
+    // pierre-slotted card directly so a future pierre-specific divergence
+    // (or a regression of the removed truncation DOM) is caught here too.
+    const LONG_DESC =
+      'A deliberately long description that would once have been clamped to ' +
+      'three lines and hidden behind a Show more toggle; it must now render ' +
+      'in full inside the pierre-slotted annotation card, verbatim.';
+    const { bridge, container } = makePierreEnv({ visibleLines: ['RIGHT:11'] });
+    const r = new TourRenderer({ pierreBridge: bridge, _tourGen: 1 });
+    r.setStops([
+      makeStop({ file_path: 'src/pierre.js', line_start: 11, line_end: 11, description: LONG_DESC }),
+    ]);
+
+    const row = await r.mountStop(0);
+    const p = row.querySelector('.tour-annotation-description');
+    expect(p).toBeTruthy();
+    expect(p.textContent).toBe(LONG_DESC);
+    // The <p> is a direct child of the card — no clamp wrapper in between.
+    expect(p.parentElement.classList.contains('tour-annotation')).toBe(true);
+    // None of the removed truncation DOM exists on the pierre card.
+    expect(row.querySelector('.tour-annotation-description-wrap')).toBeNull();
+    expect(row.querySelector('.tour-annotation-footer')).toBeNull();
+    expect(row.querySelector('.tour-annotation-show-more-btn')).toBeNull();
+    // The slotted element in the container is the same, fully-expanded card.
+    expect(container.querySelector('.tour-annotation-show-more-btn')).toBeNull();
   });
 
   it('anchors at line_end, scanning back through the range to the first visible line', async () => {


### PR DESCRIPTION
## Summary

The recent full-width comments/suggestions change narrowed tour stop annotations too far — the `.tour-annotation` card was capped at the prose measure (`80ch`) as a whole, so stops looked too cramped (especially in unified view).

This change:

1. **Widens tour stops.** The card now spans the diff width (viewport-guarded), matching full-width comments/suggestions. Only the description *prose* is capped to a readable measure (`min(100%, var(--annotation-prose-max, 80ch))`), the same pattern as `.user-comment-body` — so the card is wide while the text stays readable.
2. **Always shows the full description.** Removes the truncation and "Show more"/"Show less" toggle entirely — stops are short by design. This drops the line-clamp wrapper, footer, and all toggle machinery (`_expandedDescriptions`, `_scheduleOverflowCheck`, `_evaluateDescriptionOverflow`, `_appendShowMoreButton`, `_toggleDescriptionExpansion`) across **both** the legacy table and pierre render engines, which share `_buildAnnotationInner`.

## Tests

- **Unit:** asserts full-text rendering and absence of the removed DOM on both the legacy and pierre paths (61 passing).
- **E2E:** replaces the Show-more toggle test with a full-description test, plus a wide-viewport guard that the card spans the row while the prose stays capped — guarding against a regression that re-caps the whole card (14 passing, PR + Local).

## Review

Reviewed via pair-review **Dream Team** council (2 rounds). Round 1 surfaced 3 stale comments + 2 test-coverage gaps (all fixed); the blockers-only gate round returned no findings: *"No blocking issues... It is ready to merge."*

🤖 Generated with [Claude Code](https://claude.com/claude-code)