### PR TITLE
feat: add dismissal reasons for AI suggestions

### DIFF
--- a/.changeset/suggestion-dismissal-reasons.md
+++ b/.changeset/suggestion-dismissal-reasons.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Add dismissal reasons for AI suggestions. The suggestion status endpoint (`POST /api/reviews/:reviewId/suggestions/:id/status`) now accepts an optional `reason` string (≤2000 chars) that is stored and returned as `status_reason` on suggestion objects. The reason is valid only with status `"dismissed"` (400 if sent with `"active"`), and restoring a suggestion to active clears any stored reason. The loop (pair-loop plugin) and in-app chat agents write a one-sentence explanation when dismissing after discussion, and the UI renders it as a reply-styled note beneath the suggestion. Deleting a comment that was adopted from a suggestion now dismisses the parent suggestion with an auto-generated reason noting the adopted comment was removed. Documented in the chat API reference and cheat sheet (served via `GET /api.md`).

--- a/plugin-pair-loop/skills/loop/SKILL.md
+++ b/plugin-pair-loop/skills/loop/SKILL.md
@@ -162,11 +162,12 @@ curl -s -X POST http://localhost:<port>/api/reviews/<run.review_id>/suggestions/
 
 - Only `"dismissed"` and `"active"` are accepted; `"adopted"` is reserved
   for the human's adopt flow — never send it.
-- Newer servers accept a `reason` field on this endpoint (check
-  `http://localhost:<port>/api.md?reviewId=<reviewId>` if unsure); when
-  supported, include it: `"Fixed in loop round <n>: ..."` or
-  `"Dismissed: <why>"`. Otherwise the fixed-vs-rejected distinction lives in
-  your round log and final report.
+- Current servers accept a `reason` field on this endpoint — include it:
+  `"Fixed in loop round <n>: ..."` or `"Dismissed: <why>"`. Older servers
+  (still in the wild) ignore it; if you need to confirm support, check that
+  `http://localhost:<port>/api.md?reviewId=<reviewId>` documents `reason`.
+  When unsupported, the fixed-vs-rejected distinction lives in your round log
+  and final report.
 - The human may be triaging in the same UI: before fixing, you may re-check
   `GET /api/reviews/<reviewId>/suggestions` and skip findings whose status
   is no longer `active` — the human got there first. Do not resurrect

--- a/public/css/pr.css
+++ b/public/css/pr.css
@@ -2436,6 +2436,32 @@ tr.newly-expanded .d2h-code-line-ctn {
   background: none;
 }
 
