### PR TITLE
feat: chat prompt snippets library

### DIFF
--- a/.changeset/chat-prompt-snippets.md
+++ b/.changeset/chat-prompt-snippets.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": minor
+---
+
+Add chat prompt snippets: save reusable prompts, insert them from a new button in the chat input (Cmd/Ctrl+click to insert and send), Alt-click any of your previous chat messages to save it as a snippet, and manage snippets from the chat popup or the global settings page.

--- a/README.md
+++ b/README.md
@@ -736,6 +736,7 @@ Chat with a full coding agent while you review — it can read the codebase, ans
 - Create and edit review comments through chat
 - Trigger new analysis runs with custom instructions
 - Start conversations from context — an analysis run, an AI suggestion, a comment, any line or file
+- Save reusable **prompt snippets** and insert them from a button in the chat input (Cmd/Ctrl+click to insert and send); Alt-click one of your sent messages to save it as a snippet; manage them from the chat popup or the [global settings page](#global-settings-page)
 
 **Setup:**
 

--- a/plans/chat-prompt-snippets.md
+++ b/plans/chat-prompt-snippets.md
@@ -1,0 +1,140 @@
+# Chat Prompt Snippets Library
+
+## Context
+
+The user reuses the same prompts in chat constantly. This adds a global (user-level, not repo-specific) library of prompt snippets, insertable from a new button in the chat input area. Decisions made with the user:
+
+- **Button** sits to the LEFT of the send button in `.chat-panel__input-actions`.
+- **Popup** lists snippets in MRU order, with a small "Snippets" header + gear icon.
+- **Click inserts** the snippet into the input; **Cmd/Ctrl+click inserts AND sends**.
+- **Body-only snippets** (no titles); popup shows a ~60-char single-line truncated preview.
+- **Management** = shared editor component, reachable from the popup gear (as a modal) AND as a "Chat Snippets" section on the global settings page.
+- **Global storage** now; schema must not preclude future repo-level snippets.
+- Works in both PR and local mode (automatic — ChatPanel is one shared component via `PanelGroup.js:60`).
+
+## Design decisions
+
+- **Dedicated `chat_snippets` table (migration 54)**, not a JSON blob in `global_settings`: `GlobalSettingsService` validates keys against the settings registry (would need special-casing), and MRU touch would rewrite the whole array (racy with concurrent edits). `CouncilRepository` (`src/database.js:5699`) is the exact template — it already has `touchLastUsedAt()` (line 5767) and MRU ordering `ORDER BY last_used_at DESC NULLS LAST, updated_at DESC` (line 5756).
+- **New `src/routes/snippets.js`** (pattern: `src/routes/councils.js`), not folded into settings routes.
+- **`public/js/components/SnippetManager.js`**: one class, two entry points — inline mount for settings page, static `SnippetManager.openModal()` wrapper (modal shell pattern from `ReviewModal.js`, but `addEventListener` not inline `onclick`).
+- **MRU touch on every insert** (plain and cmd-click), fire-and-forget: `fetch(...).catch(() => {})`, never awaited, never blocks insert.
+
+## Step 1 — Database (`src/database.js`)
+
+- Line 24: `CURRENT_SCHEMA_VERSION` 53 → 54.
+- `SCHEMA_SQL` (after `global_settings`, ~line 374):
+  ```sql
+  CREATE TABLE IF NOT EXISTS chat_snippets (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    body TEXT NOT NULL,
+    last_used_at DATETIME,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+  )
+  ```
+  No `repository` column now; repo-scoping later = `ALTER TABLE ADD COLUMN` + a `WHERE` filter. Nothing precluded.
+- `INDEX_SQL`: `CREATE INDEX IF NOT EXISTS idx_chat_snippets_last_used ON chat_snippets(last_used_at DESC)`.
+- `MIGRATIONS[54]`: copy migration 53's idempotent shape (`tableExists` guard + `IF NOT EXISTS` index). Fresh installs get the table from `setupSchema()`'s `SCHEMA_SQL` loop, so the guard is mandatory.
+- New `ChatSnippetRepository` class next to `CouncilRepository`, modeled on it:
+  - `create({ body })` (validate non-empty string), `getById(id)`, `list()` (MRU order, same SQL as councils), `update(id, { body })` (bumps `updated_at`), `touchLastUsedAt(id)`, `delete(id)`. All boolean-returning mutators return false for unknown id.
+- Export `ChatSnippetRepository` from `module.exports` (~line 6153).
+
+## Step 2 — API routes (new `src/routes/snippets.js`)
+
+Copyright header; `logger` (never console); top-level requires. Handlers build `new ChatSnippetRepository(req.app.get('db'))`; try/catch → `logger.error` + 500.
+
+| Method | Path | Body | Response |
+|---|---|---|---|
+| GET | `/api/snippets` | — | `200 { snippets: [...] }` MRU order |
+| POST | `/api/snippets` | `{ body }` | `201 { snippet }`; `400` missing/empty/non-string/>10000 chars |
+| PUT | `/api/snippets/:id` | `{ body }` | `200 { snippet }`; `400` / `404` |
+| DELETE | `/api/snippets/:id` | — | `200 { success: true }`; `404` |
+| POST | `/api/snippets/:id/touch` | — | `200 { success: true }`; `404` |
+
+`:id` via `Number.parseInt`, NaN → 400.
+
+**Mount in BOTH servers**: `src/server.js` (~line 489, next to `settingsRoutes`) AND `tests/e2e/global-setup.js` (~line 698). Missing the second makes every snippet E2E test 404.
+
+## Step 3 — Shared editor (new `public/js/components/SnippetManager.js`)
+
+- `new SnippetManager(container, { onChange })`: list of snippet rows (truncated preview + Edit/Delete sibling buttons — rows are divs, NOT buttons, per no-nested-interactive rule in `public/js/CONVENTIONS.md`), "Add snippet" button, textarea add/edit form. All data via Step-2 API; re-fetch after each mutation; `onChange()` after success. `destroy()` removes document listeners + clears container.
+- Static `SnippetManager.openModal({ onClose })`: `.modal-overlay`/`.modal-backdrop`/`.modal-container` shell, header "Manage snippets", mounts an instance; teardown destroys instance, removes overlay, `onClose(changed)`.
+- Escape all snippet text (`textContent` or escapeHtml helper).
+- Export: `window.SnippetManager = ...` + `if (typeof module !== 'undefined')` CommonJS export (pattern: bottom of `ChatPanel.js`).
+- Script tags before ChatPanel.js/settings.js in: `public/pr.html` (~line 435), `public/local.html` (~line 632), `public/settings.html` (~line 126).
+
+## Step 4 — ChatPanel wiring (`public/js/components/ChatPanel.js`)
+
+**Naming hazard**: "snippet" already means *code-snippet enrichment* in this file (lines 2812–2876, `_enrich...snippet`). Use distinct names for the new UI: `_promptSnippet*` methods / `chat-panel__snippet-picker` CSS is fine (no CSS collision), but method names must not collide or confuse — prefix with `_snippetDropdown`/`_insertSnippet` is acceptable if grep-distinct; prefer `_promptSnippet` prefix for clarity.
+
+- **Markup** in `_render()`, inside `.chat-panel__input-actions` (line 867), BEFORE send button (868): picker wrapper div (`position: relative`) with button + hidden dropdown div.
+- **Refs** cached near lines 890–892; **event** bound in `_bindEvents()` near line 933.
+- **New methods** (copy provider-dropdown lifecycle, lines 1692–1778):
+  - `_toggleSnippetDropdown()` / `async _showSnippetDropdown()` / `_hideSnippetDropdown()` / `_renderSnippetDropdown(snippets)`.
+  - `_showSnippetDropdown()`: hide provider + session dropdowns first; `await` GET `/api/snippets` (`[]` on failure); **after the await, bail if panel closed or dropdown toggled meanwhile**; track an in-flight flag so double-click doesn't double-fetch. Outside-click one-shot document handler via `setTimeout(..., 0)` — guard the timeout callback so a fast hide doesn't leak the listener.
+  - Render: header row (div) with "Snippets" span + gear button; empty state ("No snippets yet" + Manage button); items as buttons with escaped 60-char first-line previews. Full bodies in a `Map` (`this._snippetsById`), not data-attributes.
+  - Item click: `_insertSnippet(id, { send: e.metaKey || e.ctrlKey })`, then hide dropdown. Gear/Manage: hide dropdown, `SnippetManager.openModal()` (guard `typeof`).
+- **`_insertSnippet(id, { send })`**:
+  - Insert at cursor (`selectionStart/End`); prefix `\n` if preceding char exists and isn't whitespace; caret to end of insertion; focus input.
+  - Programmatic value change bypasses the `input` listener (952–955) — replicate: `_autoResizeTextarea()` + recompute `sendBtn.disabled` (the adopt/update handlers are the precedent).
+  - Fire-and-forget touch POST (both click variants).
+  - If `send`: call `this.sendMessage()` — its own guards handle empty (2227) and streaming (2235, returns BEFORE input is cleared at 2244, so cmd-click-while-streaming degrades to insert-only). Do NOT duplicate those guards.
+- **Mutual-exclusion sites** (all must be touched — pairwise hand-maintained):
+  - `close()` (~1388) and `_startNewConversation()` (~1434): add `_hideSnippetDropdown()`.
+  - `_showProviderDropdown()` (1704) and `_showSessionDropdown()` (1838): each also hides snippet dropdown; snippet show hides the other two.
+  - `destroy()` (~4996): call `_hideSnippetDropdown()` before clearing container (prevents document-listener leak).
+- **CSS** in `public/css/pr.css` (loaded by pr.html, local.html AND settings.html — one stylesheet serves all): picker `position: relative`; dropdown `position: absolute; bottom: calc(100% + 6px); right: 0` (opens **upward** — input is at panel bottom, unlike header dropdowns); `min-width: 260px; max-height: 320px; overflow-y: auto`; ellipsis previews; SnippetManager list/form styles; dark-theme overrides near line 10771.
+
+## Step 5 — Settings page
+
+- `public/settings.html`: after repos section (~line 114), static `<section id="snippets-section">` with header "Chat Snippets" + `<div id="snippets-manager">` mount point. Visible by default (component renders own empty/error states).
+- `public/js/settings.js`:
+  - `init()` (~113): after `loadRepos()`, mount `new SnippetManager(...)` (guard `typeof`), set `this.snippetsVisible`.
+  - `navItems(sections, includeRepos)` (line 721): **add a third boolean param** `includeSnippets` (additive — keeps existing unit-test call sites at `tests/unit/settings-page.test.js:639–655` working). Update caller `buildNavigation()` (757).
+- `src/settings/registry.js` untouched (list editor doesn't fit scalar registry rows).
+
+## Step 6 — Tests
+
+- **Schema**: add `chat_snippets` DDL + index to `tests/utils/schema.js` (next to `global_settings`, line 336) — index name must match production exactly. This single file feeds both integration and E2E DBs (CLAUDE.md's older pointers to global-setup.js/routes.test.js both delegate here now).
+- `tests/unit/chat-snippet-repository.test.js` (model: `council-repository.test.js`): create/reject-empty, getById miss, MRU ordering (unused rows after used; ties by `updated_at DESC`), update bumps `updated_at` (backdate via SQL then assert strictly-greater — NO sleeps per `tests/CONVENTIONS.md`), touch, delete, unknown-id falses.
+- `tests/integration/snippets-routes.test.js` (model: `council-routes.test.js`): **`listenOnLoopback` + `request(server)`, never `request(app)`**. All 5 endpoints: happy, 400s, 404s, GET order changes after touch.
+- `tests/unit/snippet-manager.test.js` (jsdom, mocked fetch): inline mount render/empty state, CRUD calls + re-render, onChange, openModal mount + backdrop teardown removes overlay and listeners.
+- `tests/unit/chat-panel-snippets.test.js` (scaffold from `chat-panel.test.js`; don't `vi.clearAllMocks()`): `_insertSnippet` empty/mid-text/newline-prefix/disabled-recompute/touch-fired/send:true invokes sendMessage/send-while-streaming leaves text; dropdown mutual exclusion; `close()` hides.
+- `tests/e2e/chat-snippets.spec.js` (model: `chat-tabs.spec.js`): button visible; empty state → manage; gear → modal → add; insert fills textarea + enables send; MRU re-order after insert (seed via `page.request.post`); exercise BOTH PR and local mode; settings page shows section + CRUD round-trip.
+- Extend `tests/unit/settings-page.test.js` navItems describe for the new flag.
+
+## Step 7 — Changeset + polish
+
+- `.changeset/chat-prompt-snippets.md`, bump **minor**, describing the feature.
+- Copyright header on every new file.
+- README: short mention under chat features.
+
+## Sequencing
+
+1. DB + test schema + repo unit tests
+2. Routes + both mounts + integration tests
+3. SnippetManager + unit tests + script tags
+4. ChatPanel wiring + CSS + unit tests
+5. Settings section + nav + tests
+6. E2E spec; run `pnpm test` and `pnpm run test:e2e`
+7. Changeset
+
+## Verification
+
+- `pnpm test` (unit + integration), `pnpm run test:e2e`.
+- Manual: start a local review AND a PR review; verify button, popup MRU, insert-at-cursor, cmd-click send, gear modal, settings section, dark theme.
+
+## Hazards
+
+- **`_render()`/`_bindEvents()` shared by both modes** — a markup error breaks chat everywhere; ref-caching (890–911) has no null guards, so template elements must exist before refs are cached.
+- **`sendMessage()` callers** (2225): send click (933), Enter keydown (969/976), adopt/update handlers, and now snippet cmd-click. Guards: empty → return 2227; streaming → return 2235 BEFORE input clear 2244. Don't duplicate guards divergently.
+- **Programmatic input mutation bypasses `input` listener (952–955)** — must replicate disabled-recompute + autosize or send stays disabled.
+- **Dropdown exclusion is pairwise/hand-maintained** — third dropdown touches SIX sites: two show methods, `close()`, `_startNewConversation()`, plus new show hiding both, plus `destroy()`.
+- **Outside-click `setTimeout(...,0)` leak** — fast toggle can attach the document listener after hide nulled the ref; guard the timeout callback. `destroy()` currently doesn't remove dropdown listeners; ours must.
+- **Async race in `_showSnippetDropdown`** — panel can close / another dropdown open during the fetch await; bail after await. Don't blindly copy `_showSessionDropdown` (1838) — it lacks this guard. Two rapid clicks = two in-flight fetches; use an in-flight flag.
+- **Touch vs list refresh race** — reopening popup right after insert may show pre-touch order. Accepted; never await touch.
+- **Two servers mount routes** — `src/server.js` AND `tests/e2e/global-setup.js`; prior art: `settingsRoutes` mounted in both.
+- **`navItems` arity** — two call sites (`buildNavigation()` at settings.js:757, unit tests at settings-page.test.js:639–655); additive third param keeps both working.
+- **Migration idempotency** — fresh installs create the table via `SCHEMA_SQL` before migrations; `tableExists` guard + `IF NOT EXISTS` index mandatory; index name identical in `INDEX_SQL`, migration, and `tests/utils/schema.js`.
+- **"snippet" naming collision** — ChatPanel already uses "snippet" for code-snippet enrichment (2812–2876). Choose grep-distinct method names (e.g. `_promptSnippet*` or `*SnippetDropdown`), never reuse existing names.
+- **No nested interactive elements** (`public/js/CONVENTIONS.md`) — popup header is a div with a gear button; manager rows are divs with sibling Edit/Delete buttons.

--- a/public/css/pr.css
+++ b/public/css/pr.css
@@ -11832,6 +11832,7 @@ body.resizing * {
 
 /* Chat Input Area */
 .chat-panel__input-area {
+  position: relative; /* anchor for .chat-panel__snippet-dropdown */
   display: flex;
   flex-direction: column;
   margin: 0 12px 12px;
@@ -11908,6 +11909,192 @@ body.resizing * {
 .chat-panel__send-btn:disabled {
   opacity: 0.4;
   cursor: not-allowed;
+}
+
+/* ── Prompt-snippet picker (chat input) ─────────────────────────────────── */
+.chat-panel__snippet-picker {
+  /* NOT position:relative — the dropdown anchors to .chat-panel__input-area
+     so it spans the input box instead of growing leftward out of the panel. */
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+}
+
+.chat-panel__snippet-picker-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border: 1px solid var(--color-border-default, rgba(0, 0, 0, 0.1));
+  background: transparent;
+  color: var(--color-text-secondary, #656d76);
+  border-radius: 6px;
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+}
+
+.chat-panel__snippet-picker-btn:hover,
+.chat-panel__snippet-picker-btn--open {
+  background: var(--color-bg-tertiary, rgba(128, 128, 128, 0.1));
+  color: var(--color-text-primary, #1f2328);
+}
+
+/* Dropdown opens UPWARD — the input sits at the panel bottom. Anchored to
+   .chat-panel__input-area (position:relative) so it spans the input box and
+   stays inside the chat panel at any panel width; previews ellipsize. */
+.chat-panel__snippet-dropdown {
+  position: absolute;
+  bottom: calc(100% + 6px);
+  left: 0;
+  right: 0;
+  max-height: 320px;
+  overflow-y: auto;
+  background: var(--color-bg-primary, #fff);
+  border: 1px solid var(--color-border-primary, #d0d7de);
+  border-radius: 8px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+  z-index: 100;
+  padding: 4px;
+}
+
+.chat-panel__snippet-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 4px 8px;
+  border-bottom: 1px solid var(--color-border-muted, rgba(128, 128, 128, 0.15));
+  margin-bottom: 4px;
+}
+
+.chat-panel__snippet-header-title {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--color-text-tertiary, #8b949e);
+}
+
+.chat-panel__snippet-manage-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border: none;
+  background: transparent;
+  color: var(--color-text-tertiary, #8b949e);
+  border-radius: 5px;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.chat-panel__snippet-manage-btn:hover {
+  background: var(--color-bg-tertiary, rgba(128, 128, 128, 0.1));
+  color: var(--color-text-primary, #1f2328);
+}
+
+.chat-panel__snippet-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  padding: 16px 12px;
+  text-align: center;
+  color: var(--color-text-tertiary, #8b949e);
+  font-size: 12px;
+}
+
+.chat-panel__snippet-manage-empty-btn {
+  border: 1px solid var(--color-border-primary, #d0d7de);
+  background: transparent;
+  color: var(--color-text-primary, #1f2328);
+  border-radius: 6px;
+  padding: 4px 10px;
+  font-size: 12px;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+.chat-panel__snippet-manage-empty-btn:hover {
+  background: var(--color-bg-tertiary, rgba(128, 128, 128, 0.1));
+}
+
+.chat-panel__snippet-list {
+  display: flex;
+  flex-direction: column;
+}
+
+.chat-panel__snippet-item {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  padding: 8px 12px;
+  border: none;
+  background: transparent;
+  text-align: left;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background 0.15s ease;
+  font-size: 13px;
+  color: var(--color-text-primary, #1f2328);
+}
+
+.chat-panel__snippet-item:hover {
+  background: var(--color-bg-tertiary, rgba(128, 128, 128, 0.08));
+}
+
+.chat-panel__snippet-item-preview {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+  flex: 1;
+}
+
+[data-theme="dark"] .chat-panel__snippet-dropdown {
+  background: var(--color-bg-primary, #0d1117);
+  border-color: var(--color-border-primary, #30363d);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+}
+
+[data-theme="dark"] .chat-panel__snippet-item {
+  color: var(--color-text-primary, #e6edf3);
+}
+
+[data-theme="dark"] .chat-panel__snippet-manage-empty-btn {
+  color: var(--color-text-primary, #e6edf3);
+  border-color: var(--color-border-primary, #30363d);
+}
+
+/* Save-as-snippet pill (alt-click a submitted user message) */
+.chat-panel__save-snippet-pill {
+  position: fixed;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 12px;
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 1;
+  color: #ffffff;
+  background: var(--color-accent-primary);
+  border: none;
+  border-radius: 999px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.24);
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.15s ease, opacity 0.15s ease;
+}
+
+.chat-panel__save-snippet-pill:hover:not(:disabled) {
+  background: var(--color-accent-hover);
+}
+
+.chat-panel__save-snippet-pill:disabled {
+  opacity: 0.7;
+  cursor: default;
 }
 
 .chat-panel__stop-btn {

--- a/public/css/snippet-manager.css
+++ b/public/css/snippet-manager.css
@@ -1,0 +1,233 @@
+/* Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0 */
+
+/*
+ * Styles for the SnippetManager component (public/js/components/SnippetManager.js).
+ * Loaded on the settings page (inline mount) and on the PR/local pages (for the
+ * chat-picker modal). Colors reference the shared CSS custom properties defined
+ * by pr.css so light and dark themes both work.
+ */
+
+/* ─── Inline manager ──────────────────────────────────────────────────────── */
+
+.snippet-manager {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.snippet-manager__loading,
+.snippet-manager__empty {
+  color: var(--color-text-secondary, #57606a);
+  font-size: 13px;
+  padding: 8px 0;
+}
+
+.snippet-manager__error {
+  color: var(--color-danger, #cf222e);
+  font-size: 13px;
+  padding: 8px 12px;
+  border: 1px solid var(--color-danger, #cf222e);
+  border-radius: var(--radius-md, 6px);
+  background: var(--color-bg-secondary, #f6f8fa);
+}
+
+.snippet-manager__list-wrap {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.snippet-manager__list {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--color-border-primary, #d1d9e0);
+  border-radius: var(--radius-md, 6px);
+  overflow: hidden;
+}
+
+.snippet-manager__row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--color-border-primary, #d1d9e0);
+  background: var(--color-bg-primary, #ffffff);
+}
+
+.snippet-manager__row:last-child {
+  border-bottom: none;
+}
+
+.snippet-manager__preview {
+  flex: 1 1 auto;
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-size: 13px;
+  color: var(--color-text-primary, #1f2328);
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+}
+
+.snippet-manager__row-actions {
+  flex: 0 0 auto;
+  display: flex;
+  gap: 6px;
+}
+
+.snippet-manager__row-btn,
+.snippet-manager__add-btn,
+.snippet-manager__save-btn,
+.snippet-manager__cancel-btn {
+  font-size: 12px;
+  padding: 4px 10px;
+  border-radius: var(--radius-md, 6px);
+  border: 1px solid var(--color-border-primary, #d1d9e0);
+  background: var(--color-bg-secondary, #f6f8fa);
+  color: var(--color-text-primary, #1f2328);
+  cursor: pointer;
+}
+
+.snippet-manager__row-btn:hover,
+.snippet-manager__add-btn:hover,
+.snippet-manager__cancel-btn:hover {
+  background: var(--color-bg-tertiary, #eaeef2);
+}
+
+.snippet-manager__delete-btn:hover {
+  border-color: var(--color-danger, #cf222e);
+  color: var(--color-danger, #cf222e);
+}
+
+.snippet-manager__add-btn {
+  align-self: flex-start;
+}
+
+.snippet-manager__save-btn {
+  background: var(--color-accent-primary, #0969da);
+  border-color: var(--color-accent-primary, #0969da);
+  color: #ffffff;
+  font-weight: 600;
+}
+
+.snippet-manager__save-btn:hover {
+  background: var(--color-accent-hover, var(--color-accent-primary, #0860ca));
+}
+
+.snippet-manager__save-btn:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+/* ─── Add / edit form ─────────────────────────────────────────────────────── */
+
+.snippet-manager__form {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.snippet-manager__form-label {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--color-text-primary, #1f2328);
+}
+
+.snippet-manager__textarea {
+  width: 100%;
+  box-sizing: border-box;
+  resize: vertical;
+  min-height: 96px;
+  padding: 8px 10px;
+  font-size: 13px;
+  line-height: 1.5;
+  border-radius: var(--radius-md, 6px);
+  border: 1px solid var(--color-border-primary, #d1d9e0);
+  background: var(--color-bg-primary, #ffffff);
+  color: var(--color-text-primary, #1f2328);
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+}
+
+.snippet-manager__textarea:focus {
+  outline: none;
+  border-color: var(--color-accent-primary, #0969da);
+  box-shadow: 0 0 0 3px var(--color-accent-subtle, rgba(9, 105, 218, 0.1));
+}
+
+.snippet-manager__form-actions {
+  display: flex;
+  gap: 8px;
+}
+
+/* ─── Modal shell ─────────────────────────────────────────────────────────── */
+
+/*
+ * Self-contained modal styling so the picker modal works on any page, whether
+ * or not another stylesheet also defines `.modal-overlay`. Scoped to the
+ * snippet-manager-modal class to avoid overriding other modals.
+ */
+.snippet-manager-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.snippet-manager-modal .modal-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  cursor: pointer;
+}
+
+.snippet-manager-modal__container {
+  position: relative;
+  width: min(560px, 92vw);
+  max-height: 82vh;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  background: var(--color-bg-primary, #ffffff);
+  border: 1px solid var(--color-border-primary, #d1d9e0);
+  border-radius: var(--radius-lg, 12px);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
+}
+
+.snippet-manager-modal__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 20px;
+  border-bottom: 1px solid var(--color-border-primary, #d1d9e0);
+}
+
+.snippet-manager-modal__header h3 {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--color-text-primary, #1f2328);
+}
+
+.snippet-manager-modal__close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px;
+  border: none;
+  background: none;
+  color: var(--color-text-secondary, #57606a);
+  cursor: pointer;
+  border-radius: var(--radius-md, 6px);
+}
+
+.snippet-manager-modal__close:hover {
+  background: var(--color-bg-tertiary, #eaeef2);
+  color: var(--color-text-primary, #1f2328);
+}
+
+.snippet-manager-modal__body {
+  padding: 16px 20px;
+  overflow-y: auto;
+}

--- a/public/js/components/ChatPanel.js
+++ b/public/js/components/ChatPanel.js
@@ -865,6 +865,14 @@ class ChatPanel {
           <div class="chat-panel__input-footer">
             <span class="chat-panel__input-hint" title="Configure with chat.enter_to_send">${this._enterToSend ? 'Enter to send, Shift+Enter for newline' : `${typeof navigator !== 'undefined' && navigator.platform?.includes('Mac') ? '\u2318' : 'Ctrl'}+Enter to send`}</span>
             <div class="chat-panel__input-actions">
+              <div class="chat-panel__snippet-picker">
+                <button class="chat-panel__snippet-picker-btn" title="Insert prompt snippet">
+                  <svg viewBox="0 0 16 16" fill="currentColor" width="14" height="14">
+                    <path d="M6.78 1.97a.75.75 0 0 1 0 1.06L3.81 6h6.44A4.75 4.75 0 0 1 15 10.75v2.5a.75.75 0 0 1-1.5 0v-2.5a3.25 3.25 0 0 0-3.25-3.25H3.81l2.97 2.97a.75.75 0 1 1-1.06 1.06L1.47 7.28a.75.75 0 0 1 0-1.06l4.25-4.25a.75.75 0 0 1 1.06 0Z"/>
+                  </svg>
+                </button>
+                <div class="chat-panel__snippet-dropdown" style="display: none;"></div>
+              </div>
               <button class="chat-panel__send-btn" title="Send" disabled>
                 <svg viewBox="0 0 16 16" fill="currentColor" width="14" height="14">
                   <path d="M.989 8 .064 2.68a1.342 1.342 0 0 1 1.85-1.462l13.402 5.744a1.13 1.13 0 0 1 0 2.076L1.913 14.782a1.343 1.343 0 0 1-1.85-1.463L.99 8Zm.603-4.776L2.296 7.25h5.954a.75.75 0 0 1 0 1.5H2.296l-.704 4.026L13.788 8Z"/>
@@ -888,6 +896,9 @@ class ChatPanel {
     this.tabStripItemsEl = this.container.querySelector('.chat-panel__tab-strip-items');
     this.tabNewBtn = this.container.querySelector('.chat-panel__tab-new-btn');
     this.inputEl = this.container.querySelector('.chat-panel__input');
+    this.snippetPickerEl = this.container.querySelector('.chat-panel__snippet-picker');
+    this.snippetPickerBtn = this.container.querySelector('.chat-panel__snippet-picker-btn');
+    this.snippetDropdown = this.container.querySelector('.chat-panel__snippet-dropdown');
     this.sendBtn = this.container.querySelector('.chat-panel__send-btn');
     this.stopBtn = this.container.querySelector('.chat-panel__stop-btn');
     this.closeBtn = this.container.querySelector('.chat-panel__close-btn');
@@ -928,6 +939,9 @@ class ChatPanel {
 
     // Session history button
     this.historyBtn.addEventListener('click', () => this._toggleSessionDropdown());
+
+    // Prompt-snippet picker button
+    this.snippetPickerBtn?.addEventListener('click', () => this._toggleSnippetDropdown());
 
     // Send button
     this.sendBtn.addEventListener('click', () => this.sendMessage());
@@ -983,10 +997,18 @@ class ChatPanel {
     // Escape: close dropdown if open, stop agent if streaming, blur textarea if focused, otherwise close panel
     this._onKeydown = (e) => {
       if (e.key === 'Escape' && this.isOpen) {
-        if (this._isProviderDropdownOpen()) {
+        // Escape ladder (first match wins): save-snippet pill → provider
+        // dropdown → session dropdown → snippet dropdown → stop streaming →
+        // blur input → close panel. The pill goes first so dismissing it
+        // never falls through to closing the panel.
+        if (this._saveSnippetPill) {
+          this._hideSaveSnippetPill();
+        } else if (this._isProviderDropdownOpen()) {
           this._hideProviderDropdown();
         } else if (this._isSessionDropdownOpen()) {
           this._hideSessionDropdown();
+        } else if (this._isSnippetDropdownOpen()) {
+          this._hideSnippetDropdown();
         } else if (this.isStreaming) {
           this._stopAgent();
         } else if (document.activeElement === this.inputEl) {
@@ -1005,6 +1027,18 @@ class ChatPanel {
         e.preventDefault();
         this._handleFileLinkClick(link);
       }
+    });
+
+    // Alt-click on a submitted USER message reveals a "Save as snippet" pill.
+    // Separate listener so plain clicks keep their exact prior behavior — we
+    // act only when e.altKey is set. Assistant/error messages are not savable.
+    this.messagesStackEl?.addEventListener('click', (e) => {
+      if (!e.altKey) return;
+      const msgEl = e.target.closest?.('.chat-panel__message--user');
+      if (!msgEl) return;
+      e.preventDefault();
+      e.stopPropagation();
+      this._showSaveSnippetPill(msgEl, e);
     });
 
     // Re-read chat providers once the <head> config fetch resolves
@@ -1387,6 +1421,8 @@ class ChatPanel {
   close() {
     this._hideProviderDropdown();
     this._hideSessionDropdown();
+    this._hideSnippetDropdown();
+    this._hideSaveSnippetPill();
     // Reset UI streaming state (buttons) but keep isStreaming and _streamingContent
     // intact so the background WebSocket handler can continue accumulating events.
     this.sendBtn.style.display = '';
@@ -1433,6 +1469,7 @@ class ChatPanel {
   async _startNewConversation() {
     this._hideProviderDropdown();
     this._hideSessionDropdown();
+    this._hideSnippetDropdown();
     // Multi-chat replaces the legacy in-place reset with a fresh tab; the
     // per-tab restore path inside _appendTab handles context cards
     // (including thread cards introduced by external-comments) so the
@@ -1703,8 +1740,9 @@ class ChatPanel {
 
   _showProviderDropdown() {
     if (!this.providerDropdown) return;
-    // Close session dropdown if open
+    // Close session + snippet dropdowns if open
     this._hideSessionDropdown();
+    this._hideSnippetDropdown();
 
     this._renderProviderDropdown();
     this.providerDropdown.style.display = '';
@@ -1821,6 +1859,308 @@ class ChatPanel {
     this._renderTabStrip();
   }
 
+  // ── Prompt-snippet picker dropdown ─────────────────────────────────────
+  // NOTE: "snippet" here means a reusable *chat prompt* the user inserts from
+  // the library. This is distinct from the code-snippet enrichment (_fetch...
+  // Snippet / _stripMarkdownForSnippet) used to give the agent file context.
+
+  _isSnippetDropdownOpen() {
+    return this.snippetDropdown && this.snippetDropdown.style.display !== 'none';
+  }
+
+  _toggleSnippetDropdown() {
+    if (this._isSnippetDropdownOpen()) {
+      this._hideSnippetDropdown();
+    } else {
+      this._showSnippetDropdown();
+    }
+  }
+
+  async _showSnippetDropdown() {
+    if (!this.snippetDropdown) return;
+    // Close the sibling dropdowns — exclusion is pairwise/hand-maintained.
+    this._hideProviderDropdown();
+    this._hideSessionDropdown();
+
+    // In-flight guard so a double-click doesn't fire two overlapping fetches.
+    if (this._snippetDropdownLoading) return;
+    this._snippetDropdownLoading = true;
+
+    let snippets = [];
+    try {
+      const res = await fetch('/api/snippets');
+      if (res.ok) {
+        const data = await res.json();
+        snippets = Array.isArray(data?.snippets) ? data.snippets : [];
+      }
+    } catch {
+      snippets = [];
+    } finally {
+      this._snippetDropdownLoading = false;
+    }
+
+    // The panel may have closed, or the dropdown been dismissed, while the
+    // fetch was in flight. Bail rather than pop open a stale list.
+    if (this._snippetDropdownDismissed) {
+      this._snippetDropdownDismissed = false;
+      return;
+    }
+    if (!this.isOpen || !this.snippetDropdown) return;
+
+    this._renderSnippetDropdown(snippets);
+    this.snippetDropdown.style.display = '';
+    this.snippetPickerBtn?.classList.add('chat-panel__snippet-picker-btn--open');
+
+    // Bind outside-click-to-close (one-shot). Guard the timeout callback so a
+    // fast hide before the tick doesn't leak the document listener.
+    this._snippetOutsideClickHandler = (e) => {
+      if (this.snippetPickerEl && !this.snippetPickerEl.contains(e.target)) {
+        this._hideSnippetDropdown();
+      }
+    };
+    setTimeout(() => {
+      // Only attach if the dropdown is still open (ref not nulled by a hide
+      // that ran between scheduling and now).
+      if (this._snippetOutsideClickHandler && this._isSnippetDropdownOpen()) {
+        document.addEventListener('click', this._snippetOutsideClickHandler);
+      } else {
+        this._snippetOutsideClickHandler = null;
+      }
+    }, 0);
+  }
+
+  _hideSnippetDropdown() {
+    if (!this.snippetDropdown) return;
+    // If a fetch is in flight, mark it dismissed so its post-await show bails.
+    if (this._snippetDropdownLoading) this._snippetDropdownDismissed = true;
+    this.snippetDropdown.style.display = 'none';
+    this.snippetPickerBtn?.classList.remove('chat-panel__snippet-picker-btn--open');
+    if (this._snippetOutsideClickHandler) {
+      document.removeEventListener('click', this._snippetOutsideClickHandler);
+      this._snippetOutsideClickHandler = null;
+    }
+  }
+
+  _renderSnippetDropdown(snippets) {
+    if (!this.snippetDropdown) return;
+
+    // Full bodies live in a Map keyed by id — never in data-attributes (avoids
+    // re-escaping large multi-line bodies through the DOM).
+    this._promptSnippetsById = new Map();
+
+    const header = `
+      <div class="chat-panel__snippet-header">
+        <span class="chat-panel__snippet-header-title">Snippets</span>
+        <button class="chat-panel__snippet-manage-btn" type="button" title="Manage snippets" aria-label="Manage snippets">
+          <svg viewBox="0 0 16 16" fill="currentColor" width="12" height="12">
+            <path d="M8 0a8.2 8.2 0 0 1 .701.031C9.444.095 9.99.645 10.16 1.29l.288 1.107c.018.066.079.158.212.224.231.114.454.243.668.386.123.082.233.09.299.071l1.103-.303c.644-.176 1.392.021 1.813.63.183.264.352.539.506.822.294.542.188 1.219-.226 1.6l-.796.796c-.058.06-.079.161-.048.281.037.146.061.298.061.451s-.024.305-.061.451c-.031.12-.01.221.048.281l.796.796c.414.381.52 1.058.226 1.6a7.912 7.912 0 0 1-.506.822c-.421.609-1.169.806-1.813.63l-1.103-.303c-.066-.019-.176-.011-.299.071a4.759 4.759 0 0 1-.668.386c-.133.066-.194.158-.212.224l-.288 1.107c-.17.645-.716 1.195-1.459 1.259a8.174 8.174 0 0 1-1.402 0c-.743-.064-1.289-.614-1.459-1.259l-.288-1.107c-.018-.066-.079-.158-.212-.224a4.759 4.759 0 0 1-.668-.386c-.123-.082-.233-.09-.299-.071l-1.103.303c-.644.176-1.392-.021-1.813-.63a7.884 7.884 0 0 1-.506-.822c-.294-.542-.188-1.219.226-1.6l.796-.796c.058-.06.079-.161.048-.281A1.85 1.85 0 0 1 1.3 8c0-.153.024-.305.061-.451.031-.12.01-.221-.048-.281l-.796-.796c-.414-.381-.52-1.058-.226-1.6.154-.283.323-.558.506-.822.421-.609 1.169-.806 1.813-.63l1.103.303c.066.019.176.011.299-.071.214-.143.437-.272.668-.386.133-.066.194-.158.212-.224l.288-1.107C6.01.645 6.556.095 7.299.03 7.53.01 7.764 0 8 0Zm0 5a3 3 0 1 0 0 6 3 3 0 0 0 0-6Z"/>
+          </svg>
+        </button>
+      </div>
+    `;
+
+    if (!snippets.length) {
+      this.snippetDropdown.innerHTML = `
+        ${header}
+        <div class="chat-panel__snippet-empty">
+          <span>No snippets yet</span>
+          <button class="chat-panel__snippet-manage-empty-btn" type="button">Manage snippets</button>
+        </div>
+      `;
+    } else {
+      const items = snippets.map(s => {
+        this._promptSnippetsById.set(String(s.id), s.body);
+        const firstLine = String(s.body || '').split('\n')[0];
+        const preview = firstLine.length > 60
+          ? firstLine.slice(0, 60) + '…'
+          : firstLine;
+        return `
+          <button class="chat-panel__snippet-item" type="button" data-snippet-id="${this._escapeHtml(String(s.id))}">
+            <span class="chat-panel__snippet-item-preview">${this._escapeHtml(preview)}</span>
+          </button>
+        `;
+      }).join('');
+      this.snippetDropdown.innerHTML = header + `<div class="chat-panel__snippet-list">${items}</div>`;
+    }
+
+    // Manage (gear + empty-state button): open the shared editor modal.
+    const openManager = () => {
+      this._hideSnippetDropdown();
+      if (typeof SnippetManager !== 'undefined') {
+        SnippetManager.openModal({ onClose: () => {} });
+      }
+    };
+    this.snippetDropdown.querySelector('.chat-panel__snippet-manage-btn')
+      ?.addEventListener('click', openManager);
+    this.snippetDropdown.querySelector('.chat-panel__snippet-manage-empty-btn')
+      ?.addEventListener('click', openManager);
+
+    // Item click: insert (cmd/ctrl-click also sends), then hide.
+    this.snippetDropdown.querySelectorAll('.chat-panel__snippet-item').forEach(btn => {
+      btn.addEventListener('click', (e) => {
+        this._insertPromptSnippet(btn.dataset.snippetId, { send: e.metaKey || e.ctrlKey });
+        this._hideSnippetDropdown();
+      });
+    });
+  }
+
+  /**
+   * Insert a prompt snippet's body into the input at the caret. A programmatic
+   * value change bypasses the `input` listener (952–955), so we replicate its
+   * effects: autosize + recompute sendBtn.disabled. MRU touch is fire-and-
+   * forget (never awaited). With `send`, hands off to sendMessage() whose own
+   * guards cover empty/streaming — we do not duplicate them.
+   * @param {string|number} id - Snippet id
+   * @param {{ send?: boolean }} [opts]
+   */
+  _insertPromptSnippet(id, { send = false } = {}) {
+    if (!this.inputEl) return;
+    // Respect the "Connecting to review…" disabled contract (_disableInput):
+    // don't mutate a disabled textarea, and don't let cmd-click reach
+    // sendMessage() (which has no disabled-input guard of its own).
+    if (this.inputEl.disabled) return;
+    const body = this._promptSnippetsById?.get(String(id));
+    if (body == null) return;
+
+    const el = this.inputEl;
+    const value = el.value || '';
+    let start = typeof el.selectionStart === 'number' ? el.selectionStart : value.length;
+    let end = typeof el.selectionEnd === 'number' ? el.selectionEnd : value.length;
+    if (start > value.length) start = value.length;
+    if (end > value.length) end = value.length;
+
+    // Prefix a newline when inserting directly after non-whitespace text so
+    // the snippet doesn't fuse onto the previous word.
+    const prevChar = start > 0 ? value[start - 1] : '';
+    const prefix = prevChar && !/\s/.test(prevChar) ? '\n' : '';
+    const insertText = prefix + body;
+
+    el.value = value.slice(0, start) + insertText + value.slice(end);
+    const caret = start + insertText.length;
+    if (typeof el.setSelectionRange === 'function') {
+      el.setSelectionRange(caret, caret);
+    } else {
+      el.selectionStart = el.selectionEnd = caret;
+    }
+    el.focus();
+
+    // Replicate the input-listener side effects the programmatic change skips.
+    this._autoResizeTextarea();
+    this.sendBtn.disabled = !el.value.trim() || this.isStreaming || el.disabled;
+
+    // MRU touch — fire-and-forget, NEVER awaited, must not block insert.
+    fetch(`/api/snippets/${id}/touch`, { method: 'POST' }).catch(() => {});
+
+    // Cmd/Ctrl-click: send. sendMessage() owns the empty/streaming guards.
+    if (send) this.sendMessage();
+  }
+
+  // ── Save-as-snippet pill (alt-click a user message) ────────────────────
+  // Distinct from the prompt-snippet *picker* above: this is the reverse
+  // direction — capturing a message the user already sent into the library.
+
+  /**
+   * Show the single "Save as snippet" pill anchored near the alt-click point.
+   * Only one pill exists at a time; alt-clicking another message moves it.
+   * @param {HTMLElement} msgEl - The `.chat-panel__message--user` element
+   * @param {MouseEvent} e - The originating alt-click (for positioning)
+   */
+  _showSaveSnippetPill(msgEl, e) {
+    this._hideSaveSnippetPill();
+
+    // Raw body stashed by addMessage — preserves newlines/formatting. Fall
+    // back to the bubble text only if the property is somehow missing.
+    const body = (msgEl && msgEl._chatRawContent != null)
+      ? msgEl._chatRawContent
+      : (msgEl?.querySelector?.('.chat-panel__bubble')?.textContent || '');
+    if (!body) return;
+    this._saveSnippetPillContent = body;
+
+    const pill = document.createElement('button');
+    pill.type = 'button';
+    pill.className = 'chat-panel__save-snippet-pill';
+    pill.textContent = 'Save as snippet';
+    // Fixed positioning at the click point sidesteps the scrolling messages
+    // container's overflow clipping; the pill is ephemeral (dismissed on any
+    // scroll-independent interaction) so it needn't track content.
+    pill.style.position = 'fixed';
+    pill.style.left = `${e.clientX}px`;
+    pill.style.top = `${e.clientY}px`;
+    pill.style.zIndex = '200';
+    pill.addEventListener('click', (ev) => {
+      ev.stopPropagation();
+      this._saveSnippetFromPill();
+    });
+    document.body.appendChild(pill);
+    this._saveSnippetPill = pill;
+
+    // Outside-click dismiss (one-shot). Guard the timeout callback so a fast
+    // dismiss before the tick doesn't leak the document listener.
+    this._saveSnippetOutsideClickHandler = (ev) => {
+      if (this._saveSnippetPill && ev.target !== this._saveSnippetPill) {
+        this._hideSaveSnippetPill();
+      }
+    };
+    setTimeout(() => {
+      if (this._saveSnippetOutsideClickHandler && this._saveSnippetPill) {
+        document.addEventListener('click', this._saveSnippetOutsideClickHandler);
+      } else {
+        this._saveSnippetOutsideClickHandler = null;
+      }
+    }, 0);
+  }
+
+  _hideSaveSnippetPill() {
+    if (this._saveSnippetOutsideClickHandler) {
+      document.removeEventListener('click', this._saveSnippetOutsideClickHandler);
+      this._saveSnippetOutsideClickHandler = null;
+    }
+    if (this._saveSnippetPill) {
+      if (this._saveSnippetPill.parentNode) {
+        this._saveSnippetPill.parentNode.removeChild(this._saveSnippetPill);
+      } else if (typeof this._saveSnippetPill.remove === 'function') {
+        this._saveSnippetPill.remove();
+      }
+      this._saveSnippetPill = null;
+    }
+    this._saveSnippetPillContent = null;
+  }
+
+  /**
+   * Persist the pilled message body as a snippet. Fire-and-forget from the
+   * click handler; never throws (POST failure degrades to a brief "Failed"
+   * label, then the pill dismisses).
+   */
+  async _saveSnippetFromPill() {
+    const pill = this._saveSnippetPill;
+    const body = this._saveSnippetPillContent;
+    if (!pill || body == null) return;
+    pill.disabled = true;
+    try {
+      const res = await fetch('/api/snippets', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ body }),
+      });
+      if (!res.ok) throw new Error(`save snippet failed: ${res.status}`);
+      this._hideSaveSnippetPill();
+      if (window.toast?.showSuccess) {
+        window.toast.showSuccess('Saved as snippet');
+      } else if (window.showToast) {
+        window.showToast('Saved as snippet', 'success');
+      }
+    } catch {
+      // Keep quiet but visible: label the pill, then dismiss it. Guard against
+      // a pill that was already replaced/dismissed while the POST was inflight.
+      if (this._saveSnippetPill === pill) {
+        pill.textContent = 'Failed';
+        setTimeout(() => {
+          if (this._saveSnippetPill === pill) this._hideSaveSnippetPill();
+        }, 1200);
+      }
+    }
+  }
+
   // ── Session picker dropdown ────────────────────────────────────────────
 
   _isSessionDropdownOpen() {
@@ -1837,8 +2177,9 @@ class ChatPanel {
 
   async _showSessionDropdown() {
     if (!this.sessionDropdown) return;
-    // Close provider dropdown if open
+    // Close provider + snippet dropdowns if open
     this._hideProviderDropdown();
+    this._hideSnippetDropdown();
 
     const sessions = await this._fetchSessions();
     this._renderSessionDropdown(sessions);
@@ -3963,6 +4304,11 @@ class ChatPanel {
     const msgEl = document.createElement('div');
     msgEl.className = `chat-panel__message chat-panel__message--${role}`;
     if (id) msgEl.dataset.messageId = id;
+    // Stash the raw content on the element (not an attribute) so the
+    // alt-click "Save as snippet" affordance can persist the exact body —
+    // newlines/formatting intact — rather than the rendered bubble's
+    // textContent. User messages only; assistant/error aren't savable.
+    if (role === 'user') msgEl._chatRawContent = content;
 
     const bubble = document.createElement('div');
     bubble.className = 'chat-panel__bubble';
@@ -4996,6 +5342,13 @@ class ChatPanel {
   destroy() {
     document.removeEventListener('keydown', this._onKeydown);
     window.removeEventListener('chat-state-changed', this._onChatStateChanged);
+    // Remove any lingering outside-click document listeners before the
+    // container is cleared (each open dropdown holds a one-shot handler;
+    // these hide methods safely no-op when their dropdown is already closed).
+    this._hideProviderDropdown();
+    this._hideSessionDropdown();
+    this._hideSnippetDropdown();
+    this._hideSaveSnippetPill();
     this._closeSubscriptions();
     this.tabs = [];
     this.activeTabKey = null;

--- a/public/js/components/SnippetManager.js
+++ b/public/js/components/SnippetManager.js
@@ -1,0 +1,463 @@
+// Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+/**
+ * SnippetManager — shared editor for chat prompt snippets.
+ *
+ * One class, two entry points:
+ *   - Inline mount: `new SnippetManager(container, { onChange })` renders a
+ *     list of snippets with Edit/Delete controls plus an add/edit form. Used by
+ *     the global settings page's "Chat Snippets" section.
+ *   - Modal: `SnippetManager.openModal({ onClose })` wraps an instance in a
+ *     modal shell (reachable from the chat input's snippet-picker gear).
+ *
+ * All data flows through the /api/snippets endpoints. The list is re-fetched
+ * after every successful mutation so it stays in MRU order, and `onChange()`
+ * fires after each success so callers (e.g. an open chat dropdown) can refresh.
+ *
+ * Snippet bodies are untrusted text and are always rendered via textContent /
+ * DOM construction — never string-interpolated into innerHTML.
+ */
+
+/* global window, document, fetch, module */
+
+class SnippetManager {
+  /**
+   * @param {HTMLElement} container - Mount point; its contents are managed here.
+   * @param {Object} [options]
+   * @param {Function} [options.onChange] - Called after any successful mutation.
+   */
+  constructor(container, { onChange } = {}) {
+    this.container = container;
+    this.onChange = typeof onChange === 'function' ? onChange : null;
+
+    // View state: 'list' | 'add' | 'edit'.
+    this._mode = 'list';
+    // Id of the snippet being edited (only meaningful in 'edit' mode).
+    this._editingId = null;
+    // Latest snippet list from the API.
+    this._snippets = [];
+    // Guards against overlapping saves/deletes.
+    this._busy = false;
+    // In-progress form text preserved across a failed-save re-render (null when
+    // no draft is pending). See _save / _buildForm.
+    this._formDraft = null;
+    // Last error message to surface in the banner (null when clear).
+    this._error = null;
+
+    // Document-level listeners we attach (currently none for the inline view,
+    // but tracked so destroy() can always tear them down safely).
+    this._docListeners = [];
+
+    if (this.container) {
+      this._renderLoading();
+      this._fetchAndRender();
+    }
+  }
+
+  // ─── Data ──────────────────────────────────────────────────────────────────
+
+  async _fetchAndRender() {
+    try {
+      const response = await fetch('/api/snippets');
+      if (!response.ok) throw new Error(`Failed to load snippets (${response.status})`);
+      const data = await response.json();
+      this._snippets = Array.isArray(data.snippets) ? data.snippets : [];
+      this._error = null;
+    } catch (error) {
+      this._snippets = [];
+      this._error = error && error.message ? error.message : 'Failed to load snippets';
+    }
+    this._render();
+  }
+
+  // ─── Rendering ─────────────────────────────────────────────────────────────
+
+  _renderLoading() {
+    if (!this.container) return;
+    this.container.innerHTML = '';
+    const loading = document.createElement('div');
+    loading.className = 'snippet-manager__loading';
+    loading.textContent = 'Loading snippets…';
+    this.container.appendChild(loading);
+  }
+
+  _render() {
+    if (!this.container) return;
+    this.container.innerHTML = '';
+
+    const root = document.createElement('div');
+    root.className = 'snippet-manager';
+
+    if (this._error) {
+      const err = document.createElement('div');
+      err.className = 'snippet-manager__error';
+      err.textContent = this._error;
+      root.appendChild(err);
+    }
+
+    if (this._mode === 'add' || this._mode === 'edit') {
+      root.appendChild(this._buildForm());
+    } else {
+      root.appendChild(this._buildList());
+    }
+
+    this.container.appendChild(root);
+  }
+
+  _buildList() {
+    const wrap = document.createElement('div');
+    wrap.className = 'snippet-manager__list-wrap';
+
+    if (this._snippets.length === 0) {
+      const empty = document.createElement('div');
+      empty.className = 'snippet-manager__empty';
+      empty.textContent = 'No snippets yet.';
+      wrap.appendChild(empty);
+    } else {
+      const list = document.createElement('div');
+      list.className = 'snippet-manager__list';
+      for (const snippet of this._snippets) {
+        list.appendChild(this._buildRow(snippet));
+      }
+      wrap.appendChild(list);
+    }
+
+    const addBtn = document.createElement('button');
+    addBtn.type = 'button';
+    addBtn.className = 'snippet-manager__add-btn';
+    addBtn.textContent = 'Add snippet';
+    addBtn.addEventListener('click', () => this._showAddForm());
+    wrap.appendChild(addBtn);
+
+    return wrap;
+  }
+
+  /**
+   * One snippet row: a DIV holding a single-line truncated preview and sibling
+   * Edit/Delete buttons. Rows are DIVs (not buttons) so the action buttons are
+   * never nested inside an interactive element (see public/js/CONVENTIONS.md).
+   */
+  _buildRow(snippet) {
+    const row = document.createElement('div');
+    row.className = 'snippet-manager__row';
+    row.dataset.id = String(snippet.id);
+
+    const preview = document.createElement('span');
+    preview.className = 'snippet-manager__preview';
+    // textContent + CSS ellipsis (white-space:nowrap) collapses any newlines to
+    // a single line and escapes the body.
+    preview.textContent = snippet.body || '';
+    preview.title = snippet.body || '';
+    row.appendChild(preview);
+
+    const actions = document.createElement('div');
+    actions.className = 'snippet-manager__row-actions';
+
+    const editBtn = document.createElement('button');
+    editBtn.type = 'button';
+    editBtn.className = 'snippet-manager__row-btn snippet-manager__edit-btn';
+    editBtn.textContent = 'Edit';
+    editBtn.addEventListener('click', () => this._showEditForm(snippet.id));
+    actions.appendChild(editBtn);
+
+    const deleteBtn = document.createElement('button');
+    deleteBtn.type = 'button';
+    deleteBtn.className = 'snippet-manager__row-btn snippet-manager__delete-btn';
+    deleteBtn.textContent = 'Delete';
+    deleteBtn.addEventListener('click', () => this._delete(snippet.id));
+    actions.appendChild(deleteBtn);
+
+    row.appendChild(actions);
+    return row;
+  }
+
+  _buildForm() {
+    const isEdit = this._mode === 'edit';
+    const editing = isEdit ? this._snippets.find(s => s.id === this._editingId) : null;
+
+    const form = document.createElement('form');
+    form.className = 'snippet-manager__form';
+
+    const label = document.createElement('label');
+    label.className = 'snippet-manager__form-label';
+    label.textContent = isEdit ? 'Edit snippet' : 'New snippet';
+    form.appendChild(label);
+
+    const textarea = document.createElement('textarea');
+    textarea.className = 'snippet-manager__textarea';
+    textarea.rows = 5;
+    textarea.placeholder = 'Enter a reusable prompt snippet…';
+    // Prefer a preserved draft (from a failed save) over the stored body so the
+    // user's in-progress text survives an error re-render.
+    textarea.value = this._formDraft != null
+      ? this._formDraft
+      : (editing ? (editing.body || '') : '');
+    form.appendChild(textarea);
+    this._formTextarea = textarea;
+
+    const actions = document.createElement('div');
+    actions.className = 'snippet-manager__form-actions';
+
+    const saveBtn = document.createElement('button');
+    saveBtn.type = 'submit';
+    saveBtn.className = 'snippet-manager__save-btn';
+    saveBtn.textContent = 'Save';
+    actions.appendChild(saveBtn);
+
+    const cancelBtn = document.createElement('button');
+    cancelBtn.type = 'button';
+    cancelBtn.className = 'snippet-manager__cancel-btn';
+    cancelBtn.textContent = 'Cancel';
+    cancelBtn.addEventListener('click', () => this._cancelForm());
+    actions.appendChild(cancelBtn);
+
+    form.appendChild(actions);
+
+    const syncDisabled = () => {
+      saveBtn.disabled = textarea.value.trim() === '' || this._busy;
+    };
+    textarea.addEventListener('input', syncDisabled);
+    syncDisabled();
+
+    form.addEventListener('submit', (e) => {
+      e.preventDefault();
+      this._save(textarea.value);
+    });
+
+    // Focus the textarea so typing can begin immediately.
+    setTimeout(() => { try { textarea.focus(); } catch (_) { /* jsdom */ } }, 0);
+
+    return form;
+  }
+
+  // ─── View transitions ──────────────────────────────────────────────────────
+
+  _showAddForm() {
+    this._mode = 'add';
+    this._editingId = null;
+    this._formDraft = null; // fresh form
+    this._error = null; // don't carry a stale banner across the transition
+    this._render();
+  }
+
+  _showEditForm(id) {
+    this._mode = 'edit';
+    this._editingId = id;
+    this._formDraft = null; // fresh form
+    this._error = null;
+    this._render();
+  }
+
+  _cancelForm() {
+    this._mode = 'list';
+    this._editingId = null;
+    this._formDraft = null; // discard the in-progress draft
+    this._error = null;
+    this._render();
+  }
+
+  // ─── Mutations ─────────────────────────────────────────────────────────────
+
+  async _save(rawBody) {
+    // Persist the body verbatim — leading/trailing whitespace and newlines are
+    // user content (the snippet is inserted into chat unmodified later). Only
+    // the empty-guard uses a trimmed copy; the backend rejects all-whitespace.
+    const body = rawBody == null ? '' : String(rawBody);
+    if (body.trim() === '' || this._busy) return;
+    this._busy = true;
+
+    const isEdit = this._mode === 'edit';
+    const id = this._editingId;
+
+    try {
+      const response = isEdit
+        ? await fetch(`/api/snippets/${encodeURIComponent(id)}`, {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ body })
+          })
+        : await fetch('/api/snippets', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ body })
+          });
+
+      if (!response.ok) {
+        const data = await response.json().catch(() => ({}));
+        throw new Error(data.error || `Failed to save snippet (${response.status})`);
+      }
+
+      this._busy = false;
+      this._mode = 'list';
+      this._editingId = null;
+      this._formDraft = null; // committed — discard the in-progress draft
+      this._error = null;
+      this._notifyChanged();
+      await this._fetchAndRender();
+    } catch (error) {
+      this._busy = false;
+      // Preserve the user's in-progress text across the error re-render so a
+      // failed save doesn't wipe what they typed. _buildForm prefers the draft.
+      this._formDraft = body;
+      this._error = error && error.message ? error.message : 'Failed to save snippet';
+      this._render();
+    }
+  }
+
+  /**
+   * Confirm a destructive delete. Prefers the repo's styled confirmDialog
+   * (available in the chat modal context, where it stacks above via a higher
+   * z-index); falls back to native confirm on pages that don't load it (e.g.
+   * the settings page). Returns true when the user confirms.
+   */
+  async _confirmDelete() {
+    const message = 'Delete this snippet? This cannot be undone.';
+    if (typeof window !== 'undefined' && window.confirmDialog && typeof window.confirmDialog.show === 'function') {
+      const choice = await window.confirmDialog.show({
+        title: 'Delete snippet',
+        message,
+        confirmText: 'Delete',
+        confirmClass: 'btn-danger'
+      });
+      return choice === 'confirm';
+    }
+    if (typeof window !== 'undefined' && typeof window.confirm === 'function') {
+      return window.confirm(message);
+    }
+    return true;
+  }
+
+  async _delete(id) {
+    if (this._busy) return;
+    if (!(await this._confirmDelete())) return;
+    this._busy = true;
+
+    try {
+      const response = await fetch(`/api/snippets/${encodeURIComponent(id)}`, {
+        method: 'DELETE'
+      });
+      if (!response.ok) {
+        const data = await response.json().catch(() => ({}));
+        throw new Error(data.error || `Failed to delete snippet (${response.status})`);
+      }
+      this._busy = false;
+      this._notifyChanged();
+      await this._fetchAndRender();
+    } catch (error) {
+      this._busy = false;
+      this._error = error && error.message ? error.message : 'Failed to delete snippet';
+      this._render();
+    }
+  }
+
+  _notifyChanged() {
+    if (this.onChange) {
+      try { this.onChange(); } catch (_) { /* callback errors must not break the UI */ }
+    }
+  }
+
+  // ─── Teardown ──────────────────────────────────────────────────────────────
+
+  destroy() {
+    for (const { target, type, handler } of this._docListeners) {
+      target.removeEventListener(type, handler);
+    }
+    this._docListeners = [];
+    this._formTextarea = null;
+    if (this.container) {
+      this.container.innerHTML = '';
+    }
+  }
+
+  // ─── Modal entry point ─────────────────────────────────────────────────────
+
+  /**
+   * Open the snippet manager in a modal. Mirrors the modal shell structure of
+   * ReviewModal (`.modal-overlay` / `.modal-backdrop` / `.modal-container`) but
+   * wires teardown with addEventListener (no inline onclick globals).
+   *
+   * @param {Object} [options]
+   * @param {Function} [options.onClose] - Called with `(changed: boolean)` when
+   *   the modal is dismissed; `changed` is true if any mutation succeeded.
+   * @returns {SnippetManager} the mounted instance.
+   */
+  static openModal({ onClose } = {}) {
+    let changed = false;
+
+    const overlay = document.createElement('div');
+    overlay.className = 'modal-overlay snippet-manager-modal';
+
+    const backdrop = document.createElement('div');
+    backdrop.className = 'modal-backdrop';
+
+    const containerEl = document.createElement('div');
+    containerEl.className = 'modal-container snippet-manager-modal__container';
+
+    const header = document.createElement('div');
+    header.className = 'modal-header snippet-manager-modal__header';
+
+    const heading = document.createElement('h3');
+    heading.textContent = 'Manage snippets';
+    header.appendChild(heading);
+
+    const closeBtn = document.createElement('button');
+    closeBtn.type = 'button';
+    closeBtn.className = 'modal-close-btn snippet-manager-modal__close';
+    closeBtn.title = 'Close';
+    closeBtn.setAttribute('aria-label', 'Close');
+    closeBtn.innerHTML = '<svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M3.72 3.72a.75.75 0 011.06 0L8 6.94l3.22-3.22a.75.75 0 111.06 1.06L9.06 8l3.22 3.22a.75.75 0 11-1.06 1.06L8 9.06l-3.22 3.22a.75.75 0 01-1.06-1.06L6.94 8 3.72 4.78a.75.75 0 010-1.06z"/></svg>';
+    header.appendChild(closeBtn);
+
+    const bodyEl = document.createElement('div');
+    bodyEl.className = 'modal-body snippet-manager-modal__body';
+
+    containerEl.appendChild(header);
+    containerEl.appendChild(bodyEl);
+    overlay.appendChild(backdrop);
+    overlay.appendChild(containerEl);
+    document.body.appendChild(overlay);
+
+    const instance = new SnippetManager(bodyEl, { onChange: () => { changed = true; } });
+
+    let torndown = false;
+    const teardown = () => {
+      if (torndown) return;
+      torndown = true;
+      // Must pass the SAME capture flag as addEventListener or the listener leaks.
+      document.removeEventListener('keydown', onKey, true);
+      instance.destroy();
+      if (overlay.parentNode) overlay.parentNode.removeChild(overlay);
+      if (typeof onClose === 'function') onClose(changed);
+    };
+
+    // Capture phase + stopPropagation so Escape closes only this modal and does
+    // not bubble to ChatPanel's own keydown handler (which would also close the
+    // chat panel behind the modal).
+    const onKey = (e) => {
+      if (e.key !== 'Escape') return;
+      // A nested confirm dialog (the delete confirmation) stacks above this
+      // modal and handles Escape from its own bubble-phase listener. Because we
+      // run in the capture phase, we'd otherwise swallow the event and tear down
+      // the whole modal, orphaning the confirm dialog. Yield to it. (Repo
+      // pattern: TextInputDialog.js.)
+      if (window.confirmDialog && window.confirmDialog.isVisible) return;
+      e.stopPropagation();
+      teardown();
+    };
+
+    backdrop.addEventListener('click', teardown);
+    closeBtn.addEventListener('click', teardown);
+    document.addEventListener('keydown', onKey, true);
+
+    return instance;
+  }
+}
+
+// Make SnippetManager available globally.
+if (typeof window !== 'undefined') {
+  window.SnippetManager = SnippetManager;
+}
+
+// Export for CommonJS testing environments.
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { SnippetManager };
+}

--- a/public/js/settings.js
+++ b/public/js/settings.js
@@ -77,6 +77,10 @@ const SOURCE_DISPLAY = {
 const REPOS_SECTION_ID = 'repos-section';
 const REPOS_NAV_TITLE = 'Repositories';
 
+// Stable DOM id for the (static) Chat Snippets section, and its nav title.
+const SNIPPETS_SECTION_ID = 'snippets-section';
+const SNIPPETS_NAV_TITLE = 'Chat Snippets';
+
 class SettingsPage {
   constructor() {
     // Map of key -> descriptor from the API (kept in sync after PUT/DELETE).
@@ -104,6 +108,10 @@ class SettingsPage {
     this.sections = [];
     // Whether the Repositories section is visible (loaded successfully).
     this.reposVisible = false;
+    // Whether the Chat Snippets section is visible (mounted successfully).
+    this.snippetsVisible = false;
+    // Mounted SnippetManager instance, if any.
+    this._snippetManager = null;
     // Current active nav target id (scrollspy).
     this.activeNavId = null;
 
@@ -121,6 +129,7 @@ class SettingsPage {
     await Promise.all([this.loadProviders(), this.loadChatProviders(), this.loadCouncils()]);
     await this.loadSettings();
     await this.loadRepos();
+    this.mountSnippets();
 
     // Build the side navigation once the sections it points at are in the DOM.
     this.buildNavigation();
@@ -230,6 +239,32 @@ class SettingsPage {
     } catch (error) {
       console.error('Error loading repositories:', error);
       // Leave the section hidden on error — it is supplementary.
+    }
+  }
+
+  /**
+   * Mount the shared SnippetManager into the (static) Chat Snippets section.
+   * The component fetches its own data and renders its own empty/error states,
+   * so the section stays visible as long as the component is available. Hidden
+   * if the component script failed to load.
+   */
+  mountSnippets() {
+    const section = document.getElementById(SNIPPETS_SECTION_ID);
+    const mount = document.getElementById('snippets-manager');
+    if (!section || !mount) return;
+
+    if (typeof SnippetManager === 'undefined') {
+      section.style.display = 'none';
+      return;
+    }
+
+    try {
+      this._snippetManager = new SnippetManager(mount);
+      section.style.display = '';
+      this.snippetsVisible = true;
+    } catch (error) {
+      console.error('Error mounting snippet manager:', error);
+      section.style.display = 'none';
     }
   }
 
@@ -716,9 +751,12 @@ class SettingsPage {
    * visible, the Repositories section. Derives entirely from `sections` (the
    * same data renderSections used) so it cannot drift from the page.
    *
+   * @param {Array} sections - rendered dynamic sections
+   * @param {boolean} includeRepos - append the Repositories nav item
+   * @param {boolean} [includeSnippets] - append the Chat Snippets nav item
    * @returns {Array<{id: string, title: string}>}
    */
-  navItems(sections, includeRepos) {
+  navItems(sections, includeRepos, includeSnippets) {
     const items = (sections || []).map(s => {
       // Only attach `badge` when the section actually has one, so callers that
       // build sections without badges keep a clean {id, title} shape.
@@ -726,6 +764,11 @@ class SettingsPage {
       if (s.badge) item.badge = s.badge;
       return item;
     });
+    // Chat Snippets precedes Repositories so Repositories stays the terminal
+    // section (both the static markup and the scrollspy depend on this order).
+    if (includeSnippets) {
+      items.push({ id: SNIPPETS_SECTION_ID, title: SNIPPETS_NAV_TITLE });
+    }
     if (includeRepos) {
       items.push({ id: REPOS_SECTION_ID, title: REPOS_NAV_TITLE });
     }
@@ -754,7 +797,7 @@ class SettingsPage {
    * once after settings + repos have loaded so every target section exists.
    */
   buildNavigation() {
-    const items = this.navItems(this.sections, this.reposVisible);
+    const items = this.navItems(this.sections, this.reposVisible, this.snippetsVisible);
     this.navItemsList = items;
     this.renderNav(items);
     this.setupNavClickHandler();

--- a/public/local.html
+++ b/public/local.html
@@ -42,6 +42,7 @@
     <link rel="stylesheet" href="/css/pr.css">
     <link rel="stylesheet" href="/css/ai-summary-modal.css">
     <link rel="stylesheet" href="/css/analysis-config.css">
+    <link rel="stylesheet" href="/css/snippet-manager.css">
     <link rel="stylesheet" href="/css/styles.css">
 
     <!-- Highlight.js for syntax highlighting (legacy/context-file rendering; diffs use @pierre/diffs Shiki) -->
@@ -661,6 +662,7 @@
     <script src="/js/components/TourBar.js"></script>
 
     <!-- Chat Panel Component -->
+    <script src="/js/components/SnippetManager.js"></script>
     <script src="/js/components/ChatPanel.js"></script>
 
     <!-- Panel Group Component -->

--- a/public/pr.html
+++ b/public/pr.html
@@ -50,6 +50,7 @@
     <link rel="stylesheet" href="/css/pr.css">
     <link rel="stylesheet" href="/css/ai-summary-modal.css">
     <link rel="stylesheet" href="/css/analysis-config.css">
+    <link rel="stylesheet" href="/css/snippet-manager.css">
     <link rel="stylesheet" href="/css/styles.css">
 
     <!-- Highlight.js for syntax highlighting (legacy/context-file rendering; diffs use @pierre/diffs Shiki) -->
@@ -465,6 +466,7 @@
     <script src="/js/components/TourBar.js"></script>
 
     <!-- Chat Panel Component -->
+    <script src="/js/components/SnippetManager.js"></script>
     <script src="/js/components/ChatPanel.js"></script>
 
     <!-- External review-comment renderer (must load after chat-panel + comment-manager) -->

--- a/public/settings.html
+++ b/public/settings.html
@@ -15,6 +15,7 @@
     <link rel="stylesheet" href="/css/pr.css">
     <link rel="stylesheet" href="/css/council-dropdown.css">
     <link rel="stylesheet" href="/css/council-card.css">
+    <link rel="stylesheet" href="/css/snippet-manager.css">
     <link rel="stylesheet" href="/css/settings.css">
 </head>
 <body>
@@ -102,7 +103,19 @@
                         <!-- Setting sections rendered dynamically -->
                         <div id="settings-sections"></div>
 
-                        <!-- Repositories section -->
+                        <!-- Chat Snippets section -->
+                        <section class="settings-section" id="snippets-section">
+                            <div class="section-header">
+                                <h2>Chat Snippets</h2>
+                                <p class="section-description">
+                                    Reusable prompt snippets available from the chat input on any review.
+                                </p>
+                            </div>
+                            <div id="snippets-manager"></div>
+                        </section>
+
+                        <!-- Repositories section (kept last so scrollspy's bottom
+                             guard has a stable terminal section) -->
                         <section class="settings-section" id="repos-section" style="display: none;">
                             <div class="section-header">
                                 <h2>Repositories</h2>
@@ -124,6 +137,7 @@
     <!-- JavaScript -->
     <script src="/js/components/CouncilDropdown.js"></script>
     <script src="/js/components/CouncilCard.js"></script>
+    <script src="/js/components/SnippetManager.js"></script>
     <script src="/js/settings.js"></script>
 </body>
 </html>

--- a/src/database.js
+++ b/src/database.js
@@ -21,7 +21,7 @@ function getDbPath() {
 /**
  * Current schema version - increment this when adding new migrations
  */
-const CURRENT_SCHEMA_VERSION = 53;
+const CURRENT_SCHEMA_VERSION = 54;
 
 /**
  * Database schema SQL statements
@@ -372,6 +372,19 @@ const SCHEMA_SQL = {
       created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
       updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
     )
+  `,
+
+  // Global (user-level) reusable chat prompt snippets. No `repository` column
+  // now; repo-scoping later is a non-breaking ALTER TABLE ADD COLUMN + WHERE
+  // filter. MRU order comes from last_used_at (see ChatSnippetRepository).
+  chat_snippets: `
+    CREATE TABLE IF NOT EXISTS chat_snippets (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      body TEXT NOT NULL,
+      last_used_at DATETIME,
+      created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+      updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+    )
   `
 };
 
@@ -429,7 +442,9 @@ const INDEX_SQL = [
   'CREATE INDEX IF NOT EXISTS idx_external_comments_parent_lookup ON external_comments(review_id, source, in_reply_to_id)',
   // Global settings (in-app overrides). key is already UNIQUE in the table, but
   // the explicit index keeps parity with the test schema and lookup by key fast.
-  'CREATE UNIQUE INDEX IF NOT EXISTS idx_global_settings_key ON global_settings(key)'
+  'CREATE UNIQUE INDEX IF NOT EXISTS idx_global_settings_key ON global_settings(key)',
+  // Chat snippets MRU lookup by last_used_at.
+  'CREATE INDEX IF NOT EXISTS idx_chat_snippets_last_used ON chat_snippets(last_used_at DESC)'
 ];
 
 /**
@@ -2288,6 +2303,23 @@ const MIGRATIONS = {
     }
     db.exec('CREATE UNIQUE INDEX IF NOT EXISTS idx_global_settings_key ON global_settings(key)');
     console.log('Migration to schema version 53 complete');
+  },
+
+  // Migration to version 54: add the chat_snippets table backing the reusable
+  // chat prompt snippets library. Fresh installs already create the table via
+  // SCHEMA_SQL before migrations run, so the tableExists guard keeps this
+  // idempotent. The index is created separately (also idempotent) so the schema
+  // matches SCHEMA_SQL + INDEX_SQL exactly.
+  54: (db) => {
+    console.log('Running migration to schema version 54: Add chat_snippets table...');
+    if (!tableExists(db, 'chat_snippets')) {
+      db.exec(SCHEMA_SQL.chat_snippets);
+      console.log('  Created chat_snippets table');
+    } else {
+      console.log('  Table chat_snippets already exists');
+    }
+    db.exec('CREATE INDEX IF NOT EXISTS idx_chat_snippets_last_used ON chat_snippets(last_used_at DESC)');
+    console.log('Migration to schema version 54 complete');
   }
 };
 
@@ -5844,6 +5876,116 @@ class CouncilRepository {
 }
 
 /**
+ * ChatSnippetRepository class for managing reusable chat prompt snippets.
+ *
+ * Snippets are global (user-level) body-only prompts inserted into the chat
+ * input. Modeled on CouncilRepository: MRU ordering via last_used_at and a
+ * touchLastUsedAt() bump on every insert.
+ */
+class ChatSnippetRepository {
+  /**
+   * Create a new ChatSnippetRepository instance
+   * @param {Database} db - Database instance
+   */
+  constructor(db) {
+    this.db = db;
+  }
+
+  /**
+   * Create a new snippet
+   * @param {Object} snippetData - Snippet data
+   * @param {string} snippetData.body - Snippet body text (non-empty)
+   * @returns {Promise<Object>} Created snippet record
+   */
+  async create({ body }) {
+    if (typeof body !== 'string' || !body.trim()) {
+      throw new Error('body is required and must be a non-empty string');
+    }
+
+    const result = await run(this.db, `
+      INSERT INTO chat_snippets (body)
+      VALUES (?)
+    `, [body]);
+
+    return this.getById(result.lastID);
+  }
+
+  /**
+   * Get a snippet by ID
+   * @param {number} id - Snippet ID
+   * @returns {Promise<Object|null>} Snippet record or null
+   */
+  async getById(id) {
+    const row = await queryOne(this.db, `
+      SELECT id, body, last_used_at, created_at, updated_at
+      FROM chat_snippets
+      WHERE id = ?
+    `, [id]);
+
+    return row || null;
+  }
+
+  /**
+   * List all snippets in MRU order (most recently used first)
+   * @returns {Promise<Array<Object>>} Array of snippet records
+   */
+  async list() {
+    return query(this.db, `
+      SELECT id, body, last_used_at, created_at, updated_at
+      FROM chat_snippets
+      ORDER BY last_used_at DESC NULLS LAST, updated_at DESC
+    `);
+  }
+
+  /**
+   * Update a snippet's body
+   * @param {number} id - Snippet ID
+   * @param {Object} updates - Fields to update
+   * @param {string} updates.body - New body text (non-empty)
+   * @returns {Promise<boolean>} True if record was updated (snippet exists)
+   */
+  async update(id, { body }) {
+    if (typeof body !== 'string' || !body.trim()) {
+      throw new Error('body is required and must be a non-empty string');
+    }
+
+    const result = await run(this.db, `
+      UPDATE chat_snippets
+      SET body = ?, updated_at = CURRENT_TIMESTAMP
+      WHERE id = ?
+    `, [body, id]);
+
+    return result.changes > 0;
+  }
+
+  /**
+   * Update the last_used_at timestamp for a snippet (for MRU tracking)
+   * @param {number} id - Snippet ID
+   * @returns {Promise<boolean>} True if record was updated (snippet exists)
+   */
+  async touchLastUsedAt(id) {
+    const result = await run(this.db, `
+      UPDATE chat_snippets SET last_used_at = CURRENT_TIMESTAMP WHERE id = ?
+    `, [id]);
+
+    return result.changes > 0;
+  }
+
+  /**
+   * Delete a snippet
+   * @param {number} id - Snippet ID
+   * @returns {Promise<boolean>} True if record was deleted (snippet existed)
+   */
+  async delete(id) {
+    const result = await run(this.db, `
+      DELETE FROM chat_snippets WHERE id = ?
+    `, [id]);
+
+    return result.changes > 0;
+  }
+}
+
+/**
  * ContextFileRepository class for managing context file range records.
  * Context files allow pinning specific line ranges from non-diff files
  * into the diff panel for review.
@@ -6175,6 +6317,7 @@ module.exports = {
   AnalysisRunRepository,
   GitHubReviewRepository,
   CouncilRepository,
+  ChatSnippetRepository,
   ContextFileRepository,
   HunkSummaryRepository,
   TourRepository,

--- a/src/routes/snippets.js
+++ b/src/routes/snippets.js
@@ -1,0 +1,154 @@
+// Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+/**
+ * Chat Snippet Routes
+ *
+ * CRUD endpoints for the reusable chat prompt snippets library. Snippets are
+ * global (user-level) body-only prompts inserted into the chat input, ordered
+ * most-recently-used first.
+ */
+
+const express = require('express');
+const logger = require('../utils/logger');
+const { ChatSnippetRepository } = require('../database');
+
+const router = express.Router();
+
+const MAX_BODY_LENGTH = 10000;
+
+/**
+ * Validate a snippet body value.
+ * @param {*} body - Candidate body
+ * @returns {string|null} Error message or null if valid
+ */
+function validateBody(body) {
+  if (typeof body !== 'string' || !body.trim()) {
+    return 'body is required and must be a non-empty string';
+  }
+  if (body.length > MAX_BODY_LENGTH) {
+    return `body must be ${MAX_BODY_LENGTH} characters or fewer`;
+  }
+  return null;
+}
+
+/**
+ * Parse a route :id param into an integer, or null if not a valid number.
+ * @param {string} raw - Raw param value
+ * @returns {number|null}
+ */
+function parseId(raw) {
+  const id = Number.parseInt(raw, 10);
+  return Number.isNaN(id) ? null : id;
+}
+
+/**
+ * GET /api/snippets — List all snippets in MRU order
+ */
+router.get('/api/snippets', async (req, res) => {
+  try {
+    const repo = new ChatSnippetRepository(req.app.get('db'));
+    const snippets = await repo.list();
+    res.json({ snippets });
+  } catch (error) {
+    logger.error('Error listing snippets:', error);
+    res.status(500).json({ error: 'Failed to list snippets' });
+  }
+});
+
+/**
+ * POST /api/snippets — Create a new snippet
+ */
+router.post('/api/snippets', async (req, res) => {
+  try {
+    const { body } = req.body || {};
+
+    const validationError = validateBody(body);
+    if (validationError) {
+      return res.status(400).json({ error: validationError });
+    }
+
+    const repo = new ChatSnippetRepository(req.app.get('db'));
+    const snippet = await repo.create({ body });
+    res.status(201).json({ snippet });
+  } catch (error) {
+    logger.error('Error creating snippet:', error);
+    res.status(500).json({ error: 'Failed to create snippet' });
+  }
+});
+
+/**
+ * PUT /api/snippets/:id — Update a snippet's body
+ */
+router.put('/api/snippets/:id', async (req, res) => {
+  try {
+    const id = parseId(req.params.id);
+    if (id === null) {
+      return res.status(400).json({ error: 'Invalid snippet id' });
+    }
+
+    const { body } = req.body || {};
+    const validationError = validateBody(body);
+    if (validationError) {
+      return res.status(400).json({ error: validationError });
+    }
+
+    const repo = new ChatSnippetRepository(req.app.get('db'));
+    const updated = await repo.update(id, { body });
+    if (!updated) {
+      return res.status(404).json({ error: 'Snippet not found' });
+    }
+
+    const snippet = await repo.getById(id);
+    res.json({ snippet });
+  } catch (error) {
+    logger.error('Error updating snippet:', error);
+    res.status(500).json({ error: 'Failed to update snippet' });
+  }
+});
+
+/**
+ * DELETE /api/snippets/:id — Delete a snippet
+ */
+router.delete('/api/snippets/:id', async (req, res) => {
+  try {
+    const id = parseId(req.params.id);
+    if (id === null) {
+      return res.status(400).json({ error: 'Invalid snippet id' });
+    }
+
+    const repo = new ChatSnippetRepository(req.app.get('db'));
+    const existed = await repo.delete(id);
+    if (!existed) {
+      return res.status(404).json({ error: 'Snippet not found' });
+    }
+
+    res.json({ success: true });
+  } catch (error) {
+    logger.error('Error deleting snippet:', error);
+    res.status(500).json({ error: 'Failed to delete snippet' });
+  }
+});
+
+/**
+ * POST /api/snippets/:id/touch — Bump last_used_at for MRU tracking
+ */
+router.post('/api/snippets/:id/touch', async (req, res) => {
+  try {
+    const id = parseId(req.params.id);
+    if (id === null) {
+      return res.status(400).json({ error: 'Invalid snippet id' });
+    }
+
+    const repo = new ChatSnippetRepository(req.app.get('db'));
+    const touched = await repo.touchLastUsedAt(id);
+    if (!touched) {
+      return res.status(404).json({ error: 'Snippet not found' });
+    }
+
+    res.json({ success: true });
+  } catch (error) {
+    logger.error('Error touching snippet:', error);
+    res.status(500).json({ error: 'Failed to touch snippet' });
+  }
+});
+
+module.exports = router;

--- a/src/server.js
+++ b/src/server.js
@@ -465,6 +465,7 @@ async function startServer(sharedDb = null, sharedPoolLifecycle = null, options 
     const stackAnalysisRoutes = require('./routes/stack-analysis');
     const externalCommentsRoutes = require('./routes/external-comments');
     const settingsRoutes = require('./routes/settings');
+    const snippetsRoutes = require('./routes/snippets');
     const { createSoundRouter } = require('./routes/sound');
 
     // Initialize chat session manager
@@ -487,6 +488,7 @@ async function startServer(sharedDb = null, sharedPoolLifecycle = null, options 
     app.use('/', bulkAnalysisConfigsRoutes);
     app.use('/', stackAnalysisRoutes);
     app.use('/', settingsRoutes);
+    app.use('/', snippetsRoutes);
     // External-comments routes (GitHub PR review-comment sync + fetch) are
     // gated by the `external_comments` config flag. When disabled, the
     // router is not mounted so any GET/POST against `/api/reviews/*/

--- a/tests/e2e/chat-snippet-save.spec.js
+++ b/tests/e2e/chat-snippet-save.spec.js
@@ -1,0 +1,159 @@
+// Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+/**
+ * E2E Tests: Save a chat message as a snippet (alt-click affordance)
+ *
+ * Complements chat-snippets.spec.js (which covers the insert direction). Here we
+ * lock down the reverse direction: alt-clicking a message the user already sent
+ * reveals a single "Save as snippet" pill; clicking it persists that message's
+ * body to the global snippet library.
+ *
+ *   1. Alt-click a submitted USER message → pill appears; clicking it POSTs the
+ *      body to /api/snippets (verified via a follow-up GET).
+ *   2. Escape dismisses the pill WITHOUT closing the chat panel.
+ *   3. Works in both PR mode and local mode (ChatPanel is one shared component).
+ *
+ * Snippets live in the per-worker E2E DB shared across tests in a worker; only
+ * the snippet specs touch /api/snippets, so each test wipes the table first.
+ */
+
+import { test, expect } from './fixtures.js';
+import { waitForDiffToRender } from './helpers.js';
+
+/**
+ * Force chat into "available" state so the toggle is interactive and a session
+ * can be created. Pi isn't installed in E2E — same shim as chat-tabs.spec.js.
+ */
+async function enableChat(page) {
+  await page.evaluate(() => {
+    document.documentElement.setAttribute('data-chat', 'available');
+    window.__pairReview = window.__pairReview || {};
+    window.__pairReview.chatProvider = 'pi';
+    window.__pairReview.chatProviders = [
+      { id: 'pi', name: 'Pi', type: 'pi', available: true },
+    ];
+    window.dispatchEvent(new CustomEvent('chat-state-changed', { detail: { state: 'available' } }));
+  });
+}
+
+/** Delete every snippet so a test starts from a known-empty library. */
+async function clearSnippets(page) {
+  const res = await page.request.get('/api/snippets');
+  if (!res.ok()) return;
+  const data = await res.json();
+  for (const s of (data.snippets || [])) {
+    await page.request.delete(`/api/snippets/${s.id}`);
+  }
+}
+
+/** Open the chat panel via its toggle and wait for it to be visible. */
+async function openChatPanel(page) {
+  await page.locator('#chat-toggle-btn').click();
+  await expect(page.locator('.chat-panel')).toBeVisible();
+}
+
+/** Send a chat message and wait for its user bubble to render. */
+async function sendMessage(page, body) {
+  await page.locator('.chat-panel__input').fill(body);
+  await page.locator('.chat-panel__send-btn').click();
+  await expect(page.locator('.chat-panel__message--user', { hasText: body })).toBeVisible();
+}
+
+/** Wipe persisted chat-tab state, then load the given review URL. */
+async function bootReview(page, url) {
+  await page.goto('/');
+  await page.evaluate(() => {
+    try {
+      Object.keys(localStorage)
+        .filter((k) => k.startsWith('pair-review:chat-tabs:'))
+        .forEach((k) => localStorage.removeItem(k));
+    } catch { /* noop */ }
+  });
+  await clearSnippets(page);
+  await page.goto(url);
+  await waitForDiffToRender(page);
+  await enableChat(page);
+}
+
+/** Poll the snippet library until a snippet with the exact body exists. */
+async function expectSnippetSaved(page, body) {
+  await expect.poll(async () => {
+    const res = await page.request.get('/api/snippets');
+    if (!res.ok()) return false;
+    const data = await res.json();
+    return (data.snippets || []).some((s) => s.body === body);
+  }, { timeout: 5000 }).toBe(true);
+}
+
+// ─── PR mode ──────────────────────────────────────────────────────────────
+
+test.describe('Save chat message as snippet (PR mode)', () => {
+  test.beforeEach(async ({ page }) => {
+    await bootReview(page, '/pr/test-owner/test-repo/1');
+  });
+
+  test('alt-click a user message → pill saves its body to the library', async ({ page }) => {
+    await openChatPanel(page);
+
+    // Unique body so the save assertion can't match a restored message.
+    const body = 'Save-as-snippet marker 7c19: check error handling';
+    await sendMessage(page, body);
+
+    // Alt-click the sent user message to reveal the pill.
+    await page.locator('.chat-panel__message--user', { hasText: body }).click({ modifiers: ['Alt'] });
+    const pill = page.locator('.chat-panel__save-snippet-pill');
+    await expect(pill).toBeVisible();
+    await expect(pill).toHaveText('Save as snippet');
+
+    // Click the pill and confirm the POST landed, then the pill dismisses.
+    const saveResp = page.waitForResponse(
+      (r) => r.url().endsWith('/api/snippets') && r.request().method() === 'POST'
+    );
+    await pill.click();
+    await saveResp;
+    await expect(pill).toHaveCount(0);
+
+    await expectSnippetSaved(page, body);
+  });
+
+  test('Escape dismisses the pill without closing the chat panel', async ({ page }) => {
+    await openChatPanel(page);
+    const body = 'Escape-dismiss marker 3b8e';
+    await sendMessage(page, body);
+
+    await page.locator('.chat-panel__message--user', { hasText: body }).click({ modifiers: ['Alt'] });
+    await expect(page.locator('.chat-panel__save-snippet-pill')).toBeVisible();
+
+    await page.keyboard.press('Escape');
+
+    // Pill gone, panel still open.
+    await expect(page.locator('.chat-panel__save-snippet-pill')).toHaveCount(0);
+    await expect(page.locator('.chat-panel')).toBeVisible();
+  });
+});
+
+// ─── Local mode ─────────────────────────────────────────────────────────────
+
+test.describe('Save chat message as snippet (local mode)', () => {
+  test.beforeEach(async ({ page }) => {
+    // Seeded local review id=2 (see tests/e2e/global-setup.js).
+    await bootReview(page, '/local/2');
+  });
+
+  test('alt-click a user message → pill saves its body in local mode', async ({ page }) => {
+    await openChatPanel(page);
+    const body = 'Local-mode save marker 9d42';
+    await sendMessage(page, body);
+
+    await page.locator('.chat-panel__message--user', { hasText: body }).click({ modifiers: ['Alt'] });
+    const pill = page.locator('.chat-panel__save-snippet-pill');
+    await expect(pill).toBeVisible();
+
+    const saveResp = page.waitForResponse(
+      (r) => r.url().endsWith('/api/snippets') && r.request().method() === 'POST'
+    );
+    await pill.click();
+    await saveResp;
+
+    await expectSnippetSaved(page, body);
+  });
+});

--- a/tests/e2e/chat-snippets.spec.js
+++ b/tests/e2e/chat-snippets.spec.js
@@ -1,0 +1,334 @@
+// Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+/**
+ * E2E Tests: Chat prompt snippets
+ *
+ * The prompt-snippets feature adds a reusable-prompt library, insertable from a
+ * new button in the chat input (to the left of send), plus a shared editor
+ * reachable from the picker's gear AND the global settings page. Flows locked
+ * down here:
+ *
+ *   1. Picker button renders left of send; empty state offers a "Manage" way in.
+ *   2. Gear opens the manage modal; adding a snippet makes it appear in the
+ *      picker dropdown.
+ *   3. Clicking a snippet inserts its body into the input and enables send
+ *      (WITHOUT sending — plain click never submits).
+ *   4. Inserting a snippet touches its MRU timestamp so it sorts first on reopen.
+ *   5. The core insert flow works in BOTH PR mode and local mode (ChatPanel is a
+ *      single shared component, but parity is verified end-to-end).
+ *   6. The settings page exposes a "Chat Snippets" section + nav item with a
+ *      full add/edit/delete round-trip in the inline editor.
+ *
+ * Snippets are stored globally in the per-worker E2E DB, which is shared across
+ * tests in a worker. Only this spec touches /api/snippets, so each test wipes
+ * the table first (clearSnippets) to stay isolated and order-independent.
+ */
+
+import { test, expect } from './fixtures.js';
+import { waitForDiffToRender } from './helpers.js';
+
+/**
+ * Force chat into "available" state so the toggle button is interactive. Pi
+ * isn't installed in E2E, so we bypass the data-chat availability gate — same
+ * shim used by chat-tabs.spec.js.
+ */
+async function enableChat(page) {
+  await page.evaluate(() => {
+    document.documentElement.setAttribute('data-chat', 'available');
+    window.__pairReview = window.__pairReview || {};
+    window.__pairReview.chatProvider = 'pi';
+    window.__pairReview.chatProviders = [
+      { id: 'pi', name: 'Pi', type: 'pi', available: true },
+    ];
+    window.dispatchEvent(new CustomEvent('chat-state-changed', { detail: { state: 'available' } }));
+  });
+}
+
+/** Delete every snippet so a test starts from a known-empty library. */
+async function clearSnippets(page) {
+  const res = await page.request.get('/api/snippets');
+  if (!res.ok()) return;
+  const data = await res.json();
+  for (const s of (data.snippets || [])) {
+    await page.request.delete(`/api/snippets/${s.id}`);
+  }
+}
+
+/** Create a snippet via the API and return its id. */
+async function seedSnippet(page, body) {
+  const res = await page.request.post('/api/snippets', { data: { body } });
+  expect(res.ok()).toBeTruthy();
+  const data = await res.json();
+  return data.snippet.id;
+}
+
+/** Open the chat panel via its toggle and wait for it to be visible. */
+async function openChatPanel(page) {
+  await page.locator('#chat-toggle-btn').click();
+  await expect(page.locator('.chat-panel')).toBeVisible();
+}
+
+/** Open the snippet picker dropdown and wait for it to render. */
+async function openSnippetDropdown(page) {
+  await page.locator('.chat-panel__snippet-picker-btn').click();
+  await expect(page.locator('.chat-panel__snippet-dropdown')).toBeVisible();
+}
+
+// ─── PR mode ──────────────────────────────────────────────────────────────
+
+test.describe('Chat prompt snippets (PR mode)', () => {
+  test.beforeEach(async ({ page }) => {
+    // Wipe persisted chat-tab state before booting the panel (bounce through the
+    // origin root, which doesn't mount ChatPanel) — same pattern as chat-tabs.
+    await page.goto('/');
+    await page.evaluate(() => {
+      try {
+        Object.keys(localStorage)
+          .filter((k) => k.startsWith('pair-review:chat-tabs:'))
+          .forEach((k) => localStorage.removeItem(k));
+      } catch { /* noop */ }
+    });
+    await clearSnippets(page);
+    await page.goto('/pr/test-owner/test-repo/1');
+    await waitForDiffToRender(page);
+    await enableChat(page);
+  });
+
+  test('picker button sits left of send; empty state offers a manage affordance', async ({ page }) => {
+    await openChatPanel(page);
+
+    const pickerBtn = page.locator('.chat-panel__snippet-picker-btn');
+    const sendBtn = page.locator('.chat-panel__send-btn');
+    await expect(pickerBtn).toBeVisible();
+    await expect(sendBtn).toBeVisible();
+
+    // Geometry: the picker is to the LEFT of the send button.
+    const pickerBox = await pickerBtn.boundingBox();
+    const sendBox = await sendBtn.boundingBox();
+    expect(pickerBox.x).toBeLessThan(sendBox.x);
+
+    // Empty library → dropdown shows the empty state with a "Manage" way in.
+    await openSnippetDropdown(page);
+    const empty = page.locator('.chat-panel__snippet-empty');
+    await expect(empty).toBeVisible();
+    await expect(empty).toContainText('No snippets yet');
+    await expect(page.locator('.chat-panel__snippet-manage-empty-btn')).toBeVisible();
+    // The header gear is present even in the empty state.
+    await expect(page.locator('.chat-panel__snippet-manage-btn')).toBeVisible();
+  });
+
+  test('dropdown with long previews stays inside the chat panel', async ({ page }) => {
+    // Regression: the dropdown used to size to its longest nowrap preview and
+    // grow leftward out of the panel, sliding under the file navigator.
+    await seedSnippet(
+      page,
+      'This is a deliberately long snippet body that would previously force the dropdown to grow far wider than the chat panel itself'
+    );
+    await openChatPanel(page);
+    await openSnippetDropdown(page);
+
+    const panelBox = await page.locator('.chat-panel').boundingBox();
+    const dropBox = await page.locator('.chat-panel__snippet-dropdown').boundingBox();
+    expect(dropBox.x).toBeGreaterThanOrEqual(panelBox.x);
+    expect(dropBox.x + dropBox.width).toBeLessThanOrEqual(panelBox.x + panelBox.width);
+
+    // The long preview ellipsizes rather than widening the item.
+    const itemBox = await page.locator('.chat-panel__snippet-item').first().boundingBox();
+    expect(itemBox.width).toBeLessThanOrEqual(dropBox.width);
+  });
+
+  test('gear opens the manage modal; adding a snippet lists it in the dropdown', async ({ page }) => {
+    await openChatPanel(page);
+    await openSnippetDropdown(page);
+
+    // Gear → manage modal.
+    await page.locator('.chat-panel__snippet-manage-btn').click();
+    const modal = page.locator('.snippet-manager-modal');
+    await expect(modal).toBeVisible();
+    await expect(modal.locator('.snippet-manager-modal__header')).toContainText('Manage snippets');
+
+    // Add a snippet through the inline editor inside the modal.
+    await modal.locator('.snippet-manager__add-btn').click();
+    const textarea = modal.locator('.snippet-manager__textarea');
+    await textarea.fill('Explain this diff like I am five');
+    await modal.locator('.snippet-manager__save-btn').click();
+
+    // Row appears in the modal list.
+    await expect(modal.locator('.snippet-manager__row')).toHaveCount(1);
+    await expect(modal.locator('.snippet-manager__preview'))
+      .toContainText('Explain this diff like I am five');
+
+    // Close the modal and reopen the dropdown — it now lists the new snippet.
+    await modal.locator('.snippet-manager-modal__close').click();
+    await expect(modal).toHaveCount(0);
+
+    await openSnippetDropdown(page);
+    const items = page.locator('.chat-panel__snippet-item');
+    await expect(items).toHaveCount(1);
+    await expect(items.first()).toContainText('Explain this diff like I am five');
+  });
+
+  test('clicking a snippet inserts its body and enables send without sending', async ({ page }) => {
+    await seedSnippet(page, 'Review this for security issues');
+    await openChatPanel(page);
+    await openSnippetDropdown(page);
+
+    const input = page.locator('.chat-panel__input');
+    const sendBtn = page.locator('.chat-panel__send-btn');
+    await expect(sendBtn).toBeDisabled();
+
+    await page.locator('.chat-panel__snippet-item').first().click();
+
+    // Text landed in the textarea and send is now enabled.
+    await expect(input).toHaveValue('Review this for security issues');
+    await expect(sendBtn).toBeEnabled();
+
+    // Plain click must NOT send: sendMessage() clears the input on submit, so the
+    // text surviving in the textarea proves nothing was sent.
+    await expect(input).toHaveValue('Review this for security issues');
+
+    // Dropdown closes after an insert.
+    await expect(page.locator('.chat-panel__snippet-dropdown')).toBeHidden();
+  });
+
+  test('Cmd/Ctrl+click a snippet inserts AND sends it', async ({ page }) => {
+    // Unique body so the assertion can't match a message restored from the
+    // shared per-worker session.
+    const body = 'Cmd-click send snippet marker 4f2a';
+    await seedSnippet(page, body);
+    await openChatPanel(page);
+    await openSnippetDropdown(page);
+
+    const input = page.locator('.chat-panel__input');
+    await expect(input).toHaveValue('');
+
+    // Modifier-click sends: _insertPromptSnippet(id, { send: true }) → sendMessage().
+    // The mock chat session manager in test-server.js persists the send and the
+    // panel renders it optimistically as a user bubble.
+    await page.locator('.chat-panel__snippet-item').first().click({
+      modifiers: [process.platform === 'darwin' ? 'Meta' : 'Control'],
+    });
+
+    // The snippet body shows as a sent user message, and the input was cleared
+    // by sendMessage() — together these prove it sent (a plain insert would keep
+    // the text in the input and render no message).
+    await expect(page.locator('.chat-panel__message--user', { hasText: body })).toBeVisible();
+    await expect(input).toHaveValue('');
+    await expect(page.locator('.chat-panel__snippet-dropdown')).toBeHidden();
+  });
+
+  test('inserting a snippet bumps it to the top of the MRU order', async ({ page }) => {
+    // Both start unused; touching one via insert gives it a real last_used_at
+    // that definitively wins the MRU ordering regardless of the initial order.
+    const idA = await seedSnippet(page, 'Alpha snippet body');
+    await seedSnippet(page, 'Beta snippet body');
+
+    await openChatPanel(page);
+    await openSnippetDropdown(page);
+
+    const items = page.locator('.chat-panel__snippet-item');
+    await expect(items).toHaveCount(2);
+
+    // Insert Alpha. Wait for the fire-and-forget touch to land so the reopened
+    // dropdown reflects the new order deterministically.
+    const touchResp = page.waitForResponse(
+      (r) => /\/api\/snippets\/\d+\/touch$/.test(r.url()) && r.request().method() === 'POST'
+    );
+    await items.getByText('Alpha snippet body').click();
+    await touchResp;
+
+    // Reopen — Alpha now leads because its last_used_at was touched.
+    await openSnippetDropdown(page);
+    const reopened = page.locator('.chat-panel__snippet-item');
+    await expect(reopened).toHaveCount(2);
+    await expect(reopened.first()).toHaveAttribute('data-snippet-id', String(idA));
+  });
+});
+
+// ─── Local mode ─────────────────────────────────────────────────────────────
+
+test.describe('Chat prompt snippets (local mode)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.evaluate(() => {
+      try {
+        Object.keys(localStorage)
+          .filter((k) => k.startsWith('pair-review:chat-tabs:'))
+          .forEach((k) => localStorage.removeItem(k));
+      } catch { /* noop */ }
+    });
+    await clearSnippets(page);
+    // Seeded local review id=2 (see tests/e2e/global-setup.js).
+    await page.goto('/local/2');
+    await waitForDiffToRender(page);
+    await enableChat(page);
+  });
+
+  test('inserts a snippet into the chat input in local mode', async ({ page }) => {
+    await seedSnippet(page, 'Summarize the local changes');
+    await openChatPanel(page);
+    await openSnippetDropdown(page);
+
+    const input = page.locator('.chat-panel__input');
+    const sendBtn = page.locator('.chat-panel__send-btn');
+    await expect(sendBtn).toBeDisabled();
+
+    await page.locator('.chat-panel__snippet-item').first().click();
+
+    await expect(input).toHaveValue('Summarize the local changes');
+    await expect(sendBtn).toBeEnabled();
+    await expect(page.locator('.chat-panel__snippet-dropdown')).toBeHidden();
+  });
+});
+
+// ─── Settings page ──────────────────────────────────────────────────────────
+
+test.describe('Chat prompt snippets (settings page)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await clearSnippets(page);
+  });
+
+  test('shows the Chat Snippets nav item + section and round-trips CRUD', async ({ page }) => {
+    await page.goto('/settings');
+
+    // Nav item points at the snippets section, which exists on the page.
+    const navList = page.locator('#settings-nav-list');
+    const navItem = navList.locator('.settings-nav-item[data-target="snippets-section"]');
+    await expect(navItem).toBeVisible({ timeout: 5000 });
+    await expect(navItem).toContainText('Chat Snippets');
+    await expect(page.locator('#snippets-section')).toHaveCount(1);
+
+    const manager = page.locator('#snippets-manager');
+    // Starts empty.
+    await expect(manager.locator('.snippet-manager__empty')).toBeVisible();
+
+    // ── Add ──
+    await manager.locator('.snippet-manager__add-btn').click();
+    await manager.locator('.snippet-manager__textarea').fill('Draft a changelog entry');
+    await manager.locator('.snippet-manager__save-btn').click();
+
+    const row = manager.locator('.snippet-manager__row');
+    await expect(row).toHaveCount(1);
+    await expect(manager.locator('.snippet-manager__preview')).toContainText('Draft a changelog entry');
+
+    // ── Edit ──
+    await manager.locator('.snippet-manager__edit-btn').click();
+    const textarea = manager.locator('.snippet-manager__textarea');
+    await expect(textarea).toHaveValue('Draft a changelog entry');
+    await textarea.fill('Draft a detailed changelog entry');
+    await manager.locator('.snippet-manager__save-btn').click();
+
+    await expect(manager.locator('.snippet-manager__preview'))
+      .toContainText('Draft a detailed changelog entry');
+    await expect(manager.locator('.snippet-manager__row')).toHaveCount(1);
+
+    // ── Delete ──
+    // Delete is guarded by a confirmation. The settings page doesn't load the
+    // styled confirmDialog, so SnippetManager falls back to native window.confirm
+    // — accept it (Playwright auto-dismisses dialogs by default).
+    page.once('dialog', (dialog) => dialog.accept());
+    await manager.locator('.snippet-manager__delete-btn').click();
+    await expect(manager.locator('.snippet-manager__row')).toHaveCount(0);
+    await expect(manager.locator('.snippet-manager__empty')).toBeVisible();
+  });
+});

--- a/tests/e2e/global-setup.js
+++ b/tests/e2e/global-setup.js
@@ -652,6 +652,7 @@ async function globalSetup() {
   const contextFilesRoutes = require('../../src/routes/context-files');
   const bulkAnalysisConfigsRoutes = require('../../src/routes/bulk-analysis-configs');
   const settingsRoutes = require('../../src/routes/settings');
+  const snippetsRoutes = require('../../src/routes/snippets');
 
   // Mock chat session manager for E2E (reads from DB, no real bridge)
   app.chatSessionManager = {
@@ -696,6 +697,7 @@ async function globalSetup() {
   app.use('/', contextFilesRoutes);
   app.use('/', bulkAnalysisConfigsRoutes);
   app.use('/', settingsRoutes);
+  app.use('/', snippetsRoutes);
 
   // Error handling
   app.use((error, req, res, next) => {

--- a/tests/e2e/test-server.js
+++ b/tests/e2e/test-server.js
@@ -829,6 +829,7 @@ async function startTestServer(port) {
   const contextFilesRoutes = require('../../src/routes/context-files');
   const bulkAnalysisConfigsRoutes = require('../../src/routes/bulk-analysis-configs');
   const settingsRoutes = require('../../src/routes/settings');
+  const snippetsRoutes = require('../../src/routes/snippets');
 
   // Mock chat session manager for E2E (reads from DB, no real bridge).
   // createSession/sendMessage write to the DB so multi-tab tests that open
@@ -917,6 +918,7 @@ async function startTestServer(port) {
   app.use('/', contextFilesRoutes);
   app.use('/', bulkAnalysisConfigsRoutes);
   app.use('/', settingsRoutes);
+  app.use('/', snippetsRoutes);
 
   // Error handling
   app.use((error, req, res, next) => {

--- a/tests/integration/snippets-routes.test.js
+++ b/tests/integration/snippets-routes.test.js
@@ -1,0 +1,188 @@
+// Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+/**
+ * Integration tests for chat snippet API routes
+ *
+ * Tests the CRUD + touch endpoints backing the chat prompt snippets library.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import { createTestDatabase, closeTestDatabase } from '../utils/schema';
+import { listenOnLoopback, closeServer } from '../utils/loopback-server';
+
+const snippetsRoutes = require('../../src/routes/snippets');
+
+function createTestApp(db) {
+  const app = express();
+  app.use(express.json());
+  app.set('db', db);
+  app.use('/', snippetsRoutes);
+  return app;
+}
+
+describe('Snippet Routes', () => {
+  let db;
+  let app;
+  let server;
+
+  beforeEach(async () => {
+    db = await createTestDatabase();
+    app = createTestApp(db);
+    server = await listenOnLoopback(app);
+  });
+
+  afterEach(async () => {
+    await closeServer(server);
+    closeTestDatabase(db);
+  });
+
+  async function createSnippet(body) {
+    const res = await request(server).post('/api/snippets').send({ body });
+    return res.body.snippet;
+  }
+
+  describe('POST /api/snippets', () => {
+    it('should create a snippet and return 201', async () => {
+      const res = await request(server)
+        .post('/api/snippets')
+        .send({ body: 'Check for edge cases' });
+
+      expect(res.status).toBe(201);
+      expect(res.body.snippet).toBeDefined();
+      expect(res.body.snippet.id).toBeDefined();
+      expect(res.body.snippet.body).toBe('Check for edge cases');
+    });
+
+    it('should return 400 for a missing body', async () => {
+      const res = await request(server).post('/api/snippets').send({});
+      expect(res.status).toBe(400);
+      expect(res.body.error).toContain('body');
+    });
+
+    it('should return 400 for an empty body', async () => {
+      const res = await request(server).post('/api/snippets').send({ body: '   ' });
+      expect(res.status).toBe(400);
+    });
+
+    it('should return 400 for a non-string body', async () => {
+      const res = await request(server).post('/api/snippets').send({ body: 42 });
+      expect(res.status).toBe(400);
+    });
+
+    it('should return 400 for a body over 10000 characters', async () => {
+      const res = await request(server)
+        .post('/api/snippets')
+        .send({ body: 'x'.repeat(10001) });
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe('GET /api/snippets', () => {
+    it('should return an empty array when no snippets exist', async () => {
+      const res = await request(server).get('/api/snippets');
+      expect(res.status).toBe(200);
+      expect(res.body.snippets).toEqual([]);
+    });
+
+    it('should return all snippets', async () => {
+      await createSnippet('First');
+      await createSnippet('Second');
+
+      const res = await request(server).get('/api/snippets');
+      expect(res.status).toBe(200);
+      expect(res.body.snippets).toHaveLength(2);
+    });
+
+    it('should reflect MRU order after a touch', async () => {
+      const first = await createSnippet('First');
+      await createSnippet('Second');
+
+      // Touch the first snippet — it should jump to the front
+      const touchRes = await request(server).post(`/api/snippets/${first.id}/touch`);
+      expect(touchRes.status).toBe(200);
+
+      const res = await request(server).get('/api/snippets');
+      expect(res.status).toBe(200);
+      expect(res.body.snippets[0].id).toBe(first.id);
+    });
+  });
+
+  describe('PUT /api/snippets/:id', () => {
+    it('should update a snippet body', async () => {
+      const snippet = await createSnippet('Original');
+
+      const res = await request(server)
+        .put(`/api/snippets/${snippet.id}`)
+        .send({ body: 'Updated' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.snippet.body).toBe('Updated');
+    });
+
+    it('should return 400 for an invalid body', async () => {
+      const snippet = await createSnippet('Original');
+      const res = await request(server)
+        .put(`/api/snippets/${snippet.id}`)
+        .send({ body: '' });
+      expect(res.status).toBe(400);
+    });
+
+    it('should return 400 for a non-numeric id', async () => {
+      const res = await request(server)
+        .put('/api/snippets/not-a-number')
+        .send({ body: 'Updated' });
+      expect(res.status).toBe(400);
+    });
+
+    it('should return 404 for a non-existent snippet', async () => {
+      const res = await request(server)
+        .put('/api/snippets/99999')
+        .send({ body: 'Updated' });
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe('DELETE /api/snippets/:id', () => {
+    it('should delete an existing snippet', async () => {
+      const snippet = await createSnippet('Delete me');
+
+      const res = await request(server).delete(`/api/snippets/${snippet.id}`);
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+
+      const getRes = await request(server).get('/api/snippets');
+      expect(getRes.body.snippets).toHaveLength(0);
+    });
+
+    it('should return 400 for a non-numeric id', async () => {
+      const res = await request(server).delete('/api/snippets/not-a-number');
+      expect(res.status).toBe(400);
+    });
+
+    it('should return 404 for a non-existent snippet', async () => {
+      const res = await request(server).delete('/api/snippets/99999');
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe('POST /api/snippets/:id/touch', () => {
+    it('should touch an existing snippet and return success', async () => {
+      const snippet = await createSnippet('Touch me');
+
+      const res = await request(server).post(`/api/snippets/${snippet.id}/touch`);
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+    });
+
+    it('should return 400 for a non-numeric id', async () => {
+      const res = await request(server).post('/api/snippets/not-a-number/touch');
+      expect(res.status).toBe(400);
+    });
+
+    it('should return 404 for a non-existent snippet', async () => {
+      const res = await request(server).post('/api/snippets/99999/touch');
+      expect(res.status).toBe(404);
+    });
+  });
+});

--- a/tests/unit/chat-panel-snippets.test.js
+++ b/tests/unit/chat-panel-snippets.test.js
@@ -1,0 +1,644 @@
+// Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+/**
+ * Unit tests for the ChatPanel prompt-snippet picker wiring (Step 4 of the
+ * chat-prompt-snippets feature).
+ *
+ * Covers:
+ * - _insertPromptSnippet: insert into empty input; insert at caret mid-text;
+ *   newline prefix when preceding char is non-whitespace; sendBtn.disabled
+ *   recomputed; MRU touch fired (fire-and-forget, not awaited); {send:true}
+ *   invokes sendMessage; cmd-click-while-streaming leaves text in the input.
+ * - Dropdown mutual exclusion: showing the snippet dropdown hides the provider
+ *   and session dropdowns, and vice versa.
+ * - close() hides the snippet dropdown.
+ *
+ * These tests deliberately avoid vi.clearAllMocks() — per tests/CONVENTIONS.md,
+ * files that build many vi.fn() per test must clear an explicit set instead.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Minimal DOM harness. Every selector resolves to a persistent mock element so
+// ChatPanel's ref-caching (no null guards) and _bindEvents never hit null.
+// ---------------------------------------------------------------------------
+
+/** Document-level click listeners registered via addEventListener. */
+let documentClickListeners;
+
+function makeClassList() {
+  const set = new Set();
+  return {
+    _set: set,
+    add: (...c) => c.forEach(x => set.add(x)),
+    remove: (...c) => c.forEach(x => set.delete(x)),
+    contains: (c) => set.has(c),
+    toggle: (c) => (set.has(c) ? set.delete(c) : set.add(c)),
+  };
+}
+
+function createMockElement(tag = 'div') {
+  let _innerHTML = '';
+  let _textContent = '';
+  const el = {
+    tagName: tag.toUpperCase(),
+    style: { display: '' },
+    classList: makeClassList(),
+    dataset: {},
+    disabled: false,
+    // textContent setter escapes into innerHTML so _escapeHtml (which round-
+    // trips through a detached div) behaves like the real DOM.
+    get innerHTML() { return _innerHTML; },
+    set innerHTML(v) { _innerHTML = v; },
+    get textContent() { return _textContent; },
+    set textContent(v) {
+      _textContent = String(v);
+      _innerHTML = String(v)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;');
+    },
+    children: [],
+    _listeners: {},
+    querySelector: vi.fn(() => null),
+    querySelectorAll: vi.fn(() => []),
+    addEventListener: vi.fn(function (ev, fn) {
+      (this._listeners[ev] = this._listeners[ev] || []).push(fn);
+    }),
+    removeEventListener: vi.fn(),
+    appendChild: vi.fn((c) => { el.children.push(c); return c; }),
+    insertBefore: vi.fn((c) => { el.children.push(c); return c; }),
+    removeChild: vi.fn(),
+    remove: vi.fn(),
+    contains: vi.fn(() => false),
+    closest: vi.fn(() => null),
+    focus: vi.fn(),
+    blur: vi.fn(),
+    getBoundingClientRect: vi.fn(() => ({ top: 0, bottom: 20, left: 0, right: 40, width: 40, height: 20 })),
+    setAttribute: vi.fn(),
+    getAttribute: vi.fn(() => null),
+    removeAttribute: vi.fn(),
+  };
+  return el;
+}
+
+/**
+ * A textarea mock with working selection semantics so insert-at-caret can be
+ * asserted precisely.
+ */
+function createInputMock() {
+  const el = createMockElement('textarea');
+  el.value = '';
+  el.scrollHeight = 30;
+  el.selectionStart = 0;
+  el.selectionEnd = 0;
+  el.setSelectionRange = vi.fn(function (s, e) {
+    this.selectionStart = s;
+    this.selectionEnd = e;
+  });
+  return el;
+}
+
+/**
+ * Build a container whose querySelector returns a persistent mock per selector.
+ * Specific elements (input, dropdowns, buttons) are pre-seeded so tests can
+ * hold references to them.
+ */
+function buildContainer(refs) {
+  const cache = new Map();
+  const container = createMockElement('div');
+  container.querySelector = vi.fn((selector) => {
+    if (refs[selector]) return refs[selector];
+    if (!cache.has(selector)) cache.set(selector, createMockElement('div'));
+    return cache.get(selector);
+  });
+  return container;
+}
+
+// ---------------------------------------------------------------------------
+// Globals — must exist BEFORE requiring ChatPanel (IIFE reads window/document).
+// ---------------------------------------------------------------------------
+
+global.window = global.window || {};
+global.window.__pairReview = { chatProvider: 'pi', chatProviders: [], chatEnterToSend: true };
+global.window.renderMarkdown = (t) => `<p>${t}</p>`;
+global.window.escapeHtmlAttribute = (t) => String(t);
+global.window.panelGroup = { _onChatVisibilityChanged: vi.fn() };
+global.window.addEventListener = vi.fn();
+global.window.removeEventListener = vi.fn();
+global.window.innerWidth = 1200;
+global.window.innerHeight = 800;
+
+documentClickListeners = [];
+global.document = {
+  documentElement: {
+    style: { setProperty: vi.fn(), getPropertyValue: vi.fn(() => '') },
+    getAttribute: vi.fn(() => null),
+  },
+  body: {
+    classList: makeClassList(),
+    appendChild: vi.fn(),
+    removeChild: vi.fn(),
+  },
+  activeElement: null,
+  createElement: vi.fn((tag) => createMockElement(tag)),
+  getElementById: vi.fn(() => null),
+  querySelector: vi.fn(() => null),
+  addEventListener: vi.fn((ev, fn) => {
+    if (ev === 'click') documentClickListeners.push(fn);
+  }),
+  removeEventListener: vi.fn((ev, fn) => {
+    if (ev === 'click') documentClickListeners = documentClickListeners.filter(h => h !== fn);
+  }),
+};
+
+// Run setTimeout(fn, 0) callbacks synchronously so outside-click wiring is
+// deterministic (mirrors the approach in chat-panel.test.js).
+const _realSetTimeout = global.setTimeout;
+global.setTimeout = vi.fn((cb) => { cb(); return 0; });
+global.clearTimeout = vi.fn();
+global.requestAnimationFrame = vi.fn((cb) => { cb(); return 0; });
+global.fetch = vi.fn();
+
+require('../../public/js/utils/time.js');
+const { ChatPanel } = require('../../public/js/components/ChatPanel.js');
+
+// ---------------------------------------------------------------------------
+// Panel factory
+// ---------------------------------------------------------------------------
+
+function createPanel() {
+  const refs = {
+    '.chat-panel__input': createInputMock(),
+    '.chat-panel__send-btn': createMockElement('button'),
+    '.chat-panel__stop-btn': createMockElement('button'),
+    '.chat-panel__snippet-picker': createMockElement('div'),
+    '.chat-panel__snippet-picker-btn': createMockElement('button'),
+    '.chat-panel__snippet-dropdown': createMockElement('div'),
+    '.chat-panel__provider-picker': createMockElement('div'),
+    '.chat-panel__provider-picker-btn': createMockElement('button'),
+    '.chat-panel__provider-dropdown': createMockElement('div'),
+    '.chat-panel__session-picker': createMockElement('div'),
+    '.chat-panel__session-dropdown': createMockElement('div'),
+    '.chat-panel__history-btn': createMockElement('button'),
+  };
+  // Dropdowns start hidden, matching the `style="display: none;"` in _render's
+  // markup (our mock innerHTML doesn't parse inline styles).
+  refs['.chat-panel__snippet-dropdown'].style.display = 'none';
+  refs['.chat-panel__provider-dropdown'].style.display = 'none';
+  refs['.chat-panel__session-dropdown'].style.display = 'none';
+
+  const container = buildContainer(refs);
+  global.document.getElementById = vi.fn((id) => (id === 'chat-container' ? container : null));
+
+  const panel = new ChatPanel('chat-container');
+  panel.isOpen = true;
+  panel._refs = refs;
+  return panel;
+}
+
+/** Give the panel a single active tab so _getActiveTab()/sendMessage resolve. */
+function attachTab(panel, init = {}) {
+  const tab = panel._createTab(init);
+  panel.tabs = [tab];
+  panel.activeTabKey = panel._tabKey(tab);
+  return tab;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('ChatPanel prompt-snippet picker', () => {
+  let panel;
+  let input;
+
+  beforeEach(() => {
+    global.fetch.mockReset();
+    global.fetch.mockResolvedValue({ ok: true, json: async () => ({ snippets: [] }) });
+    documentClickListeners = [];
+    panel = createPanel();
+    input = panel.inputEl;
+  });
+
+  describe('_insertPromptSnippet', () => {
+    beforeEach(() => {
+      panel._promptSnippetsById = new Map([['7', 'Review this for bugs']]);
+    });
+
+    it('inserts the body into an empty input and focuses it', () => {
+      input.value = '';
+      input.selectionStart = input.selectionEnd = 0;
+
+      panel._insertPromptSnippet('7', {});
+
+      expect(input.value).toBe('Review this for bugs');
+      expect(input.selectionStart).toBe('Review this for bugs'.length);
+      expect(input.focus).toHaveBeenCalled();
+    });
+
+    it('inserts at the caret in the middle of existing text', () => {
+      input.value = 'abcXYZ';
+      input.selectionStart = input.selectionEnd = 3; // between abc and XYZ
+      panel._promptSnippetsById = new Map([['7', '--']]);
+
+      panel._insertPromptSnippet('7', {});
+
+      // preceding char 'c' is non-whitespace -> newline prefix
+      expect(input.value).toBe('abc\n--XYZ');
+      expect(input.selectionStart).toBe('abc\n--'.length);
+    });
+
+    it('does NOT prefix a newline when the preceding char is whitespace', () => {
+      input.value = 'abc ';
+      input.selectionStart = input.selectionEnd = 4;
+      panel._promptSnippetsById = new Map([['7', 'X']]);
+
+      panel._insertPromptSnippet('7', {});
+
+      expect(input.value).toBe('abc X');
+    });
+
+    it('does NOT prefix a newline at the start of the input', () => {
+      input.value = 'tail';
+      input.selectionStart = input.selectionEnd = 0;
+      panel._promptSnippetsById = new Map([['7', 'head']]);
+
+      panel._insertPromptSnippet('7', {});
+
+      expect(input.value).toBe('headtail');
+    });
+
+    it('recomputes sendBtn.disabled after inserting (was disabled, now enabled)', () => {
+      panel.sendBtn.disabled = true;
+      input.value = '';
+      input.selectionStart = input.selectionEnd = 0;
+
+      panel._insertPromptSnippet('7', {});
+
+      expect(panel.sendBtn.disabled).toBe(false);
+    });
+
+    it('keeps sendBtn disabled while streaming even after insert', () => {
+      const tab = attachTab(panel);
+      tab.isStreaming = true;
+      input.value = '';
+      input.selectionStart = input.selectionEnd = 0;
+
+      panel._insertPromptSnippet('7', {});
+
+      expect(panel.sendBtn.disabled).toBe(true);
+    });
+
+    it('fires the MRU touch endpoint fire-and-forget (not awaited)', () => {
+      // A touch fetch that never resolves must not block the synchronous insert.
+      global.fetch.mockReturnValue(new Promise(() => {}));
+      input.value = '';
+      input.selectionStart = input.selectionEnd = 0;
+
+      panel._insertPromptSnippet('7', {});
+
+      expect(global.fetch).toHaveBeenCalledWith('/api/snippets/7/touch', { method: 'POST' });
+      // Insert completed despite the pending promise.
+      expect(input.value).toBe('Review this for bugs');
+    });
+
+    it('does not throw when the touch fetch rejects', () => {
+      global.fetch.mockRejectedValue(new Error('network'));
+      input.value = '';
+      input.selectionStart = input.selectionEnd = 0;
+
+      expect(() => panel._insertPromptSnippet('7', {})).not.toThrow();
+    });
+
+    it('invokes sendMessage when {send:true}', () => {
+      const spy = vi.spyOn(panel, 'sendMessage').mockImplementation(() => {});
+      input.value = '';
+      input.selectionStart = input.selectionEnd = 0;
+
+      panel._insertPromptSnippet('7', { send: true });
+
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+
+    it('does NOT invoke sendMessage when {send:false}', () => {
+      const spy = vi.spyOn(panel, 'sendMessage').mockImplementation(() => {});
+      panel._insertPromptSnippet('7', { send: false });
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    it('cmd-click-while-streaming leaves the inserted text in the input (send guard)', () => {
+      const tab = attachTab(panel);
+      tab.isStreaming = true;
+      input.value = '';
+      input.selectionStart = input.selectionEnd = 0;
+
+      // Real sendMessage: bails on tab.isStreaming BEFORE clearing input.
+      panel._insertPromptSnippet('7', { send: true });
+
+      expect(input.value).toBe('Review this for bugs');
+    });
+
+    it('is a no-op for an unknown snippet id', () => {
+      input.value = 'keep';
+      panel._insertPromptSnippet('999', {});
+      expect(input.value).toBe('keep');
+    });
+  });
+
+  describe('dropdown rendering', () => {
+    it('populates _promptSnippetsById and renders truncated previews', () => {
+      const longBody = 'x'.repeat(80);
+      panel._renderSnippetDropdown([
+        { id: 1, body: 'first line\nsecond line' },
+        { id: 2, body: longBody },
+      ]);
+
+      expect(panel._promptSnippetsById.get('1')).toBe('first line\nsecond line');
+      expect(panel._promptSnippetsById.get('2')).toBe(longBody);
+      // First line only, sliced to 60 + ellipsis.
+      expect(panel.snippetDropdown.innerHTML).toContain('first line');
+      expect(panel.snippetDropdown.innerHTML).toContain('…');
+    });
+
+    it('renders an empty state with a Manage button when there are no snippets', () => {
+      panel._renderSnippetDropdown([]);
+      expect(panel.snippetDropdown.innerHTML).toContain('No snippets yet');
+      expect(panel.snippetDropdown.innerHTML).toContain('chat-panel__snippet-manage-empty-btn');
+    });
+  });
+
+  describe('mutual exclusion', () => {
+    it('showing the snippet dropdown hides provider and session dropdowns', async () => {
+      panel.providerDropdown.style.display = '';
+      panel.sessionDropdown.style.display = '';
+
+      await panel._showSnippetDropdown();
+
+      expect(panel.providerDropdown.style.display).toBe('none');
+      expect(panel.sessionDropdown.style.display).toBe('none');
+      expect(panel.snippetDropdown.style.display).toBe('');
+    });
+
+    it('showing the provider dropdown hides the snippet dropdown', () => {
+      panel.snippetDropdown.style.display = '';
+      panel._showProviderDropdown();
+      expect(panel.snippetDropdown.style.display).toBe('none');
+    });
+
+    it('showing the session dropdown hides the snippet dropdown', async () => {
+      panel.snippetDropdown.style.display = '';
+      vi.spyOn(panel, '_fetchSessions').mockResolvedValue([]);
+      await panel._showSessionDropdown();
+      expect(panel.snippetDropdown.style.display).toBe('none');
+    });
+
+    it('bails after the fetch await if the dropdown was dismissed meanwhile', async () => {
+      // Defer the fetch so we can hide mid-flight.
+      let resolveFetch;
+      global.fetch.mockReturnValue(new Promise(r => { resolveFetch = r; }));
+
+      const showPromise = panel._showSnippetDropdown();
+      // Simulate a concurrent hide (e.g. panel close) while fetch is pending.
+      panel._hideSnippetDropdown();
+      resolveFetch({ ok: true, json: async () => ({ snippets: [] }) });
+      await showPromise;
+
+      expect(panel.snippetDropdown.style.display).toBe('none');
+    });
+  });
+
+  describe('teardown', () => {
+    it('close() hides the snippet dropdown', () => {
+      panel.snippetDropdown.style.display = '';
+      // close() reads a few tab-context fields; an active tab keeps it simple.
+      attachTab(panel);
+      panel.close();
+      expect(panel.snippetDropdown.style.display).toBe('none');
+    });
+
+    it('_hideSnippetDropdown removes a registered outside-click listener', async () => {
+      await panel._showSnippetDropdown();
+      expect(documentClickListeners.length).toBe(1);
+      panel._hideSnippetDropdown();
+      expect(documentClickListeners.length).toBe(0);
+    });
+
+    it('destroy() removes a leaked provider-dropdown outside-click listener', () => {
+      panel._showProviderDropdown();
+      expect(documentClickListeners.length).toBe(1);
+      panel.destroy();
+      expect(documentClickListeners.length).toBe(0);
+      expect(panel._providerOutsideClickHandler).toBeNull();
+    });
+
+    it('destroy() removes a leaked session-dropdown outside-click listener', async () => {
+      vi.spyOn(panel, '_fetchSessions').mockResolvedValue([]);
+      await panel._showSessionDropdown();
+      expect(documentClickListeners.length).toBe(1);
+      panel.destroy();
+      expect(documentClickListeners.length).toBe(0);
+      expect(panel._sessionOutsideClickHandler).toBeNull();
+    });
+  });
+
+  describe('Escape ladder', () => {
+    it('Escape with the snippet dropdown open hides it and does NOT close the panel', () => {
+      const closeSpy = vi.spyOn(panel, 'close').mockImplementation(() => {});
+      panel.snippetDropdown.style.display = ''; // open
+
+      panel._onKeydown({ key: 'Escape' });
+
+      expect(panel.snippetDropdown.style.display).toBe('none');
+      expect(closeSpy).not.toHaveBeenCalled();
+    });
+
+    it('a second Escape (dropdown already closed) then closes the panel', () => {
+      const closeSpy = vi.spyOn(panel, 'close').mockImplementation(() => {});
+      panel.snippetDropdown.style.display = ''; // open
+
+      panel._onKeydown({ key: 'Escape' }); // hides dropdown
+      expect(closeSpy).not.toHaveBeenCalled();
+
+      panel._onKeydown({ key: 'Escape' }); // nothing open -> close panel
+      expect(closeSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('_insertPromptSnippet — disabled input contract', () => {
+    beforeEach(() => {
+      panel._promptSnippetsById = new Map([['7', 'Review this for bugs']]);
+    });
+
+    it('bails when the input is disabled: value unchanged, sendBtn stays disabled, no touch', () => {
+      input.value = 'existing';
+      input.disabled = true;
+      panel.sendBtn.disabled = true;
+
+      panel._insertPromptSnippet('7', {});
+
+      expect(input.value).toBe('existing');
+      expect(panel.sendBtn.disabled).toBe(true);
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('cmd-click on a disabled input does not reach sendMessage', () => {
+      const sendSpy = vi.spyOn(panel, 'sendMessage').mockImplementation(() => {});
+      input.disabled = true;
+
+      panel._insertPromptSnippet('7', { send: true });
+
+      expect(sendSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Save-as-snippet pill (alt-click a submitted user message)
+  // -------------------------------------------------------------------------
+  describe('save-as-snippet pill', () => {
+    /** Invoke every click listener registered on the messages stack. */
+    function fireStackClick(p, event) {
+      const listeners = p.messagesStackEl?._listeners?.click || [];
+      for (const fn of listeners) fn(event);
+    }
+
+    /** Build a fake click event whose target.closest resolves the given map. */
+    function clickEvent({ altKey = false, closestMap = {}, clientX = 100, clientY = 200 } = {}) {
+      return {
+        altKey,
+        clientX,
+        clientY,
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+        target: { closest: (sel) => closestMap[sel] || null },
+      };
+    }
+
+    function userMsg(content) {
+      const el = createMockElement('div');
+      el._chatRawContent = content;
+      return el;
+    }
+
+    describe('alt-click delegation', () => {
+      it('alt-click on a user message shows the pill', () => {
+        const msg = userMsg('Save me please');
+        fireStackClick(panel, clickEvent({ altKey: true, closestMap: { '.chat-panel__message--user': msg } }));
+
+        expect(panel._saveSnippetPill).toBeTruthy();
+        expect(panel._saveSnippetPillContent).toBe('Save me please');
+      });
+
+      it('alt-click on an assistant message does nothing (no user match)', () => {
+        // closest('.chat-panel__message--user') returns null for assistant.
+        fireStackClick(panel, clickEvent({ altKey: true, closestMap: {} }));
+        expect(panel._saveSnippetPill).toBeFalsy();
+      });
+
+      it('a plain click (no Alt) never shows the pill', () => {
+        const msg = userMsg('hi');
+        fireStackClick(panel, clickEvent({ altKey: false, closestMap: { '.chat-panel__message--user': msg } }));
+        expect(panel._saveSnippetPill).toBeFalsy();
+      });
+
+      it('only one pill at a time — alt-clicking another message moves it', () => {
+        const a = userMsg('first');
+        fireStackClick(panel, clickEvent({ altKey: true, closestMap: { '.chat-panel__message--user': a } }));
+        const firstPill = panel._saveSnippetPill;
+
+        const b = userMsg('second');
+        fireStackClick(panel, clickEvent({ altKey: true, closestMap: { '.chat-panel__message--user': b } }));
+
+        expect(firstPill.remove).toHaveBeenCalled();
+        expect(panel._saveSnippetPillContent).toBe('second');
+        expect(panel._saveSnippetPill).not.toBe(firstPill);
+      });
+    });
+
+    describe('saving', () => {
+      it('pill click POSTs the exact body and dismisses, then toasts success', async () => {
+        global.window.toast = { showSuccess: vi.fn() };
+        const body = 'Line one\nLine two';
+        const msg = userMsg(body);
+        fireStackClick(panel, clickEvent({ altKey: true, closestMap: { '.chat-panel__message--user': msg } }));
+
+        await panel._saveSnippetFromPill();
+
+        expect(global.fetch).toHaveBeenCalledWith('/api/snippets', expect.objectContaining({
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ body }),
+        }));
+        expect(panel._saveSnippetPill).toBeNull();
+        expect(global.window.toast.showSuccess).toHaveBeenCalled();
+        delete global.window.toast;
+      });
+
+      it('a failed POST does not throw; pill shows "Failed" then dismisses', async () => {
+        global.fetch.mockRejectedValue(new Error('network'));
+        const msg = userMsg('body');
+        fireStackClick(panel, clickEvent({ altKey: true, closestMap: { '.chat-panel__message--user': msg } }));
+        const pill = panel._saveSnippetPill;
+
+        await expect(panel._saveSnippetFromPill()).resolves.toBeUndefined();
+
+        expect(pill.textContent).toBe('Failed');
+        // The synchronous fake setTimeout runs the deferred dismiss immediately.
+        expect(panel._saveSnippetPill).toBeNull();
+      });
+
+      it('a non-ok response is treated as failure (no throw, no toast)', async () => {
+        global.window.toast = { showSuccess: vi.fn() };
+        global.fetch.mockResolvedValue({ ok: false, status: 400, json: async () => ({}) });
+        const msg = userMsg('body');
+        fireStackClick(panel, clickEvent({ altKey: true, closestMap: { '.chat-panel__message--user': msg } }));
+
+        await expect(panel._saveSnippetFromPill()).resolves.toBeUndefined();
+
+        expect(global.window.toast.showSuccess).not.toHaveBeenCalled();
+        delete global.window.toast;
+      });
+    });
+
+    describe('dismissal', () => {
+      it('outside click dismisses the pill', () => {
+        const msg = userMsg('body');
+        fireStackClick(panel, clickEvent({ altKey: true, closestMap: { '.chat-panel__message--user': msg } }));
+        expect(documentClickListeners.length).toBe(1);
+
+        // Simulate a document click on something other than the pill.
+        documentClickListeners[0]({ target: createMockElement('div') });
+
+        expect(panel._saveSnippetPill).toBeNull();
+        expect(documentClickListeners.length).toBe(0);
+      });
+
+      it('Escape dismisses the pill and does NOT close the panel', () => {
+        const closeSpy = vi.spyOn(panel, 'close').mockImplementation(() => {});
+        const msg = userMsg('body');
+        fireStackClick(panel, clickEvent({ altKey: true, closestMap: { '.chat-panel__message--user': msg } }));
+
+        panel._onKeydown({ key: 'Escape' });
+
+        expect(panel._saveSnippetPill).toBeNull();
+        expect(closeSpy).not.toHaveBeenCalled();
+
+        // A second Escape (nothing open) then closes the panel.
+        panel._onKeydown({ key: 'Escape' });
+        expect(closeSpy).toHaveBeenCalledTimes(1);
+      });
+
+      it('destroy() removes the pill and its outside-click listener', () => {
+        const msg = userMsg('body');
+        fireStackClick(panel, clickEvent({ altKey: true, closestMap: { '.chat-panel__message--user': msg } }));
+        expect(documentClickListeners.length).toBe(1);
+
+        panel.destroy();
+
+        expect(panel._saveSnippetPill).toBeNull();
+        expect(documentClickListeners.length).toBe(0);
+      });
+    });
+  });
+});

--- a/tests/unit/chat-snippet-repository.test.js
+++ b/tests/unit/chat-snippet-repository.test.js
@@ -1,0 +1,180 @@
+// Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+/**
+ * Unit tests for ChatSnippetRepository
+ *
+ * Tests CRUD operations, MRU ordering, and edge cases.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createTestDatabase } from '../utils/schema.js';
+
+const { ChatSnippetRepository, run: dbRun } = require('../../src/database.js');
+
+describe('ChatSnippetRepository', () => {
+  let db;
+  let repo;
+
+  beforeEach(async () => {
+    db = await createTestDatabase();
+    repo = new ChatSnippetRepository(db);
+  });
+
+  describe('create', () => {
+    it('should create a snippet and return it', async () => {
+      const snippet = await repo.create({ body: 'Review this for security issues' });
+
+      expect(snippet).toBeDefined();
+      expect(snippet.id).toBeDefined();
+      expect(snippet.body).toBe('Review this for security issues');
+      expect(snippet.last_used_at).toBeNull();
+      expect(snippet.created_at).toBeDefined();
+      expect(snippet.updated_at).toBeDefined();
+    });
+
+    it('should reject an empty body', async () => {
+      await expect(repo.create({ body: '' })).rejects.toThrow('body is required');
+      await expect(repo.create({ body: '   ' })).rejects.toThrow('body is required');
+    });
+
+    it('should reject a non-string body', async () => {
+      await expect(repo.create({ body: 42 })).rejects.toThrow('body is required');
+      await expect(repo.create({})).rejects.toThrow('body is required');
+    });
+  });
+
+  describe('getById', () => {
+    it('should return a snippet by id', async () => {
+      const created = await repo.create({ body: 'Hello' });
+      const snippet = await repo.getById(created.id);
+
+      expect(snippet).toBeDefined();
+      expect(snippet.id).toBe(created.id);
+      expect(snippet.body).toBe('Hello');
+    });
+
+    it('should return null for a non-existent id', async () => {
+      const snippet = await repo.getById(99999);
+      expect(snippet).toBeNull();
+    });
+  });
+
+  describe('list', () => {
+    it('should return an empty array when no snippets exist', async () => {
+      const snippets = await repo.list();
+      expect(snippets).toEqual([]);
+    });
+
+    it('should return all snippets', async () => {
+      await repo.create({ body: 'One' });
+      await repo.create({ body: 'Two' });
+
+      const snippets = await repo.list();
+      expect(snippets).toHaveLength(2);
+    });
+
+    it('should order snippets with last_used_at before those without', async () => {
+      const never = await repo.create({ body: 'Never Used' });
+      const used = await repo.create({ body: 'Recently Used' });
+
+      await repo.touchLastUsedAt(used.id);
+
+      const snippets = await repo.list();
+      expect(snippets).toHaveLength(2);
+      expect(snippets[0].id).toBe(used.id);
+      expect(snippets[1].id).toBe(never.id);
+    });
+
+    it('should order most recently used snippets first', async () => {
+      const a = await repo.create({ body: 'First Used' });
+      const b = await repo.create({ body: 'Second Used' });
+
+      // Set explicit timestamps (CURRENT_TIMESTAMP has 1s resolution)
+      await dbRun(db, `UPDATE chat_snippets SET last_used_at = '2025-01-01 00:00:01' WHERE id = ?`, [a.id]);
+      await dbRun(db, `UPDATE chat_snippets SET last_used_at = '2025-01-01 00:00:02' WHERE id = ?`, [b.id]);
+
+      const snippets = await repo.list();
+      expect(snippets[0].id).toBe(b.id);
+      expect(snippets[1].id).toBe(a.id);
+    });
+
+    it('should break ties among unused snippets by updated_at DESC', async () => {
+      const older = await repo.create({ body: 'Older' });
+      const newer = await repo.create({ body: 'Newer' });
+
+      await dbRun(db, `UPDATE chat_snippets SET updated_at = '2020-01-01 00:00:00' WHERE id = ?`, [older.id]);
+      await dbRun(db, `UPDATE chat_snippets SET updated_at = '2025-01-01 00:00:00' WHERE id = ?`, [newer.id]);
+
+      const snippets = await repo.list();
+      expect(snippets[0].id).toBe(newer.id);
+      expect(snippets[1].id).toBe(older.id);
+    });
+  });
+
+  describe('update', () => {
+    it('should update the body and return true', async () => {
+      const created = await repo.create({ body: 'Original' });
+      const result = await repo.update(created.id, { body: 'Changed' });
+      expect(result).toBe(true);
+
+      const snippet = await repo.getById(created.id);
+      expect(snippet.body).toBe('Changed');
+    });
+
+    it('should bump updated_at', async () => {
+      const created = await repo.create({ body: 'Original' });
+
+      // Backdate so the CURRENT_TIMESTAMP write (1s resolution) is guaranteed
+      // to differ — no sleep needed
+      await dbRun(db, `UPDATE chat_snippets SET updated_at = '2020-01-01 00:00:00' WHERE id = ?`, [created.id]);
+      const before = await repo.getById(created.id);
+
+      await repo.update(created.id, { body: 'Changed' });
+      const after = await repo.getById(created.id);
+
+      expect(new Date(after.updated_at).getTime()).toBeGreaterThan(new Date(before.updated_at).getTime());
+    });
+
+    it('should return false for a non-existent id', async () => {
+      const result = await repo.update(99999, { body: 'Nope' });
+      expect(result).toBe(false);
+    });
+
+    it('should reject an empty body', async () => {
+      const created = await repo.create({ body: 'Original' });
+      await expect(repo.update(created.id, { body: '' })).rejects.toThrow('body is required');
+    });
+  });
+
+  describe('touchLastUsedAt', () => {
+    it('should set last_used_at and return true for an existing snippet', async () => {
+      const created = await repo.create({ body: 'Touch me' });
+
+      const result = await repo.touchLastUsedAt(created.id);
+      expect(result).toBe(true);
+
+      const snippet = await repo.getById(created.id);
+      expect(snippet.last_used_at).not.toBeNull();
+    });
+
+    it('should return false for a non-existent snippet', async () => {
+      const result = await repo.touchLastUsedAt(99999);
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('delete', () => {
+    it('should delete an existing snippet and return true', async () => {
+      const created = await repo.create({ body: 'Delete me' });
+      const result = await repo.delete(created.id);
+      expect(result).toBe(true);
+
+      const snippet = await repo.getById(created.id);
+      expect(snippet).toBeNull();
+    });
+
+    it('should return false for a non-existent snippet', async () => {
+      const result = await repo.delete(99999);
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/tests/unit/settings-page.test.js
+++ b/tests/unit/settings-page.test.js
@@ -9,7 +9,7 @@
  * data-loading side effects never fire.
  */
 
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 
 const { SettingsPage, SOURCE_DISPLAY, PROVIDER_KEYS, CHAT_PROVIDER_KEYS, MODEL_KEYS, COUNCIL_KEYS } = require('../../public/js/settings.js');
 
@@ -662,6 +662,88 @@ describe('navItems', () => {
     const page = createPage();
     expect(page.navItems([], true)).toEqual([{ id: 'repos-section', title: 'Repositories' }]);
     expect(page.navItems([], false)).toEqual([]);
+  });
+
+  it('appends the Chat Snippets item only when includeSnippets is true', () => {
+    const page = createPage();
+    const withSnippets = page.navItems([{ id: 'section-general', title: 'General' }], false, true);
+    expect(withSnippets[withSnippets.length - 1]).toEqual({ id: 'snippets-section', title: 'Chat Snippets' });
+
+    const withoutSnippets = page.navItems([{ id: 'section-general', title: 'General' }], false, false);
+    expect(withoutSnippets.some(i => i.id === 'snippets-section')).toBe(false);
+  });
+
+  it('appends Chat Snippets then Repositories (repos stays terminal) when both are visible', () => {
+    const page = createPage();
+    const items = page.navItems([{ id: 'section-general', title: 'General' }], true, true);
+    expect(items).toEqual([
+      { id: 'section-general', title: 'General' },
+      { id: 'snippets-section', title: 'Chat Snippets' },
+      { id: 'repos-section', title: 'Repositories' }
+    ]);
+  });
+
+  it('omits the snippets item when includeSnippets is absent (back-compat arity)', () => {
+    const page = createPage();
+    // Existing two-argument callers must keep producing snippet-free nav.
+    const items = page.navItems([{ id: 'section-general', title: 'General' }], true);
+    expect(items.some(i => i.id === 'snippets-section')).toBe(false);
+  });
+});
+
+describe('mountSnippets', () => {
+  function setupDom() {
+    document.body.innerHTML = `
+      <section class="settings-section" id="snippets-section">
+        <div id="snippets-manager"></div>
+      </section>`;
+  }
+
+  afterEach(() => {
+    delete global.SnippetManager;
+    document.body.innerHTML = '';
+    vi.restoreAllMocks();
+  });
+
+  it('is a no-op when the mount node is missing (no throw, stays hidden)', () => {
+    document.body.innerHTML = ''; // neither section nor mount present
+    const page = createPage();
+    expect(() => page.mountSnippets()).not.toThrow();
+    expect(page.snippetsVisible).toBeFalsy();
+    expect(page._snippetManager).toBeFalsy();
+  });
+
+  it('hides the section when SnippetManager is undefined', () => {
+    setupDom();
+    delete global.SnippetManager;
+    const page = createPage();
+    page.mountSnippets();
+    expect(document.getElementById('snippets-section').style.display).toBe('none');
+    expect(page.snippetsVisible).toBeFalsy();
+  });
+
+  it('hides the section and logs when the constructor throws', () => {
+    setupDom();
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    global.SnippetManager = function () { throw new Error('boom'); };
+    const page = createPage();
+    page.mountSnippets();
+    expect(document.getElementById('snippets-section').style.display).toBe('none');
+    expect(page.snippetsVisible).toBeFalsy();
+    expect(errSpy).toHaveBeenCalled();
+  });
+
+  it('mounts the component and marks the section visible on success', () => {
+    setupDom();
+    const calls = [];
+    global.SnippetManager = function (container) { calls.push(container); this.container = container; };
+    const page = createPage();
+    page.mountSnippets();
+    expect(page.snippetsVisible).toBe(true);
+    expect(page._snippetManager).toBeInstanceOf(global.SnippetManager);
+    expect(calls[0]).toBe(document.getElementById('snippets-manager'));
+    // Visible = display cleared (not 'none').
+    expect(document.getElementById('snippets-section').style.display).not.toBe('none');
   });
 });
 

--- a/tests/unit/snippet-manager.test.js
+++ b/tests/unit/snippet-manager.test.js
@@ -1,0 +1,472 @@
+// Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+// @vitest-environment jsdom
+/**
+ * Unit tests for the shared SnippetManager component
+ * (public/js/components/SnippetManager.js). Imports the real class via its
+ * CommonJS export and drives it against a routed fetch mock backed by an
+ * in-memory store, so re-fetch-after-mutation behaves like the real API.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const { SnippetManager } = require('../../public/js/components/SnippetManager.js');
+
+/** Minimal fetch Response stand-in with an async json() body. */
+function makeResponse(body, { ok = true, status = 200 } = {}) {
+  return { ok, status, json: async () => body };
+}
+
+/**
+ * Install a routed fetch mock backed by `store` ({ list, nextId }). Mutations
+ * update the store so the component's re-fetch returns fresh data.
+ */
+function installFetch(store) {
+  global.fetch = vi.fn(async (url, opts = {}) => {
+    const method = (opts.method || 'GET').toUpperCase();
+
+    if (url === '/api/snippets' && method === 'GET') {
+      return makeResponse({ snippets: store.list.slice() });
+    }
+    if (url === '/api/snippets' && method === 'POST') {
+      const body = JSON.parse(opts.body).body;
+      const snippet = { id: store.nextId++, body };
+      store.list.unshift(snippet); // newest first (MRU-ish)
+      return makeResponse({ snippet }, { status: 201 });
+    }
+
+    const m = url.match(/^\/api\/snippets\/(\d+)$/);
+    if (m) {
+      const id = Number(m[1]);
+      const found = store.list.find(s => s.id === id);
+      if (method === 'PUT') {
+        if (!found) return makeResponse({ error: 'not found' }, { ok: false, status: 404 });
+        found.body = JSON.parse(opts.body).body;
+        return makeResponse({ snippet: found });
+      }
+      if (method === 'DELETE') {
+        if (!found) return makeResponse({ error: 'not found' }, { ok: false, status: 404 });
+        store.list = store.list.filter(s => s.id !== id);
+        return makeResponse({ success: true });
+      }
+    }
+    return makeResponse({ error: 'unexpected' }, { ok: false, status: 500 });
+  });
+  return global.fetch;
+}
+
+function mount() {
+  document.body.innerHTML = '<div id="host"></div>';
+  return document.getElementById('host');
+}
+
+beforeEach(() => {
+  // Delete is gated behind a confirmation. Default to "no styled dialog present,
+  // native confirm accepts" so happy-path delete tests proceed; individual tests
+  // override window.confirm / window.confirmDialog as needed.
+  delete window.confirmDialog;
+  window.confirm = vi.fn(() => true);
+});
+
+afterEach(() => {
+  document.body.innerHTML = '';
+  vi.restoreAllMocks();
+  delete global.fetch;
+  delete window.confirmDialog;
+});
+
+describe('SnippetManager inline mount', () => {
+  it('renders the snippet list with truncated previews', async () => {
+    installFetch({ list: [{ id: 1, body: 'First snippet' }, { id: 2, body: 'Second' }], nextId: 3 });
+    const host = mount();
+    new SnippetManager(host);
+
+    await vi.waitFor(() => {
+      expect(host.querySelectorAll('.snippet-manager__row')).toHaveLength(2);
+    });
+    const previews = [...host.querySelectorAll('.snippet-manager__preview')].map(p => p.textContent);
+    expect(previews).toEqual(['First snippet', 'Second']);
+    // Each row exposes sibling Edit/Delete buttons (never nested in the row).
+    const firstRow = host.querySelector('.snippet-manager__row');
+    expect(firstRow.tagName).toBe('DIV');
+    expect(firstRow.querySelector('.snippet-manager__edit-btn')).toBeTruthy();
+    expect(firstRow.querySelector('.snippet-manager__delete-btn')).toBeTruthy();
+  });
+
+  it('renders an empty state when there are no snippets', async () => {
+    installFetch({ list: [], nextId: 1 });
+    const host = mount();
+    new SnippetManager(host);
+
+    await vi.waitFor(() => {
+      expect(host.querySelector('.snippet-manager__empty')).toBeTruthy();
+    });
+    expect(host.querySelector('.snippet-manager__empty').textContent).toContain('No snippets yet');
+    expect(host.querySelector('.snippet-manager__add-btn')).toBeTruthy();
+  });
+
+  it('renders an error state when the list fetch fails', async () => {
+    global.fetch = vi.fn(async () => makeResponse({ error: 'boom' }, { ok: false, status: 500 }));
+    const host = mount();
+    new SnippetManager(host);
+
+    await vi.waitFor(() => {
+      expect(host.querySelector('.snippet-manager__error')).toBeTruthy();
+    });
+  });
+
+  it('escapes snippet bodies (no HTML injection)', async () => {
+    const evil = '<img src=x onerror="window.__pwned=1">';
+    installFetch({ list: [{ id: 1, body: evil }], nextId: 2 });
+    const host = mount();
+    new SnippetManager(host);
+
+    await vi.waitFor(() => {
+      expect(host.querySelector('.snippet-manager__preview')).toBeTruthy();
+    });
+    // Rendered as text, not parsed into an <img> element.
+    expect(host.querySelector('img')).toBeNull();
+    expect(host.querySelector('.snippet-manager__preview').textContent).toBe(evil);
+  });
+});
+
+describe('SnippetManager add', () => {
+  it('POSTs a new snippet, re-fetches, and fires onChange', async () => {
+    const store = { list: [], nextId: 1 };
+    const fetchMock = installFetch(store);
+    const onChange = vi.fn();
+    const host = mount();
+    new SnippetManager(host, { onChange });
+
+    await vi.waitFor(() => expect(host.querySelector('.snippet-manager__add-btn')).toBeTruthy());
+    host.querySelector('.snippet-manager__add-btn').click();
+
+    const textarea = host.querySelector('.snippet-manager__textarea');
+    expect(textarea).toBeTruthy();
+    textarea.value = 'Brand new snippet';
+    textarea.dispatchEvent(new window.Event('input'));
+    host.querySelector('.snippet-manager__form').dispatchEvent(new window.Event('submit'));
+
+    await vi.waitFor(() => {
+      expect(host.querySelectorAll('.snippet-manager__row')).toHaveLength(1);
+    });
+    const postCall = fetchMock.mock.calls.find(([u, o]) => u === '/api/snippets' && o && o.method === 'POST');
+    expect(postCall).toBeTruthy();
+    expect(JSON.parse(postCall[1].body)).toEqual({ body: 'Brand new snippet' });
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(host.querySelector('.snippet-manager__preview').textContent).toBe('Brand new snippet');
+  });
+
+  it('does not POST an empty/whitespace body (Save stays disabled)', async () => {
+    const fetchMock = installFetch({ list: [], nextId: 1 });
+    const host = mount();
+    new SnippetManager(host);
+
+    await vi.waitFor(() => expect(host.querySelector('.snippet-manager__add-btn')).toBeTruthy());
+    host.querySelector('.snippet-manager__add-btn').click();
+
+    const saveBtn = host.querySelector('.snippet-manager__save-btn');
+    expect(saveBtn.disabled).toBe(true);
+    const textarea = host.querySelector('.snippet-manager__textarea');
+    textarea.value = '   ';
+    textarea.dispatchEvent(new window.Event('input'));
+    expect(saveBtn.disabled).toBe(true);
+
+    const posted = fetchMock.mock.calls.some(([u, o]) => u === '/api/snippets' && o && o.method === 'POST');
+    expect(posted).toBe(false);
+  });
+
+  it('persists the body verbatim (leading/trailing whitespace preserved)', async () => {
+    const fetchMock = installFetch({ list: [], nextId: 1 });
+    const host = mount();
+    new SnippetManager(host);
+
+    await vi.waitFor(() => expect(host.querySelector('.snippet-manager__add-btn')).toBeTruthy());
+    host.querySelector('.snippet-manager__add-btn').click();
+
+    const verbatim = '  Leading and trailing kept\n\n';
+    const textarea = host.querySelector('.snippet-manager__textarea');
+    textarea.value = verbatim;
+    textarea.dispatchEvent(new window.Event('input'));
+    host.querySelector('.snippet-manager__form').dispatchEvent(new window.Event('submit'));
+
+    await vi.waitFor(() => {
+      expect(fetchMock.mock.calls.some(([u, o]) => u === '/api/snippets' && o && o.method === 'POST')).toBe(true);
+    });
+    const postCall = fetchMock.mock.calls.find(([u, o]) => u === '/api/snippets' && o && o.method === 'POST');
+    // Sent unmodified — NOT trimmed.
+    expect(JSON.parse(postCall[1].body)).toEqual({ body: verbatim });
+  });
+
+  it('preserves in-progress text and resets _busy after a failed save', async () => {
+    // GET succeeds (empty), POST fails.
+    global.fetch = vi.fn(async (url, opts = {}) => {
+      const method = (opts.method || 'GET').toUpperCase();
+      if (method === 'GET') return makeResponse({ snippets: [] });
+      return makeResponse({ error: 'server down' }, { ok: false, status: 500 });
+    });
+    const host = mount();
+    const mgr = new SnippetManager(host);
+
+    await vi.waitFor(() => expect(host.querySelector('.snippet-manager__add-btn')).toBeTruthy());
+    host.querySelector('.snippet-manager__add-btn').click();
+
+    const typed = 'A carefully written snippet I do not want to lose';
+    let textarea = host.querySelector('.snippet-manager__textarea');
+    textarea.value = typed;
+    textarea.dispatchEvent(new window.Event('input'));
+    host.querySelector('.snippet-manager__form').dispatchEvent(new window.Event('submit'));
+
+    // After the failed save re-render: error banner shown, still on the form,
+    // and the textarea retains the user's text.
+    await vi.waitFor(() => expect(host.querySelector('.snippet-manager__error')).toBeTruthy());
+    textarea = host.querySelector('.snippet-manager__textarea');
+    expect(textarea).toBeTruthy();
+    expect(textarea.value).toBe(typed);
+    expect(mgr._busy).toBe(false);
+  });
+});
+
+describe('SnippetManager edit', () => {
+  it('prefills the form and PUTs the update to the right id', async () => {
+    const store = { list: [{ id: 7, body: 'Original body' }], nextId: 8 };
+    const fetchMock = installFetch(store);
+    const onChange = vi.fn();
+    const host = mount();
+    new SnippetManager(host, { onChange });
+
+    await vi.waitFor(() => expect(host.querySelector('.snippet-manager__edit-btn')).toBeTruthy());
+    host.querySelector('.snippet-manager__edit-btn').click();
+
+    const textarea = host.querySelector('.snippet-manager__textarea');
+    expect(textarea.value).toBe('Original body');
+    textarea.value = 'Updated body';
+    textarea.dispatchEvent(new window.Event('input'));
+    host.querySelector('.snippet-manager__form').dispatchEvent(new window.Event('submit'));
+
+    await vi.waitFor(() => {
+      expect(host.querySelector('.snippet-manager__preview').textContent).toBe('Updated body');
+    });
+    const putCall = fetchMock.mock.calls.find(([u, o]) => u === '/api/snippets/7' && o && o.method === 'PUT');
+    expect(putCall).toBeTruthy();
+    expect(JSON.parse(putCall[1].body)).toEqual({ body: 'Updated body' });
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('Cancel returns to the list without a request', async () => {
+    const fetchMock = installFetch({ list: [{ id: 1, body: 'A' }], nextId: 2 });
+    const host = mount();
+    new SnippetManager(host);
+
+    await vi.waitFor(() => expect(host.querySelector('.snippet-manager__edit-btn')).toBeTruthy());
+    const callsBefore = fetchMock.mock.calls.length;
+    host.querySelector('.snippet-manager__edit-btn').click();
+    host.querySelector('.snippet-manager__cancel-btn').click();
+
+    expect(host.querySelector('.snippet-manager__list-wrap')).toBeTruthy();
+    expect(fetchMock.mock.calls.length).toBe(callsBefore); // no PUT/GET beyond initial
+  });
+});
+
+describe('SnippetManager delete', () => {
+  it('DELETEs the snippet, re-fetches, and fires onChange', async () => {
+    const store = { list: [{ id: 3, body: 'Doomed' }, { id: 4, body: 'Survivor' }], nextId: 5 };
+    const fetchMock = installFetch(store);
+    const onChange = vi.fn();
+    const host = mount();
+    new SnippetManager(host, { onChange });
+
+    await vi.waitFor(() => expect(host.querySelectorAll('.snippet-manager__row')).toHaveLength(2));
+    host.querySelector('.snippet-manager__row').querySelector('.snippet-manager__delete-btn').click();
+
+    await vi.waitFor(() => {
+      expect(host.querySelectorAll('.snippet-manager__row')).toHaveLength(1);
+    });
+    const delCall = fetchMock.mock.calls.find(([u, o]) => u === '/api/snippets/3' && o && o.method === 'DELETE');
+    expect(delCall).toBeTruthy();
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(host.querySelector('.snippet-manager__preview').textContent).toBe('Survivor');
+  });
+
+  it('uses the styled confirmDialog when present and deletes on confirm', async () => {
+    window.confirmDialog = { show: vi.fn().mockResolvedValue('confirm') };
+    const fetchMock = installFetch({ list: [{ id: 9, body: 'Doomed' }], nextId: 10 });
+    const host = mount();
+    new SnippetManager(host);
+
+    await vi.waitFor(() => expect(host.querySelector('.snippet-manager__delete-btn')).toBeTruthy());
+    host.querySelector('.snippet-manager__delete-btn').click();
+
+    await vi.waitFor(() => expect(host.querySelector('.snippet-manager__empty')).toBeTruthy());
+    expect(window.confirmDialog.show).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls.some(([u, o]) => u === '/api/snippets/9' && o && o.method === 'DELETE')).toBe(true);
+  });
+
+  it('does NOT delete when the confirmation is declined', async () => {
+    window.confirmDialog = { show: vi.fn().mockResolvedValue('cancel') };
+    const fetchMock = installFetch({ list: [{ id: 5, body: 'Kept' }], nextId: 6 });
+    const host = mount();
+    new SnippetManager(host);
+
+    await vi.waitFor(() => expect(host.querySelector('.snippet-manager__delete-btn')).toBeTruthy());
+    host.querySelector('.snippet-manager__delete-btn').click();
+
+    // Give the declined promise a chance to settle, then assert nothing changed.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(window.confirmDialog.show).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls.some(([u, o]) => u === '/api/snippets/5' && o && o.method === 'DELETE')).toBe(false);
+    expect(host.querySelectorAll('.snippet-manager__row')).toHaveLength(1);
+  });
+
+  it('falls back to native confirm(false) and does not delete', async () => {
+    window.confirm = vi.fn(() => false); // no styled dialog on this page
+    const fetchMock = installFetch({ list: [{ id: 2, body: 'Kept' }], nextId: 3 });
+    const host = mount();
+    new SnippetManager(host);
+
+    await vi.waitFor(() => expect(host.querySelector('.snippet-manager__delete-btn')).toBeTruthy());
+    host.querySelector('.snippet-manager__delete-btn').click();
+
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(window.confirm).toHaveBeenCalled();
+    expect(fetchMock.mock.calls.some(([u, o]) => o && o.method === 'DELETE')).toBe(false);
+    expect(host.querySelectorAll('.snippet-manager__row')).toHaveLength(1);
+  });
+
+  it('shows an error banner and resets _busy=false after a failed delete', async () => {
+    global.fetch = vi.fn(async (url, opts = {}) => {
+      const method = (opts.method || 'GET').toUpperCase();
+      if (method === 'GET') return makeResponse({ snippets: [{ id: 1, body: 'X' }] });
+      return makeResponse({ error: 'nope' }, { ok: false, status: 500 });
+    });
+    const host = mount();
+    const mgr = new SnippetManager(host);
+
+    await vi.waitFor(() => expect(host.querySelector('.snippet-manager__delete-btn')).toBeTruthy());
+    host.querySelector('.snippet-manager__delete-btn').click();
+
+    await vi.waitFor(() => expect(host.querySelector('.snippet-manager__error')).toBeTruthy());
+    expect(mgr._busy).toBe(false);
+  });
+});
+
+describe('SnippetManager.openModal', () => {
+  let addSpy;
+  let removeSpy;
+
+  beforeEach(() => {
+    addSpy = vi.spyOn(document, 'addEventListener');
+    removeSpy = vi.spyOn(document, 'removeEventListener');
+  });
+
+  it('mounts a modal shell and tears it down on backdrop click', async () => {
+    installFetch({ list: [{ id: 1, body: 'X' }], nextId: 2 });
+    const onClose = vi.fn();
+    SnippetManager.openModal({ onClose });
+
+    const overlay = document.querySelector('.snippet-manager-modal');
+    expect(overlay).toBeTruthy();
+    expect(overlay.querySelector('.snippet-manager-modal__header h3').textContent).toBe('Manage snippets');
+    // A document-level keydown listener is registered in the CAPTURE phase so
+    // Escape doesn't bubble to ChatPanel's own handler.
+    expect(addSpy).toHaveBeenCalledWith('keydown', expect.any(Function), true);
+
+    await vi.waitFor(() => {
+      expect(overlay.querySelector('.snippet-manager__row')).toBeTruthy();
+    });
+
+    overlay.querySelector('.modal-backdrop').click();
+
+    expect(document.querySelector('.snippet-manager-modal')).toBeNull();
+    // Teardown MUST remove the listener with the same capture flag or it leaks.
+    expect(removeSpy).toHaveBeenCalledWith('keydown', expect.any(Function), true);
+    expect(onClose).toHaveBeenCalledWith(false);
+  });
+
+  it('closes via the close button and reports changed=true after a mutation', async () => {
+    installFetch({ list: [], nextId: 1 });
+    const onClose = vi.fn();
+    SnippetManager.openModal({ onClose });
+
+    const overlay = document.querySelector('.snippet-manager-modal');
+    await vi.waitFor(() => expect(overlay.querySelector('.snippet-manager__add-btn')).toBeTruthy());
+
+    overlay.querySelector('.snippet-manager__add-btn').click();
+    const textarea = overlay.querySelector('.snippet-manager__textarea');
+    textarea.value = 'From modal';
+    textarea.dispatchEvent(new window.Event('input'));
+    overlay.querySelector('.snippet-manager__form').dispatchEvent(new window.Event('submit'));
+
+    await vi.waitFor(() => expect(overlay.querySelector('.snippet-manager__row')).toBeTruthy());
+
+    overlay.querySelector('.snippet-manager-modal__close').click();
+    expect(document.querySelector('.snippet-manager-modal')).toBeNull();
+    expect(onClose).toHaveBeenCalledWith(true);
+  });
+
+  it('teardown is idempotent (backdrop then Escape does not double-fire onClose)', async () => {
+    installFetch({ list: [], nextId: 1 });
+    const onClose = vi.fn();
+    SnippetManager.openModal({ onClose });
+
+    const overlay = document.querySelector('.snippet-manager-modal');
+    await vi.waitFor(() => expect(overlay.querySelector('.snippet-manager__add-btn')).toBeTruthy());
+
+    overlay.querySelector('.modal-backdrop').click();
+    document.dispatchEvent(new window.KeyboardEvent('keydown', { key: 'Escape' }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('Escape tears down the modal when no confirm dialog is visible', async () => {
+    installFetch({ list: [{ id: 1, body: 'X' }], nextId: 2 });
+    const onClose = vi.fn();
+    SnippetManager.openModal({ onClose });
+
+    const overlay = document.querySelector('.snippet-manager-modal');
+    await vi.waitFor(() => expect(overlay.querySelector('.snippet-manager__row')).toBeTruthy());
+
+    // No window.confirmDialog present (deleted in beforeEach).
+    document.dispatchEvent(new window.KeyboardEvent('keydown', { key: 'Escape' }));
+
+    expect(document.querySelector('.snippet-manager-modal')).toBeNull();
+    expect(removeSpy).toHaveBeenCalledWith('keydown', expect.any(Function), true);
+    expect(onClose).toHaveBeenCalledWith(false);
+  });
+
+  it('Escape yields to a stacked delete confirmation instead of tearing down', async () => {
+    installFetch({ list: [{ id: 1, body: 'X' }], nextId: 2 });
+    const onClose = vi.fn();
+    SnippetManager.openModal({ onClose });
+
+    const overlay = document.querySelector('.snippet-manager-modal');
+    await vi.waitFor(() => expect(overlay.querySelector('.snippet-manager__row')).toBeTruthy());
+
+    // Simulate the delete-confirmation dialog stacked above the modal.
+    window.confirmDialog = { isVisible: true };
+    document.dispatchEvent(new window.KeyboardEvent('keydown', { key: 'Escape' }));
+
+    // Modal is untouched: overlay still present, teardown not run, listener kept.
+    expect(document.querySelector('.snippet-manager-modal')).toBe(overlay);
+    expect(onClose).not.toHaveBeenCalled();
+    expect(removeSpy).not.toHaveBeenCalledWith('keydown', expect.any(Function), true);
+
+    // Once the confirm dialog is dismissed, Escape resumes tearing down.
+    window.confirmDialog.isVisible = false;
+    document.dispatchEvent(new window.KeyboardEvent('keydown', { key: 'Escape' }));
+    expect(document.querySelector('.snippet-manager-modal')).toBeNull();
+    expect(onClose).toHaveBeenCalledWith(false);
+  });
+});
+
+describe('SnippetManager.destroy', () => {
+  it('clears the container', async () => {
+    installFetch({ list: [{ id: 1, body: 'X' }], nextId: 2 });
+    const host = mount();
+    const mgr = new SnippetManager(host);
+    await vi.waitFor(() => expect(host.querySelector('.snippet-manager__row')).toBeTruthy());
+
+    mgr.destroy();
+    expect(host.innerHTML).toBe('');
+  });
+});

--- a/tests/utils/schema.js
+++ b/tests/utils/schema.js
@@ -340,6 +340,16 @@ const SCHEMA_SQL = {
       created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
       updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
     )
+  `,
+
+  chat_snippets: `
+    CREATE TABLE IF NOT EXISTS chat_snippets (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      body TEXT NOT NULL,
+      last_used_at DATETIME,
+      created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+      updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+    )
   `
 };
 
@@ -395,7 +405,9 @@ const INDEX_SQL = [
   'CREATE INDEX IF NOT EXISTS idx_external_comments_anchor ON external_comments(review_id, file, line_end)',
   'CREATE INDEX IF NOT EXISTS idx_external_comments_parent_lookup ON external_comments(review_id, source, in_reply_to_id)',
   // Global settings (in-app overrides). Must match production src/database.js.
-  'CREATE UNIQUE INDEX IF NOT EXISTS idx_global_settings_key ON global_settings(key)'
+  'CREATE UNIQUE INDEX IF NOT EXISTS idx_global_settings_key ON global_settings(key)',
+  // Chat snippets MRU lookup. Must match production src/database.js.
+  'CREATE INDEX IF NOT EXISTS idx_chat_snippets_last_used ON chat_snippets(last_used_at DESC)'
 ];
 
 /**


### PR DESCRIPTION
## Summary

Adds a **global library of reusable chat prompts** — save the prompts you type all the time and reuse them from the chat input.

- **Snippet picker button** in the chat input (left of send). The dropdown lists snippets in MRU order and opens upward, anchored to the input box so it stays inside the panel at any width.
- **Click inserts** the snippet at the cursor (newline-aware); **Cmd/Ctrl+click inserts and sends**.
- **Alt-click one of your sent messages** to save it as a snippet via a small "Save as snippet" pill — raw content is preserved (newlines/formatting), not the rendered bubble text.
- **Management** via a shared `SnippetManager` editor: modal from the picker's gear, and an inline **Chat Snippets** section on the global settings page.
- Snippets are **global** (user-level, not repo-specific); the schema leaves room for repo-scoped snippets later.
- Works in **both PR mode and local mode** via the shared `ChatPanel`.

## Implementation

- `chat_snippets` table (migration 54) with `last_used_at` MRU tracking; `ChatSnippetRepository` modeled on `CouncilRepository`
- `/api/snippets` CRUD + fire-and-forget `POST /:id/touch` for MRU (never blocks insert)
- Review-feedback hardening: Escape-key layering (panel → dropdowns → modal → stacked confirm dialog), disabled-input gating during connect, draft preservation on failed saves, delete confirmation, verbatim body persistence (no trim), outside-click listener leak fixes in `destroy()`

## Deliberate calls

- Settings-page delete uses native `confirm`: loading ConfirmDialog's stylesheet there would restyle the settings header (unscoped `.header-icon`/`.header-subtitle` in `analysis-config.css`)
- Dropdown-controller consolidation (provider/session/snippet trio) deferred as a follow-up per review

## Testing

- `pnpm test`: 272 files / 9026 tests passed
- `pnpm run test:e2e`: 387 passed, 1 skipped; 1 pre-existing flake (`gutter-buttons.spec.js:90`, passes in isolation, unrelated)
- New coverage: repository unit tests, route integration tests, SnippetManager + ChatPanel jsdom tests, two E2E specs (picker/MRU/modal/settings + alt-click save), including a regression test pinning the dropdown inside the panel bounds

🤖 Generated with [Claude Code](https://claude.com/claude-code)