### PR TITLE
feat: render PR-stack quick-switcher items as real links

### DIFF
--- a/.changeset/stack-nav-real-links.md
+++ b/.changeset/stack-nav-real-links.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+The PR-stack quick-switcher in the header now renders each PR as a real link, so you can right-click, cmd/ctrl-click, or middle-click a stacked PR title to open it in a new tab.

--- a/public/js/pr.js
+++ b/public/js/pr.js
@@ -3240,10 +3240,15 @@ class PRManager {
     const displayPRs = [...stackPRs].reverse();
     for (const stackPR of displayPRs) {
       const isCurrent = stackPR.prNumber === pr.number;
-      const item = document.createElement('div');
+      // Render as a real anchor so right-click / cmd-click / middle-click can
+      // open the PR in a new tab natively. The current PR gets no href (not a
+      // link to itself).
+      const item = document.createElement('a');
       item.className = 'stack-nav-item';
       if (isCurrent) {
         item.classList.add('current');
+      } else {
+        item.href = `/pr/${encodeURIComponent(pr.owner)}/${encodeURIComponent(pr.repo)}/${stackPR.prNumber}`;
       }
       item.dataset.pr = stackPR.prNumber;
 
@@ -3281,10 +3286,20 @@ class PRManager {
 
       item.appendChild(textCol);
 
-      // Navigate on click
-      item.addEventListener('click', () => {
-        if (stackPR.prNumber !== pr.number) {
-          window.location.href = `/pr/${encodeURIComponent(pr.owner)}/${encodeURIComponent(pr.repo)}/${stackPR.prNumber}`;
+      // Navigation is handled natively by the anchor's href (enabling
+      // open-in-new-tab). A plain left-click follows the link and unloads the
+      // page; for modified clicks (cmd/ctrl/middle → new tab) or the current
+      // PR, just close the menu without navigating the current tab.
+      item.addEventListener('click', (e) => {
+        // Modified clicks open a new tab — leave the current page as-is.
+        if (e.metaKey || e.ctrlKey || e.shiftKey || e.button !== 0) {
+          dropdown.classList.remove('open');
+          trigger.setAttribute('aria-expanded', 'false');
+          return;
+        }
+        // Current PR has no href; nothing to navigate to.
+        if (stackPR.prNumber === pr.number) {
+          e.preventDefault();
         }
         dropdown.classList.remove('open');
         trigger.setAttribute('aria-expanded', 'false');

--- a/tests/unit/pr-stack-nav-links.test.js
+++ b/tests/unit/pr-stack-nav-links.test.js
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+ */
+/** @vitest-environment jsdom */
+
+/**
+ * Regression test for the stack-nav quick-switcher rendering real links.
+ *
+ * The header PR-stack switcher used to render each PR title as a <div> with a
+ * JS click handler that set window.location.href. That made right-click "open
+ * in new tab" and cmd/ctrl/middle-click impossible. The items are now real
+ * <a href> anchors so the browser handles open-in-new-tab natively; the click
+ * handler only closes the menu (and avoids double-navigating on modified
+ * clicks). The current PR renders as an anchor with no href.
+ *
+ * PRManager is loaded into a vm sandbox (the established pattern in
+ * pr-manager-manual-start.test.js / pr-pending-draft-host-name.test.js) wired
+ * to the real jsdom document so _renderStackNavDropdown builds a live DOM.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+function loadPRManager() {
+  const code = fs.readFileSync(
+    path.join(__dirname, '../../public/js/pr.js'),
+    'utf8'
+  );
+  const sandbox = {
+    window: global.window,
+    document: global.document,
+    navigator: global.navigator,
+    console,
+    localStorage: { getItem() { return null; }, setItem() {} },
+    fetch: () => Promise.resolve({ ok: false, status: 404, json: () => Promise.resolve({}) }),
+    setTimeout,
+    clearTimeout,
+    URLSearchParams,
+    module: { exports: {} },
+  };
+  sandbox.globalThis = sandbox;
+  sandbox.self = sandbox;
+  const context = vm.createContext(sandbox);
+  vm.runInContext(code, context, { filename: 'pr.js' });
+  return sandbox.module.exports.PRManager;
+}
+
+describe('PRManager stack-nav switcher — real anchor links', () => {
+  let PRManager;
+
+  const pr = {
+    owner: 'acme',
+    repo: 'widget',
+    number: 7,
+    stack_data: [
+      { branch: 'main', isTrunk: true },
+      { branch: 'feat-base', isTrunk: false, prNumber: 6, title: 'Base PR' },
+      { branch: 'feat-top', isTrunk: false, prNumber: 7, title: 'Top PR' },
+    ],
+  };
+
+  beforeEach(() => {
+    document.body.innerHTML =
+      '<div class="pr-title-wrapper"><h1 id="pr-title-text">Top PR</h1></div>';
+    PRManager = loadPRManager();
+  });
+
+  function makeManager() {
+    return Object.create(PRManager.prototype);
+  }
+
+  it('renders each non-current PR as an <a> with the correct href', () => {
+    const mgr = makeManager();
+    mgr._renderStackNavDropdown(pr);
+
+    const items = document.querySelectorAll('.stack-nav-item');
+    expect(items.length).toBe(2);
+
+    for (const item of items) {
+      expect(item.tagName).toBe('A');
+    }
+
+    // #6 is the other (non-current) PR — it must be a real navigable link.
+    const other = document.querySelector('.stack-nav-item[data-pr="6"]');
+    expect(other.getAttribute('href')).toBe('/pr/acme/widget/6');
+  });
+
+  it('renders the current PR as an anchor with no href', () => {
+    const mgr = makeManager();
+    mgr._renderStackNavDropdown(pr);
+
+    const current = document.querySelector('.stack-nav-item.current');
+    expect(current).not.toBeNull();
+    expect(current.dataset.pr).toBe('7');
+    expect(current.hasAttribute('href')).toBe(false);
+  });
+
+  it('encodes owner/repo into the href', () => {
+    const mgr = makeManager();
+    mgr._renderStackNavDropdown({ ...pr, owner: 'a c/me', repo: 'wid get' });
+
+    const other = document.querySelector('.stack-nav-item[data-pr="6"]');
+    expect(other.getAttribute('href')).toBe(
+      `/pr/${encodeURIComponent('a c/me')}/${encodeURIComponent('wid get')}/6`
+    );
+  });
+
+  it('does not navigate the current tab on a plain left-click (href does)', () => {
+    const mgr = makeManager();
+    mgr._renderStackNavDropdown(pr);
+
+    const dropdown = document.querySelector('.stack-nav-dropdown');
+    const trigger = document.querySelector('.stack-nav-trigger');
+    dropdown.classList.add('open');
+    trigger.setAttribute('aria-expanded', 'true');
+
+    const other = document.querySelector('.stack-nav-item[data-pr="6"]');
+    // jsdom does not follow anchor navigation; assert the handler leaves
+    // navigation to the browser (no manual location assignment) and closes
+    // the menu. preventDefault must NOT be called for a real link.
+    const evt = new window.MouseEvent('click', { bubbles: true, cancelable: true, button: 0 });
+    const prevented = !other.dispatchEvent(evt);
+
+    expect(prevented).toBe(false); // handler let the link proceed
+    expect(dropdown.classList.contains('open')).toBe(false);
+    expect(trigger.getAttribute('aria-expanded')).toBe('false');
+  });
+
+  it('closes the menu on a modified (cmd) click without preventing the new tab', () => {
+    const mgr = makeManager();
+    mgr._renderStackNavDropdown(pr);
+
+    const dropdown = document.querySelector('.stack-nav-dropdown');
+    const trigger = document.querySelector('.stack-nav-trigger');
+    dropdown.classList.add('open');
+    trigger.setAttribute('aria-expanded', 'true');
+
+    const other = document.querySelector('.stack-nav-item[data-pr="6"]');
+    const evt = new window.MouseEvent('click', {
+      bubbles: true, cancelable: true, button: 0, metaKey: true,
+    });
+    const prevented = !other.dispatchEvent(evt);
+
+    expect(prevented).toBe(false); // did not preventDefault — new tab opens
+    expect(dropdown.classList.contains('open')).toBe(false);
+    expect(trigger.getAttribute('aria-expanded')).toBe('false');
+  });
+});


### PR DESCRIPTION
## Summary

The header PR-stack quick-switcher rendered each stacked PR as a `<div>` that navigated via a JS click handler setting `window.location.href`. That meant right-click "Open in new tab", cmd/ctrl-click, and middle-click could not open a PR in a new tab.

Each non-current PR is now a real `<a href="/pr/{owner}/{repo}/{number}">` anchor, so the browser handles open-in-new-tab natively:

- Non-current PRs get an `href` (owner/repo URL-encoded); the current PR is an anchor with no `href`.
- The click handler no longer navigates manually — the browser follows the `href`. It only closes the menu, and on modified clicks (cmd/ctrl/shift/middle → new tab) it bails without navigating the current tab, so you don't get a new tab *and* a navigation in the current one.
- This is the shared `_renderStackNavDropdown`, so it covers **both PR mode and Local mode**. The `/pr/...` target is unchanged from the old handler.

## Testing

- New unit test `tests/unit/pr-stack-nav-links.test.js` (5 cases, all passing): anchors + correct href, current PR has no href, owner/repo encoding, plain-click doesn't double-navigate, modified-click preserves the new tab.
- Full E2E suite: **358 passed / 1 skipped / 0 failed**.

Changeset: `patch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)