+/* Dismissal reason section appended below the reasoning bullets in the popover.
+   Uses the same themeable variables as the rest of the popover, so it adapts to
+   both light and dark. Rendered on its own when a suggestion has a dismissal
+   reason but no reasoning steps. */
+.reasoning-popover-dismissal {
+  margin-top: 10px;
+  padding-top: 10px;
+  border-top: 1px solid var(--color-border-secondary, rgba(255, 255, 255, 0.06));
+}
+
+.reasoning-popover-content > .reasoning-popover-dismissal:first-child {
+  margin-top: 0;
+  padding-top: 0;
+  border-top: none;
+}
+
+.reasoning-popover-dismissal-heading {
+  display: block;
+  margin-bottom: 4px;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-text-tertiary, #6e7681);
+}
+
 /* Compact reasoning button in collapsed suggestion rows */
 .ai-suggestion.collapsed .ai-suggestion-header-right {
   margin-left: auto;
@@ -2620,20 +2646,58 @@ tr.newly-expanded .d2h-code-line-ctn {
   position: relative;
 }
 
-.collapsed-text {
-  color: var(--color-text-tertiary);
-  font-style: italic;
-  font-size: 12px;
-}
-
 .collapsed-title {
-  flex: 1;
+  flex: 0 1 auto;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
   color: var(--color-text-secondary);
   min-width: 0;
   font-size: 13px;
+}
+
+/* Expanded reply-styled dismissal note. Mirrors the external-comment
+   `is-reply` treatment: indented, muted, with a small label. Sits under the
+   suggestion body of a dismissed suggestion. Hidden while the card is
+   collapsed (the body is hidden then too). */
+.ai-dismissal-note {
+  margin: 4px 16px 12px 32px;
+  padding: 8px 12px;
+  border-left: 3px solid var(--color-border-secondary, #d0d7de);
+  border-radius: 4px;
+  background: var(--color-bg-secondary, #f6f8fa);
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--color-text-secondary, #57606a);
+  max-width: min(100%, var(--annotation-prose-max, 80ch));
+  box-sizing: border-box;
+}
+
+.ai-dismissal-note-label {
+  display: block;
+  font-weight: 600;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--color-text-tertiary, #6e7681);
+  margin-bottom: 2px;
+}
+
+.ai-dismissal-note-body {
+  display: block;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+}
+
+.ai-suggestion.collapsed .ai-dismissal-note {
+  display: none;
+}
+
+[data-theme="dark"] .ai-dismissal-note {
+  background: var(--color-bg-tertiary, #161b22);
+  border-left-color: var(--color-border-secondary, #30363d);
+  color: var(--color-text-secondary, #8b949e);
 }
 
 .ai-suggestion.collapsed .ai-suggestion-header {
@@ -9284,6 +9348,20 @@ body.resizing * {
 
 .finding-item.finding-dismissed .finding-dot {
   opacity: 0.5;
+}
+
+/* Muted second line under a dismissed finding's title carrying the reason it
+   was dismissed. Truncation is done in JS; ellipsis guards long single words.
+   Not struck through (the reason is meta about the dismissal, not the title). */
+.finding-dismissal-reason {
+  font-size: 11px;
+  font-style: italic;
+  color: var(--color-text-tertiary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 100%;
+  text-decoration: none;
 }
 
 /* Status indicator icon in lower right corner for dismissed - no-entry symbol (circle with diagonal line) */

--- a/public/js/components/AIPanel.js
+++ b/public/js/components/AIPanel.js
@@ -1623,6 +1623,14 @@ class AIPanel {
         const category = finding.category || finding.type || '';
         const isActive = finding.status !== 'dismissed' && finding.status !== 'adopted';
 
+        // Dismissal reason: only shown for dismissed findings that carry one.
+        // Full text goes in the item tooltip; a truncated muted line renders
+        // under the title.
+        const dismissalReason = finding.status === 'dismissed' ? (finding.status_reason || '') : '';
+        const itemTitle = dismissalReason
+            ? (fullLocation ? `${fullLocation} — ${dismissalReason}` : dismissalReason)
+            : fullLocation;
+
         // Use star icon for praise, dot for other types
         const indicator = type === 'praise'
             ? `<span class="finding-star">${this.getTypeIcon('praise')}</span>`
@@ -1667,12 +1675,13 @@ class AIPanel {
 
         return `
             <div class="finding-item-wrapper">
-                <button class="finding-item finding-${type} ${statusClass}" data-index="${index}" data-id="${finding.id || ''}" data-file="${finding.file || ''}" data-line="${lineNum || ''}" data-item-type="finding" title="${fullLocation}">
+                <button class="finding-item finding-${type} ${statusClass}" data-index="${index}" data-id="${finding.id || ''}" data-file="${finding.file || ''}" data-line="${lineNum || ''}" data-item-type="finding" title="${window.escapeHtmlAttribute(itemTitle)}">
                     ${indicator}
                     <div class="finding-content">
                         <span class="finding-title">${this.escapeHtml(title)}</span>
                         ${category || finding.severity ? `<span class="finding-meta">${category ? `<span class="finding-category">${this.escapeHtml(category)}</span>` : ''}${finding.severity ? `<span class="severity-badge severity-${finding.severity}">${this.escapeHtml(finding.severity.toUpperCase())}</span>` : ''}</span>` : ''}
                         ${fileName ? `<span class="finding-location">${this.escapeHtml(fileName)}</span>` : ''}
+                        ${dismissalReason ? `<span class="finding-dismissal-reason">${this.escapeHtml(this.truncateText(dismissalReason, 60))}</span>` : ''}
                     </div>
                 </button>
                 ${quickActions}
@@ -1906,6 +1915,19 @@ class AIPanel {
                 findingEl.classList.add('finding-adopted');
             } else {
                 findingEl.classList.add('finding-active');
+            }
+
+            // Leaving the dismissed state: strip the stale dismissal-reason line
+            // and reset the tooltip to the plain location. renderFindingItem only
+            // adds these for dismissed findings, so an in-place status swap must
+            // undo them here (the finding may keep a status_reason in the array).
+            if (status !== 'dismissed') {
+                const reasonSpan = findingEl.querySelector('.finding-dismissal-reason');
+                if (reasonSpan) reasonSpan.remove();
+                const filePath = finding?.file || findingEl.dataset.file || '';
+                const fileName = filePath ? filePath.split('/').pop() : null;
+                const lineNum = finding?.line_start || findingEl.dataset.line || '';
+                findingEl.title = fileName ? `${fileName}${lineNum ? ':' + lineNum : ''}` : '';
             }
 
             const wrapper = findingEl.closest('.finding-item-wrapper');

--- a/public/js/modules/file-comment-manager.js
+++ b/public/js/modules/file-comment-manager.js
@@ -474,6 +474,19 @@ class FileCommentManager {
       card.classList.add('collapsed');
     }
 
+    // Collapsed-bar state tooltip (replaces the old inline state text).
+    const collapsedStateLabel = isAdopted ? 'Adopted' : (isDismissed ? 'Dismissed' : '');
+
+    // The reasoning brain button surfaces both the reasoning steps and, when the
+    // suggestion was dismissed with a recorded reason, that reason. Show the
+    // button when either is present. data-reasoning holds the steps;
+    // data-dismissal-reason holds the (agent-controlled) reason, encoded so
+    // quotes/angle brackets cannot break out of the attribute.
+    const hasReasoning = Array.isArray(suggestion.reasoning) && suggestion.reasoning.length > 0;
+    const dismissalReasonAttr = suggestion.status_reason ? encodeURIComponent(suggestion.status_reason) : '';
+    const reasoningDataAttr = hasReasoning ? encodeURIComponent(JSON.stringify(suggestion.reasoning)) : '';
+    const showReasoningBtn = hasReasoning || !!suggestion.status_reason;
+
     // Get category label for display (same as line-level)
     const categoryLabel = suggestion.type || suggestion.category || '';
 
@@ -494,22 +507,21 @@ class FileCommentManager {
           <span class="ai-title">${this.escapeHtml(suggestion.title || '')}</span>
         </div>
         <div class="ai-suggestion-header-right">
-          ${suggestion.reasoning && suggestion.reasoning.length > 0 ? `
-          <button class="btn-reasoning-toggle" title="View reasoning" data-suggestion-id="${suggestion.id}" data-reasoning="${encodeURIComponent(JSON.stringify(suggestion.reasoning))}">
+          ${showReasoningBtn ? `
+          <button class="btn-reasoning-toggle" title="View reasoning" data-suggestion-id="${suggestion.id}" data-reasoning="${reasoningDataAttr}" data-dismissal-reason="${dismissalReasonAttr}">
             <svg viewBox="0 0 24 24" width="14" height="14" fill="currentColor"><path d="M21.33 12.91c.09 1.55-.62 3.04-1.89 3.95l.77 1.49c.23.45.26.98.06 1.45c-.19.47-.58.84-1.06 1l-.79.25a1.69 1.69 0 0 1-1.86-.55L14.44 18c-.89-.15-1.73-.53-2.44-1.1c-.5.15-1 .23-1.5.23c-.88 0-1.76-.27-2.5-.79c-.53.16-1.07.23-1.62.22c-.79.01-1.57-.15-2.3-.45a4.1 4.1 0 0 1-2.43-3.61c-.08-.72.04-1.45.35-2.11c-.29-.75-.32-1.57-.07-2.33C2.3 7.11 3 6.32 3.87 5.82c.58-1.69 2.21-2.82 4-2.7c1.6-1.5 4.05-1.66 5.83-.37c.42-.11.86-.17 1.3-.17c1.36-.03 2.65.57 3.5 1.64c2.04.53 3.5 2.35 3.58 4.47c.05 1.11-.25 2.2-.86 3.13c.07.36.11.72.11 1.09m-5-1.41c.57.07 1.02.5 1.02 1.07a1 1 0 0 1-1 1h-.63c-.32.9-.88 1.69-1.62 2.29c.25.09.51.14.77.21c5.13-.07 4.53-3.2 4.53-3.25a2.59 2.59 0 0 0-2.69-2.49a1 1 0 0 1-1-1a1 1 0 0 1 1-1c1.23.03 2.41.49 3.33 1.3c.05-.29.08-.59.08-.89c-.06-1.24-.62-2.32-2.87-2.53c-1.25-2.96-4.4-1.32-4.4-.4c-.03.23.21.72.25.75a1 1 0 0 1 1 1c0 .55-.45 1-1 1c-.53-.02-1.03-.22-1.43-.56c-.48.31-1.03.5-1.6.56c-.57.05-1.04-.35-1.07-.9a.97.97 0 0 1 .88-1.1c.16-.02.94-.14.94-.77c0-.66.25-1.29.68-1.79c-.92-.25-1.91.08-2.91 1.29C6.75 5 6 5.25 5.45 7.2C4.5 7.67 4 8 3.78 9c1.08-.22 2.19-.13 3.22.25c.5.19.78.75.59 1.29c-.19.52-.77.78-1.29.59c-.73-.32-1.55-.34-2.3-.06c-.32.27-.32.83-.32 1.27c0 .74.37 1.43 1 1.83c.53.27 1.12.41 1.71.4q-.225-.39-.39-.81a1.038 1.038 0 0 1 1.96-.68c.4 1.14 1.42 1.92 2.62 2.05c1.37-.07 2.59-.88 3.19-2.13c.23-1.38 1.34-1.5 2.56-1.5m2 7.47l-.62-1.3l-.71.16l1 1.25zm-4.65-8.61a1 1 0 0 0-.91-1.03c-.71-.04-1.4.2-1.93.67c-.57.58-.87 1.38-.84 2.19a1 1 0 0 0 1 1c.57 0 1-.45 1-1c0-.27.07-.54.23-.76c.12-.1.27-.15.43-.15c.55.03 1.02-.38 1.02-.92"/></svg>
           </button>
           ` : ''}
         </div>
       </div>
-      <div class="ai-suggestion-collapsed-content">
+      <div class="ai-suggestion-collapsed-content"${collapsedStateLabel ? ` title="${collapsedStateLabel}"` : ''}>
         ${suggestion.type === 'praise'
           ? `<span class="praise-badge" title="Nice Work"><svg viewBox="0 0 16 16"><path d="M8 .25a.75.75 0 01.673.418l1.882 3.815 4.21.612a.75.75 0 01.416 1.279l-3.046 2.97.719 4.192a.75.75 0 01-1.088.791L8 12.347l-3.766 1.98a.75.75 0 01-1.088-.79l.72-4.194L.818 6.374a.75.75 0 01.416-1.28l4.21-.611L7.327.668A.75.75 0 018 .25z"/></svg>Nice Work</span>`
           : `<span class="ai-suggestion-badge collapsed" data-type="${suggestion.type}" title="AI Suggestion"><svg viewBox="0 0 16 16" fill="currentColor" width="10" height="10"><path d="M9.6 2.279a.426.426 0 0 1 .8 0l.407 1.112a6.386 6.386 0 0 0 3.802 3.802l1.112.407a.426.426 0 0 1 0 .8l-1.112.407a6.386 6.386 0 0 0-3.802 3.802l-.407 1.112a.426.426 0 0 1-.8 0l-.407-1.112a6.386 6.386 0 0 0-3.802-3.802L4.279 8.4a.426.426 0 0 1 0-.8l1.112-.407a6.386 6.386 0 0 0 3.802-3.802L9.6 2.279Zm-4.267 8.837a.178.178 0 0 1 .334 0l.169.464a2.662 2.662 0 0 0 1.584 1.584l.464.169a.178.178 0 0 1 0 .334l-.464.169a2.662 2.662 0 0 0-1.584 1.584l-.169.464a.178.178 0 0 1-.334 0l-.169-.464a2.662 2.662 0 0 0-1.584-1.584l-.464-.169a.178.178 0 0 1 0-.334l.464-.169a2.662 2.662 0 0 0 1.584-1.584l.169-.464ZM2.8.14a.213.213 0 0 1 .4 0l.203.556a3.2 3.2 0 0 0 1.901 1.901l.556.203a.213.213 0 0 1 0 .4l-.556.203a3.2 3.2 0 0 0-1.901 1.901L3.2 5.86a.213.213 0 0 1-.4 0l-.203-.556A3.2 3.2 0 0 0 .696 3.403L.14 3.2a.213.213 0 0 1 0-.4l.556-.203A3.2 3.2 0 0 0 2.597.696L2.8.14Z"/></svg>AI Suggestion</span>`}
-        <span class="collapsed-text">${isAdopted ? 'Suggestion adopted' : 'Hidden AI suggestion'}</span>
         <span class="collapsed-title">${this.escapeHtml(suggestion.title || '')}</span>
         <div class="ai-suggestion-header-right">
-          ${suggestion.reasoning && suggestion.reasoning.length > 0 ? `
-          <button class="btn-reasoning-toggle collapsed-reasoning" title="View reasoning" data-suggestion-id="${suggestion.id}" data-reasoning="${encodeURIComponent(JSON.stringify(suggestion.reasoning))}">
+          ${showReasoningBtn ? `
+          <button class="btn-reasoning-toggle collapsed-reasoning" title="View reasoning" data-suggestion-id="${suggestion.id}" data-reasoning="${reasoningDataAttr}" data-dismissal-reason="${dismissalReasonAttr}">
             <svg viewBox="0 0 24 24" width="12" height="12" fill="currentColor"><path d="M21.33 12.91c.09 1.55-.62 3.04-1.89 3.95l.77 1.49c.23.45.26.98.06 1.45c-.19.47-.58.84-1.06 1l-.79.25a1.69 1.69 0 0 1-1.86-.55L14.44 18c-.89-.15-1.73-.53-2.44-1.1c-.5.15-1 .23-1.5.23c-.88 0-1.76-.27-2.5-.79c-.53.16-1.07.23-1.62.22c-.79.01-1.57-.15-2.3-.45a4.1 4.1 0 0 1-2.43-3.61c-.08-.72.04-1.45.35-2.11c-.29-.75-.32-1.57-.07-2.33C2.3 7.11 3 6.32 3.87 5.82c.58-1.69 2.21-2.82 4-2.7c1.6-1.5 4.05-1.66 5.83-.37c.42-.11.86-.17 1.3-.17c1.36-.03 2.65.57 3.5 1.64c2.04.53 3.5 2.35 3.58 4.47c.05 1.11-.25 2.2-.86 3.13c.07.36.11.72.11 1.09m-5-1.41c.57.07 1.02.5 1.02 1.07a1 1 0 0 1-1 1h-.63c-.32.9-.88 1.69-1.62 2.29c.25.09.51.14.77.21c5.13-.07 4.53-3.2 4.53-3.25a2.59 2.59 0 0 0-2.69-2.49a1 1 0 0 1-1-1a1 1 0 0 1 1-1c1.23.03 2.41.49 3.33 1.3c.05-.29.08-.59.08-.89c-.06-1.24-.62-2.32-2.87-2.53c-1.25-2.96-4.4-1.32-4.4-.4c-.03.23.21.72.25.75a1 1 0 0 1 1 1c0 .55-.45 1-1 1c-.53-.02-1.03-.22-1.43-.56c-.48.31-1.03.5-1.6.56c-.57.05-1.04-.35-1.07-.9a.97.97 0 0 1 .88-1.1c.16-.02.94-.14.94-.77c0-.66.25-1.29.68-1.79c-.92-.25-1.91.08-2.91 1.29C6.75 5 6 5.25 5.45 7.2C4.5 7.67 4 8 3.78 9c1.08-.22 2.19-.13 3.22.25c.5.19.78.75.59 1.29c-.19.52-.77.78-1.29.59c-.73-.32-1.55-.34-2.3-.06c-.32.27-.32.83-.32 1.27c0 .74.37 1.43 1 1.83c.53.27 1.12.41 1.71.4q-.225-.39-.39-.81a1.038 1.038 0 0 1 1.96-.68c.4 1.14 1.42 1.92 2.62 2.05c1.37-.07 2.59-.88 3.19-2.13c.23-1.38 1.34-1.5 2.56-1.5m2 7.47l-.62-1.3-.71.16l1 1.25zm-4.65-8.61a1 1 0 0 0-.91-1.03c-.71-.04-1.4.2-1.93.67c-.57.58-.87 1.38-.84 2.19a1 1 0 0 0 1 1c.57 0 1-.45 1-1c0-.27.07-.54.23-.76c.12-.1.27-.15.43-.15c.55.03 1.02-.38 1.02-.92"/></svg>
           </button>
           ` : ''}
@@ -524,6 +536,7 @@ class FileCommentManager {
       <div class="ai-suggestion-body">
         ${renderedBody}
       </div>
+      ${window.SuggestionUI?.buildDismissalNoteHtml?.(suggestion.status_reason) || ''}
       <div class="ai-suggestion-actions">
         <button class="ai-action ai-action-adopt">
           <svg viewBox="0 0 16 16" width="16" height="16"><path fill-rule="evenodd" d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z"></path></svg>
@@ -594,11 +607,7 @@ class FileCommentManager {
       const suggestionCard = zone.querySelector(`[data-suggestion-id="${suggestion.id}"]`);
       if (suggestionCard) {
         suggestionCard.classList.add('collapsed');
-        // Update collapsed text to show "Suggestion adopted"
-        const collapsedText = suggestionCard.querySelector('.collapsed-text');
-        if (collapsedText) {
-          collapsedText.textContent = 'Suggestion adopted';
-        }
+        window.SuggestionUI?.setCollapsedStateTooltip?.(suggestionCard, 'Adopted');
       }
 
       // Use the server-formatted body — server is the single source of truth
@@ -676,11 +685,7 @@ class FileCommentManager {
       const card = zone.querySelector(`[data-suggestion-id="${suggestionId}"]`);
       if (card) {
         card.classList.add('collapsed');
-        // Update collapsed text to show "Hidden AI suggestion"
-        const collapsedText = card.querySelector('.collapsed-text');
-        if (collapsedText) {
-          collapsedText.textContent = 'Hidden AI suggestion';
-        }
+        window.SuggestionUI?.setCollapsedStateTooltip?.(card, 'Dismissed');
       }
 
       this.updateCommentCount(zone);
@@ -728,6 +733,12 @@ class FileCommentManager {
       const card = zone.querySelector(`[data-suggestion-id="${suggestionId}"]`);
       if (card) {
         card.classList.remove('collapsed');
+        // Restored to active — clear the collapsed-bar state tooltip.
+        window.SuggestionUI?.setCollapsedStateTooltip?.(card, '');
+        // Strip stale dismissal-reason markup (note + popover attr/brain button)
+        // baked in while dismissed; same-tab broadcasts are suppressed so no
+        // refetch rescues this card.
+        window.SuggestionUI?.clearDismissalReasonUI?.(card);
       }
 
       // Update finding status in AI Panel (mark suggestion as active)
@@ -864,11 +875,7 @@ class FileCommentManager {
       const suggestionCard = zone.querySelector(`[data-suggestion-id="${suggestion.id}"]`);
       if (suggestionCard) {
         suggestionCard.classList.add('collapsed');
-        // Update collapsed text to show "Suggestion adopted"
-        const collapsedText = suggestionCard.querySelector('.collapsed-text');
-        if (collapsedText) {
-          collapsedText.textContent = 'Suggestion adopted';
-        }
+        window.SuggestionUI?.setCollapsedStateTooltip?.(suggestionCard, 'Adopted');
       }
 
       // Use the server-formatted body — server is the single source of truth

--- a/public/js/modules/suggestion-manager.js
+++ b/public/js/modules/suggestion-manager.js
@@ -71,22 +71,34 @@ class SuggestionManager {
    * @param {HTMLElement} toggleBtn - The brain icon button that was clicked
    */
   _openReasoningPopover(toggleBtn) {
+    // Reasoning steps and an optional dismissal reason are stored separately on
+    // the button. Either may be present; the popover opens when at least one is.
+    let reasoning = null;
     const reasoningData = toggleBtn.dataset.reasoning;
-    if (!reasoningData) return;
-
-    let reasoning;
-    try {
-      reasoning = JSON.parse(decodeURIComponent(reasoningData));
-    } catch {
-      return;
+    if (reasoningData) {
+      try {
+        reasoning = JSON.parse(decodeURIComponent(reasoningData));
+      } catch {
+        reasoning = null;
+      }
     }
-    if (!Array.isArray(reasoning)) return;
 
-    const escapeHtml = this.prManager?.escapeHtml?.bind(this.prManager) || ((s) => s);
-    const bulletMd = reasoning.map(step => `- ${step}`).join('\n');
-    const rendered = window.renderMarkdown
-      ? window.renderMarkdown(bulletMd)
-      : `<ul>${reasoning.map(step => `<li>${escapeHtml(step)}</li>`).join('')}</ul>`;
+    let dismissalReason = '';
+    const dismissalData = toggleBtn.dataset.dismissalReason;
+    if (dismissalData) {
+      try {
+        dismissalReason = decodeURIComponent(dismissalData);
+      } catch {
+        dismissalReason = '';
+      }
+    }
+
+    const hasReasoning = Array.isArray(reasoning) && reasoning.length > 0;
+    if (!hasReasoning && !dismissalReason) return;
+
+    const rendered = window.SuggestionUI?.buildReasoningPopoverContentHtml
+      ? window.SuggestionUI.buildReasoningPopoverContentHtml(hasReasoning ? reasoning : null, dismissalReason)
+      : '';
 
     const popover = document.createElement('div');
     popover.className = 'reasoning-popover';
@@ -635,13 +647,27 @@ class SuggestionManager {
       // Apply collapsed class if the suggestion is dismissed or was adopted
       // Check both: wasAdopted (from user comments with parent_id) OR status='adopted' (from DB)
       const isAdopted = wasAdopted || suggestion.status === 'adopted';
+      const isDismissed = !isAdopted && suggestion.status === 'dismissed';
       if (isAdopted) {
         suggestionDiv.classList.add('collapsed');
         // Mark the suggestion div as adopted after it's created
         suggestionDiv.dataset.hiddenForAdoption = 'true';
-      } else if (suggestion.status === 'dismissed') {
+      } else if (isDismissed) {
         suggestionDiv.classList.add('collapsed');
       }
+
+      // Collapsed-bar state tooltip (replaces the old inline state text).
+      const collapsedStateLabel = isAdopted ? 'Adopted' : (isDismissed ? 'Dismissed' : '');
+
+      // The reasoning brain button surfaces both the reasoning steps and, when
+      // the suggestion was dismissed with a recorded reason, that reason. Show
+      // the button when either is present. data-reasoning holds the steps;
+      // data-dismissal-reason holds the (agent-controlled) reason, encoded so
+      // quotes/angle brackets cannot break out of the attribute.
+      const hasReasoning = Array.isArray(suggestion.reasoning) && suggestion.reasoning.length > 0;
+      const dismissalReasonAttr = suggestion.status_reason ? encodeURIComponent(suggestion.status_reason) : '';
+      const reasoningDataAttr = hasReasoning ? encodeURIComponent(JSON.stringify(suggestion.reasoning)) : '';
+      const showReasoningBtn = hasReasoning || !!suggestion.status_reason;
 
       // Get category label for display
       const categoryLabel = suggestion.type || suggestion.category || '';
@@ -657,22 +683,22 @@ class SuggestionManager {
             <span class="ai-title">${escapeHtml(suggestion.title || '')}</span>
           </div>
           <div class="ai-suggestion-header-right">
-            ${suggestion.reasoning && suggestion.reasoning.length > 0 ? `
-            <button class="btn-reasoning-toggle" title="View reasoning" data-suggestion-id="${suggestion.id}" data-reasoning="${encodeURIComponent(JSON.stringify(suggestion.reasoning))}">
+            ${showReasoningBtn ? `
+            <button class="btn-reasoning-toggle" title="View reasoning" data-suggestion-id="${suggestion.id}" data-reasoning="${reasoningDataAttr}" data-dismissal-reason="${dismissalReasonAttr}">
               <svg viewBox="0 0 24 24" width="14" height="14" fill="currentColor"><path d="M21.33 12.91c.09 1.55-.62 3.04-1.89 3.95l.77 1.49c.23.45.26.98.06 1.45c-.19.47-.58.84-1.06 1l-.79.25a1.69 1.69 0 0 1-1.86-.55L14.44 18c-.89-.15-1.73-.53-2.44-1.1c-.5.15-1 .23-1.5.23c-.88 0-1.76-.27-2.5-.79c-.53.16-1.07.23-1.62.22c-.79.01-1.57-.15-2.3-.45a4.1 4.1 0 0 1-2.43-3.61c-.08-.72.04-1.45.35-2.11c-.29-.75-.32-1.57-.07-2.33C2.3 7.11 3 6.32 3.87 5.82c.58-1.69 2.21-2.82 4-2.7c1.6-1.5 4.05-1.66 5.83-.37c.42-.11.86-.17 1.3-.17c1.36-.03 2.65.57 3.5 1.64c2.04.53 3.5 2.35 3.58 4.47c.05 1.11-.25 2.2-.86 3.13c.07.36.11.72.11 1.09m-5-1.41c.57.07 1.02.5 1.02 1.07a1 1 0 0 1-1 1h-.63c-.32.9-.88 1.69-1.62 2.29c.25.09.51.14.77.21c5.13-.07 4.53-3.2 4.53-3.25a2.59 2.59 0 0 0-2.69-2.49a1 1 0 0 1-1-1a1 1 0 0 1 1-1c1.23.03 2.41.49 3.33 1.3c.05-.29.08-.59.08-.89c-.06-1.24-.62-2.32-2.87-2.53c-1.25-2.96-4.4-1.32-4.4-.4c-.03.23.21.72.25.75a1 1 0 0 1 1 1c0 .55-.45 1-1 1c-.53-.02-1.03-.22-1.43-.56c-.48.31-1.03.5-1.6.56c-.57.05-1.04-.35-1.07-.9a.97.97 0 0 1 .88-1.1c.16-.02.94-.14.94-.77c0-.66.25-1.29.68-1.79c-.92-.25-1.91.08-2.91 1.29C6.75 5 6 5.25 5.45 7.2C4.5 7.67 4 8 3.78 9c1.08-.22 2.19-.13 3.22.25c.5.19.78.75.59 1.29c-.19.52-.77.78-1.29.59c-.73-.32-1.55-.34-2.3-.06c-.32.27-.32.83-.32 1.27c0 .74.37 1.43 1 1.83c.53.27 1.12.41 1.71.4q-.225-.39-.39-.81a1.038 1.038 0 0 1 1.96-.68c.4 1.14 1.42 1.92 2.62 2.05c1.37-.07 2.59-.88 3.19-2.13c.23-1.38 1.34-1.5 2.56-1.5m2 7.47l-.62-1.3l-.71.16l1 1.25zm-4.65-8.61a1 1 0 0 0-.91-1.03c-.71-.04-1.4.2-1.93.67c-.57.58-.87 1.38-.84 2.19a1 1 0 0 0 1 1c.57 0 1-.45 1-1c0-.27.07-.54.23-.76c.12-.1.27-.15.43-.15c.55.03 1.02-.38 1.02-.92"/></svg>
             </button>
             ` : ''}
           </div>
         </div>
-        <div class="ai-suggestion-collapsed-content">
+        <div class="ai-suggestion-collapsed-content"${collapsedStateLabel ? ` title="${collapsedStateLabel}"` : ''}>
           ${suggestion.type === 'praise'
             ? `<span class="praise-badge" title="Nice Work"><svg viewBox="0 0 16 16"><path d="M8 .25a.75.75 0 01.673.418l1.882 3.815 4.21.612a.75.75 0 01.416 1.279l-3.046 2.97.719 4.192a.75.75 0 01-1.088.791L8 12.347l-3.766 1.98a.75.75 0 01-1.088-.79l.72-4.194L.818 6.374a.75.75 0 01.416-1.28l4.21-.611L7.327.668A.75.75 0 018 .25z"/></svg>Nice Work</span>`
             : `<span class="ai-suggestion-badge collapsed" data-type="${suggestion.type}" title="${this.getTypeDescription(suggestion.type)}"><svg viewBox="0 0 16 16" fill="currentColor" width="10" height="10"><path d="M9.6 2.279a.426.426 0 0 1 .8 0l.407 1.112a6.386 6.386 0 0 0 3.802 3.802l1.112.407a.426.426 0 0 1 0 .8l-1.112.407a6.386 6.386 0 0 0-3.802 3.802l-.407 1.112a.426.426 0 0 1-.8 0l-.407-1.112a6.386 6.386 0 0 0-3.802-3.802L4.279 8.4a.426.426 0 0 1 0-.8l1.112-.407a6.386 6.386 0 0 0 3.802-3.802L9.6 2.279Zm-4.267 8.837a.178.178 0 0 1 .334 0l.169.464a2.662 2.662 0 0 0 1.584 1.584l.464.169a.178.178 0 0 1 0 .334l-.464.169a2.662 2.662 0 0 0-1.584 1.584l-.169.464a.178.178 0 0 1-.334 0l-.169-.464a2.662 2.662 0 0 0-1.584-1.584l-.464-.169a.178.178 0 0 1 0-.334l.464-.169a2.662 2.662 0 0 0 1.584-1.584l.169-.464ZM2.8.14a.213.213 0 0 1 .4 0l.203.556a3.2 3.2 0 0 0 1.901 1.901l.556.203a.213.213 0 0 1 0 .4l-.556.203a3.2 3.2 0 0 0-1.901 1.901L3.2 5.86a.213.213 0 0 1-.4 0l-.203-.556A3.2 3.2 0 0 0 .696 3.403L.14 3.2a.213.213 0 0 1 0-.4l.556-.203A3.2 3.2 0 0 0 2.597.696L2.8.14Z"/></svg>AI Suggestion</span>`}
           ${suggestion.severity ? `<span class="severity-badge severity-${suggestion.severity}">${escapeHtml(suggestion.severity.toUpperCase())}</span>` : ''}
           <span class="collapsed-title">${escapeHtml(suggestion.title || '')}</span>
           <div class="ai-suggestion-header-right">
-            ${suggestion.reasoning && suggestion.reasoning.length > 0 ? `
-            <button class="btn-reasoning-toggle collapsed-reasoning" title="View reasoning" data-suggestion-id="${suggestion.id}" data-reasoning="${encodeURIComponent(JSON.stringify(suggestion.reasoning))}">
+            ${showReasoningBtn ? `
+            <button class="btn-reasoning-toggle collapsed-reasoning" title="View reasoning" data-suggestion-id="${suggestion.id}" data-reasoning="${reasoningDataAttr}" data-dismissal-reason="${dismissalReasonAttr}">
               <svg viewBox="0 0 24 24" width="12" height="12" fill="currentColor"><path d="M21.33 12.91c.09 1.55-.62 3.04-1.89 3.95l.77 1.49c.23.45.26.98.06 1.45c-.19.47-.58.84-1.06 1l-.79.25a1.69 1.69 0 0 1-1.86-.55L14.44 18c-.89-.15-1.73-.53-2.44-1.1c-.5.15-1 .23-1.5.23c-.88 0-1.76-.27-2.5-.79c-.53.16-1.07.23-1.62.22c-.79.01-1.57-.15-2.3-.45a4.1 4.1 0 0 1-2.43-3.61c-.08-.72.04-1.45.35-2.11c-.29-.75-.32-1.57-.07-2.33C2.3 7.11 3 6.32 3.87 5.82c.58-1.69 2.21-2.82 4-2.7c1.6-1.5 4.05-1.66 5.83-.37c.42-.11.86-.17 1.3-.17c1.36-.03 2.65.57 3.5 1.64c2.04.53 3.5 2.35 3.58 4.47c.05 1.11-.25 2.2-.86 3.13c.07.36.11.72.11 1.09m-5-1.41c.57.07 1.02.5 1.02 1.07a1 1 0 0 1-1 1h-.63c-.32.9-.88 1.69-1.62 2.29c.25.09.51.14.77.21c5.13-.07 4.53-3.2 4.53-3.25a2.59 2.59 0 0 0-2.69-2.49a1 1 0 0 1-1-1a1 1 0 0 1 1-1c1.23.03 2.41.49 3.33 1.3c.05-.29.08-.59.08-.89c-.06-1.24-.62-2.32-2.87-2.53c-1.25-2.96-4.4-1.32-4.4-.4c-.03.23.21.72.25.75a1 1 0 0 1 1 1c0 .55-.45 1-1 1c-.53-.02-1.03-.22-1.43-.56c-.48.31-1.03.5-1.6.56c-.57.05-1.04-.35-1.07-.9a.97.97 0 0 1 .88-1.1c.16-.02.94-.14.94-.77c0-.66.25-1.29.68-1.79c-.92-.25-1.91.08-2.91 1.29C6.75 5 6 5.25 5.45 7.2C4.5 7.67 4 8 3.78 9c1.08-.22 2.19-.13 3.22.25c.5.19.78.75.59 1.29c-.19.52-.77.78-1.29.59c-.73-.32-1.55-.34-2.3-.06c-.32.27-.32.83-.32 1.27c0 .74.37 1.43 1 1.83c.53.27 1.12.41 1.71.4q-.225-.39-.39-.81a1.038 1.038 0 0 1 1.96-.68c.4 1.14 1.42 1.92 2.62 2.05c1.37-.07 2.59-.88 3.19-2.13c.23-1.38 1.34-1.5 2.56-1.5m2 7.47l-.62-1.3-.71.16l1 1.25zm-4.65-8.61a1 1 0 0 0-.91-1.03c-.71-.04-1.4.2-1.93.67c-.57.58-.87 1.38-.84 2.19a1 1 0 0 0 1 1c.57 0 1-.45 1-1c0-.27.07-.54.23-.76c.12-.1.27-.15.43-.15c.55.03 1.02-.38 1.02-.92"/></svg>
             </button>
             ` : ''}
@@ -696,6 +722,7 @@ class SuggestionManager {
             return window.renderMarkdown ? window.renderMarkdown(displayBody) : escapeHtml(displayBody);
           })()}
         </div>
+        ${window.SuggestionUI?.buildDismissalNoteHtml?.(suggestion.status_reason) || ''}
         <div class="ai-suggestion-actions">
           <button class="ai-action ai-action-adopt" onclick="prManager.adoptSuggestion(${suggestion.id})">
             <svg viewBox="0 0 16 16" width="16" height="16"><path fill-rule="evenodd" d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z"></path></svg>

--- a/public/js/pr.js
+++ b/public/js/pr.js
@@ -6657,7 +6657,7 @@ class PRManager {
 
   /**
    * Collapse a suggestion div in the UI after adoption.
-   * Handles adding collapsed class, updating text to 'Suggestion adopted',
+   * Handles adding collapsed class, setting the 'Adopted' state tooltip,
    * updating the restore button, and setting hiddenForAdoption flag.
    *
    * With legacy rendering, `suggestionRow` is the `<tr>` containing the
@@ -6673,8 +6673,7 @@ class PRManager {
       : document.querySelector(`[data-suggestion-id="${suggestionId}"]`);
     if (!targetDiv) return;
     targetDiv.classList.add('collapsed');
-    const collapsedContent = targetDiv.querySelector('.collapsed-text');
-    if (collapsedContent) collapsedContent.textContent = 'Suggestion adopted';
+    window.SuggestionUI?.setCollapsedStateTooltip?.(targetDiv, 'Adopted');
     const restoreButton = targetDiv.querySelector('.btn-restore');
     if (restoreButton) {
       restoreButton.title = 'Show suggestion';
@@ -6996,8 +6995,11 @@ class PRManager {
       // If this suggestion was adopted, only toggle visibility - don't change status
       // The adoption still exists (there's a user comment linked to this suggestion)
       if (suggestionDiv?.dataset?.hiddenForAdoption === 'true') {
-        // suggestionDiv is guaranteed to exist since we just queried for it
+        // suggestionDiv is guaranteed to exist since we just queried for it.
+        // The suggestion stays adopted here; we only re-hide it, so the
+        // collapsed-bar tooltip keeps reading 'Adopted'.
         suggestionDiv.classList.add('collapsed');
+        window.SuggestionUI?.setCollapsedStateTooltip?.(suggestionDiv, 'Adopted');
 
         const button = suggestionDiv.querySelector('.btn-restore');
         if (button) {
@@ -7018,6 +7020,7 @@ class PRManager {
 
       if (suggestionDiv) {
         suggestionDiv.classList.add('collapsed');
+        window.SuggestionUI?.setCollapsedStateTooltip?.(suggestionDiv, 'Dismissed');
         const restoreButton = suggestionDiv.querySelector('.btn-restore');
         if (restoreButton) {
           restoreButton.title = 'Show suggestion';
@@ -7063,11 +7066,13 @@ class PRManager {
 
         // Find the button within this specific suggestion div, not the first one in the row
         const button = suggestionDiv.querySelector('.btn-restore');
+        const isNowCollapsed = suggestionDiv.classList.contains('collapsed');
         if (button) {
-          const isNowCollapsed = suggestionDiv.classList.contains('collapsed');
           button.title = isNowCollapsed ? 'Show suggestion' : 'Hide suggestion';
           button.querySelector('.btn-text').textContent = isNowCollapsed ? 'Show' : 'Hide';
         }
+        // Still adopted; keep the 'Adopted' tooltip only while re-hidden.
+        window.SuggestionUI?.setCollapsedStateTooltip?.(suggestionDiv, isNowCollapsed ? 'Adopted' : '');
         return;
       }
 
@@ -7081,6 +7086,12 @@ class PRManager {
 
       if (suggestionDiv) {
         suggestionDiv.classList.remove('collapsed');
+        // Restored to active — clear the collapsed-bar state tooltip.
+        window.SuggestionUI?.setCollapsedStateTooltip?.(suggestionDiv, '');
+        // Strip stale dismissal-reason markup (note + popover attr/brain button)
+        // baked in while dismissed; same-tab broadcasts are suppressed so no
+        // refetch rescues this card.
+        window.SuggestionUI?.clearDismissalReasonUI?.(suggestionDiv);
       }
 
       if (this.suggestionNavigator?.suggestions) {

--- a/public/js/utils/suggestion-ui.js
+++ b/public/js/utils/suggestion-ui.js
@@ -6,10 +6,150 @@
 
 (function() {
   /**
-   * Text shown when an AI suggestion is hidden/dismissed
+   * Label shown above a dismissal reason note.
    * @constant {string}
    */
-  const HIDDEN_SUGGESTION_TEXT = 'Hidden AI suggestion';
+  const DISMISSAL_NOTE_LABEL = 'Dismissal note';
+
+  /**
+   * Heading shown above the dismissal reason inside the reasoning popover.
+   * @constant {string}
+   */
+  const POPOVER_DISMISSAL_HEADING = 'Dismissal';
+
+  /**
+   * Minimal HTML escaper. Self-contained so the reason builders can be called
+   * from any render path (suggestion cards, file-comment cards, AI panel)
+   * without depending on the caller's escape helper.
+   * @param {*} text
+   * @returns {string}
+   */
+  function escapeReasonHtml(text) {
+    if (text == null) return '';
+    return String(text)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
+  /**
+   * Build the expanded reply-styled dismissal note block. Rendered under the
+   * suggestion body of a dismissed AI suggestion when a reason is present.
+   * Returns an empty string when there is no reason so callers can inline it.
+   *
+   * @param {string|null|undefined} statusReason - The dismissal reason
+   * @returns {string} HTML string (empty when no reason)
+   */
+  function buildDismissalNoteHtml(statusReason) {
+    if (!statusReason) return '';
+    const safe = escapeReasonHtml(statusReason);
+    return `
+      <div class="ai-dismissal-note" role="note">
+        <span class="ai-dismissal-note-label">${DISMISSAL_NOTE_LABEL}</span>
+        <span class="ai-dismissal-note-body">${safe}</span>
+      </div>`;
+  }
+
+  /**
+   * Build the inner HTML for a reasoning popover's content area.
+   *
+   * Renders the reasoning steps as a markdown bullet list (as before) and, when
+   * a dismissal reason is present, appends a "Dismissal" section beneath it.
+   * Either part may be absent: a reason-only popover renders just the Dismissal
+   * section, and a reasoning-only popover renders just the bullets. Returns an
+   * empty string when neither is present.
+   *
+   * Content is rendered through window.renderMarkdown when available (which uses
+   * markdown-it with html:false, so agent-controlled text stays inert). When it
+   * is unavailable the text is HTML-escaped instead, matching the reasoning
+   * bullets' own fallback.
+   *
+   * @param {Array<string>|null|undefined} reasoning - Reasoning steps
+   * @param {string|null|undefined} dismissalReason - The dismissal reason
+   * @returns {string} HTML string for the popover content (empty when neither)
+   */
+  function buildReasoningPopoverContentHtml(reasoning, dismissalReason) {
+    const renderMd = (typeof window !== 'undefined' && window.renderMarkdown)
+      ? window.renderMarkdown
+      : null;
+
+    let html = '';
+
+    if (Array.isArray(reasoning) && reasoning.length > 0) {
+      const bulletMd = reasoning.map(step => `- ${step}`).join('\n');
+      html += renderMd
+        ? renderMd(bulletMd)
+        : `<ul>${reasoning.map(step => `<li>${escapeReasonHtml(step)}</li>`).join('')}</ul>`;
+    }
+
+    if (dismissalReason) {
+      const reasonHtml = renderMd
+        ? renderMd(dismissalReason)
+        : `<p>${escapeReasonHtml(dismissalReason)}</p>`;
+      html += `
+        <div class="reasoning-popover-dismissal">
+          <span class="reasoning-popover-dismissal-heading">${POPOVER_DISMISSAL_HEADING}</span>
+          ${reasonHtml}
+        </div>`;
+    }
+
+    return html;
+  }
+
+  /**
+   * Set (or clear) the collapsed-bar state tooltip on a suggestion card.
+   *
+   * The collapsed bar no longer shows inline state text; the dismissed/adopted
+   * signal now lives in a tooltip on the collapsed-content container. Pass a
+   * falsy label to clear it (e.g. when restoring a suggestion to active).
+   *
+   * @param {HTMLElement|null} suggestionDiv - The .ai-suggestion element
+   * @param {string} [label] - 'Dismissed', 'Adopted', or '' to clear
+   */
+  function setCollapsedStateTooltip(suggestionDiv, label) {
+    if (!suggestionDiv) return;
+    const collapsedContent = suggestionDiv.querySelector('.ai-suggestion-collapsed-content');
+    if (!collapsedContent) return;
+    if (label) {
+      collapsedContent.title = label;
+    } else {
+      collapsedContent.removeAttribute('title');
+    }
+  }
+
+  /**
+   * Strip stale dismissal-reason UI from a suggestion card when it is restored
+   * to active. While dismissed, the reason is baked into the card markup in two
+   * places: the expanded reply-styled note (`.ai-dismissal-note`) and the
+   * reasoning popover (via `data-dismissal-reason` on the brain buttons). Restore
+   * paths only flip the `collapsed` class, so without this the reason survives on
+   * a now-active suggestion.
+   *
+   * Shared by the line-level card (pr.js `restoreSuggestion`) and the file-level
+   * card (file-comment-manager `restoreAISuggestion`), which have identical
+   * reason markup.
+   *
+   * @param {HTMLElement|null} cardEl - The `.ai-suggestion` card element
+   */
+  function clearDismissalReasonUI(cardEl) {
+    if (!cardEl) return;
+
+    // Remove the expanded reply-styled note(s).
+    cardEl.querySelectorAll('.ai-dismissal-note').forEach(el => el.remove());
+
+    // Clear the stale reason from both reasoning-toggle buttons (expanded +
+    // collapsed). A brain button that exists ONLY because of the reason (no
+    // reasoning steps, so an empty data-reasoning) is removed entirely; one that
+    // also carries reasoning steps stays but drops its Dismissal section.
+    cardEl.querySelectorAll('.btn-reasoning-toggle').forEach(btn => {
+      btn.removeAttribute('data-dismissal-reason');
+      if (!btn.getAttribute('data-reasoning')) {
+        btn.remove();
+      }
+    });
+  }
 
   /**
    * Update the UI for a dismissed AI suggestion.
@@ -28,11 +168,8 @@
       // Collapse the suggestion
       suggestionDiv.classList.add('collapsed');
 
-      // Update collapsed content text to indicate dismissed state
-      const collapsedText = suggestionDiv.querySelector('.collapsed-text');
-      if (collapsedText) {
-        collapsedText.textContent = HIDDEN_SUGGESTION_TEXT;
-      }
+      // Signal the dismissed state via the collapsed-bar tooltip
+      setCollapsedStateTooltip(suggestionDiv, 'Dismissed');
 
       // Update the suggestion div dataset
       suggestionDiv.dataset.hiddenForAdoption = 'false';
@@ -46,7 +183,19 @@
 
   // Export to global scope
   window.SuggestionUI = {
-    HIDDEN_SUGGESTION_TEXT,
+    DISMISSAL_NOTE_LABEL,
+    POPOVER_DISMISSAL_HEADING,
+    escapeReasonHtml,
+    buildDismissalNoteHtml,
+    buildReasoningPopoverContentHtml,
+    setCollapsedStateTooltip,
+    clearDismissalReasonUI,
     updateDismissedSuggestionUI
   };
+
+  // Support CommonJS require() in unit tests (jsdom / vm sandbox) while keeping
+  // the browser IIFE behavior of assigning to window.
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = window.SuggestionUI;
+  }
 })();

--- a/src/chat/api-reference.js
+++ b/src/chat/api-reference.js
@@ -127,7 +127,7 @@ curl -s -X PUT http://localhost:{{PORT}}/api/reviews/{{REVIEW_ID}}/comments/COMM
 
 > **Terminology note:** The UI refers to this operation as "dismiss." When a user asks to "dismiss a comment," use this DELETE endpoint.
 
-Soft-deletes the comment. If the comment was adopted from an AI suggestion, the parent suggestion is automatically transitioned to "dismissed" status.
+Soft-deletes the comment. If the comment was adopted from an AI suggestion, the parent suggestion is automatically transitioned to "dismissed" status with an auto-generated \`status_reason\` noting the adopted comment was deleted.
 
 \`\`\`bash
 curl -s -X DELETE http://localhost:{{PORT}}/api/reviews/{{REVIEW_ID}}/comments/COMMENT_ID
@@ -169,7 +169,9 @@ Optional query params:
 - \`levels\` — comma-separated list of levels: \`"final"\`, \`"1"\`, \`"2"\`, \`"3"\`. Default: \`"final"\` (orchestrated suggestions only).
 - \`runId\` — specific analysis run UUID. Default: latest run.
 
-**Response:** \`{ "suggestions": [{ "id": 1, "file": "...", "line_start": 10, "type": "bug", "title": "...", "body": "...", "status": "active", ... }] }\`
+**Response:** \`{ "suggestions": [{ "id": 1, "file": "...", "line_start": 10, "type": "bug", "title": "...", "body": "...", "status": "active", "status_reason": null, ... }] }\`
+
+Each suggestion carries \`status_reason\` (string|null) — the explanation stored when it was dismissed (see "Update AI suggestion status"), or \`null\`.
 
 ### Check if suggestions exist
 
@@ -186,14 +188,16 @@ Optional query param: \`runId\` (specific analysis run UUID).
 \`\`\`bash
 curl -s -X POST http://localhost:{{PORT}}/api/reviews/{{REVIEW_ID}}/suggestions/SUGGESTION_ID/status \\
   -H 'Content-Type: application/json' \\
-  -d '{ "status": "dismissed" }'
+  -d '{ "status": "dismissed", "reason": "Confirmed intentional behavior; no change needed." }'
 \`\`\`
 
 Valid statuses: \`"dismissed"\`, \`"active"\` (restore).
 
+Optional field: \`reason\` (string, ≤2000 chars) — a concise, one-sentence explanation of why the suggestion is being dismissed. Valid **only** with status \`"dismissed"\`; sending it with \`"active"\` returns 400. Restoring to \`"active"\` clears any stored reason. You SHOULD include a \`reason\` whenever you dismiss a suggestion — it is surfaced in the UI as a reply-styled note under the suggestion. The stored reason is returned as \`status_reason\` (string|null) on suggestion objects in GET responses.
+
 > **Note:** Setting status to \`"adopted"\` directly is not allowed. Adoption must create a linked user comment via \`parent_id\`, which is why raw status-setting cannot do it. Use \`POST /suggestions/:id/adopt\` for adopt-as-is or \`POST /suggestions/:id/edit\` for adopt-with-edits.
 
-**Response:** \`{ "success": true, "status": "dismissed" }\`
+**Response:** \`{ "success": true, "status": "dismissed", "status_reason": "Confirmed intentional behavior; no change needed." }\` (\`status_reason\` is the stored trimmed reason, or \`null\`)
 
 ### Adopt an AI suggestion as-is
 
@@ -503,7 +507,7 @@ Base: \`http://localhost:{{PORT}}\` | Review: \`{{REVIEW_ID}}\`
 ## Suggestions — /api/reviews/{{REVIEW_ID}}/suggestions
 - \`GET\` — List (?levels=final,1,2,3 &runId=UUID)
 - \`GET /check\` — Exists? (?runId=UUID)
-- \`POST /:id/status\` — Dismiss/restore {status}
+- \`POST /:id/status\` — Dismiss/restore {status, ?reason} (reason: dismissed-only, ≤2000 chars, include when dismissing)
 - \`POST /:id/adopt\` — Adopt as-is (no body)
 - \`POST /:id/edit\` — Adopt edited {action:"adopt_edited", editedText:"..."}
 

--- a/src/chat/prompt-builder.js
+++ b/src/chat/prompt-builder.js
@@ -46,6 +46,7 @@ function buildChatPrompt({ review, prData, chatInstructions, commentFormatTempla
     '- **Suggestions** are AI-generated findings from analysis runs.',
     '- **Workflow**: AI generates suggestions → reviewer triages (adopt, edit, or dismiss) → adopted suggestions become comments.',
     '- **IMPORTANT**: Do NOT adopt, dismiss, or modify suggestions or comments unless the user explicitly asks you to. Your role is to discuss and explain — the reviewer decides what action to take.',
+    '- When you DO dismiss a suggestion (only after the user asks), include a `reason` field on the status request with a one-sentence summary of why, grounded in the discussion (e.g. reason: "User confirmed the behavior is intentional").',
     '- **Analysis runs** are the process that produces suggestions. Each run has a provider, model, tier, and status.',
     '- **Review ID** is a stable integer identifying this review session, used in all API calls.',
     '- **IMPORTANT**: Never mention internal IDs (comment IDs, suggestion IDs, run IDs) in your responses to the user. These are meaningless to the user and not shown in the UI. Refer to comments and suggestions by their content, title, file location, or line number instead.'
@@ -206,7 +207,7 @@ function parseReasoning(reasoning) {
  * @returns {Object} Formatted suggestion
  */
 function formatSuggestionForContext(s) {
-  return {
+  const formatted = {
     id: s.id,
     file: s.file,
     line_start: s.line_start,
@@ -219,6 +220,12 @@ function formatSuggestionForContext(s) {
     ai_confidence: s.ai_confidence,
     is_file_level: s.is_file_level
   };
+  // Include the dismissal reason when present so the agent sees WHY a
+  // suggestion was already dismissed (e.g. by a prior pair-loop write-back).
+  if (s.status_reason) {
+    formatted.status_reason = s.status_reason;
+  }
+  return formatted;
 }
 
 /**

--- a/src/database.js
+++ b/src/database.js
@@ -21,7 +21,7 @@ function getDbPath() {
 /**
  * Current schema version - increment this when adding new migrations
  */
-const CURRENT_SCHEMA_VERSION = 51;
+const CURRENT_SCHEMA_VERSION = 52;
 
 /**
  * Database schema SQL statements
@@ -90,6 +90,7 @@ const SCHEMA_SQL = {
       reasoning TEXT,
 
       status TEXT DEFAULT 'active' CHECK(status IN ('active', 'dismissed', 'adopted', 'submitted', 'draft', 'inactive')),
+      status_reason TEXT,
       adopted_as_id INTEGER,
       parent_id INTEGER,
       is_file_level INTEGER DEFAULT 0,
@@ -2237,6 +2238,26 @@ const MIGRATIONS = {
       console.log('  Table github_pr_cache absent; nothing to reindex');
     }
     console.log('Migration to schema version 51 complete');
+  },
+
+  // Migration to version 52: add status_reason column to comments table.
+  // Stores the human/agent-provided reason a suggestion was dismissed (and the
+  // canonical cascade reason when an adopted comment is deleted). Nullable; the
+  // invariant is that it is only ever populated on 'dismissed' suggestions.
+  52: (db) => {
+    console.log('Running migration to schema version 52: add status_reason to comments...');
+    if (!tableExists(db, 'comments')) {
+      console.log('  comments table does not exist, skipping');
+      console.log('Migration to schema version 52 complete');
+      return;
+    }
+    if (!columnExists(db, 'comments', 'status_reason')) {
+      db.prepare('ALTER TABLE comments ADD COLUMN status_reason TEXT').run();
+      console.log('  Added status_reason column to comments');
+    } else {
+      console.log('  status_reason column already present; nothing to do');
+    }
+    console.log('Migration to schema version 52 complete');
   }
 };
 
@@ -3562,33 +3583,48 @@ class CommentRepository {
 
   /**
    * Update AI suggestion status and link to adopted comment
+   *
+   * status_reason invariant: a reason only ever lives on a 'dismissed'
+   * suggestion. Restoring to 'active' and adopting both clear it.
    * @param {number} suggestionId - AI suggestion comment ID
    * @param {string} status - New status ('adopted', 'dismissed', 'active')
    * @param {number} [adoptedAsId] - ID of the user comment if adopted
+   * @param {string|null} [reason] - Dismissal reason (only meaningful for 'dismissed'); trimmed empty → null
    * @returns {Promise<boolean>} True if updated successfully
    */
-  async updateSuggestionStatus(suggestionId, status, adoptedAsId = null) {
+  async updateSuggestionStatus(suggestionId, status, adoptedAsId = null, reason = null) {
     const validStatuses = ['adopted', 'dismissed', 'active'];
     if (!validStatuses.includes(status)) {
       throw new Error('Invalid status. Must be "adopted", "dismissed", or "active"');
     }
 
-    // When restoring to active, clear adopted_as_id
+    // When restoring to active, clear adopted_as_id and status_reason
     if (status === 'active') {
       const result = await run(this.db, `
         UPDATE comments
-        SET status = ?, adopted_as_id = NULL, updated_at = CURRENT_TIMESTAMP
+        SET status = ?, adopted_as_id = NULL, status_reason = NULL, updated_at = CURRENT_TIMESTAMP
         WHERE id = ?
       `, [status, suggestionId]);
       return result.changes > 0;
     }
 
-    // For adopted/dismissed, optionally set adopted_as_id
+    // Adopting clears any prior dismissal reason (invariant: reason only on 'dismissed').
+    if (status === 'adopted') {
+      const result = await run(this.db, `
+        UPDATE comments
+        SET status = ?, adopted_as_id = ?, status_reason = NULL, updated_at = CURRENT_TIMESTAMP
+        WHERE id = ?
+      `, [status, adoptedAsId, suggestionId]);
+      return result.changes > 0;
+    }
+
+    // Dismissing: persist the (already trimmed/normalized) reason, or null.
+    const normalizedReason = typeof reason === 'string' && reason.trim() ? reason.trim() : null;
     const result = await run(this.db, `
       UPDATE comments
-      SET status = ?, adopted_as_id = ?, updated_at = CURRENT_TIMESTAMP
+      SET status = ?, adopted_as_id = ?, status_reason = ?, updated_at = CURRENT_TIMESTAMP
       WHERE id = ?
-    `, [status, adoptedAsId, suggestionId]);
+    `, [status, adoptedAsId, normalizedReason, suggestionId]);
 
     return result.changes > 0;
   }
@@ -3662,7 +3698,7 @@ class CommentRepository {
 
     // If this comment was adopted from an AI suggestion, dismiss the parent suggestion
     if (comment.parent_id) {
-      await this.updateSuggestionStatus(comment.parent_id, 'dismissed');
+      await this.updateSuggestionStatus(comment.parent_id, 'dismissed', null, 'Adopted comment was deleted');
       dismissedSuggestionId = comment.parent_id;
     }
 
@@ -3711,7 +3747,8 @@ class CommentRepository {
       const placeholders = dismissedSuggestionIds.map(() => '?').join(',');
       await run(this.db, `
         UPDATE comments
-        SET status = 'dismissed', updated_at = CURRENT_TIMESTAMP
+        SET status = 'dismissed', status_reason = 'Adopted comment was deleted',
+            adopted_as_id = NULL, updated_at = CURRENT_TIMESTAMP
         WHERE id IN (${placeholders})
       `, dismissedSuggestionIds);
     }
@@ -3802,7 +3839,7 @@ class CommentRepository {
       SELECT
         id, ai_run_id, ai_level, ai_confidence,
         file, line_start, line_end, type, title, body,
-        reasoning, status, is_file_level, severity, created_at
+        reasoning, status, status_reason, is_file_level, severity, created_at
       FROM comments
       WHERE ${conditions.join('\n          AND ')}
       ORDER BY file, line_start

--- a/src/routes/chat.js
+++ b/src/routes/chat.js
@@ -288,7 +288,7 @@ router.post('/api/chat/session', async (req, res) => {
           SELECT
             id, ai_run_id, ai_level, ai_confidence,
             file, line_start, line_end, type, title, body,
-            reasoning, status, is_file_level, severity
+            reasoning, status, status_reason, is_file_level, severity
           FROM comments
           WHERE review_id = ?
             AND source = 'ai'
@@ -653,7 +653,7 @@ router.get('/api/chat/analysis-context/:runId', async (req, res) => {
       SELECT
         id, ai_run_id, ai_level, ai_confidence,
         file, line_start, line_end, type, title, body,
-        reasoning, status, is_file_level, severity
+        reasoning, status, status_reason, is_file_level, severity
       FROM comments
       WHERE review_id = ?
         AND source = 'ai'

--- a/src/routes/mcp.js
+++ b/src/routes/mcp.js
@@ -421,6 +421,7 @@ function createMCPServer(db, options = {}) {
               ai_confidence: s.ai_confidence,
               severity: s.severity,
               status: s.status,
+              status_reason: s.status_reason,
               reasoning: safeParseJson(s.reasoning),
             }))
           }, null, 2)

--- a/src/routes/reviews.js
+++ b/src/routes/reviews.js
@@ -572,6 +572,7 @@ router.get('/api/reviews/:reviewId/suggestions', validateReviewId, async (req, r
         suggestion_text,
         reasoning,
         status,
+        status_reason,
         is_file_level,
         severity,
         created_at,
@@ -634,7 +635,7 @@ router.get('/api/reviews/:reviewId/suggestions', validateReviewId, async (req, r
 router.post('/api/reviews/:reviewId/suggestions/:id/status', validateReviewId, async (req, res) => {
   try {
     const { id } = req.params;
-    const { status } = req.body;
+    const { status, reason } = req.body;
 
     if (!['dismissed', 'active'].includes(status)) {
       if (status === 'adopted') {
@@ -645,6 +646,30 @@ router.post('/api/reviews/:reviewId/suggestions/:id/status', validateReviewId, a
       return res.status(400).json({
         error: 'Invalid status. Must be "dismissed" or "active"'
       });
+    }
+
+    // A dismissal reason is only meaningful when dismissing. Reject it on restore
+    // so callers can't silently attach a reason that would immediately be cleared.
+    if (reason !== undefined && reason !== null && status !== 'dismissed') {
+      return res.status(400).json({
+        error: 'A reason may only be provided when status is "dismissed"'
+      });
+    }
+
+    // Normalize the reason: coerce to string, trim, enforce max length, empty → null.
+    const MAX_REASON_LENGTH = 2000;
+    let normalizedReason = null;
+    if (reason !== undefined && reason !== null) {
+      if (typeof reason !== 'string') {
+        return res.status(400).json({ error: 'Reason must be a string' });
+      }
+      const trimmed = reason.trim();
+      if (trimmed.length > MAX_REASON_LENGTH) {
+        return res.status(400).json({
+          error: `Reason must be ${MAX_REASON_LENGTH} characters or fewer`
+        });
+      }
+      normalizedReason = trimmed || null;
     }
 
     const db = req.app.get('db');
@@ -666,12 +691,14 @@ router.post('/api/reviews/:reviewId/suggestions/:id/status', validateReviewId, a
       });
     }
 
-    // Update suggestion status using repository
-    await commentRepo.updateSuggestionStatus(id, status);
+    // Update suggestion status using repository. Restoring to 'active' clears any
+    // stored reason inside updateSuggestionStatus, so status_reason is always null then.
+    await commentRepo.updateSuggestionStatus(id, status, null, normalizedReason);
 
     res.json({
       success: true,
-      status
+      status,
+      status_reason: status === 'dismissed' ? normalizedReason : null
     });
     broadcastReviewEvent(req.reviewId, { type: 'review:suggestions_changed' }, { sourceClientId: req.get('X-Client-Id') });
 

--- a/tests/e2e/suggestion-dismissal-reason.spec.js
+++ b/tests/e2e/suggestion-dismissal-reason.spec.js
@@ -1,0 +1,110 @@
+// Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+/**
+ * E2E: AI-suggestion dismissal-reason rendering.
+ *
+ * When the loop/chat agent dismisses an AI suggestion it records a
+ * `status_reason`. The UI surfaces that reason as:
+ *   - the expanded reply-styled note under the suggestion body (hidden while
+ *     the card is collapsed)
+ *   - a "Dismissal" section inside the reasoning popover (opened via the brain
+ *     button on the collapsed card)
+ *   - a muted second line on the finding item in the AI panel (+ tooltip)
+ * The collapsed bar itself only carries a "Dismissed"/"Adopted" state tooltip.
+ *
+ * The reason is seeded directly via a test-only endpoint (global-setup.js)
+ * because there is no UI affordance that produces a reason — human dismissals
+ * are reason-less by design.
+ */
+
+import { test, expect } from './fixtures.js';
+import { waitForDiffToRender, seedAISuggestions } from './helpers.js';
+
+const REASON = 'Dismissed by the agent: guarded by an upstream null check.';
+const TITLE = 'Seeded dismissed finding';
+
+test.describe('AI suggestion dismissal reason', () => {
+  test('renders the reason on the diff card and the AI panel finding', async ({ page }) => {
+    await page.goto('/pr/test-owner/test-repo/1');
+    await waitForDiffToRender(page);
+
+    // Seed the active suggestions (creates the analysis run this dismissed
+    // finding attaches to).
+    await seedAISuggestions(page);
+
+    // Seed a dismissed suggestion carrying a status_reason, then reload
+    // suggestions so it flows through the normal fetch -> render path.
+    const seed = await page.evaluate(async ({ reason, title }) => {
+      const resp = await fetch('/test/seed-dismissed-suggestion', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status_reason: reason, title, file: 'src/utils.js', line_start: 3 })
+      });
+      if (!resp.ok) throw new Error(`seed failed: ${resp.status}`);
+      const body = await resp.json();
+      if (window.prManager?.loadAISuggestions) {
+        await window.prManager.loadAISuggestions();
+      }
+      return body;
+    }, { reason: REASON, title: TITLE });
+
+    expect(seed.id).toBeTruthy();
+
+    // --- Diff card: the collapsed bar no longer shows the reason inline ---
+    const collapsedCard = page.locator('.ai-suggestion.collapsed', { hasText: TITLE }).first();
+    await expect(collapsedCard).toBeVisible();
+    await expect(collapsedCard.locator('.collapsed-dismissal-reason')).toHaveCount(0);
+    // The dismissed state is signalled by a tooltip on the collapsed-content.
+    await expect(collapsedCard.locator('.ai-suggestion-collapsed-content'))
+      .toHaveAttribute('title', 'Dismissed');
+
+    // --- Reasoning popover: the brain button reveals the Dismissal section ---
+    const brainBtn = collapsedCard.locator('.btn-reasoning-toggle.collapsed-reasoning');
+    await expect(brainBtn).toBeVisible();
+    await brainBtn.click();
+    const popover = page.locator('.reasoning-popover');
+    await expect(popover).toBeVisible();
+    await expect(popover.locator('.reasoning-popover-dismissal-heading')).toHaveText('Dismissal');
+    await expect(popover.locator('.reasoning-popover-dismissal')).toContainText(REASON);
+
+    // The expanded reply-styled note is present in the DOM (hidden while the
+    // card is collapsed) and carries the full reason text.
+    const note = page.locator('.ai-suggestion .ai-dismissal-note').first();
+    await expect(note).toHaveCount(1);
+    await expect(note.locator('.ai-dismissal-note-body')).toHaveText(REASON);
+    await expect(note.locator('.ai-dismissal-note-label')).toBeAttached();
+
+    // --- AI panel: dismissed finding shows the muted reason line + tooltip ---
+    await page.evaluate(() => window.aiPanel?.expand());
+    await page.waitForSelector('.finding-item', { timeout: 5000 });
+
+    const dismissedFinding = page.locator('.finding-item.finding-dismissed', { hasText: TITLE }).first();
+    await expect(dismissedFinding).toBeVisible();
+
+    const reasonLine = dismissedFinding.locator('.finding-dismissal-reason');
+    await expect(reasonLine).toBeVisible();
+    await expect(reasonLine).toHaveText(REASON);
+
+    // Full reason is in the finding-item tooltip alongside the location.
+    const tooltip = await dismissedFinding.getAttribute('title');
+    expect(tooltip).toContain(REASON);
+
+    // --- Restore clears the baked-in reason UI on the originating tab ---
+    // Same-tab suggestion broadcasts are suppressed, so no refetch rescues these
+    // cards; the restore paths must strip the stale reason markup in place.
+    await page.evaluate(async (id) => {
+      await window.prManager.restoreSuggestion(id);
+    }, seed.id);
+
+    const restoredCard = page.locator(`.ai-suggestion[data-suggestion-id="${seed.id}"]`).first();
+    await expect(restoredCard).not.toHaveClass(/\bcollapsed\b/);
+    // The reply-styled note is gone and the reason-only brain button is removed.
+    await expect(restoredCard.locator('.ai-dismissal-note')).toHaveCount(0);
+    await expect(restoredCard.locator('.btn-reasoning-toggle')).toHaveCount(0);
+
+    // The AI panel finding drops its reason line and resets its tooltip.
+    const restoredFinding = page.locator(`.finding-item[data-id="${seed.id}"]`).first();
+    await expect(restoredFinding.locator('.finding-dismissal-reason')).toHaveCount(0);
+    const restoredTooltip = await restoredFinding.getAttribute('title');
+    expect(restoredTooltip || '').not.toContain(REASON);
+  });
+});

--- a/tests/e2e/test-server.js
+++ b/tests/e2e/test-server.js
@@ -435,6 +435,57 @@ async function startTestServer(port) {
     }, MOCK_ANALYSIS_DURATION_MS);
   });
 
+  // Test-only endpoint: seed a dismissed AI suggestion carrying a status_reason.
+  // The loop/chat agent sets status_reason when it dismisses a finding; there is
+  // no UI affordance for it (human dismissals are reason-less), so tests inject
+  // one directly rather than perturbing the shared mock suggestion fixtures.
+  app.post('/test/seed-dismissed-suggestion', (req, res) => {
+    const {
+      owner = 'test-owner',
+      repo = 'test-repo',
+      number = 1,
+      status_reason = 'Dismissed by the agent: already handled upstream.',
+      file = 'src/utils.js',
+      line_start = 3,
+      title = 'Seeded dismissed finding',
+      type = 'bug'
+    } = req.body || {};
+
+    const repository = `${owner}/${repo}`;
+    const review = db.prepare('SELECT id FROM reviews WHERE pr_number = ? AND repository = ?')
+      .get(parseInt(number), repository);
+    if (!review) {
+      return res.status(404).json({ error: 'review not found' });
+    }
+
+    // Attach to the most recent analysis run so it appears in the default view.
+    const latestRun = db.prepare(
+      'SELECT id FROM analysis_runs WHERE review_id = ? ORDER BY started_at DESC LIMIT 1'
+    ).get(review.id);
+
+    const now = new Date().toISOString();
+    const info = db.prepare(`
+      INSERT INTO comments (
+        review_id, source, ai_run_id, ai_level, file, line_start, line_end,
+        type, title, body, reasoning, status, status_reason, created_at, updated_at
+      ) VALUES (?, 'ai', ?, NULL, ?, ?, ?, ?, ?, ?, NULL, 'dismissed', ?, ?, ?)
+    `).run(
+      review.id,
+      latestRun ? latestRun.id : null,
+      file,
+      line_start,
+      line_start,
+      type,
+      title,
+      'Body of the seeded dismissed finding.',
+      status_reason,
+      now,
+      now
+    );
+
+    res.json({ id: Number(info.lastInsertRowid), reviewId: review.id });
+  });
+
   // Mock SSE endpoint for analysis progress
   app.get('/api/analyses/:id/progress', (req, res) => {
     res.writeHead(200, {
@@ -521,7 +572,7 @@ async function startTestServer(port) {
       const rows = db.prepare(`
         SELECT id, source, author, ai_run_id, ai_level, ai_confidence,
                file, line_start, line_end, side, type, title, body,
-               reasoning, status, is_file_level, created_at, updated_at
+               reasoning, status, status_reason, is_file_level, created_at, updated_at
         FROM comments
         WHERE review_id = ? AND source = 'ai'
           AND (ai_level IS NULL)
@@ -551,7 +602,14 @@ async function startTestServer(port) {
     }
 
     try {
-      db.prepare('UPDATE comments SET status = ? WHERE id = ?').run(status, parseInt(id));
+      // Mirror production (updateSuggestionStatus): a status_reason may only
+      // live on a dismissed row. Set it when dismissing; clear it (NULL) when
+      // restoring to active or adopting. `req.body.reason` may be undefined for
+      // human/adopt/restore actions, so default it to null.
+      const { reason = null } = req.body;
+      const statusReason = status === 'dismissed' ? reason : null;
+      db.prepare('UPDATE comments SET status = ?, status_reason = ? WHERE id = ?')
+        .run(status, statusReason, parseInt(id));
       res.json({ success: true, status });
     } catch (e) {
       res.status(500).json({ error: 'Failed to update status' });

--- a/tests/integration/routes.test.js
+++ b/tests/integration/routes.test.js
@@ -1887,6 +1887,20 @@ describe('AI Suggestion Endpoints', () => {
       expect(response.body.suggestions[0].type).toBe('improvement');
     });
 
+    it('should include status_reason in the response', async () => {
+      await run(db, `
+        INSERT INTO comments (review_id, source, file, line_start, type, title, body, status, status_reason, ai_run_id)
+        VALUES (?, 'ai', 'file.js', 10, 'improvement', 'Dismissed one', 'body', 'dismissed', 'Out of scope', 'test-run-reason')
+      `, [prId]);
+
+      const response = await request(server)
+        .get(`/api/reviews/${prId}/suggestions`);
+
+      expect(response.status).toBe(200);
+      expect(response.body.suggestions.length).toBe(1);
+      expect(response.body.suggestions[0]).toHaveProperty('status_reason', 'Out of scope');
+    });
+
     it('should return formattedBody for each suggestion', async () => {
       await run(db, `
         INSERT INTO comments (review_id, source, file, line_start, type, title, body, suggestion_text, status, ai_run_id)
@@ -2326,6 +2340,100 @@ describe('AI Suggestion Endpoints', () => {
       const suggestion = await queryOne(db, 'SELECT status, adopted_as_id FROM comments WHERE id = ?', [suggestionId]);
       expect(suggestion.status).toBe('active');
       expect(suggestion.adopted_as_id).toBeNull();
+    });
+
+    it('should dismiss with a reason and persist status_reason', async () => {
+      const { lastID } = await run(db, `
+        INSERT INTO comments (review_id, source, file, line_start, body, status)
+        VALUES (?, 'ai', 'file.js', 10, 'Suggestion', 'active')
+      `, [prId]);
+
+      const response = await request(server)
+        .post(`/api/reviews/${prId}/suggestions/${lastID}/status`)
+        .send({ status: 'dismissed', reason: '  Not applicable to this file  ' });
+
+      expect(response.status).toBe(200);
+      expect(response.body.success).toBe(true);
+      expect(response.body.status).toBe('dismissed');
+      // Response echoes the trimmed reason
+      expect(response.body.status_reason).toBe('Not applicable to this file');
+
+      const suggestion = await queryOne(db, 'SELECT status, status_reason FROM comments WHERE id = ?', [lastID]);
+      expect(suggestion.status).toBe('dismissed');
+      expect(suggestion.status_reason).toBe('Not applicable to this file');
+    });
+
+    it('should return 400 when a reason is provided with status active', async () => {
+      const { lastID } = await run(db, `
+        INSERT INTO comments (review_id, source, file, line_start, body, status)
+        VALUES (?, 'ai', 'file.js', 10, 'Suggestion', 'dismissed')
+      `, [prId]);
+
+      const response = await request(server)
+        .post(`/api/reviews/${prId}/suggestions/${lastID}/status`)
+        .send({ status: 'active', reason: 'should not be allowed' });
+
+      expect(response.status).toBe(400);
+      expect(response.body.error).toContain('reason');
+
+      // Status unchanged
+      const suggestion = await queryOne(db, 'SELECT status FROM comments WHERE id = ?', [lastID]);
+      expect(suggestion.status).toBe('dismissed');
+    });
+
+    it('should return 400 when reason exceeds the max length', async () => {
+      const { lastID } = await run(db, `
+        INSERT INTO comments (review_id, source, file, line_start, body, status)
+        VALUES (?, 'ai', 'file.js', 10, 'Suggestion', 'active')
+      `, [prId]);
+
+      const response = await request(server)
+        .post(`/api/reviews/${prId}/suggestions/${lastID}/status`)
+        .send({ status: 'dismissed', reason: 'x'.repeat(2001) });
+
+      expect(response.status).toBe(400);
+      expect(response.body.error).toContain('2000');
+
+      // Status unchanged (validation rejected before the update)
+      const suggestion = await queryOne(db, 'SELECT status, status_reason FROM comments WHERE id = ?', [lastID]);
+      expect(suggestion.status).toBe('active');
+      expect(suggestion.status_reason).toBeNull();
+    });
+
+    it('should store null when the reason is empty after trimming', async () => {
+      const { lastID } = await run(db, `
+        INSERT INTO comments (review_id, source, file, line_start, body, status)
+        VALUES (?, 'ai', 'file.js', 10, 'Suggestion', 'active')
+      `, [prId]);
+
+      const response = await request(server)
+        .post(`/api/reviews/${prId}/suggestions/${lastID}/status`)
+        .send({ status: 'dismissed', reason: '   ' });
+
+      expect(response.status).toBe(200);
+      expect(response.body.status_reason).toBeNull();
+
+      const suggestion = await queryOne(db, 'SELECT status, status_reason FROM comments WHERE id = ?', [lastID]);
+      expect(suggestion.status).toBe('dismissed');
+      expect(suggestion.status_reason).toBeNull();
+    });
+
+    it('should clear a previously stored reason when restoring to active', async () => {
+      const { lastID } = await run(db, `
+        INSERT INTO comments (review_id, source, file, line_start, body, status, status_reason)
+        VALUES (?, 'ai', 'file.js', 10, 'Suggestion', 'dismissed', 'Was dismissed earlier')
+      `, [prId]);
+
+      const response = await request(server)
+        .post(`/api/reviews/${prId}/suggestions/${lastID}/status`)
+        .send({ status: 'active' });
+
+      expect(response.status).toBe(200);
+      expect(response.body.status_reason).toBeNull();
+
+      const suggestion = await queryOne(db, 'SELECT status, status_reason FROM comments WHERE id = ?', [lastID]);
+      expect(suggestion.status).toBe('active');
+      expect(suggestion.status_reason).toBeNull();
     });
   });
 

--- a/tests/unit/ai-panel-collapse.test.js
+++ b/tests/unit/ai-panel-collapse.test.js
@@ -34,6 +34,10 @@ global.localStorage = {
 };
 global.CustomEvent = class CustomEvent {};
 
+// Real attribute-escaping implementation from production markdown.js, used by
+// AIPanel's finding-item title tooltip (browser loads markdown.js before AIPanel.js).
+const { escapeHtmlAttribute } = require('../../public/js/utils/markdown.js');
+
 // Import the actual AIPanel class from production code
 const { AIPanel } = require('../../public/js/components/AIPanel.js');
 
@@ -96,6 +100,9 @@ beforeEach(() => {
     panelGroup: {
       _onReviewVisibilityChanged: vi.fn(),
     },
+    // renderFindingItem escapes the title tooltip for attribute context;
+    // provided by markdown.js in the browser (loaded before AIPanel.js).
+    escapeHtmlAttribute,
   };
 });
 

--- a/tests/unit/chat/prompt-builder.test.js
+++ b/tests/unit/chat/prompt-builder.test.js
@@ -372,6 +372,52 @@ describe('buildInitialContext', () => {
       expect(context).toContain('src/utils.js');
     });
 
+    it('should include status_reason for a dismissed suggestion so the agent sees WHY', () => {
+      const suggestions = [
+        {
+          id: 1,
+          file: 'src/index.js',
+          line_start: 10,
+          line_end: 15,
+          type: 'bug',
+          title: 'Potential null pointer',
+          body: 'The variable may be null here',
+          reasoning: null,
+          status: 'dismissed',
+          status_reason: 'Guarded by an earlier assertion',
+          ai_confidence: 0.9,
+          is_file_level: 0
+        }
+      ];
+
+      const context = buildInitialContext({ suggestions });
+
+      expect(context).toContain('status_reason');
+      expect(context).toContain('Guarded by an earlier assertion');
+    });
+
+    it('should omit status_reason when absent to keep the context lean', () => {
+      const suggestions = [
+        {
+          id: 1,
+          file: 'src/index.js',
+          line_start: 10,
+          type: 'bug',
+          title: 'Active finding',
+          body: 'Body',
+          reasoning: null,
+          status: 'active',
+          status_reason: null,
+          ai_confidence: 0.9,
+          is_file_level: 0
+        }
+      ];
+
+      const context = buildInitialContext({ suggestions });
+
+      expect(context).not.toContain('status_reason');
+    });
+
     it('should parse reasoning from JSON string', () => {
       const suggestions = [
         {

--- a/tests/unit/comment-repository-final-suggestions.test.js
+++ b/tests/unit/comment-repository-final-suggestions.test.js
@@ -102,7 +102,7 @@ describe('CommentRepository.getFinalSuggestionsByRunId', () => {
     const expectedKeys = [
       'id', 'ai_run_id', 'ai_level', 'ai_confidence',
       'file', 'line_start', 'line_end', 'type', 'title', 'body',
-      'reasoning', 'status', 'is_file_level', 'severity', 'created_at',
+      'reasoning', 'status', 'status_reason', 'is_file_level', 'severity', 'created_at',
     ];
     expect(Object.keys(rows[0]).sort()).toEqual([...expectedKeys].sort());
   });

--- a/tests/unit/comment-repository.test.js
+++ b/tests/unit/comment-repository.test.js
@@ -298,6 +298,77 @@ describe('CommentRepository', () => {
     it('should throw error for invalid status', async () => {
       await expect(commentRepo.updateSuggestionStatus(1, 'invalid')).rejects.toThrow('Invalid status');
     });
+
+    it('should persist status_reason when dismissing with a reason', async () => {
+      const aiSuggestionId = await run(db, `
+        INSERT INTO comments (review_id, source, file, line_start, body, status)
+        VALUES (?, ?, ?, ?, ?, ?)
+      `, [1, 'ai', 'test.js', 10, 'AI suggestion', 'active']);
+
+      await commentRepo.updateSuggestionStatus(aiSuggestionId.lastID, 'dismissed', null, '  Duplicate finding  ');
+
+      const suggestion = await queryOne(db, 'SELECT * FROM comments WHERE id = ?', [aiSuggestionId.lastID]);
+      expect(suggestion.status).toBe('dismissed');
+      // Reason is trimmed before storage
+      expect(suggestion.status_reason).toBe('Duplicate finding');
+    });
+
+    it('should store null status_reason when dismissing with no reason', async () => {
+      const aiSuggestionId = await run(db, `
+        INSERT INTO comments (review_id, source, file, line_start, body, status)
+        VALUES (?, ?, ?, ?, ?, ?)
+      `, [1, 'ai', 'test.js', 10, 'AI suggestion', 'active']);
+
+      await commentRepo.updateSuggestionStatus(aiSuggestionId.lastID, 'dismissed');
+
+      const suggestion = await queryOne(db, 'SELECT * FROM comments WHERE id = ?', [aiSuggestionId.lastID]);
+      expect(suggestion.status).toBe('dismissed');
+      expect(suggestion.status_reason).toBeNull();
+    });
+
+    it('should store null when a dismissal reason is only whitespace', async () => {
+      const aiSuggestionId = await run(db, `
+        INSERT INTO comments (review_id, source, file, line_start, body, status)
+        VALUES (?, ?, ?, ?, ?, ?)
+      `, [1, 'ai', 'test.js', 10, 'AI suggestion', 'active']);
+
+      await commentRepo.updateSuggestionStatus(aiSuggestionId.lastID, 'dismissed', null, '   ');
+
+      const suggestion = await queryOne(db, 'SELECT * FROM comments WHERE id = ?', [aiSuggestionId.lastID]);
+      expect(suggestion.status_reason).toBeNull();
+    });
+
+    it('should clear status_reason when restoring to active', async () => {
+      const aiSuggestionId = await run(db, `
+        INSERT INTO comments (review_id, source, file, line_start, body, status, status_reason)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+      `, [1, 'ai', 'test.js', 10, 'AI suggestion', 'dismissed', 'Was dismissed']);
+
+      await commentRepo.updateSuggestionStatus(aiSuggestionId.lastID, 'active');
+
+      const suggestion = await queryOne(db, 'SELECT * FROM comments WHERE id = ?', [aiSuggestionId.lastID]);
+      expect(suggestion.status).toBe('active');
+      expect(suggestion.status_reason).toBeNull();
+    });
+
+    it('should clear status_reason when adopting a previously dismissed suggestion', async () => {
+      const userCommentId = await run(db, `
+        INSERT INTO comments (review_id, source, file, line_start, body, status)
+        VALUES (?, ?, ?, ?, ?, ?)
+      `, [1, 'user', 'test.js', 10, 'Adopted comment', 'active']);
+
+      const aiSuggestionId = await run(db, `
+        INSERT INTO comments (review_id, source, file, line_start, body, status, status_reason)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+      `, [1, 'ai', 'test.js', 10, 'AI suggestion', 'dismissed', 'Was dismissed']);
+
+      await commentRepo.updateSuggestionStatus(aiSuggestionId.lastID, 'adopted', userCommentId.lastID);
+
+      const suggestion = await queryOne(db, 'SELECT * FROM comments WHERE id = ?', [aiSuggestionId.lastID]);
+      expect(suggestion.status).toBe('adopted');
+      expect(suggestion.adopted_as_id).toBe(userCommentId.lastID);
+      expect(suggestion.status_reason).toBeNull();
+    });
   });
 
   describe('getComment', () => {
@@ -407,6 +478,24 @@ describe('CommentRepository', () => {
       const suggestion = await queryOne(db, 'SELECT * FROM comments WHERE id = ?', [aiSuggestionId.lastID]);
       expect(suggestion.status).toBe('dismissed');
     });
+
+    it('should set the canonical cascade reason on the dismissed parent suggestion', async () => {
+      const aiSuggestionId = await run(db, `
+        INSERT INTO comments (review_id, source, file, line_start, body, status)
+        VALUES (?, ?, ?, ?, ?, ?)
+      `, [1, 'ai', 'test.js', 10, 'AI suggestion', 'adopted']);
+
+      const userCommentId = await run(db, `
+        INSERT INTO comments (review_id, source, file, line_start, body, status, parent_id)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+      `, [1, 'user', 'test.js', 10, 'Adopted comment', 'active', aiSuggestionId.lastID]);
+
+      await commentRepo.deleteComment(userCommentId.lastID);
+
+      const suggestion = await queryOne(db, 'SELECT * FROM comments WHERE id = ?', [aiSuggestionId.lastID]);
+      expect(suggestion.status).toBe('dismissed');
+      expect(suggestion.status_reason).toBe('Adopted comment was deleted');
+    });
   });
 
   describe('bulkDeleteComments', () => {
@@ -468,6 +557,48 @@ describe('CommentRepository', () => {
       // Verify the AI suggestion was dismissed
       const suggestion = await queryOne(db, 'SELECT * FROM comments WHERE id = ?', [aiSuggestionId.lastID]);
       expect(suggestion.status).toBe('dismissed');
+    });
+
+    it('should set the canonical cascade reason on bulk-dismissed parent suggestions', async () => {
+      const aiSuggestionId = await run(db, `
+        INSERT INTO comments (review_id, source, file, line_start, body, status)
+        VALUES (?, ?, ?, ?, ?, ?)
+      `, [1, 'ai', 'test.js', 10, 'AI suggestion', 'adopted']);
+
+      await run(db, `
+        INSERT INTO comments (review_id, source, file, line_start, body, status, parent_id)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+      `, [1, 'user', 'test.js', 10, 'Adopted comment', 'active', aiSuggestionId.lastID]);
+
+      await commentRepo.bulkDeleteComments(1);
+
+      const suggestion = await queryOne(db, 'SELECT * FROM comments WHERE id = ?', [aiSuggestionId.lastID]);
+      expect(suggestion.status).toBe('dismissed');
+      expect(suggestion.status_reason).toBe('Adopted comment was deleted');
+    });
+
+    it('should clear adopted_as_id on bulk-dismissed parent suggestions', async () => {
+      // The adopted comment is soft-deleted by the bulk delete, so the parent
+      // suggestion must not keep pointing at it (parity with the single-delete
+      // path, which routes through updateSuggestionStatus and nulls it).
+      const userCommentId = await run(db, `
+        INSERT INTO comments (review_id, source, file, line_start, body, status)
+        VALUES (?, ?, ?, ?, ?, ?)
+      `, [1, 'user', 'test.js', 10, 'Adopted comment', 'active']);
+
+      const aiSuggestionId = await run(db, `
+        INSERT INTO comments (review_id, source, file, line_start, body, status, adopted_as_id)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+      `, [1, 'ai', 'test.js', 10, 'AI suggestion', 'adopted', userCommentId.lastID]);
+
+      // Point the user comment back at the suggestion so bulk delete cascades.
+      await run(db, 'UPDATE comments SET parent_id = ? WHERE id = ?', [aiSuggestionId.lastID, userCommentId.lastID]);
+
+      await commentRepo.bulkDeleteComments(1);
+
+      const suggestion = await queryOne(db, 'SELECT * FROM comments WHERE id = ?', [aiSuggestionId.lastID]);
+      expect(suggestion.status).toBe('dismissed');
+      expect(suggestion.adopted_as_id).toBeNull();
     });
   });
 

--- a/tests/unit/reasoning-popover.test.js
+++ b/tests/unit/reasoning-popover.test.js
@@ -93,6 +93,11 @@ global.document = {
 // Set up global.window
 global.window = global.window || {};
 
+// suggestion-ui.js is a browser IIFE that attaches window.SuggestionUI. Load it
+// before the managers so _openReasoningPopover can drive the real shared popover
+// content builder (buildReasoningPopoverContentHtml) rather than a copy.
+require('../../public/js/utils/suggestion-ui.js');
+
 // Import the actual production classes
 const { SuggestionManager } = require('../../public/js/modules/suggestion-manager.js');
 const { FileCommentManager } = require('../../public/js/modules/file-comment-manager.js');

--- a/tests/unit/suggestion-dismissal-reason.test.js
+++ b/tests/unit/suggestion-dismissal-reason.test.js
@@ -1,0 +1,505 @@
+// Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+// @vitest-environment jsdom
+
+/**
+ * Tests for AI-suggestion dismissal-reason rendering.
+ *
+ * A dismissed AI suggestion may carry a `status_reason` (set by the loop/chat
+ * agent when it dismisses a finding). It surfaces in three places:
+ *   1. The expanded reply-styled note under the suggestion body
+ *      (buildDismissalNoteHtml, rendered by both suggestion managers).
+ *   2. The reasoning popover, appended as a "Dismissal" section beneath the
+ *      reasoning bullets (buildReasoningPopoverContentHtml). The brain button
+ *      that opens the popover renders whenever there is reasoning OR a reason,
+ *      carrying the reason in an encoded data-dismissal-reason attribute.
+ *   3. The AI panel finding item (AIPanel.renderFindingItem).
+ *
+ * The collapsed suggestion bar itself no longer shows the reason inline; the
+ * dismissed/adopted state is signalled by a tooltip on the collapsed-content
+ * container (setCollapsedStateTooltip). The shared builders live in
+ * public/js/utils/suggestion-ui.js so the render paths stay in sync. When
+ * status_reason is null the note and popover section must be omitted, and
+ * reason text must be HTML-escaped / kept inert.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+
+// markdown.js exports window.escapeHtmlAttribute (attribute-safe escaping used
+// by AIPanel's title tooltip). Load it so the finding-item template can escape
+// the reason for attribute context.
+require('../../public/js/utils/markdown.js');
+// Load the shared helpers first so window.SuggestionUI is populated before the
+// card templates (which reference it at render time) run.
+const SuggestionUI = require('../../public/js/utils/suggestion-ui.js');
+const { SuggestionManager } = require('../../public/js/modules/suggestion-manager.js');
+const { FileCommentManager } = require('../../public/js/modules/file-comment-manager.js');
+const { AIPanel } = require('../../public/js/components/AIPanel.js');
+
+describe('SuggestionUI dismissal-reason builders', () => {
+  describe('buildDismissalNoteHtml', () => {
+    it('returns a labeled note block when a reason is present', () => {
+      const html = SuggestionUI.buildDismissalNoteHtml('Already handled upstream');
+      expect(html).toContain('ai-dismissal-note');
+      expect(html).toContain('ai-dismissal-note-label');
+      expect(html).toContain(SuggestionUI.DISMISSAL_NOTE_LABEL);
+      expect(html).toContain('Already handled upstream');
+    });
+
+    it('returns an empty string when the reason is null, undefined, or empty', () => {
+      expect(SuggestionUI.buildDismissalNoteHtml(null)).toBe('');
+      expect(SuggestionUI.buildDismissalNoteHtml(undefined)).toBe('');
+      expect(SuggestionUI.buildDismissalNoteHtml('')).toBe('');
+    });
+
+    it('escapes HTML in the reason to prevent injection', () => {
+      const html = SuggestionUI.buildDismissalNoteHtml('<img src=x onerror=alert(1)>');
+      expect(html).not.toContain('<img');
+      expect(html).toContain('&lt;img');
+    });
+  });
+
+  describe('buildReasoningPopoverContentHtml', () => {
+    it('renders reasoning bullets and appends the Dismissal section when both are present', () => {
+      const html = SuggestionUI.buildReasoningPopoverContentHtml(
+        ['step one', 'step two'],
+        'Out of scope'
+      );
+      expect(html).toContain('reasoning-popover-dismissal');
+      expect(html).toContain(SuggestionUI.POPOVER_DISMISSAL_HEADING);
+      expect(html).toContain('Out of scope');
+      expect(html).toContain('step one');
+      expect(html).toContain('step two');
+    });
+
+    it('renders only the Dismissal section when there is no reasoning', () => {
+      const html = SuggestionUI.buildReasoningPopoverContentHtml(null, 'Reason only');
+      expect(html).toContain('reasoning-popover-dismissal');
+      expect(html).toContain('Reason only');
+      // No reasoning bullet list is emitted.
+      expect(html).not.toContain('<ul>');
+      expect(html).not.toContain('<li>');
+    });
+
+    it('renders only reasoning when there is no dismissal reason', () => {
+      const html = SuggestionUI.buildReasoningPopoverContentHtml(['only step'], '');
+      expect(html).toContain('only step');
+      expect(html).not.toContain('reasoning-popover-dismissal');
+    });
+
+    it('returns an empty string when neither reasoning nor reason is present', () => {
+      expect(SuggestionUI.buildReasoningPopoverContentHtml(null, '')).toBe('');
+      expect(SuggestionUI.buildReasoningPopoverContentHtml([], null)).toBe('');
+    });
+
+    it('keeps an XSS payload in the reason inert', () => {
+      const html = SuggestionUI.buildReasoningPopoverContentHtml(
+        null,
+        '<img src=x onerror=alert(1)>'
+      );
+      expect(html).not.toContain('<img');
+      expect(html).toContain('&lt;img');
+    });
+  });
+
+  describe('setCollapsedStateTooltip', () => {
+    function makeCard() {
+      const card = document.createElement('div');
+      card.className = 'ai-suggestion collapsed';
+      const collapsed = document.createElement('div');
+      collapsed.className = 'ai-suggestion-collapsed-content';
+      card.appendChild(collapsed);
+      return { card, collapsed };
+    }
+
+    it('sets the tooltip on the collapsed-content container', () => {
+      const { card, collapsed } = makeCard();
+      SuggestionUI.setCollapsedStateTooltip(card, 'Dismissed');
+      expect(collapsed.getAttribute('title')).toBe('Dismissed');
+    });
+
+    it('clears the tooltip when given a falsy label', () => {
+      const { card, collapsed } = makeCard();
+      collapsed.title = 'Adopted';
+      SuggestionUI.setCollapsedStateTooltip(card, '');
+      expect(collapsed.hasAttribute('title')).toBe(false);
+    });
+
+    it('is a no-op when the card or collapsed-content is missing', () => {
+      expect(() => SuggestionUI.setCollapsedStateTooltip(null, 'Dismissed')).not.toThrow();
+      const bare = document.createElement('div');
+      expect(() => SuggestionUI.setCollapsedStateTooltip(bare, 'Dismissed')).not.toThrow();
+    });
+  });
+});
+
+describe('SuggestionUI.clearDismissalReasonUI', () => {
+  // Build a realistic dismissed line-level card via the production template so
+  // the helper is exercised against the exact markup it must clean up.
+  function makeCard(suggestion) {
+    const mgr = Object.create(SuggestionManager.prototype);
+    mgr.prManager = { escapeHtml: (s) => String(s), userComments: [] };
+    const row = mgr.createSuggestionRow([suggestion]);
+    return row.querySelector('.ai-suggestion');
+  }
+
+  it('removes the reply-styled note and the reason-only brain button on restore', () => {
+    const card = makeCard({
+      id: 1,
+      type: 'bug',
+      title: 'Null deref',
+      body: 'Body text',
+      status: 'dismissed',
+      status_reason: 'Guarded elsewhere'
+      // no reasoning array -> brain button exists ONLY because of the reason
+    });
+    // Sanity: the dismissed markup is present before cleanup.
+    expect(card.querySelector('.ai-dismissal-note')).not.toBeNull();
+    expect(card.querySelector('.btn-reasoning-toggle')).not.toBeNull();
+
+    SuggestionUI.clearDismissalReasonUI(card);
+
+    // Note gone, and the reason-only brain buttons removed entirely.
+    expect(card.querySelector('.ai-dismissal-note')).toBeNull();
+    expect(card.querySelector('.btn-reasoning-toggle')).toBeNull();
+    // No stale reason attr survives on any residual toggle.
+    expect(card.querySelector('[data-dismissal-reason]')).toBeNull();
+  });
+
+  it('keeps a brain button that also carries reasoning but strips its dismissal reason', () => {
+    const card = makeCard({
+      id: 2,
+      type: 'bug',
+      title: 'Null deref',
+      body: 'Body text',
+      status: 'dismissed',
+      status_reason: 'Guarded elsewhere',
+      reasoning: ['step one', 'step two']
+    });
+    SuggestionUI.clearDismissalReasonUI(card);
+
+    // The reasoning brain buttons survive (they still have reasoning steps)...
+    const buttons = card.querySelectorAll('.btn-reasoning-toggle');
+    expect(buttons.length).toBeGreaterThan(0);
+    buttons.forEach(btn => {
+      // ...but no longer advertise a dismissal reason.
+      expect(btn.hasAttribute('data-dismissal-reason')).toBe(false);
+      // The reasoning payload is untouched.
+      expect(btn.dataset.reasoning).not.toBe('');
+    });
+    // And the expanded note is gone.
+    expect(card.querySelector('.ai-dismissal-note')).toBeNull();
+  });
+
+  it('is a no-op on a null card or a card with no dismissal markup', () => {
+    expect(() => SuggestionUI.clearDismissalReasonUI(null)).not.toThrow();
+    const bare = document.createElement('div');
+    expect(() => SuggestionUI.clearDismissalReasonUI(bare)).not.toThrow();
+  });
+});
+
+describe('SuggestionManager.createSuggestionRow dismissal reason', () => {
+  function makeManager() {
+    const mgr = Object.create(SuggestionManager.prototype);
+    mgr.prManager = { escapeHtml: (s) => String(s), userComments: [] };
+    return mgr;
+  }
+
+  it('renders the reply-styled note for a dismissed suggestion but no inline collapsed reason', () => {
+    const mgr = makeManager();
+    const row = mgr.createSuggestionRow([{
+      id: 1,
+      type: 'bug',
+      title: 'Null deref',
+      body: 'Body text',
+      status: 'dismissed',
+      status_reason: 'Guarded elsewhere'
+    }]);
+    const html = row.innerHTML;
+    expect(html).toContain('ai-dismissal-note');
+    expect(html).toContain('Guarded elsewhere');
+    // The collapsed bar no longer shows the reason inline.
+    expect(html).not.toContain('collapsed-dismissal-reason');
+    // The dismissed state is signalled via the collapsed-content tooltip.
+    const collapsed = row.querySelector('.ai-suggestion-collapsed-content');
+    expect(collapsed.getAttribute('title')).toBe('Dismissed');
+    // The old inline state text is gone.
+    expect(html).not.toContain('Hidden AI suggestion');
+  });
+
+  it('shows the reasoning brain button (carrying the reason) for a reason-only dismissal', () => {
+    const mgr = makeManager();
+    const row = mgr.createSuggestionRow([{
+      id: 2,
+      type: 'bug',
+      title: 'Null deref',
+      body: 'Body text',
+      status: 'dismissed',
+      status_reason: 'Guarded elsewhere'
+      // no reasoning array
+    }]);
+    // Two templates render the button (expanded + collapsed); grab any.
+    const btn = row.querySelector('.btn-reasoning-toggle');
+    expect(btn).not.toBeNull();
+    // The reason rides in the encoded data attribute, decodable back to source.
+    expect(decodeURIComponent(btn.dataset.dismissalReason)).toBe('Guarded elsewhere');
+    // No reasoning steps, so data-reasoning is empty.
+    expect(btn.dataset.reasoning).toBe('');
+  });
+
+  it('renders no reasoning button when there is neither reasoning nor a reason', () => {
+    const mgr = makeManager();
+    const row = mgr.createSuggestionRow([{
+      id: 3,
+      type: 'bug',
+      title: 'Active finding',
+      body: 'Body',
+      status: 'pending',
+      status_reason: null
+    }]);
+    const html = row.innerHTML;
+    expect(html).not.toContain('ai-dismissal-note');
+    expect(html).not.toContain('collapsed-dismissal-reason');
+    expect(row.querySelector('.btn-reasoning-toggle')).toBeNull();
+  });
+
+  it('escapes HTML in the rendered reason note (no live element injected)', () => {
+    const mgr = makeManager();
+    const row = mgr.createSuggestionRow([{
+      id: 4,
+      type: 'bug',
+      title: 'X',
+      body: 'B',
+      status: 'dismissed',
+      status_reason: '<script>bad()</script>'
+    }]);
+    // The reason must not create a real <script> element — it stays inert text.
+    expect(row.querySelector('script')).toBeNull();
+    const noteBody = row.querySelector('.ai-dismissal-note-body');
+    expect(noteBody).not.toBeNull();
+    expect(noteBody.textContent).toBe('<script>bad()</script>');
+  });
+
+  it('keeps a quote-breakout reason inert in the data-dismissal-reason attribute', () => {
+    const mgr = makeManager();
+    const payload = 'a" onmouseover="alert(1)';
+    const row = mgr.createSuggestionRow([{
+      id: 5,
+      type: 'bug',
+      title: 'X',
+      body: 'B',
+      status: 'dismissed',
+      status_reason: payload
+    }]);
+    const btn = row.querySelector('.btn-reasoning-toggle');
+    expect(btn).not.toBeNull();
+    // encodeURIComponent escaped the quote, so jsdom parsed a single clean
+    // attribute that round-trips back to the exact payload — no breakout,
+    // no injected onmouseover handler.
+    expect(decodeURIComponent(btn.dataset.dismissalReason)).toBe(payload);
+    expect(btn.getAttribute('onmouseover')).toBeNull();
+  });
+});
+
+describe('FileCommentManager.displayAISuggestion dismissal reason', () => {
+  function makeZone() {
+    const zone = document.createElement('div');
+    zone.className = 'file-comments-zone';
+    const container = document.createElement('div');
+    container.className = 'file-comments-container';
+    zone.appendChild(container);
+    return zone;
+  }
+
+  function makeManager() {
+    const mgr = Object.create(FileCommentManager.prototype);
+    mgr.prManager = { userComments: [] };
+    return mgr;
+  }
+
+  it('renders the note and the reason-carrying brain button, but no inline collapsed reason', () => {
+    const mgr = makeManager();
+    const zone = makeZone();
+    mgr.displayAISuggestion(zone, {
+      id: 10,
+      type: 'bug',
+      title: 'File issue',
+      body: 'Body',
+      status: 'dismissed',
+      status_reason: 'Intentional pattern'
+    });
+    const container = zone.querySelector('.file-comments-container');
+    const html = container.innerHTML;
+    expect(html).toContain('ai-dismissal-note');
+    expect(html).toContain('Intentional pattern');
+    expect(html).not.toContain('collapsed-dismissal-reason');
+    // Old inline state text is gone; state lives in the collapsed-content tooltip.
+    expect(html).not.toContain('Hidden AI suggestion');
+    const collapsed = container.querySelector('.ai-suggestion-collapsed-content');
+    expect(collapsed.getAttribute('title')).toBe('Dismissed');
+    // Brain button renders (reason-only) with the encoded reason.
+    const btn = container.querySelector('.btn-reasoning-toggle');
+    expect(btn).not.toBeNull();
+    expect(decodeURIComponent(btn.dataset.dismissalReason)).toBe('Intentional pattern');
+  });
+
+  it('omits the note and the brain button when there is no reason', () => {
+    const mgr = makeManager();
+    const zone = makeZone();
+    mgr.displayAISuggestion(zone, {
+      id: 11,
+      type: 'bug',
+      title: 'File issue',
+      body: 'Body',
+      status: 'pending',
+      status_reason: null
+    });
+    const container = zone.querySelector('.file-comments-container');
+    const html = container.innerHTML;
+    expect(html).not.toContain('ai-dismissal-note');
+    expect(html).not.toContain('collapsed-dismissal-reason');
+    expect(container.querySelector('.btn-reasoning-toggle')).toBeNull();
+  });
+});
+
+describe('AIPanel.renderFindingItem dismissal reason', () => {
+  function makePanel() {
+    return Object.create(AIPanel.prototype);
+  }
+
+  it('adds a muted reason line and includes the reason in the item tooltip', () => {
+    const panel = makePanel();
+    const html = panel.renderFindingItem({
+      id: 20,
+      type: 'bug',
+      title: 'Dismissed finding',
+      file: 'src/app.js',
+      line_start: 42,
+      status: 'dismissed',
+      status_reason: 'Handled by caller'
+    }, 0);
+    expect(html).toContain('finding-dismissal-reason');
+    expect(html).toContain('Handled by caller');
+    // Full reason appears in the item tooltip alongside the location.
+    expect(html).toContain('title="app.js:42 — Handled by caller"');
+  });
+
+  it('does not render a reason line for a dismissed finding without a reason', () => {
+    const panel = makePanel();
+    const html = panel.renderFindingItem({
+      id: 21,
+      type: 'bug',
+      title: 'Dismissed, no reason',
+      file: 'src/app.js',
+      line_start: 42,
+      status: 'dismissed',
+      status_reason: null
+    }, 0);
+    expect(html).not.toContain('finding-dismissal-reason');
+  });
+
+  it('does not render a reason line for an active finding even if status_reason is set', () => {
+    const panel = makePanel();
+    const html = panel.renderFindingItem({
+      id: 22,
+      type: 'bug',
+      title: 'Active finding',
+      file: 'src/app.js',
+      line_start: 42,
+      status: 'pending',
+      status_reason: 'stray reason'
+    }, 0);
+    expect(html).not.toContain('finding-dismissal-reason');
+    expect(html).not.toContain('stray reason');
+  });
+
+  it('escapes HTML in the reason line and tooltip', () => {
+    const panel = makePanel();
+    const html = panel.renderFindingItem({
+      id: 23,
+      type: 'bug',
+      title: 'X',
+      file: 'a.js',
+      line_start: 1,
+      status: 'dismissed',
+      status_reason: '<b>x</b>'
+    }, 0);
+    expect(html).not.toContain('<b>x</b>');
+    expect(html).toContain('&lt;b&gt;x&lt;/b&gt;');
+  });
+
+  it('escapes double quotes in the title tooltip so the reason cannot break out of the attribute', () => {
+    const panel = makePanel();
+    const html = panel.renderFindingItem({
+      id: 24,
+      type: 'bug',
+      title: 'X',
+      file: 'a.js',
+      line_start: 1,
+      status: 'dismissed',
+      status_reason: '" onmouseover="alert(1)'
+    }, 0);
+    // A raw double quote in the reason must be entity-escaped in the title
+    // attribute; otherwise it would close the attribute and inject a handler.
+    expect(html).not.toContain('title="a.js:1 — " onmouseover=');
+    expect(html).toContain('&quot; onmouseover=&quot;alert(1)');
+  });
+});
+
+describe('AIPanel.updateFindingStatus dismissal reason cleanup', () => {
+  // Render a dismissed finding into a findingsList, then flip status and assert
+  // the in-place DOM update strips the stale reason line and resets the tooltip.
+  function makePanelWith(finding) {
+    const panel = Object.create(AIPanel.prototype);
+    panel.findings = [finding];
+    const list = document.createElement('div');
+    list.innerHTML = panel.renderFindingItem(finding, 0);
+    panel.findingsList = list;
+    return panel;
+  }
+
+  const dismissedFinding = {
+    id: 30,
+    type: 'bug',
+    title: 'Dismissed finding',
+    file: 'src/app.js',
+    line_start: 42,
+    status: 'dismissed',
+    status_reason: 'Handled by caller'
+  };
+
+  it('removes the reason line and resets the tooltip when restored to active', () => {
+    const panel = makePanelWith({ ...dismissedFinding });
+    const findingEl = panel.findingsList.querySelector('[data-id="30"]');
+    // Sanity: the dismissed state carries the reason line and reason tooltip.
+    expect(findingEl.querySelector('.finding-dismissal-reason')).not.toBeNull();
+    expect(findingEl.getAttribute('title')).toBe('app.js:42 — Handled by caller');
+
+    panel.updateFindingStatus(30, 'active');
+
+    expect(findingEl.querySelector('.finding-dismissal-reason')).toBeNull();
+    // Tooltip resets to the plain location (matches renderFindingItem for active).
+    expect(findingEl.getAttribute('title')).toBe('app.js:42');
+    expect(findingEl.classList.contains('finding-active')).toBe(true);
+  });
+
+  it('also clears the reason line when the finding is adopted', () => {
+    const panel = makePanelWith({ ...dismissedFinding });
+    const findingEl = panel.findingsList.querySelector('[data-id="30"]');
+
+    panel.updateFindingStatus(30, 'adopted');
+
+    expect(findingEl.querySelector('.finding-dismissal-reason')).toBeNull();
+    expect(findingEl.getAttribute('title')).toBe('app.js:42');
+    expect(findingEl.classList.contains('finding-adopted')).toBe(true);
+  });
+
+  it('leaves the reason line in place while the finding stays dismissed', () => {
+    const panel = makePanelWith({ ...dismissedFinding });
+    const findingEl = panel.findingsList.querySelector('[data-id="30"]');
+
+    panel.updateFindingStatus(30, 'dismissed');
+
+    expect(findingEl.querySelector('.finding-dismissal-reason')).not.toBeNull();
+    expect(findingEl.getAttribute('title')).toBe('app.js:42 — Handled by caller');
+  });
+});

--- a/tests/unit/suggestion-status.test.js
+++ b/tests/unit/suggestion-status.test.js
@@ -13,6 +13,12 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 // Import the actual PRManager class from production code
 const { PRManager } = require('../../public/js/pr.js');
 
+// suggestion-ui.js is a browser IIFE that attaches window.SuggestionUI. Give it
+// a window at require time so collapseSuggestionForAdoption can drive the real
+// setCollapsedStateTooltip helper rather than a copied reimplementation.
+if (typeof global.window === 'undefined') global.window = {};
+const SuggestionUI = require('../../public/js/utils/suggestion-ui.js');
+
 // Mock global fetch
 const mockFetch = vi.fn();
 
@@ -1065,18 +1071,24 @@ describe('PRManager Suggestion Status', () => {
 
     beforeEach(() => {
       prManager = Object.create(PRManager.prototype);
+      // Expose the real SuggestionUI helper for this block only; the global
+      // beforeEach resets window before each test so this stays isolated.
+      global.window.SuggestionUI = SuggestionUI;
     });
 
     /**
      * Build a mock suggestion div with the DOM structure
      * collapseSuggestionForAdoption queries:
      *   - classList.add('collapsed')
-     *   - querySelector('.collapsed-text') -> { textContent }
+     *   - querySelector('.ai-suggestion-collapsed-content') -> { title } (state tooltip)
      *   - querySelector('.btn-restore') -> { title, querySelector('.btn-text') -> { textContent } }
      *   - dataset.hiddenForAdoption
      */
     function buildSuggestionDiv(id) {
-      const collapsedText = { textContent: '' };
+      const collapsedContent = {
+        title: '',
+        removeAttribute: vi.fn(function() { this.title = ''; })
+      };
       const btnText = { textContent: '' };
       const restoreBtn = { title: '', querySelector: vi.fn(() => btnText) };
 
@@ -1084,12 +1096,12 @@ describe('PRManager Suggestion Status', () => {
         dataset: { suggestionId: id },
         classList: { add: vi.fn() },
         querySelector: vi.fn((selector) => {
-          if (selector === '.collapsed-text') return collapsedText;
+          if (selector === '.ai-suggestion-collapsed-content') return collapsedContent;
           if (selector === '.btn-restore') return restoreBtn;
           return null;
         }),
         getAttribute: vi.fn((attr) => attr === 'data-suggestion-id' ? id : null),
-        _collapsedText: collapsedText,
+        _collapsedContent: collapsedContent,
         _restoreBtn: restoreBtn,
         _btnText: btnText
       };
@@ -1118,7 +1130,7 @@ describe('PRManager Suggestion Status', () => {
       prManager.collapseSuggestionForAdoption(row, 's1');
 
       expect(div.classList.add).toHaveBeenCalledWith('collapsed');
-      expect(div._collapsedText.textContent).toBe('Suggestion adopted');
+      expect(div._collapsedContent.title).toBe('Adopted');
       expect(div._restoreBtn.title).toBe('Show suggestion');
       expect(div._btnText.textContent).toBe('Show');
       expect(div.dataset.hiddenForAdoption).toBe('true');
@@ -1133,12 +1145,12 @@ describe('PRManager Suggestion Status', () => {
 
       // Target suggestion should be collapsed
       expect(divA.classList.add).toHaveBeenCalledWith('collapsed');
-      expect(divA._collapsedText.textContent).toBe('Suggestion adopted');
+      expect(divA._collapsedContent.title).toBe('Adopted');
       expect(divA.dataset.hiddenForAdoption).toBe('true');
 
       // Other suggestion on the same row should be completely unaffected
       expect(divB.classList.add).not.toHaveBeenCalled();
-      expect(divB._collapsedText.textContent).toBe('');
+      expect(divB._collapsedContent.title).toBe('');
       expect(divB.dataset.hiddenForAdoption).toBeUndefined();
     });
 
@@ -1155,7 +1167,7 @@ describe('PRManager Suggestion Status', () => {
       prManager.collapseSuggestionForAdoption(row, 's-missing');
 
       expect(divA.classList.add).not.toHaveBeenCalled();
-      expect(divA._collapsedText.textContent).toBe('');
+      expect(divA._collapsedContent.title).toBe('');
     });
   });
 });

--- a/tests/utils/schema.js
+++ b/tests/utils/schema.js
@@ -62,6 +62,7 @@ const SCHEMA_SQL = {
       suggestion_text TEXT,
       reasoning TEXT,
       status TEXT DEFAULT 'active' CHECK(status IN ('active', 'dismissed', 'adopted', 'submitted', 'draft', 'inactive')),
+      status_reason TEXT,
       adopted_as_id INTEGER,
       parent_id INTEGER,
       is_file_level INTEGER DEFAULT 0,


### PR DESCRIPTION
## Summary

Adds **dismissal reasons** for AI suggestions (migration 52 adds a `status_reason` column to `comments`).

- The suggestion status endpoint `POST /api/reviews/:reviewId/suggestions/:id/status` now accepts an optional `reason` string (≤2000 chars), stored and returned as `status_reason` on suggestion objects.
- A reason is valid **only** with status `"dismissed"` — sending one with `"active"` returns 400. Restoring a suggestion to active (or adopting) clears any stored reason. This invariant — a reason lives only on a dismissed row — is enforced centrally in `updateSuggestionStatus`.
- The **loop** (pair-loop plugin) and in-app **chat** agents write a one-sentence explanation when dismissing after discussion.
- The **UI** renders the reason as a reply-styled note beneath the suggestion, with a reasoning affordance.
- Deleting a comment adopted from a suggestion now **dismisses the parent** suggestion with an auto-generated reason noting the adopted comment was removed.
- Documented in the chat API reference and cheat sheet (served via `GET /api.md`).

Both Local mode and PR mode are covered. Changeset included (`patch`).

## Test plan

- [ ] `pnpm test` — unit + integration (new `suggestion-dismissal-reason.test.js`, `comment-repository.test.js`, `suggestion-status.test.js`, prompt-builder additions)
- [ ] `pnpm run test:e2e` — new `suggestion-dismissal-reason.spec.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)