### PR TITLE
style: remove AI-generated UI cliches, keep flat amber identity

### DIFF
--- a/.changeset/flat-ui-remove-ai-cliches.md
+++ b/.changeset/flat-ui-remove-ai-cliches.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Refresh UI styling to remove generic "AI-generated" visual tells while keeping the amber AI identity as flat color. The Analyze button is now text-only, gradient button/badge/card fills are flattened to solid colors, colored glow box-shadows and pulse-glow animations are removed (focus rings kept), `transition: all` is replaced with explicit properties, a `prefers-reduced-motion` guard is added, and the DM Sans / JetBrains Mono Google Fonts are dropped in favor of the system font stack. The sparkles icon remains the mark for AI suggestions (light-bulb already denotes the improvement category), minus its glow and float animations.

--- a/public/css/ai-summary-modal.css
+++ b/public/css/ai-summary-modal.css
@@ -4,7 +4,7 @@
  * Extracted from pr.css for better organization
  */
 
-/* AI Summary Button (sparkle icon in panel header) */
+/* AI Summary Button (light-bulb icon in panel header) */
 .ai-summary-btn {
   background: none;
   border: 2px solid transparent;

--- a/public/css/analysis-config.css
+++ b/public/css/analysis-config.css
@@ -56,7 +56,7 @@
   justify-content: space-between;
   padding: 24px 24px 16px 24px;
   border-bottom: 1px solid var(--ai-border, rgba(217, 119, 6, 0.3));
-  background: linear-gradient(to right, var(--ai-subtle, rgba(217, 119, 6, 0.08)), transparent);
+  background: var(--ai-subtle, rgba(217, 119, 6, 0.08));
 }
 
 .modal-header h3 {
@@ -316,9 +316,7 @@
   align-items: center;
   justify-content: space-between;
   padding: 16px 20px;
-  background: linear-gradient(135deg,
-    var(--color-bg-secondary) 0%,
-    var(--color-bg-tertiary) 100%);
+  background: var(--color-bg-secondary);
   border-bottom: 1px solid var(--color-border-primary);
 }
 
@@ -335,14 +333,8 @@
   width: 40px;
   height: 40px;
   border-radius: 10px;
-  background: linear-gradient(135deg, var(--color-accent-ai-dark) 0%, #d97706 100%);
+  background: var(--ai-accent-flat, #d97706);
   color: white;
-  box-shadow: 0 2px 8px rgba(245, 158, 11, 0.3);
-}
-
-[data-theme="dark"] .header-icon {
-  background: linear-gradient(135deg, var(--color-accent-ai) 0%, var(--color-accent-ai-dark) 100%);
-  box-shadow: 0 2px 12px rgba(251, 191, 36, 0.25);
 }
 
 .analysis-config-header h3 {
@@ -442,7 +434,11 @@
   font-weight: 500;
   border-radius: 10px;
   cursor: pointer;
-  transition: all 0.2s cubic-bezier(0.16, 1, 0.3, 1);
+  transition: border-color 0.2s cubic-bezier(0.16, 1, 0.3, 1),
+              background-color 0.2s cubic-bezier(0.16, 1, 0.3, 1),
+              color 0.2s cubic-bezier(0.16, 1, 0.3, 1),
+              transform 0.2s cubic-bezier(0.16, 1, 0.3, 1),
+              box-shadow 0.2s cubic-bezier(0.16, 1, 0.3, 1);
   white-space: nowrap;
 }
 
@@ -458,18 +454,14 @@
   border-color: var(--color-accent-ai-dark);
   background: rgba(245, 158, 11, 0.08);
   color: var(--color-text-primary);
-  box-shadow:
-    0 0 0 3px rgba(245, 158, 11, 0.15),
-    0 4px 12px rgba(245, 158, 11, 0.1);
+  box-shadow: 0 0 0 3px rgba(245, 158, 11, 0.15);
 }
 
 [data-theme="dark"] .provider-btn.selected {
   background: rgba(251, 191, 36, 0.1);
   border-color: var(--color-accent-ai);
   color: #fbbf24;
-  box-shadow:
-    0 0 0 3px rgba(251, 191, 36, 0.15),
-    0 4px 12px rgba(251, 191, 36, 0.08);
+  box-shadow: 0 0 0 3px rgba(251, 191, 36, 0.15);
 }
 
 /* No providers available message */
@@ -494,7 +486,7 @@
   color: var(--color-text-tertiary);
   border-radius: 4px;
   cursor: pointer;
-  transition: all 0.2s ease;
+  transition: background-color 0.2s ease, color 0.2s ease;
 }
 
 .provider-refresh-btn:hover {
@@ -538,7 +530,10 @@
   border: 2px solid var(--color-border-primary);
   border-radius: 10px;
   cursor: pointer;
-  transition: all 0.2s cubic-bezier(0.16, 1, 0.3, 1);
+  transition: border-color 0.2s cubic-bezier(0.16, 1, 0.3, 1),
+              background-color 0.2s cubic-bezier(0.16, 1, 0.3, 1),
+              transform 0.2s cubic-bezier(0.16, 1, 0.3, 1),
+              box-shadow 0.2s cubic-bezier(0.16, 1, 0.3, 1);
   text-align: center;
   aspect-ratio: 1.618 / 1;
   overflow: hidden;
@@ -555,17 +550,13 @@
 .model-card.selected {
   border-color: var(--color-accent-ai-dark);
   background: rgba(245, 158, 11, 0.08);
-  box-shadow:
-    0 0 0 3px rgba(245, 158, 11, 0.15),
-    0 4px 12px rgba(245, 158, 11, 0.1);
+  box-shadow: 0 0 0 3px rgba(245, 158, 11, 0.15);
 }
 
 [data-theme="dark"] .model-card.selected {
   background: rgba(251, 191, 36, 0.1);
   border-color: var(--color-accent-ai);
-  box-shadow:
-    0 0 0 3px rgba(251, 191, 36, 0.15),
-    0 4px 12px rgba(251, 191, 36, 0.08);
+  box-shadow: 0 0 0 3px rgba(251, 191, 36, 0.15);
 }
 
 .model-badge {
@@ -582,27 +573,27 @@
 }
 
 .badge-speed {
-  background: linear-gradient(135deg, #06b6d4 0%, #0891b2 100%);
+  background: #0891b2;
   color: white;
 }
 
 .badge-recommended {
-  background: linear-gradient(135deg, var(--color-accent-ai-dark) 0%, #d97706 100%);
+  background: var(--color-accent-ai-dark);
   color: white;
 }
 
 .badge-power {
-  background: linear-gradient(135deg, #8b5cf6 0%, #7c3aed 100%);
+  background: #7c3aed;
   color: white;
 }
 
 .badge-premium {
-  background: linear-gradient(135deg, #ec4899 0%, #db2777 100%);
+  background: #db2777;
   color: white;
 }
 
 .badge-balanced {
-  background: linear-gradient(135deg, var(--color-accent-ai-dark) 0%, #d97706 100%);
+  background: var(--color-accent-ai-dark);
   color: white;
 }
 
@@ -650,7 +641,7 @@
   color: white;
   opacity: 0;
   transform: scale(0.5);
-  transition: all 0.2s cubic-bezier(0.34, 1.56, 0.64, 1);
+  transition: opacity 0.2s ease-out, transform 0.2s ease-out;
 }
 
 [data-theme="dark"] .model-selected-indicator {
@@ -698,7 +689,7 @@
   height: 16px;
   background: white;
   border-radius: 50%;
-  transition: transform 0.2s cubic-bezier(0.34, 1.56, 0.64, 1);
+  transition: transform 0.2s ease-out;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
 }
 
@@ -756,7 +747,7 @@
   font-size: 13px;
   color: var(--color-text-secondary);
   cursor: pointer;
-  transition: all var(--transition-fast);
+  transition: background-color var(--transition-fast), border-color var(--transition-fast), color var(--transition-fast);
   user-select: none;
 }
 
@@ -836,7 +827,7 @@
   font-weight: 500;
   color: var(--color-text-secondary);
   cursor: pointer;
-  transition: all var(--transition-fast);
+  transition: background-color var(--transition-fast), border-color var(--transition-fast), color var(--transition-fast);
 }
 
 .banner-toggle:hover {
@@ -877,7 +868,7 @@
   border-radius: 4px;
   color: var(--color-text-tertiary);
   cursor: pointer;
-  transition: all var(--transition-fast);
+  transition: background-color var(--transition-fast), color var(--transition-fast);
 }
 
 .collapse-btn:hover {
@@ -973,14 +964,14 @@
 
 /* Disabled submit button state */
 .btn-analyze:disabled {
-  background: linear-gradient(135deg, #9ca3af 0%, #6b7280 100%);
+  background: #6b7280;
   cursor: not-allowed;
   box-shadow: none;
   opacity: 0.7;
 }
 
 .btn-analyze:disabled:hover {
-  background: linear-gradient(135deg, #9ca3af 0%, #6b7280 100%);
+  background: #6b7280;
   transform: none;
 }
 
@@ -1041,21 +1032,19 @@
   align-items: center;
   gap: 8px;
   padding: 10px 20px;
-  background: linear-gradient(135deg, var(--color-accent-ai-dark) 0%, #d97706 100%);
+  background: var(--color-accent-ai-dark);
   border: none;
   border-radius: 8px;
   font-size: 14px;
   font-weight: 600;
   color: white;
   cursor: pointer;
-  transition: all 0.2s ease;
-  box-shadow: 0 2px 8px rgba(245, 158, 11, 0.3);
+  transition: background-color 0.2s ease, transform 0.2s ease;
 }
 
 .btn-analyze:hover {
-  background: linear-gradient(135deg, var(--color-accent-ai) 0%, var(--color-accent-ai-dark) 100%);
+  background: var(--color-accent-ai);
   transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(245, 158, 11, 0.35);
 }
 
 .btn-analyze:active {
@@ -1063,13 +1052,8 @@
 }
 
 [data-theme="dark"] .btn-analyze {
-  background: linear-gradient(135deg, var(--color-accent-ai) 0%, var(--color-accent-ai-dark) 100%);
+  background: var(--color-accent-ai);
   color: #1a1a1a;
-  box-shadow: 0 2px 12px rgba(251, 191, 36, 0.25);
-}
-
-[data-theme="dark"] .btn-analyze:hover {
-  box-shadow: 0 4px 16px rgba(251, 191, 36, 0.3);
 }
 
 /* Responsive */

--- a/public/css/council-card.css
+++ b/public/css/council-card.css
@@ -16,15 +16,11 @@
   background: var(--color-bg-primary);
   border: 1px solid var(--color-border-primary);
   border-radius: 10px;
-  box-shadow:
-    0 0 0 3px rgba(245, 158, 11, 0.15),
-    0 4px 12px rgba(245, 158, 11, 0.1);
+  box-shadow: 0 0 0 3px rgba(245, 158, 11, 0.15);
 }
 
 [data-theme="dark"] .council-card {
-  box-shadow:
-    0 0 0 3px rgba(251, 191, 36, 0.15),
-    0 4px 12px rgba(251, 191, 36, 0.08);
+  box-shadow: 0 0 0 3px rgba(251, 191, 36, 0.15);
 }
 
 .council-card-name {

--- a/public/css/pr.css
+++ b/public/css/pr.css
@@ -110,8 +110,7 @@
   font-weight: 700;
   letter-spacing: 0.5px;
   color: #fff;
-  background: linear-gradient(135deg, #d97706 0%, #b45309 100%);
-  box-shadow: 0 2px 6px rgba(217, 119, 6, 0.35);
+  background: #b45309;
   transition: opacity 0.15s ease, transform 0.15s ease;
   white-space: nowrap;
   margin-left: 8px;
@@ -119,28 +118,23 @@
 
 
 .stale-badge.pr-closed {
-  background: linear-gradient(135deg, #cf222e 0%, #a40e26 100%);
-  box-shadow: 0 2px 6px rgba(207, 34, 46, 0.35);
+  background: #a40e26;
 }
 
 .stale-badge.pr-merged {
-  background: linear-gradient(135deg, #8250df 0%, #6639ba 100%);
-  box-shadow: 0 2px 6px rgba(130, 80, 223, 0.35);
+  background: #6639ba;
 }
 
 [data-theme="dark"] .stale-badge {
-  background: linear-gradient(135deg, #f59e0b 0%, #d97706 100%);
-  box-shadow: 0 2px 8px rgba(245, 158, 11, 0.4);
+  background: #d97706;
 }
 
 [data-theme="dark"] .stale-badge.pr-closed {
-  background: linear-gradient(135deg, #f85149 0%, #cf222e 100%);
-  box-shadow: 0 2px 8px rgba(248, 81, 73, 0.4);
+  background: #cf222e;
 }
 
 [data-theme="dark"] .stale-badge.pr-merged {
-  background: linear-gradient(135deg, #a371f7 0%, #8250df 100%);
-  box-shadow: 0 2px 8px rgba(163, 113, 247, 0.4);
+  background: #8250df;
 }
 
 .pr-title .github-link {
@@ -308,7 +302,7 @@
   color: #656d76;
   cursor: pointer;
   border-bottom: 2px solid transparent;
-  transition: all 0.2s ease;
+  transition: var(--transition-ui);
 }
 
 .tab-btn:hover {
@@ -450,7 +444,7 @@
   border-radius: 6px;
   appearance: none;
   text-decoration: none;
-  transition: all 0.2s ease;
+  transition: var(--transition-ui);
 }
 
 .btn-primary {
@@ -473,31 +467,28 @@
   background-color: var(--ai-primary);
   border-color: var(--ai-primary);
   cursor: pointer;
-  transition: all 0.3s ease;
-  box-shadow: 0 0 12px var(--ai-glow);
+  transition: var(--transition-ui-slow);
 }
 
 .btn-primary.btn-analyzing:hover {
   background-color: var(--ai-secondary);
   border-color: var(--ai-secondary);
-  box-shadow: 0 0 16px var(--ai-glow);
 }
 
-/* Pulsing animation for the analyzing sparkle icon */
-.btn-analyzing .analyzing-icon {
+/* Inline spinner shown in the analyze button while analysis runs.
+   Track/arc derive from currentColor so it stays legible on the amber
+   analyzing background in both themes (white text light, near-black dark). */
+.btn-spinner {
   display: inline-block;
-  animation: pulse-sparkle 1.2s ease-in-out infinite;
-}
-
-@keyframes pulse-sparkle {
-  0%, 100% {
-    filter: brightness(1.2) drop-shadow(0 0 2px rgba(255, 255, 255, 0.6));
-    transform: scale(1);
-  }
-  50% {
-    filter: brightness(1.5) drop-shadow(0 0 6px rgba(255, 255, 255, 0.9));
-    transform: scale(1.15);
-  }
+  width: 12px;
+  height: 12px;
+  flex-shrink: 0;
+  border: 2px solid color-mix(in srgb, currentColor 20%, transparent);
+  border-top-color: currentColor;
+  border-right-color: currentColor;
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+  vertical-align: -1px;
 }
 
 /* Refresh button spinner animation */
@@ -648,7 +639,12 @@
   --color-accent-lighter: rgba(9, 105, 218, 0.05);
   --color-accent-ai: #fbbf24;
   --color-accent-ai-dark: #f59e0b;
-  
+
+  /* Unified flat amber for settings-surface accents (header icons, save
+     buttons) across analysis-config.css, settings.css, repo-settings.css.
+     Those files all load pr.css, so this is their single source. */
+  --ai-accent-flat: #d97706;
+
   --color-danger: #d1242f;
   --color-danger-hover: #b91c1c;
   
@@ -673,7 +669,6 @@
   --ai-primary: #d97706;
   --ai-secondary: #f59e0b;
   --ai-subtle: rgba(217, 119, 6, 0.08);
-  --ai-glow: rgba(217, 119, 6, 0.15);
   --ai-border: rgba(217, 119, 6, 0.3);
   --ai-text: #92400e;
 
@@ -762,7 +757,9 @@
   --color-accent-lighter: rgba(88, 166, 255, 0.08);
   --color-accent-ai: #fbbf24;
   --color-accent-ai-dark: #f59e0b;
-  
+
+  --ai-accent-flat: #f59e0b;
+
   --color-danger: #f85149;
   --color-danger-hover: #da3633;
   
@@ -787,7 +784,6 @@
   --ai-primary: #f59e0b;
   --ai-secondary: #fbbf24;
   --ai-subtle: rgba(245, 158, 11, 0.1);
-  --ai-glow: rgba(245, 158, 11, 0.2);
   --ai-border: rgba(245, 158, 11, 0.3);
   --ai-text: #fcd34d;
 
@@ -926,7 +922,7 @@
   background: var(--color-bg-primary);
   color: var(--color-text-secondary);
   cursor: pointer;
-  transition: all 0.2s;
+  transition: var(--transition-ui);
 }
 
 .sidebar-toggle-collapsed.visible {
@@ -1022,7 +1018,7 @@
   color: var(--color-text-secondary);
   text-decoration: none;
   border-radius: 4px;
-  transition: all 0.1s;
+  transition: var(--transition-ui-fast);
   cursor: pointer;
   position: relative;
 }
@@ -1048,7 +1044,7 @@
 }
 
 .file-item .file-name {
-  font-family: var(--font-mono, 'JetBrains Mono', monospace);
+  font-family: var(--font-mono, monospace);
   font-size: 12px;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -1058,7 +1054,7 @@
 }
 
 .file-item .file-changes {
-  font-family: var(--font-mono, 'JetBrains Mono', monospace);
+  font-family: var(--font-mono, monospace);
   font-size: 11px;
   color: var(--color-text-muted);
   flex-shrink: 0;
@@ -1328,7 +1324,7 @@
   background: var(--color-bg-elevated, #1e2329);
   border: 1px solid var(--color-border-subtle, rgba(255, 255, 255, 0.06));
   border-radius: 4px;
-  transition: all 0.1s ease;
+  transition: var(--transition-ui-fast);
   line-height: 1;
 }
 
@@ -1912,7 +1908,6 @@ tr.newly-expanded .d2h-code-line-ctn {
   margin: 12px auto; /* Center horizontally with auto margins */
   border-radius: 6px;
   position: relative;
-  box-shadow: 0 0 20px var(--ai-glow, rgba(245, 158, 11, 0.2)); /* Amber glow shadow */
   /* Explicitly list transitions to exclude max-width - prevents flicker on sidebar toggle */
   transition: box-shadow 0.2s ease, opacity 0.2s ease, background 0.2s ease, border-color 0.2s ease;
   /* Account for sticky toolbar + file header when scrolling to this element */
@@ -1943,7 +1938,11 @@ tr.newly-expanded .d2h-code-line-ctn {
 }
 
 .ai-suggestion:hover {
-  box-shadow: 0 4px 24px var(--ai-glow, rgba(245, 158, 11, 0.3));
+  box-shadow: 0 3px 8px rgba(245, 158, 11, 0.18);
+}
+
+[data-theme="dark"] .ai-suggestion:hover {
+  box-shadow: 0 3px 8px rgba(245, 158, 11, 0.28);
 }
 
 .ai-suggestion.adopted {
@@ -1962,7 +1961,7 @@ tr.newly-expanded .d2h-code-line-ctn {
   justify-content: space-between;
   gap: 8px;
   padding: 12px 16px;
-  background: linear-gradient(to right, var(--ai-subtle, rgba(245, 158, 11, 0.1)), transparent); /* Amber-subtle gradient from prototype */
+  background: var(--ai-subtle, rgba(245, 158, 11, 0.1));
   border-bottom: 1px solid var(--color-border-primary, rgba(0, 0, 0, 0.1));
 }
 
@@ -2074,7 +2073,7 @@ tr.newly-expanded .d2h-code-line-ctn {
 }
 
 .ai-suggestion.ai-type-praise .ai-suggestion-header {
-  background: linear-gradient(to right, var(--ai-subtle, rgba(245, 158, 11, 0.1)), transparent);
+  background: var(--ai-subtle, rgba(245, 158, 11, 0.1));
 }
 
 .ai-suggestion.ai-type-praise .praise-badge {
@@ -2241,7 +2240,7 @@ tr.newly-expanded .d2h-code-line-ctn {
   background: var(--color-bg-elevated, rgba(30, 35, 41, 1));
   padding: 2px 6px;
   border-radius: 4px;
-  font-family: 'JetBrains Mono', 'SF Mono', 'SFMono-Regular', 'Consolas', 'Liberation Mono', 'Menlo', monospace;
+  font-family: var(--font-mono);
   font-size: 0.8125rem;
   color: var(--ai-secondary, #fbbf24);
   /* Allow long inline code (file paths, etc.) to break when needed */
@@ -2313,7 +2312,7 @@ tr.newly-expanded .d2h-code-line-ctn {
   background: transparent;
   color: var(--color-text-tertiary, #6e7681);
   cursor: pointer;
-  transition: all 0.15s ease;
+  transition: var(--transition-ui-snappy);
 }
 
 .btn-reasoning-toggle:hover {
@@ -2383,7 +2382,7 @@ tr.newly-expanded .d2h-code-line-ctn {
   background: transparent;
   color: var(--color-text-tertiary, #6e7681);
   cursor: pointer;
-  transition: all 0.15s ease;
+  transition: var(--transition-ui-snappy);
 }
 
 .reasoning-popover-close:hover {
@@ -2494,7 +2493,7 @@ tr.newly-expanded .d2h-code-line-ctn {
   border: none;
   border-radius: 4px;
   cursor: pointer;
-  transition: all 0.1s ease;
+  transition: var(--transition-ui-fast);
 }
 
 /* Adopt button: green background, white text, checkmark icon */
@@ -2563,7 +2562,7 @@ tr.newly-expanded .d2h-code-line-ctn {
   border-radius: 4px;
   border: none;
   cursor: pointer;
-  transition: all 0.1s ease;
+  transition: var(--transition-ui-fast);
 }
 
 .ai-suggestion-actions .btn-primary {
@@ -2712,7 +2711,7 @@ tr.newly-expanded .d2h-code-line-ctn {
   font-size: 12px;
   min-width: auto;
   border-radius: 4px;
-  transition: all 0.2s ease;
+  transition: var(--transition-ui);
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -2777,7 +2776,6 @@ tr.newly-expanded .d2h-code-line-ctn {
   border-left: 3px solid var(--ai-primary, #f59e0b);
   border-radius: 6px;
   overflow: visible;
-  box-shadow: 0 0 20px var(--ai-glow, rgba(245, 158, 11, 0.2));
 }
 
 [data-theme="dark"] .ai-suggestion.collapsed {
@@ -2812,7 +2810,7 @@ tr.newly-expanded .d2h-code-line-ctn {
   color: var(--color-text-primary, #24292f);
   gap: 8px;
   cursor: pointer;
-  transition: all 0.2s ease;
+  transition: var(--transition-ui);
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
   min-height: 32px;
 }
@@ -3325,7 +3323,7 @@ tr.newly-expanded .d2h-code-line-ctn {
   display: flex;
   align-items: center;
   justify-content: center;
-  transition: all 0.2s;
+  transition: var(--transition-ui);
 }
 
 .nav-btn:hover:not(:disabled) {
@@ -3660,7 +3658,7 @@ tr.newly-expanded .d2h-code-line-ctn {
   font-weight: 500;
   border-radius: 12px;
   min-height: 16px;
-  transition: all 0.2s ease;
+  transition: var(--transition-ui);
 }
 
 .btn-secondary-outline:hover {
@@ -3731,7 +3729,7 @@ tr.newly-expanded .d2h-code-line-ctn {
   width: 22px;
   height: 22px;
   /* GitHub blue with subtle depth */
-  background: linear-gradient(180deg, #0969da 0%, #0860ca 100%);
+  background: #0969da;
   color: white;
   border: none;
   border-radius: 6px;
@@ -3755,7 +3753,7 @@ tr.newly-expanded .d2h-code-line-ctn {
 }
 
 .add-comment-btn:hover {
-  background: linear-gradient(180deg, #0860ca 0%, #0757b8 100%);
+  background: #0860ca;
   transform: translateY(-50%) scale(1.08);
   box-shadow: 0 2px 6px rgba(9, 105, 218, 0.35), 0 1px 3px rgba(0, 0, 0, 0.1);
 }
@@ -3767,12 +3765,12 @@ tr.newly-expanded .d2h-code-line-ctn {
 
 /* Expanded context comment button - slightly different style to indicate limitation */
 .add-comment-btn.expanded-context-comment {
-  background: linear-gradient(180deg, #6e7781 0%, #57606a 100%);
+  background: #6e7781;
   opacity: 0;
 }
 
 .add-comment-btn.expanded-context-comment:hover {
-  background: linear-gradient(180deg, #57606a 0%, #4d5561 100%);
+  background: #57606a;
 }
 
 /* Show comment button on hover - use opacity for smoother transition */
@@ -3788,7 +3786,7 @@ tr:hover .add-comment-btn {
   transform: translateY(-50%);
   width: 22px;
   height: 22px;
-  background: linear-gradient(180deg, #0969da 0%, #0860ca 100%);
+  background: #0969da;
   color: #fff;
   border: none;
   border-radius: 6px;
@@ -3810,7 +3808,7 @@ tr:hover .add-comment-btn {
 }
 
 .chat-line-btn:hover {
-  background: linear-gradient(180deg, #0860ca 0%, #0757b8 100%);
+  background: #0860ca;
   transform: translateY(-50%) scale(1.08);
   box-shadow: 0 2px 6px rgba(9, 105, 218, 0.35), 0 1px 3px rgba(0, 0, 0, 0.1);
 }
@@ -3963,7 +3961,7 @@ tr.line-range-start .d2h-code-line-ctn {
   border-radius: 6px;
   color: #0969da;
   cursor: pointer;
-  transition: all 0.15s ease;
+  transition: var(--transition-ui-snappy);
 }
 
 .suggestion-btn:hover:not(:disabled) {
@@ -4079,7 +4077,7 @@ tr.line-range-start .d2h-code-line-ctn {
 }
 
 .user-comment {
-  background: linear-gradient(to right, #f5f0ff 0%, #ffffff 100%);
+  background: #f5f0ff;
   border: 1px solid #8b5cf6;
   border-left: 4px solid #8b5cf6;
   border-radius: 6px;
@@ -4275,7 +4273,7 @@ tr.line-range-start .d2h-code-line-ctn {
   border-radius: 4px;
   cursor: pointer;
   color: var(--color-text-secondary, #57606a);
-  transition: all 0.2s;
+  transition: var(--transition-ui);
   display: inline-flex;
   align-items: center;
 }
@@ -4584,7 +4582,7 @@ tr.line-range-start .d2h-code-line-ctn {
 }
 
 [data-theme="dark"] .user-comment {
-  background: linear-gradient(to right, rgba(139, 92, 246, 0.15) 0%, #0d1117 100%);
+  background: rgba(139, 92, 246, 0.08);
   border-color: #a78bfa;
   border-left-color: #a78bfa;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
@@ -4674,7 +4672,7 @@ div.external-comment-row {
   --ec-subtle: var(--comment-subtle);
   --ec-border: var(--comment-border);
 
-  background: linear-gradient(to right, var(--ec-subtle) 0%, var(--color-bg-primary, #ffffff) 100%);
+  background: var(--ec-subtle);
   border: 1px solid var(--ec-border);
   border-left: 4px solid var(--ec-primary);
   border-radius: 6px;
@@ -4866,7 +4864,7 @@ div.external-comment-row {
    flat-with-replies; no deeper nesting needed. */
 .external-comment.is-reply {
   margin-left: 24px;
-  background: linear-gradient(to right, var(--ec-subtle) 0%, var(--color-bg-secondary, #f6f8fa) 100%);
+  background: var(--ec-subtle);
 }
 
 /* Outdated: comment's anchor no longer maps to current diff. Faded with
@@ -4890,12 +4888,12 @@ div.external-comment-row {
 }
 
 [data-theme="dark"] .external-comment {
-  background: linear-gradient(to right, var(--ec-subtle) 0%, var(--color-bg-primary, #0d1117) 100%);
+  background: var(--ec-subtle);
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
 }
 
 [data-theme="dark"] .external-comment.is-reply {
-  background: linear-gradient(to right, var(--ec-subtle) 0%, var(--color-bg-secondary, #161b22) 100%);
+  background: var(--ec-subtle);
 }
 
 [data-theme="dark"] .external-comment-body {
@@ -5265,7 +5263,7 @@ div.external-comment-row {
   padding: 10px 12px;
   border: 1px solid var(--color-border-primary, #d1d9e0);
   border-radius: 10px;
-  transition: all 0.15s ease;
+  transition: var(--transition-ui-snappy);
   background: var(--color-bg-primary, #ffffff);
 }
 
@@ -5463,7 +5461,7 @@ div.external-comment-row {
   font-weight: 500;
   opacity: 0;
   transform: translateY(-20px);
-  transition: all 0.3s ease;
+  transition: var(--transition-ui-slow);
   pointer-events: auto;
   max-width: 500px;
 }
@@ -5476,7 +5474,7 @@ div.external-comment-row {
 .toast-fade-out {
   opacity: 0;
   transform: translateY(-10px);
-  transition: all 0.3s ease;
+  transition: var(--transition-ui-slow);
 }
 
 .toast-success {
@@ -6111,8 +6109,7 @@ div.external-comment-row {
    Typography & Font Variables
    -------------------------------------------------------------------------- */
 :root {
-  --font-sans: 'DM Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
-  --font-mono: 'JetBrains Mono', 'SF Mono', 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+  --font-mono: ui-monospace, 'SF Mono', 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
 
   /* Layout dimensions */
   --header-height: 64px;
@@ -6124,6 +6121,14 @@ div.external-comment-row {
   --transition-fast: 0.1s ease;
   --transition-default: 0.2s ease;
   --transition-slow: 0.3s ease;
+
+  /* Full UI transition property lists — the 6-property set (background-color,
+     border-color, color, box-shadow, transform, opacity) repeated across
+     interactive elements. One variant per duration actually used. */
+  --transition-ui-fast: background-color 0.1s ease, border-color 0.1s ease, color 0.1s ease, box-shadow 0.1s ease, transform 0.1s ease, opacity 0.1s ease;
+  --transition-ui-snappy: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease, box-shadow 0.15s ease, transform 0.15s ease, opacity 0.15s ease;
+  --transition-ui: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease, opacity 0.2s ease;
+  --transition-ui-slow: background-color 0.3s ease, border-color 0.3s ease, color 0.3s ease, box-shadow 0.3s ease, transform 0.3s ease, opacity 0.3s ease;
 
   /* Radii */
   --radius-sm: 4px;
@@ -6146,7 +6151,7 @@ html, body {
 }
 
 body {
-  font-family: var(--font-sans);
+  font-family: var(--font-github);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
@@ -6344,7 +6349,7 @@ body::before {
   background: transparent;
   color: var(--color-text-tertiary, #6e7681);
   cursor: pointer;
-  transition: all 0.15s ease;
+  transition: var(--transition-ui-snappy);
 }
 
 .pr-description-popover-close:hover {
@@ -6441,7 +6446,7 @@ body::before {
   border-radius: var(--radius-md);
   border: none;
   cursor: pointer;
-  transition: all var(--transition-fast);
+  transition: var(--transition-ui-fast);
   white-space: nowrap;
   text-decoration: none;
 }
@@ -6493,7 +6498,6 @@ body::before {
 
 .header .btn-primary:hover {
   background: var(--ai-secondary);
-  box-shadow: 0 0 12px var(--ai-glow);
 }
 
 /* Theme toggle in header — border is transparent at rest, visible on hover.
@@ -6739,7 +6743,7 @@ body:not([data-theme="dark"]) .theme-icon-light {
   padding: 2px 6px;
   background-color: var(--color-bg-tertiary);
   border-radius: var(--radius-sm);
-  transition: all var(--transition-fast);
+  transition: var(--transition-ui-fast);
 }
 
 .toolbar-branch:hover {
@@ -6859,7 +6863,7 @@ body:not([data-theme="dark"]) .theme-icon-light {
   cursor: pointer;
   color: var(--color-text-tertiary);
   border-radius: var(--radius-xs);
-  transition: all var(--transition-fast);
+  transition: var(--transition-ui-fast);
   opacity: 0;
 }
 
@@ -6916,7 +6920,7 @@ body:not([data-theme="dark"]) .theme-icon-light {
   padding: 2px 6px;
   background-color: var(--color-bg-tertiary);
   border-radius: var(--radius-sm);
-  transition: all var(--transition-fast);
+  transition: var(--transition-ui-fast);
 }
 
 .toolbar-commit:hover {
@@ -6942,7 +6946,7 @@ body:not([data-theme="dark"]) .theme-icon-light {
   border: 1px solid #fcd34d;
   border-radius: var(--radius-md);
   text-decoration: none;
-  transition: all var(--transition-fast);
+  transition: var(--transition-ui-fast);
   cursor: pointer;
   margin-left: 8px;
 }
@@ -7012,7 +7016,7 @@ body:not([data-theme="dark"]) .theme-icon-light {
   color: var(--color-text-secondary);
   border-radius: var(--radius-sm);
   cursor: pointer;
-  transition: all var(--transition-fast);
+  transition: var(--transition-ui-fast);
 }
 
 .toolbar-actions .btn-icon:hover {
@@ -7036,7 +7040,7 @@ body:not([data-theme="dark"]) .theme-icon-light {
   color: var(--color-text-secondary);
   border-radius: var(--radius-sm);
   cursor: pointer;
-  transition: all var(--transition-fast);
+  transition: var(--transition-ui-fast);
 }
 
 .toolbar-meta .btn-icon:hover {
@@ -7045,101 +7049,48 @@ body:not([data-theme="dark"]) .theme-icon-light {
   border-color: var(--color-border-secondary);
 }
 
-/* Magical Analyze Button - Amber AI CTA */
+/* Analyze Button - Amber AI CTA */
 #analyze-btn {
-  background: linear-gradient(135deg, #fef3c7 0%, #fde68a 100%);
+  background: #fde68a;
   border: 1px solid #fcd34d;
   color: #b45309;
   font-weight: 600;
   position: relative;
   overflow: hidden;
-  transition: all 0.3s ease;
+  transition: var(--transition-ui-slow);
   display: inline-flex;
   align-items: center;
   gap: 6px;
 }
 
-#analyze-btn::before {
-  content: '';
-  position: absolute;
-  top: 0;
-  left: -100%;
-  width: 100%;
-  height: 100%;
-  background: linear-gradient(
-    90deg,
-    transparent 0%,
-    rgba(255, 255, 255, 0.4) 50%,
-    transparent 100%
-  );
-  transition: left 0.5s ease;
-}
-
 #analyze-btn:hover {
-  background: linear-gradient(135deg, #fde68a 0%, #fcd34d 100%);
+  background: #fcd34d;
   border-color: var(--color-accent-ai-dark);
-  box-shadow: 0 0 16px rgba(245, 158, 11, 0.4), 0 0 32px rgba(245, 158, 11, 0.2);
   transform: translateY(-1px);
-}
-
-#analyze-btn:hover::before {
-  left: 100%;
-}
-
-#analyze-btn .analyze-icon {
-  color: #d97706;
-  filter: drop-shadow(0 0 2px rgba(217, 119, 6, 0.5));
-}
-
-#analyze-btn:hover .analyze-icon {
-  animation: sparkle-float 0.6s ease-in-out infinite;
-}
-
-@keyframes sparkle-float {
-  0%, 100% { transform: translateY(0) rotate(0deg); }
-  50% { transform: translateY(-2px) rotate(5deg); }
 }
 
 /* Dark theme adjustments */
 [data-theme="dark"] #analyze-btn {
-  background: linear-gradient(135deg, rgba(251, 191, 36, 0.15) 0%, rgba(245, 158, 11, 0.25) 100%);
+  background: rgba(251, 191, 36, 0.15);
   border-color: rgba(251, 191, 36, 0.4);
   color: var(--color-accent-ai);
 }
 
 [data-theme="dark"] #analyze-btn:hover {
-  background: linear-gradient(135deg, rgba(251, 191, 36, 0.25) 0%, rgba(245, 158, 11, 0.35) 100%);
+  background: rgba(251, 191, 36, 0.25);
   border-color: var(--color-accent-ai-dark);
-  box-shadow: 0 0 20px rgba(251, 191, 36, 0.3), 0 0 40px rgba(245, 158, 11, 0.15);
 }
 
-[data-theme="dark"] #analyze-btn .analyze-icon {
-  color: var(--color-accent-ai);
-  filter: drop-shadow(0 0 3px rgba(251, 191, 36, 0.6));
-}
-
-/* Analyzing state - more intense glow */
+/* Analyzing state */
 #analyze-btn.btn-analyzing {
-  background: linear-gradient(135deg, var(--color-accent-ai-dark) 0%, #d97706 100%);
+  background: #d97706;
   border-color: #b45309;
   color: #ffffff;
-  box-shadow: 0 0 20px rgba(245, 158, 11, 0.5), 0 0 40px rgba(217, 119, 6, 0.3);
-}
-
-#analyze-btn.btn-analyzing .analyze-icon {
-  color: #ffffff;
-  filter: drop-shadow(0 0 4px rgba(255, 255, 255, 0.8));
-  animation: pulse-sparkle 1.2s ease-in-out infinite;
 }
 
 [data-theme="dark"] #analyze-btn.btn-analyzing {
-  background: linear-gradient(135deg, var(--color-accent-ai) 0%, var(--color-accent-ai-dark) 100%);
+  background: var(--color-accent-ai);
   border-color: var(--color-accent-ai-dark);
-  color: #1c1917;
-  box-shadow: 0 0 24px rgba(251, 191, 36, 0.6), 0 0 48px rgba(245, 158, 11, 0.3);
-}
-
-[data-theme="dark"] #analyze-btn.btn-analyzing .analyze-icon {
   color: #1c1917;
 }
 
@@ -7973,7 +7924,7 @@ body.resizing * {
   justify-content: space-between;
   padding: 16px;
   border-bottom: 1px solid var(--ai-border);
-  background: linear-gradient(to bottom, var(--ai-subtle), transparent);
+  background: var(--ai-subtle);
   flex-shrink: 0;
 }
 
@@ -8013,7 +7964,7 @@ body.resizing * {
   color: var(--color-text-tertiary);
   border-radius: var(--radius-sm);
   cursor: pointer;
-  transition: all var(--transition-fast);
+  transition: var(--transition-ui-fast);
 }
 
 .ai-panel-close:hover {
@@ -8067,7 +8018,7 @@ body.resizing * {
   cursor: pointer;
   flex: 1;
   min-width: 0;
-  transition: all var(--transition-fast);
+  transition: var(--transition-ui-fast);
 }
 
 .analysis-context-btn:hover {
@@ -8083,29 +8034,28 @@ body.resizing * {
   background: var(--color-bg-tertiary);
 }
 
-/* Amber glow animation for new run indicator */
-@keyframes amber-pulse {
-  0%, 100% {
-    box-shadow: 0 0 4px 1px rgba(245, 158, 11, 0.4),
-                0 0 8px 2px rgba(245, 158, 11, 0.2);
-    border-color: rgba(245, 158, 11, 0.6);
-  }
-  50% {
-    box-shadow: 0 0 8px 2px rgba(245, 158, 11, 0.6),
-                0 0 16px 4px rgba(245, 158, 11, 0.3);
-    border-color: rgba(245, 158, 11, 0.8);
-  }
-}
-
+/* Solid amber fill marks a context button with a newer analysis run available
+   — a strong interrupt cue. Matches the analyzing-button treatment. */
 .analysis-context-btn.has-new-run {
-  animation: amber-pulse 2s ease-in-out infinite;
-  border-color: rgba(245, 158, 11, 0.6);
+  background: #d97706;
+  border-color: #b45309;
+  color: #ffffff;
 }
 
 .analysis-context-btn.has-new-run:hover {
-  animation: none;
-  border-color: rgba(245, 158, 11, 0.8);
-  box-shadow: 0 0 8px 2px rgba(245, 158, 11, 0.5);
+  background: #b45309;
+  border-color: #92400e;
+}
+
+[data-theme="dark"] .analysis-context-btn.has-new-run {
+  background: var(--color-accent-ai);
+  border-color: var(--color-accent-ai-dark);
+  color: #1c1917;
+}
+
+[data-theme="dark"] .analysis-context-btn.has-new-run:hover {
+  background: var(--color-accent-ai-dark);
+  border-color: var(--color-accent-ai-dark);
 }
 
 .analysis-context-label {
@@ -8174,7 +8124,7 @@ body.resizing * {
   width: 100%;
   text-align: left;
   color: var(--color-text-primary);
-  transition: all 0.1s ease;
+  transition: var(--transition-ui-fast);
 }
 
 .analysis-run-list .analysis-history-item:hover {
@@ -8634,30 +8584,6 @@ body.resizing * {
   background: var(--color-bg-tertiary);
 }
 
-/* Dark theme: amber glow for new run indicator */
-[data-theme="dark"] .analysis-context-btn.has-new-run {
-  animation: amber-pulse-dark 2s ease-in-out infinite;
-}
-
-@keyframes amber-pulse-dark {
-  0%, 100% {
-    box-shadow: 0 0 6px 1px rgba(251, 191, 36, 0.5),
-                0 0 12px 3px rgba(251, 191, 36, 0.25);
-    border-color: rgba(251, 191, 36, 0.7);
-  }
-  50% {
-    box-shadow: 0 0 10px 3px rgba(251, 191, 36, 0.7),
-                0 0 20px 6px rgba(251, 191, 36, 0.35);
-    border-color: rgba(251, 191, 36, 0.9);
-  }
-}
-
-[data-theme="dark"] .analysis-context-btn.has-new-run:hover {
-  animation: none;
-  border-color: rgba(251, 191, 36, 0.9);
-  box-shadow: 0 0 10px 3px rgba(251, 191, 36, 0.6);
-}
-
 /* Dark theme: config type badges */
 [data-theme="dark"] .analysis-history-config-council {
   color: #a78bfa;
@@ -8728,7 +8654,7 @@ body.resizing * {
   color: var(--color-text-muted);
   cursor: pointer;
   opacity: 0.8;
-  transition: all var(--transition-fast);
+  transition: var(--transition-ui-fast);
   display: flex;
   align-items: center;
   gap: 4px;
@@ -8838,7 +8764,7 @@ body.resizing * {
   border: none;
   border-radius: var(--radius-sm);
   cursor: pointer;
-  transition: all var(--transition-fast);
+  transition: var(--transition-ui-fast);
   white-space: nowrap;
   text-align: center;
 }
@@ -8917,7 +8843,7 @@ body.resizing * {
   border-radius: var(--radius-sm);
   color: var(--color-text-tertiary);
   cursor: pointer;
-  transition: all var(--transition-fast);
+  transition: var(--transition-ui-fast);
   flex-shrink: 0;
 }
 
@@ -8962,7 +8888,7 @@ body.resizing * {
   border: 1px solid var(--color-border-primary);
   border-radius: var(--radius-sm);
   cursor: pointer;
-  transition: all var(--transition-fast);
+  transition: var(--transition-ui-fast);
   white-space: nowrap;
 }
 
@@ -9030,7 +8956,7 @@ body.resizing * {
   border-radius: var(--radius-sm);
   color: var(--color-text-secondary);
   cursor: pointer;
-  transition: all var(--transition-fast);
+  transition: var(--transition-ui-fast);
 }
 
 .findings-nav-btn:hover:not(:disabled) {
@@ -9287,7 +9213,7 @@ body.resizing * {
   border: 1px solid var(--color-border-primary);
   border-radius: var(--radius-sm);
   cursor: pointer;
-  transition: all var(--transition-fast);
+  transition: var(--transition-ui-fast);
   text-align: left;
   width: 100%;
   font-family: inherit;
@@ -9623,7 +9549,7 @@ body.resizing * {
 }
 
 .file-level-indicator {
-  font-family: var(--font-sans);
+  font-family: var(--font-github);
   font-size: 0.6rem;
   font-style: italic;
   color: var(--color-text-muted);
@@ -9846,7 +9772,7 @@ body.resizing * {
 :root {
   --file-comment-bg: #f6f8fa;
   --file-comment-border: #d0d7de;
-  --file-comment-accent: linear-gradient(135deg, #0969da 0%, #8250df 100%);
+  --file-comment-accent: #8250df;
   --file-comment-header-bg: #eaeef2;
 }
 
@@ -9952,7 +9878,7 @@ body.resizing * {
 }
 
 .comment-source-badge.ai {
-  background: linear-gradient(135deg, var(--ai-primary) 0%, var(--ai-secondary) 100%);
+  background: var(--ai-primary);
   color: white;
 }
 
@@ -10104,7 +10030,7 @@ body.resizing * {
   border-radius: 4px;
   color: var(--color-text-muted);
   cursor: pointer;
-  transition: all var(--transition-fast);
+  transition: var(--transition-ui-fast);
 }
 
 .file-comment-user-btn:hover {
@@ -10157,7 +10083,7 @@ body.resizing * {
 .file-comment-card.user-comment {
   /* Override file-comment-card defaults to use user-comment styling */
   margin: 0;  /* Remove margin since container handles spacing */
-  background: linear-gradient(to right, #f5f0ff 0%, var(--file-comment-bg, #ffffff) 100%);
+  background: #f5f0ff;
   border: 1px solid #8b5cf6;
   border-left: 4px solid #8b5cf6;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
@@ -10169,7 +10095,7 @@ body.resizing * {
 }
 
 [data-theme="dark"] .file-comment-card.user-comment {
-  background: linear-gradient(to right, rgba(139, 92, 246, 0.15) 0%, var(--file-comment-bg, #0d1117) 100%);
+  background: rgba(139, 92, 246, 0.08);
   border-color: #a78bfa;
   border-left-color: #a78bfa;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
@@ -10257,11 +10183,11 @@ body.resizing * {
 .file-comment-form-btn {
   padding: 6px 16px;
   border-radius: 6px;
-  font-family: var(--font-sans);
+  font-family: var(--font-github);
   font-size: 13px;
   font-weight: 500;
   cursor: pointer;
-  transition: all var(--transition-fast);
+  transition: var(--transition-ui-fast);
 }
 
 .file-comment-form-btn.cancel {
@@ -10487,7 +10413,7 @@ body.resizing * {
   justify-content: space-between;
   padding: 12px 16px;
   border-bottom: 1px solid var(--chat-border);
-  background: linear-gradient(to bottom, var(--chat-subtle), transparent);
+  background: var(--chat-subtle);
   flex-shrink: 0;
 }
 
@@ -11212,7 +11138,7 @@ body.resizing * {
 }
 
 .chat-panel__message--assistant .chat-panel__bubble code {
-  font-family: 'JetBrains Mono', 'SFMono-Regular', 'Consolas', monospace;
+  font-family: var(--font-mono);
   font-size: 12px;
   background: var(--color-bg-tertiary);
   padding: 1px 4px;
@@ -11260,7 +11186,7 @@ body.resizing * {
 /* Chat file links (auto-linked file:line references in assistant messages) */
 .chat-file-link {
   display: inline;
-  font-family: 'JetBrains Mono', 'SFMono-Regular', 'Consolas', monospace;
+  font-family: var(--font-mono);
   font-size: 12px;
   color: var(--color-accent, #0969da);
   text-decoration: none;
@@ -12216,7 +12142,7 @@ body.resizing * {
   color: var(--color-accent-primary, #0969da);
   background: var(--color-accent-lighter, rgba(9, 105, 218, 0.08));
   border-radius: 12px;
-  font-family: var(--font-mono, 'JetBrains Mono', monospace);
+  font-family: var(--font-mono, monospace);
   white-space: nowrap;
 }
 
@@ -12399,7 +12325,6 @@ body.resizing * {
 
 .analyze-split-container:hover {
   transform: translateY(-1px);
-  box-shadow: 0 0 16px rgba(245, 158, 11, 0.4), 0 0 32px rgba(245, 158, 11, 0.2);
 }
 
 .analyze-split-container #analyze-btn {
@@ -12419,43 +12344,23 @@ body.resizing * {
   align-items: center;
   justify-content: center;
   padding: 0 8px;
-  background: linear-gradient(135deg, #fef3c7 0%, #fde68a 100%);
+  background: #fde68a;
   border: 1px solid #fcd34d;
   border-left: 1px solid rgba(180, 83, 9, 0.2);
   border-top-right-radius: var(--radius-sm, 6px);
   border-bottom-right-radius: var(--radius-sm, 6px);
   color: #b45309;
   cursor: pointer;
-  transition: all 0.3s ease;
+  transition: var(--transition-ui-slow);
   font-size: 0;
   position: relative;
   overflow: hidden;
   font-weight: 600;
 }
 
-.analyze-dropdown-toggle::before {
-  content: '';
-  position: absolute;
-  top: 0;
-  left: -100%;
-  width: 100%;
-  height: 100%;
-  background: linear-gradient(
-    90deg,
-    transparent 0%,
-    rgba(255, 255, 255, 0.4) 50%,
-    transparent 100%
-  );
-  transition: left 0.5s ease;
-}
-
 .analyze-split-container:hover .analyze-dropdown-toggle {
-  background: linear-gradient(135deg, #fde68a 0%, #fcd34d 100%);
+  background: #fcd34d;
   border-color: var(--color-accent-ai-dark);
-}
-
-.analyze-split-container:hover .analyze-dropdown-toggle::before {
-  left: 100%;
 }
 
 .analyze-dropdown-toggle svg {
@@ -12476,10 +12381,10 @@ body.resizing * {
   right: 0;
   margin-top: 4px;
   min-width: 200px;
-  background: linear-gradient(135deg, #fffbeb 0%, #fef3c7 100%);
+  background: #fffbeb;
   border: 1px solid #fcd34d;
   border-radius: var(--radius-sm, 6px);
-  box-shadow: 0 4px 16px rgba(245, 158, 11, 0.2), 0 8px 24px rgba(0, 0, 0, 0.08);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12), 0 8px 24px rgba(0, 0, 0, 0.08);
   z-index: 100;
   padding: 0;
   overflow: hidden;
@@ -12509,28 +12414,23 @@ body.resizing * {
   color: #b45309;
 }
 
-/* Dark theme — container hover */
-[data-theme="dark"] .analyze-split-container:hover {
-  box-shadow: 0 0 20px rgba(251, 191, 36, 0.3), 0 0 40px rgba(245, 158, 11, 0.15);
-}
-
+/* Dark theme — toggle */
 [data-theme="dark"] .analyze-dropdown-toggle {
-  background: linear-gradient(135deg, rgba(251, 191, 36, 0.15) 0%, rgba(245, 158, 11, 0.25) 100%);
+  background: rgba(251, 191, 36, 0.15);
   border-color: rgba(251, 191, 36, 0.4);
   border-left-color: rgba(251, 191, 36, 0.2);
   color: var(--color-accent-ai, #fbbf24);
 }
 
 [data-theme="dark"] .analyze-split-container:hover .analyze-dropdown-toggle {
-  background: linear-gradient(135deg, rgba(251, 191, 36, 0.25) 0%, rgba(245, 158, 11, 0.35) 100%);
+  background: rgba(251, 191, 36, 0.25);
   border-color: var(--color-accent-ai-dark);
 }
 
 [data-theme="dark"] .analyze-dropdown-menu {
-  background: linear-gradient(135deg, rgba(251, 191, 36, 0.08) 0%, rgba(245, 158, 11, 0.12) 100%);
   background-color: var(--color-bg-elevated, #1e2329);
   border-color: rgba(251, 191, 36, 0.4);
-  box-shadow: 0 4px 16px rgba(251, 191, 36, 0.1), 0 8px 24px rgba(0, 0, 0, 0.4);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
 }
 
 [data-theme="dark"] .analyze-dropdown-item {
@@ -12544,17 +12444,15 @@ body.resizing * {
 
 /* Analyzing state — toggle matches the main button */
 .analyze-split-container .analyze-dropdown-toggle.btn-analyzing {
-  background: linear-gradient(135deg, var(--color-accent-ai-dark, #d97706) 0%, #d97706 100%);
+  background: #d97706;
   border-color: #b45309;
   color: #ffffff;
-  box-shadow: 0 0 20px rgba(245, 158, 11, 0.5), 0 0 40px rgba(217, 119, 6, 0.3);
 }
 
 [data-theme="dark"] .analyze-split-container .analyze-dropdown-toggle.btn-analyzing {
-  background: linear-gradient(135deg, var(--color-accent-ai, #fbbf24) 0%, var(--color-accent-ai-dark, #d97706) 100%);
+  background: var(--color-accent-ai, #fbbf24);
   border-color: var(--color-accent-ai-dark, #d97706);
   color: #1c1917;
-  box-shadow: 0 0 24px rgba(251, 191, 36, 0.6), 0 0 48px rgba(245, 158, 11, 0.3);
 }
 
 /* ============================================
@@ -13441,7 +13339,7 @@ body.summaries-hidden .hunk-summary-row,
   color: #7d5700;
   /* Brighter amber matching the .tour-bar gradient so stops read as part
      of the same tour surface, not a muted variant of it. */
-  background: linear-gradient(180deg, #fff8e1 0%, #fef3c7 100%);
+  background: #fef3c7;
   border: 1px solid rgba(212, 167, 44, 0.55);
   border-left: 3px solid #d4a72c;
   border-radius: var(--radius-md, 6px);
@@ -13459,8 +13357,7 @@ body.summaries-hidden .hunk-summary-row,
   color: #e3b341;
   /* Mirror the bar's dark-mode amber wash so light- and dark-mode tours
      share one visual language. */
-  background: linear-gradient(180deg, rgba(187, 128, 9, 0.18) 0%, rgba(187, 128, 9, 0.28) 100%),
-              var(--color-bg-primary, #0d1117);
+  background: rgba(187, 128, 9, 0.22);
   border-color: rgba(187, 128, 9, 0.55);
   border-left-color: #bb8009;
 }
@@ -13611,16 +13508,15 @@ body.tour-active .d2h-file-header {
   /* Distinctive amber theme so the bar reads as a tour-mode chrome and
      not just another toolbar. Soft tinted background + a thicker amber
      bottom rule echo the per-stop annotation accent (#d4a72c). */
-  background: linear-gradient(180deg, #fff8e1 0%, #fef3c7 100%);
+  background: #fef3c7;
   border-bottom: 2px solid #d4a72c;
-  box-shadow: 0 2px 12px rgba(212, 167, 44, 0.18);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
   font-size: 13px;
   color: #7d5700;
 }
 
 [data-theme="dark"] .tour-bar {
-  background: linear-gradient(180deg, rgba(187, 128, 9, 0.18) 0%, rgba(187, 128, 9, 0.28) 100%),
-              var(--color-bg-primary, #0d1117);
+  background: rgba(187, 128, 9, 0.22);
   border-bottom-color: #bb8009;
   color: #e3b341;
   box-shadow: 0 2px 12px rgba(0, 0, 0, 0.40);
@@ -13838,7 +13734,7 @@ diffs-container {
 .pierre-gutter-btn {
   width: 22px;
   height: 22px;
-  background: linear-gradient(180deg, #0969da 0%, #0860ca 100%);
+  background: #0969da;
   color: #fff;
   border: none;
   border-radius: 6px;
@@ -13853,7 +13749,7 @@ diffs-container {
 }
 
 .pierre-gutter-btn:hover {
-  background: linear-gradient(180deg, #0860ca 0%, #0757b8 100%);
+  background: #0860ca;
   transform: scale(1.08);
   box-shadow: 0 2px 6px rgba(9, 105, 218, 0.35), 0 1px 3px rgba(0, 0, 0, 0.1);
 }
@@ -13872,4 +13768,44 @@ diffs-container {
 .pierre-chat-btn svg {
   width: 12px;
   height: 12px;
+}
+
+/* --------------------------------------------------------------------------
+   Reduced motion: honor the user's OS-level preference by neutralizing
+   animations and transitions across the app.
+   -------------------------------------------------------------------------- */
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+
+  /* Busy indicators are exempt — a frozen spinner reads as a hung UI. Re-assert
+     each spinner's own animation (higher selector specificity than the `*`
+     blanket above) so it keeps spinning at its intended rate. */
+  .loading-spinner,
+  .status-icon.spinning .spinner,
+  .btn-refresh-external-comments.is-refreshing svg,
+  #refresh-pr .spinner-icon,
+  #local-refresh-btn .spinner-icon {
+    animation: spin 1s linear infinite !important;
+  }
+
+  .spinner,
+  .council-spinner,
+  .btn-spinner,
+  .chat-panel__tool-spinner,
+  .loading-spinner-small {
+    animation: spin 0.8s linear infinite !important;
+  }
+
+  .chat-file-link--loading::after {
+    animation: chat-file-link-spin 0.6s linear infinite !important;
+  }
+
+  .chat-panel__loop-spinner svg {
+    animation: loop-spin 1.4s linear infinite !important;
+  }
 }

--- a/public/css/repo-settings.css
+++ b/public/css/repo-settings.css
@@ -131,7 +131,7 @@ html, body {
   border-radius: 8px;
   color: var(--color-text-secondary);
   cursor: pointer;
-  transition: all 0.15s ease;
+  transition: background-color 0.15s ease, color 0.15s ease, border-color 0.15s ease;
 }
 
 .theme-toggle:hover {
@@ -167,7 +167,7 @@ html, body {
   background: var(--color-bg-secondary);
   border: 1px solid var(--color-border-primary);
   border-radius: 6px;
-  transition: all 0.15s ease;
+  transition: color 0.15s ease, border-color 0.15s ease, background-color 0.15s ease;
 }
 
 .back-to-pr:hover {
@@ -201,15 +201,9 @@ html, body {
   width: 56px;
   height: 56px;
   border-radius: 14px;
-  background: linear-gradient(135deg, #f59e0b 0%, #d97706 100%);
+  background: var(--ai-accent-flat, #d97706);
   color: white;
-  box-shadow: 0 4px 12px rgba(245, 158, 11, 0.25);
   flex-shrink: 0;
-}
-
-[data-theme="dark"] .page-header .header-icon {
-  background: linear-gradient(135deg, #fbbf24 0%, #f59e0b 100%);
-  box-shadow: 0 4px 16px rgba(251, 191, 36, 0.2);
 }
 
 .header-text h1 {
@@ -358,15 +352,11 @@ html, body {
 
 .settings-model-card-static:hover {
   transform: none;
-  box-shadow:
-    0 0 0 3px rgba(245, 158, 11, 0.15),
-    0 4px 12px rgba(245, 158, 11, 0.1);
+  box-shadow: 0 0 0 3px rgba(245, 158, 11, 0.15);
 }
 
 [data-theme="dark"] .settings-model-card-static:hover {
-  box-shadow:
-    0 0 0 3px rgba(251, 191, 36, 0.15),
-    0 4px 12px rgba(251, 191, 36, 0.08);
+  box-shadow: 0 0 0 3px rgba(251, 191, 36, 0.15);
 }
 
 /* Speech bubble arrow — points left toward the settings section */
@@ -438,7 +428,7 @@ html, body {
   font-weight: 500;
   color: var(--color-text-secondary);
   cursor: pointer;
-  transition: all 0.2s ease;
+  transition: background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
 }
 
 .mode-btn:hover:not(.selected) {
@@ -840,7 +830,7 @@ html, body {
   border-radius: 6px;
   color: var(--color-text-tertiary);
   cursor: pointer;
-  transition: all 0.15s ease;
+  transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease;
 }
 
 .worktree-delete-btn:hover {
@@ -881,7 +871,7 @@ html, body {
   font-weight: 500;
   color: var(--color-danger);
   cursor: pointer;
-  transition: all 0.15s ease;
+  transition: background-color 0.15s ease, color 0.15s ease;
 }
 
 .worktree-delete-all-btn:hover {
@@ -966,7 +956,7 @@ html, body {
   font-weight: 500;
   color: var(--color-danger);
   cursor: pointer;
-  transition: all 0.15s ease;
+  transition: background-color 0.15s ease, color 0.15s ease;
 }
 
 .btn-danger-outline:hover {
@@ -1045,7 +1035,7 @@ html, body {
   font-size: 14px;
   font-weight: 500;
   cursor: pointer;
-  transition: all 0.15s ease;
+  transition: background-color 0.15s ease, color 0.15s ease, border-color 0.15s ease, transform 0.15s ease, box-shadow 0.15s ease;
   border: none;
 }
 
@@ -1062,15 +1052,13 @@ html, body {
 }
 
 .btn-primary.btn-save {
-  background: linear-gradient(135deg, #f59e0b 0%, #d97706 100%);
+  background: var(--ai-accent-flat, #d97706);
   color: white;
-  box-shadow: 0 2px 8px rgba(245, 158, 11, 0.25);
 }
 
 .btn-primary.btn-save:hover {
-  background: linear-gradient(135deg, #fbbf24 0%, #f59e0b 100%);
+  background: #f59e0b;
   transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(245, 158, 11, 0.3);
 }
 
 .btn-primary.btn-save:disabled {
@@ -1079,10 +1067,10 @@ html, body {
   transform: none;
 }
 
+/* Dark theme resolves --ai-accent-flat to the lighter #f59e0b, which needs
+   dark text for contrast. Background comes from the token above. */
 [data-theme="dark"] .btn-primary.btn-save {
-  background: linear-gradient(135deg, #fbbf24 0%, #f59e0b 100%);
   color: #1a1a1a;
-  box-shadow: 0 2px 12px rgba(251, 191, 36, 0.2);
 }
 
 /* ============================================
@@ -1154,7 +1142,7 @@ html, body {
   border-radius: 4px;
   color: var(--color-text-tertiary);
   cursor: pointer;
-  transition: all 0.15s ease;
+  transition: background-color 0.15s ease, color 0.15s ease;
 }
 
 .toast-close:hover {

--- a/public/css/settings.css
+++ b/public/css/settings.css
@@ -150,7 +150,7 @@ body {
   border-radius: 8px;
   color: var(--color-text-secondary);
   cursor: pointer;
-  transition: all 0.15s ease;
+  transition: background-color 0.15s ease, color 0.15s ease, border-color 0.15s ease;
 }
 
 .theme-toggle:hover {
@@ -261,15 +261,9 @@ body {
   width: 56px;
   height: 56px;
   border-radius: 14px;
-  background: linear-gradient(135deg, #f59e0b 0%, #d97706 100%);
+  background: var(--ai-accent-flat, #d97706);
   color: white;
-  box-shadow: 0 4px 12px rgba(245, 158, 11, 0.25);
   flex-shrink: 0;
-}
-
-[data-theme="dark"] .page-header .header-icon {
-  background: linear-gradient(135deg, #fbbf24 0%, #f59e0b 100%);
-  box-shadow: 0 4px 16px rgba(251, 191, 36, 0.2);
 }
 
 .header-text h1 {
@@ -844,7 +838,7 @@ body {
   border: 1px solid var(--color-border-primary);
   border-radius: 6px;
   cursor: pointer;
-  transition: all 0.15s ease;
+  transition: color 0.15s ease, border-color 0.15s ease, background-color 0.15s ease;
   white-space: nowrap;
 }
 
@@ -873,7 +867,7 @@ body {
   background: var(--color-bg-primary);
   border: 1px solid var(--color-border-primary);
   border-radius: 8px;
-  transition: all 0.15s ease;
+  transition: border-color 0.15s ease, background-color 0.15s ease;
 }
 
 .repo-row:hover {
@@ -1029,7 +1023,7 @@ body {
   border-radius: 4px;
   color: var(--color-text-tertiary);
   cursor: pointer;
-  transition: all 0.15s ease;
+  transition: background-color 0.15s ease, color 0.15s ease;
 }
 
 .toast-close:hover {

--- a/public/index.html
+++ b/public/index.html
@@ -21,17 +21,13 @@
     <title>Pair Review</title>
     <link rel="icon" type="image/png" href="/favicon.png">
 
-    <!-- Google Fonts: DM Sans and JetBrains Mono -->
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,300;0,9..40,400;0,9..40,500;0,9..40,600;1,9..40,400&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/css/analysis-config.css">
 
     <style>
         :root {
             /* Typography */
-            --font-sans: 'DM Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
-            --font-mono: 'JetBrains Mono', 'SF Mono', 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+            --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans", Helvetica, Arial, sans-serif;
+            --font-mono: ui-monospace, 'SF Mono', 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
 
             /* Layout dimensions */
             --header-height: 64px;
@@ -213,7 +209,7 @@
             border-radius: var(--radius-md);
             border: none;
             cursor: pointer;
-            transition: all var(--transition-fast);
+            transition: background-color var(--transition-fast), border-color var(--transition-fast), color var(--transition-fast);
             white-space: nowrap;
             text-decoration: none;
         }
@@ -336,7 +332,7 @@
             border-radius: var(--radius-md);
             color: var(--color-text-tertiary);
             cursor: pointer;
-            transition: all var(--transition-fast);
+            transition: background-color var(--transition-fast), border-color var(--transition-fast), color var(--transition-fast);
         }
 
         .help-modal-close:hover {
@@ -472,7 +468,7 @@
         }
 
         .start-review-input:focus {
-            box-shadow: 0 0 0 4px var(--ai-glow), 0 0 12px var(--ai-glow);
+            box-shadow: 0 0 0 4px var(--ai-glow);
         }
 
         .start-review-input::placeholder {
@@ -523,20 +519,6 @@
         [data-theme="dark"] .start-review-btn-primary:hover:not(:disabled) {
             background-color: #d97706;
             border-color: #d97706;
-        }
-
-        .start-review-btn-analyze {
-            transition: background-color var(--transition-fast), border-color var(--transition-fast), box-shadow 0.3s ease;
-        }
-
-        .start-review-btn-analyze:hover:not(:disabled) {
-            box-shadow: 0 0 8px rgba(217, 119, 6, 0.35), 0 0 20px rgba(251, 191, 36, 0.15);
-            animation: glow-pulse 2s ease-in-out infinite;
-        }
-
-        @keyframes glow-pulse {
-            0%, 100% { box-shadow: 0 0 8px rgba(217, 119, 6, 0.35), 0 0 20px rgba(251, 191, 36, 0.15); }
-            50% { box-shadow: 0 0 12px rgba(217, 119, 6, 0.5), 0 0 28px rgba(251, 191, 36, 0.25); }
         }
 
         .btn-browse {
@@ -769,7 +751,7 @@
             border-radius: var(--radius-md);
             color: var(--color-text-tertiary);
             cursor: pointer;
-            transition: all var(--transition-fast);
+            transition: background-color var(--transition-fast), border-color var(--transition-fast), color var(--transition-fast);
         }
 
         .btn-delete-review:hover {
@@ -801,7 +783,7 @@
             border-radius: var(--radius-md);
             color: var(--color-text-tertiary);
             cursor: pointer;
-            transition: all var(--transition-fast);
+            transition: background-color var(--transition-fast), border-color var(--transition-fast), color var(--transition-fast);
             text-decoration: none;
         }
 
@@ -853,7 +835,7 @@
             border: 1px solid var(--color-border-primary);
             border-radius: var(--radius-md);
             cursor: pointer;
-            transition: all var(--transition-fast);
+            transition: background-color var(--transition-fast), border-color var(--transition-fast), color var(--transition-fast);
         }
 
         .btn-show-more:hover:not(:disabled) {
@@ -906,7 +888,7 @@
             border: none;
             border-bottom: 2px solid transparent;
             cursor: pointer;
-            transition: all var(--transition-fast);
+            transition: background-color var(--transition-fast), border-color var(--transition-fast), color var(--transition-fast);
             white-space: nowrap;
         }
 
@@ -960,7 +942,7 @@
             border-radius: var(--radius-md);
             color: var(--color-text-tertiary);
             cursor: pointer;
-            transition: all var(--transition-fast);
+            transition: background-color var(--transition-fast), border-color var(--transition-fast), color var(--transition-fast);
         }
 
         .btn-refresh:hover {
@@ -1022,7 +1004,7 @@
             border-radius: var(--radius-md);
             color: var(--color-text-tertiary);
             cursor: pointer;
-            transition: all var(--transition-fast);
+            transition: background-color var(--transition-fast), border-color var(--transition-fast), color var(--transition-fast);
         }
 
         .team-filter-apply:hover,
@@ -1119,7 +1101,7 @@
             border-radius: var(--radius-md);
             color: var(--color-text-tertiary);
             cursor: pointer;
-            transition: all var(--transition-fast);
+            transition: background-color var(--transition-fast), border-color var(--transition-fast), color var(--transition-fast);
         }
 
         .btn-delete-session:hover {
@@ -1197,7 +1179,7 @@
             border: 1px solid var(--color-border-primary);
             border-radius: var(--radius-md);
             cursor: pointer;
-            transition: all var(--transition-fast);
+            transition: background-color var(--transition-fast), border-color var(--transition-fast), color var(--transition-fast);
         }
 
         .btn-select-toggle:hover {

--- a/public/js/pr.js
+++ b/public/js/pr.js
@@ -7917,9 +7917,16 @@ class PRManager {
 
     const btnText = btn.querySelector('.btn-text');
     if (btnText) {
+      // Insert the spinner before the label (guard against a double-call
+      // stacking two spinners), then switch the label.
+      if (!btn.querySelector('.btn-spinner')) {
+        const spinner = document.createElement('span');
+        spinner.className = 'btn-spinner';
+        btn.insertBefore(spinner, btnText);
+      }
       btnText.textContent = 'Analyzing...';
     } else {
-      btn.innerHTML = '<span class="analyzing-icon">✨</span> Analyzing...';
+      btn.innerHTML = '<span class="btn-spinner"></span> Analyzing...';
     }
   }
 
@@ -7939,6 +7946,8 @@ class PRManager {
 
     const btnText = btn.querySelector('.btn-text');
     if (btnText) {
+      const spinner = btn.querySelector('.btn-spinner');
+      if (spinner) spinner.remove();
       btnText.textContent = 'Complete';
     } else {
       btn.innerHTML = '✓ Analysis Complete';
@@ -7968,6 +7977,8 @@ class PRManager {
 
     const btnText = btn.querySelector('.btn-text');
     if (btnText) {
+      const spinner = btn.querySelector('.btn-spinner');
+      if (spinner) spinner.remove();
       btnText.textContent = 'Analyze';
     } else {
       btn.innerHTML = 'Analyze with AI';

--- a/public/local.html
+++ b/public/local.html
@@ -33,11 +33,6 @@
     <title>Pair Review - Local Mode</title>
     <link rel="icon" type="image/png" href="/favicon.png">
 
-    <!-- Google Fonts: DM Sans and JetBrains Mono -->
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,300;0,9..40,400;0,9..40,500;0,9..40,600;1,9..40,400&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
-
     <!-- PR Display Styles -->
     <link rel="stylesheet" href="/css/pr.css">
     <link rel="stylesheet" href="/css/ai-summary-modal.css">
@@ -57,7 +52,7 @@
         }
 
         body {
-            font-family: 'DM Sans', -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji";
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji";
             background-color: #f6f8fa;
             color: #24292f;
             line-height: 1.5;
@@ -81,14 +76,13 @@
             align-items: center;
             gap: 6px;
             padding: 4px 10px;
-            background: linear-gradient(135deg, #8b5cf6 0%, #6366f1 100%);
+            background: #7c3aed;
             color: #ffffff;
             font-size: 11px;
             font-weight: 600;
             text-transform: uppercase;
             letter-spacing: 0.5px;
             border-radius: 12px;
-            box-shadow: 0 2px 8px rgba(139, 92, 246, 0.3);
             margin-right: 12px;
         }
 
@@ -99,8 +93,7 @@
 
         /* Dark theme for local mode badge */
         [data-theme="dark"] .local-mode-badge {
-            background: linear-gradient(135deg, #7c3aed 0%, #4f46e5 100%);
-            box-shadow: 0 2px 8px rgba(124, 58, 237, 0.4);
+            background: #6d28d9;
         }
 
         /* Branch badge styling for local mode */
@@ -112,7 +105,7 @@
             background-color: var(--color-bg-tertiary);
             border: 1px solid var(--color-border-primary);
             border-radius: 6px;
-            font-family: 'JetBrains Mono', monospace;
+            font-family: var(--font-mono);
             font-size: 11px;
             color: var(--color-text-primary);
             white-space: nowrap;
@@ -190,7 +183,7 @@
             display: inline-flex;
             align-items: center;
             gap: 4px;
-            font-family: 'JetBrains Mono', monospace;
+            font-family: var(--font-mono);
             font-size: 11px;
             color: var(--color-text-secondary);
             max-width: 300px;
@@ -224,7 +217,7 @@
             padding: 2px 6px;
             border-radius: 4px;
             border: 1px dashed var(--color-border-primary);
-            transition: all 0.15s ease;
+            transition: background-color 0.15s ease, border-color 0.15s ease;
             max-width: 100%;
             overflow: hidden;
             text-overflow: ellipsis;
@@ -250,7 +243,7 @@
         }
 
         .local-review-name-input {
-            font-family: 'DM Sans', -apple-system, sans-serif;
+            font-family: var(--font-github);
             font-size: 15px;
             font-weight: 500;
             padding: 2px 6px;
@@ -437,9 +430,6 @@
                     <div class="diff-stats" id="diff-stats"></div>
                     <div class="toolbar-actions">
                         <button class="btn btn-sm btn-secondary" id="analyze-btn" title="Analyze with AI">
-                            <svg class="analyze-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="14" height="14">
-                                <path d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09z"/>
-                            </svg>
                             <span class="btn-text">Analyze</span>
                         </button>
                         <button class="btn btn-sm btn-icon btn-summary-toggle" id="summary-toggle-btn" title="Hide hunk summaries" aria-label="Toggle hunk summaries" aria-pressed="true" style="display: none;">

--- a/public/pr.html
+++ b/public/pr.html
@@ -41,11 +41,6 @@
     <title>Pair Review - PR Review</title>
     <link rel="icon" type="image/png" href="/favicon.png">
 
-    <!-- Google Fonts: DM Sans and JetBrains Mono -->
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,300;0,9..40,400;0,9..40,500;0,9..40,600;1,9..40,400&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
-
     <!-- PR Display Styles -->
     <link rel="stylesheet" href="/css/pr.css">
     <link rel="stylesheet" href="/css/ai-summary-modal.css">
@@ -65,7 +60,7 @@
         }
 
         body {
-            font-family: 'DM Sans', -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji";
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji";
             background-color: #f6f8fa;
             color: #24292f;
             line-height: 1.5;
@@ -233,9 +228,6 @@
                     <div class="diff-stats" id="diff-stats"></div>
                     <div class="toolbar-actions">
                         <button class="btn btn-sm btn-secondary" id="analyze-btn" title="Analyze with AI">
-                            <svg class="analyze-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="14" height="14">
-                                <path d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09z"/>
-                            </svg>
                             <span class="btn-text">Analyze</span>
                         </button>
                         <button class="btn btn-sm btn-icon btn-summary-toggle" id="summary-toggle-btn" title="Hide hunk summaries" aria-label="Toggle hunk summaries" aria-pressed="true" style="display: none;">

--- a/public/setup.html
+++ b/public/setup.html
@@ -12,15 +12,12 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Setting up review... - Pair Review</title>
     <link rel="icon" type="image/png" href="/favicon.png">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,300;0,9..40,400;0,9..40,500;0,9..40,600;1,9..40,400&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
 
     <style>
         /* ── Theme Variables ── */
         :root {
-            --font-sans: 'DM Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
-            --font-mono: 'JetBrains Mono', 'SF Mono', Consolas, monospace;
+            --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans", Helvetica, Arial, sans-serif;
+            --font-mono: ui-monospace, 'SF Mono', 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
 
             --transition-fast: 0.1s ease;
             --transition-default: 0.2s ease;
@@ -373,7 +370,7 @@
             border-radius: var(--radius-md);
             border: 1px solid transparent;
             cursor: pointer;
-            transition: all var(--transition-fast);
+            transition: background-color var(--transition-fast), border-color var(--transition-fast), color var(--transition-fast);
             text-decoration: none;
             white-space: nowrap;
         }

--- a/tests/unit/pr-manager-analyze-button.test.js
+++ b/tests/unit/pr-manager-analyze-button.test.js
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+ */
+/** @vitest-environment jsdom */
+
+/**
+ * Tests for the analyze-button spinner lifecycle.
+ *
+ * pr.html and local.html both render `<span class="btn-text">Analyze</span>`
+ * inside #analyze-btn, so setButtonAnalyzing must show the spinner from within
+ * the .btn-text branch (the else branch never runs for the live button). The
+ * restore paths (resetButton / setButtonComplete) must remove that spinner.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+function load() {
+  const code = fs.readFileSync(
+    path.join(__dirname, '../../public/js/pr.js'),
+    'utf8'
+  );
+  const moduleExports = {};
+  const sandbox = {
+    window: {},
+    document: { addEventListener() {} },
+    console,
+    localStorage: { getItem() { return null; }, setItem() {} },
+    fetch: () => Promise.resolve({ ok: false, status: 404, json: () => Promise.resolve({}) }),
+    navigator: { clipboard: {} },
+    setTimeout,
+    clearTimeout,
+    URLSearchParams,
+    module: { exports: moduleExports },
+  };
+  sandbox.globalThis = sandbox;
+  sandbox.self = sandbox;
+  sandbox.window = sandbox;
+  const context = vm.createContext(sandbox);
+  vm.runInContext(code, context, { filename: 'pr.js' });
+  const PRManager = sandbox.module.exports.PRManager;
+  return { PRManager, sandbox };
+}
+
+describe('PRManager analyze-button spinner lifecycle', () => {
+  let PRManager, sandbox, mgr, btn;
+
+  beforeEach(() => {
+    ({ PRManager, sandbox } = load());
+    // Use the real jsdom document so createElement/insertBefore/querySelector
+    // all work, but override getElementById to return our fixtures.
+    sandbox.document = document;
+    document.body.innerHTML = '';
+    btn = document.createElement('button');
+    btn.id = 'analyze-btn';
+    const label = document.createElement('span');
+    label.className = 'btn-text';
+    label.textContent = 'Analyze';
+    btn.appendChild(label);
+    document.body.appendChild(btn);
+    mgr = Object.create(PRManager.prototype);
+  });
+
+  it('inserts a spinner before the label and switches text when analyzing', () => {
+    mgr.setButtonAnalyzing('a1');
+
+    const spinner = btn.querySelector('.btn-spinner');
+    expect(spinner).not.toBeNull();
+    // Spinner precedes the label.
+    expect(btn.firstElementChild.className).toBe('btn-spinner');
+    expect(btn.querySelector('.btn-text').textContent).toBe('Analyzing...');
+    expect(btn.classList.contains('btn-analyzing')).toBe(true);
+    expect(mgr.isAnalyzing).toBe(true);
+    expect(mgr.currentAnalysisId).toBe('a1');
+  });
+
+  it('does not stack a second spinner on a repeated call', () => {
+    mgr.setButtonAnalyzing('a1');
+    mgr.setButtonAnalyzing('a2');
+    expect(btn.querySelectorAll('.btn-spinner').length).toBe(1);
+    expect(btn.querySelector('.btn-text').textContent).toBe('Analyzing...');
+  });
+
+  it('removes the spinner and restores the label on resetButton', () => {
+    mgr.setButtonAnalyzing('a1');
+    mgr.resetButton();
+
+    expect(btn.querySelector('.btn-spinner')).toBeNull();
+    expect(btn.querySelector('.btn-text').textContent).toBe('Analyze');
+    expect(btn.classList.contains('btn-analyzing')).toBe(false);
+    expect(mgr.isAnalyzing).toBe(false);
+  });
+
+  it('removes the spinner on setButtonComplete', () => {
+    mgr.setButtonAnalyzing('a1');
+    mgr.setButtonComplete();
+
+    expect(btn.querySelector('.btn-spinner')).toBeNull();
+    expect(btn.querySelector('.btn-text').textContent).toBe('Complete');
+  });
+
+  it('is a no-op without an analyze button', () => {
+    document.body.innerHTML = '';
+    expect(() => mgr.setButtonAnalyzing('a1')).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Audited the frontend against the catalog of "AI-generated UI" design tells and removed the ones that had leaked in, while keeping the GitHub-Primer baseline and the app's distinctive **flat amber AI identity**. Net −17 lines.

### Removed (the cliches)
- **~75 decorative gradient fills** flattened to solid colors — buttons, badges, model chips, headers, and the purple/amber annotation-card washes. Functional gradients kept (barber-pole progress bar, divider fade, grid texture).
- **Colored glow box-shadows** (amber/purple blur glows) — replaced with neutral elevation or nothing. Spread-only focus rings kept for accessibility.
- **Sparkle/pulse attention animations** (`pulse-sparkle`, `sparkle-float`, `amber-pulse`, shimmer-sweep shine elements) deleted.
- **`transition: all`** (~75 occurrences) expanded to explicit property lists, then tokenized as `--transition-ui-*` variants; bouncy overshoot easing removed.
- **DM Sans / JetBrains Mono Google Fonts** dropped (links + inline styles) for the GitHub system stack — also removes an external network dependency, fitting local-first.

### Kept deliberately (identity, not slop)
- The amber AI palette itself, now tokenized: `--ai-accent-flat` gives all settings surfaces one amber per theme.
- The **sparkles SVG as the AI-suggestion mark** — light-bulb already means the *improvement* category, so swapping would collide meanings. The sparkle is now static (no glow, no float).
- Colored left borders on comment cards, category colors, emoji prefixes in adopted comments (intentional for GitHub-posted content).

### Improved along the way
- Analyze button: text-only when idle; a legible `currentColor` half-arc spinner while analyzing, wired into the live `.btn-text` path in `setButtonAnalyzing` and removed by both restore paths (screenshot-verified in both themes).
- `has-new-run` got a solid amber static cue to replace the removed pulse; AI card hover shadow got a flat amber tint.
- New `prefers-reduced-motion` blanket with busy-spinner exemptions so reduced-motion users don't see frozen spinners.

## Testing
- Unit/integration: 9033/9033 pass (5 new tests for the analyze-button spinner lifecycle)
- Full Playwright E2E: 387 passed, 1 skipped, 1 known-flaky (gutter-buttons pointer-leave; passes 6/6 in isolation)
- Spinner and button states screenshot-verified in light and dark themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)