### PR TITLE
feat: add system theme option that follows prefers-color-scheme

### DIFF
--- a/.changeset/system-theme-support.md
+++ b/.changeset/system-theme-support.md
@@ -1,0 +1,14 @@
+---
+"@in-the-loop-labs/pair-review": minor
+---
+
+Add "system" theme option that follows `prefers-color-scheme` (OS dark/light schedule).
+
+The theme toggle now cycles through three states: light → dark → system → light.
+When "system" is selected, pair-review automatically matches the OS theme and
+responds to real-time changes (e.g., macOS Auto appearance schedule).
+
+- Landing page, PR review, local review, settings, and repo-settings pages all support the new system option
+- Theme icon updates to a monitor/display icon when in system mode
+- System preference changes are listened for and applied immediately when system mode is active
+- @pierre/diffs integration respects the system preference

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ public/js/vendor/pierre-diffs.js.map
 public/js/vendor/pierre-diffs-worker.js
 public/js/vendor/pierre-diffs-worker.js.map
 .pair-loop/
+PR-DESCRIPTION.md

--- a/README.md
+++ b/README.md
@@ -474,6 +474,8 @@ On first run, pair-review will prompt you to configure the application.
 
 Configuration is stored in `~/.pair-review/config.json`:
 
+> `theme` can be `"light"`, `"dark"`, or `"system"` (follows OS dark/light schedule).
+
 ```json
 {
   "github_token": "ghp_your_token_here",

--- a/config.example.json
+++ b/config.example.json
@@ -5,6 +5,7 @@
   "github_token_command": "gh auth token",
   "github_token": "ghp_your_github_personal_access_token_here",
   "port": 7247,
+  "_theme_comment": "light, dark, or system (follows OS dark/light schedule)",
   "theme": "light",
   "default_provider": "claude",
   "default_model": "opus",

--- a/public/index.html
+++ b/public/index.html
@@ -1614,6 +1614,7 @@
     <script src="/js/components/AnalysisConfigModal.js"></script>
     <script src="/js/components/VoiceCentricConfigTab.js"></script>
     <script src="/js/components/AdvancedConfigTab.js"></script>
+    <script src="/js/utils/theme.js"></script>
     <script src="/js/index.js"></script>
 </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -5,7 +5,9 @@
         // Initialize theme immediately to prevent flash
         (function() {
             const savedTheme = localStorage.getItem('theme') || 'light';
-            document.documentElement.setAttribute('data-theme', savedTheme);
+            const prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+            const theme = savedTheme === 'system' ? (prefersDark ? 'dark' : 'light') : savedTheme;
+            document.documentElement.setAttribute('data-theme', theme);
         })();
         window.__pairReview = window.__pairReview || {};
         window.__pairReview.toGraphiteUrl = function(githubUrl) {

--- a/public/index.html
+++ b/public/index.html
@@ -4,7 +4,7 @@
     <script>
         // Initialize theme immediately to prevent flash
         (function() {
-            const savedTheme = localStorage.getItem('theme') || 'light';
+            const savedTheme = localStorage.getItem('theme') || 'system';
             const prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
             const theme = savedTheme === 'system' ? (prefersDark ? 'dark' : 'light') : savedTheme;
             document.documentElement.setAttribute('data-theme', theme);

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -49,10 +49,7 @@
 
   function toggleTheme() {
     const savedTheme = localStorage.getItem('theme') || 'system';
-    const currentTheme = document.documentElement.getAttribute('data-theme') || 'light';
-    // Map current display theme back to the preference (for 'system' case)
-    const currentPreference = savedTheme;
-    const newPreference = nextTheme(currentPreference);
+    const newPreference = nextTheme(savedTheme);
     const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
     const newTheme = resolveTheme(newPreference, prefersDark);
     document.documentElement.setAttribute('data-theme', newTheme);

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -48,7 +48,7 @@
   }
 
   function toggleTheme() {
-    const savedTheme = localStorage.getItem('theme') || 'light';
+    const savedTheme = localStorage.getItem('theme') || 'system';
     const currentTheme = document.documentElement.getAttribute('data-theme') || 'light';
     // Map current display theme back to the preference (for 'system' case)
     const currentPreference = savedTheme;
@@ -63,7 +63,7 @@
   function updateThemeIcon(preference) {
     const btn = document.getElementById('theme-toggle');
     if (!btn) return;
-    const pref = preference || localStorage.getItem('theme') || 'light';
+    const pref = preference || localStorage.getItem('theme') || 'system';
     if (pref === 'system') {
       btn.innerHTML = '<svg class="theme-icon-system" viewBox="0 0 16 16" fill="currentColor" width="16" height="16"><path d="M0 2.75C0 1.784.784 1 1.75 1h12.5c.966 0 1.75.784 1.75 1.75v7.5A1.75 1.75 0 0 1 14.25 12H9.5v1.5h1.75a.75.75 0 0 1 0 1.5h-6.5a.75.75 0 0 1 0-1.5H6.5V12H1.75A1.75 1.75 0 0 1 0 10.25Zm1.75-.25a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h12.5a.25.25 0 0 0 .25-.25v-7.5a.25.25 0 0 0-.25-.25Z"/></svg>';
       btn.title = 'Theme: System (follows OS)';

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -16,61 +16,27 @@
 
   // ─── Theme Management ───────────────────────────────────────────────────────
 
-  /**
-   * Resolve a stored theme preference to an actual theme value.
-   * @param {string|null|undefined} preference - 'light', 'dark', 'system', or null/undefined
-   * @param {boolean} prefersDark - whether the OS prefers dark mode
-   * @returns {'light'|'dark'} the resolved theme
-   */
-  function resolveTheme(preference, prefersDark) {
-    if (preference === 'light') return 'light';
-    if (preference === 'dark') return 'dark';
-    // 'system' or null/undefined → follow OS preference
-    return prefersDark ? 'dark' : 'light';
-  }
-
-  /**
-   * Get the next theme preference in the cycle.
-   * @param {string} current - 'light', 'dark', or 'system'
-   * @returns {'light'|'dark'|'system'}
-   */
-  function nextTheme(current) {
-    if (current === 'light') return 'dark';
-    if (current === 'dark') return 'system';
-    return 'light'; // 'system' or unknown wraps to light
-  }
+  var resolveTheme = window.__pairReview.resolveTheme;
+  var nextTheme = window.__pairReview.nextTheme;
+  var updateThemeIcon = function (pref) {
+    window.__pairReview.updateThemeIcon(document.getElementById('theme-toggle'), pref);
+  };
 
   function initTheme() {
-    const savedTheme = localStorage.getItem('theme');
-    const prefersDark = typeof window.matchMedia === 'function' && window.matchMedia('(prefers-color-scheme: dark)').matches;
-    const theme = resolveTheme(savedTheme, prefersDark);
+    var savedTheme = localStorage.getItem('theme');
+    var prefersDark = window.__pairReview.prefersDark();
+    var theme = resolveTheme(savedTheme, prefersDark);
     document.documentElement.setAttribute('data-theme', theme);
   }
 
   function toggleTheme() {
-    const savedTheme = localStorage.getItem('theme') || 'system';
-    const newPreference = nextTheme(savedTheme);
-    const prefersDark = typeof window.matchMedia === 'function' && window.matchMedia('(prefers-color-scheme: dark)').matches;
-    const newTheme = resolveTheme(newPreference, prefersDark);
+    var savedTheme = localStorage.getItem('theme') || 'system';
+    var newPreference = nextTheme(savedTheme);
+    var prefersDark = window.__pairReview.prefersDark();
+    var newTheme = resolveTheme(newPreference, prefersDark);
     document.documentElement.setAttribute('data-theme', newTheme);
     localStorage.setItem('theme', newPreference);
     updateThemeIcon(newPreference);
-  }
-
-  function updateThemeIcon(preference) {
-    const btn = document.getElementById('theme-toggle');
-    if (!btn) return;
-    const pref = preference || localStorage.getItem('theme') || 'system';
-    if (pref === 'system') {
-      btn.innerHTML = '<svg class="theme-icon-system" viewBox="0 0 16 16" fill="currentColor" width="16" height="16"><path d="M0 2.75C0 1.784.784 1 1.75 1h12.5c.966 0 1.75.784 1.75 1.75v7.5A1.75 1.75 0 0 1 14.25 12H9.5v1.5h1.75a.75.75 0 0 1 0 1.5h-6.5a.75.75 0 0 1 0-1.5H6.5V12H1.75A1.75 1.75 0 0 1 0 10.25Zm1.75-.25a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h12.5a.25.25 0 0 0 .25-.25v-7.5a.25.25 0 0 0-.25-.25Z"/></svg>';
-      btn.title = 'Theme: System (follows OS)';
-    } else if (pref === 'dark') {
-      btn.innerHTML = '<svg class="theme-icon-dark" viewBox="0 0 16 16" fill="currentColor" width="16" height="16"><path d="M9.598 1.591a.749.749 0 0 1 .785-.175 7.001 7.001 0 1 1-8.967 8.967.75.75 0 0 1 .961-.96 5.5 5.5 0 0 0 7.046-7.046.75.75 0 0 1 .175-.786Z"/></svg>';
-      btn.title = 'Switch to system mode';
-    } else {
-      btn.innerHTML = '<svg class="theme-icon-light" viewBox="0 0 16 16" fill="currentColor" width="16" height="16"><path d="M8 12a4 4 0 1 0 0-8 4 4 0 0 0 0 8Zm0-1.5a2.5 2.5 0 1 1 0-5 2.5 2.5 0 0 1 0 5Zm0-10.5a.75.75 0 0 1 .75.75v1.5a.75.75 0 0 1-1.5 0V.75A.75.75 0 0 1 8 0Zm0 13a.75.75 0 0 1 .75.75v1.5a.75.75 0 0 1-1.5 0v-1.5A.75.75 0 0 1 8 13ZM2.343 2.343a.75.75 0 0 1 1.061 0l1.06 1.061a.75.75 0 0 1-1.06 1.06l-1.06-1.06a.75.75 0 0 1 0-1.06Zm9.193 9.193a.75.75 0 0 1 1.06 0l1.061 1.06a.75.75 0 0 1-1.06 1.061l-1.061-1.06a.75.75 0 0 1 0-1.061ZM16 8a.75.75 0 0 1-.75.75h-1.5a.75.75 0 0 1 0-1.5h1.5A.75.75 0 0 1 16 8ZM3 8a.75.75 0 0 1-.75.75H.75a.75.75 0 0 1 0-1.5h1.5A.75.75 0 0 1 3 8Zm10.657-5.657a.75.75 0 0 1 0 1.061l-1.061 1.06a.75.75 0 1 1-1.06-1.06l1.06-1.06a.75.75 0 0 1 1.06 0Zm-9.193 9.193a.75.75 0 0 1 0 1.06l-1.06 1.061a.75.75 0 0 1-1.061-1.06l1.06-1.061a.75.75 0 0 1 1.061 0Z"/></svg>';
-      btn.title = 'Switch to dark mode';
-    }
   }
 
   // Update icon after init
@@ -128,10 +94,10 @@
   // Listen for system theme changes
   if (typeof window.matchMedia === 'function') {
     window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', function (e) {
-      const savedTheme = localStorage.getItem('theme');
+      var savedTheme = localStorage.getItem('theme');
       // Update if no preference set, or preference is 'system'
       if (!savedTheme || savedTheme === 'system') {
-        const theme = resolveTheme(savedTheme, e.matches);
+        var theme = resolveTheme(savedTheme, e.matches);
         document.documentElement.setAttribute('data-theme', theme);
         updateThemeIcon(savedTheme || 'system');
       }

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -42,7 +42,7 @@
 
   function initTheme() {
     const savedTheme = localStorage.getItem('theme');
-    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    const prefersDark = typeof window.matchMedia === 'function' && window.matchMedia('(prefers-color-scheme: dark)').matches;
     const theme = resolveTheme(savedTheme, prefersDark);
     document.documentElement.setAttribute('data-theme', theme);
   }
@@ -50,7 +50,7 @@
   function toggleTheme() {
     const savedTheme = localStorage.getItem('theme') || 'system';
     const newPreference = nextTheme(savedTheme);
-    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    const prefersDark = typeof window.matchMedia === 'function' && window.matchMedia('(prefers-color-scheme: dark)').matches;
     const newTheme = resolveTheme(newPreference, prefersDark);
     document.documentElement.setAttribute('data-theme', newTheme);
     localStorage.setItem('theme', newPreference);
@@ -126,15 +126,17 @@
   });
 
   // Listen for system theme changes
-  window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', function (e) {
-    const savedTheme = localStorage.getItem('theme');
-    // Update if no preference set, or preference is 'system'
-    if (!savedTheme || savedTheme === 'system') {
-      const theme = resolveTheme(savedTheme, e.matches);
-      document.documentElement.setAttribute('data-theme', theme);
-      updateThemeIcon(savedTheme || 'system');
-    }
-  });
+  if (typeof window.matchMedia === 'function') {
+    window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', function (e) {
+      const savedTheme = localStorage.getItem('theme');
+      // Update if no preference set, or preference is 'system'
+      if (!savedTheme || savedTheme === 'system') {
+        const theme = resolveTheme(savedTheme, e.matches);
+        document.documentElement.setAttribute('data-theme', theme);
+        updateThemeIcon(savedTheme || 'system');
+      }
+    });
+  }
 
   // ─── Shared Utilities ───────────────────────────────────────────────────────
 

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -16,19 +16,68 @@
 
   // ─── Theme Management ───────────────────────────────────────────────────────
 
+  /**
+   * Resolve a stored theme preference to an actual theme value.
+   * @param {string|null|undefined} preference - 'light', 'dark', 'system', or null/undefined
+   * @param {boolean} prefersDark - whether the OS prefers dark mode
+   * @returns {'light'|'dark'} the resolved theme
+   */
+  function resolveTheme(preference, prefersDark) {
+    if (preference === 'light') return 'light';
+    if (preference === 'dark') return 'dark';
+    // 'system' or null/undefined → follow OS preference
+    return prefersDark ? 'dark' : 'light';
+  }
+
+  /**
+   * Get the next theme preference in the cycle.
+   * @param {string} current - 'light', 'dark', or 'system'
+   * @returns {'light'|'dark'|'system'}
+   */
+  function nextTheme(current) {
+    if (current === 'light') return 'dark';
+    if (current === 'dark') return 'system';
+    return 'light'; // 'system' or unknown wraps to light
+  }
+
   function initTheme() {
     const savedTheme = localStorage.getItem('theme');
     const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-    const theme = savedTheme || (prefersDark ? 'dark' : 'light');
+    const theme = resolveTheme(savedTheme, prefersDark);
     document.documentElement.setAttribute('data-theme', theme);
   }
 
   function toggleTheme() {
-    const currentTheme = document.documentElement.getAttribute('data-theme');
-    const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
+    const savedTheme = localStorage.getItem('theme') || 'light';
+    const currentTheme = document.documentElement.getAttribute('data-theme') || 'light';
+    // Map current display theme back to the preference (for 'system' case)
+    const currentPreference = savedTheme;
+    const newPreference = nextTheme(currentPreference);
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    const newTheme = resolveTheme(newPreference, prefersDark);
     document.documentElement.setAttribute('data-theme', newTheme);
-    localStorage.setItem('theme', newTheme);
+    localStorage.setItem('theme', newPreference);
+    updateThemeIcon(newPreference);
   }
+
+  function updateThemeIcon(preference) {
+    const btn = document.getElementById('theme-toggle');
+    if (!btn) return;
+    const pref = preference || localStorage.getItem('theme') || 'light';
+    if (pref === 'system') {
+      btn.innerHTML = '<svg class="theme-icon-system" viewBox="0 0 16 16" fill="currentColor" width="16" height="16"><path d="M0 2.75C0 1.784.784 1 1.75 1h12.5c.966 0 1.75.784 1.75 1.75v7.5A1.75 1.75 0 0 1 14.25 12H9.5v1.5h1.75a.75.75 0 0 1 0 1.5h-6.5a.75.75 0 0 1 0-1.5H6.5V12H1.75A1.75 1.75 0 0 1 0 10.25Zm1.75-.25a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h12.5a.25.25 0 0 0 .25-.25v-7.5a.25.25 0 0 0-.25-.25Z"/></svg>';
+      btn.title = 'Theme: System (follows OS)';
+    } else if (pref === 'dark') {
+      btn.innerHTML = '<svg class="theme-icon-dark" viewBox="0 0 16 16" fill="currentColor" width="16" height="16"><path d="M9.598 1.591a.749.749 0 0 1 .785-.175 7.001 7.001 0 1 1-8.967 8.967.75.75 0 0 1 .961-.96 5.5 5.5 0 0 0 7.046-7.046.75.75 0 0 1 .175-.786Z"/></svg>';
+      btn.title = 'Switch to system mode';
+    } else {
+      btn.innerHTML = '<svg class="theme-icon-light" viewBox="0 0 16 16" fill="currentColor" width="16" height="16"><path d="M8 12a4 4 0 1 0 0-8 4 4 0 0 0 0 8Zm0-1.5a2.5 2.5 0 1 1 0-5 2.5 2.5 0 0 1 0 5Zm0-10.5a.75.75 0 0 1 .75.75v1.5a.75.75 0 0 1-1.5 0V.75A.75.75 0 0 1 8 0Zm0 13a.75.75 0 0 1 .75.75v1.5a.75.75 0 0 1-1.5 0v-1.5A.75.75 0 0 1 8 13ZM2.343 2.343a.75.75 0 0 1 1.061 0l1.06 1.061a.75.75 0 0 1-1.06 1.06l-1.06-1.06a.75.75 0 0 1 0-1.06Zm9.193 9.193a.75.75 0 0 1 1.06 0l1.061 1.06a.75.75 0 0 1-1.06 1.061l-1.061-1.06a.75.75 0 0 1 0-1.061ZM16 8a.75.75 0 0 1-.75.75h-1.5a.75.75 0 0 1 0-1.5h1.5A.75.75 0 0 1 16 8ZM3 8a.75.75 0 0 1-.75.75H.75a.75.75 0 0 1 0-1.5h1.5A.75.75 0 0 1 3 8Zm10.657-5.657a.75.75 0 0 1 0 1.061l-1.061 1.06a.75.75 0 1 1-1.06-1.06l1.06-1.06a.75.75 0 0 1 1.06 0Zm-9.193 9.193a.75.75 0 0 1 0 1.06l-1.06 1.061a.75.75 0 0 1-1.061-1.06l1.06-1.061a.75.75 0 0 1 1.061 0Z"/></svg>';
+      btn.title = 'Switch to dark mode';
+    }
+  }
+
+  // Update icon after init
+  updateThemeIcon();
 
   // Initialize theme on page load
   initTheme();
@@ -81,8 +130,12 @@
 
   // Listen for system theme changes
   window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', function (e) {
-    if (!localStorage.getItem('theme')) {
-      document.documentElement.setAttribute('data-theme', e.matches ? 'dark' : 'light');
+    const savedTheme = localStorage.getItem('theme');
+    // Update if no preference set, or preference is 'system'
+    if (!savedTheme || savedTheme === 'system') {
+      const theme = resolveTheme(savedTheme, e.matches);
+      document.documentElement.setAttribute('data-theme', theme);
+      updateThemeIcon(savedTheme || 'system');
     }
   });
 
@@ -2610,12 +2663,17 @@
   window.__pairReview.refreshAnalysisSpinners = fetchAndApplyActiveAnalyses;
 
   // Test-only exports. In the browser `module` is undefined, so this is a
-  // no-op; under Vitest (CommonJS) it exposes the internal bulk-open helpers
+  // no-op; under Vitest (CommonJS) it exposes the internal helpers
   // for direct unit testing rather than duplicating their logic in a test.
   if (typeof module !== 'undefined' && module.exports) {
     module.exports = {
       buildReviewUrlsFromRows: buildReviewUrlsFromRows,
-      getSelectedCollectionRows: getSelectedCollectionRows
+      getSelectedCollectionRows: getSelectedCollectionRows,
+      resolveTheme: resolveTheme,
+      nextTheme: nextTheme,
+      initTheme: initTheme,
+      toggleTheme: toggleTheme,
+      updateThemeIcon: updateThemeIcon
     };
   }
 

--- a/public/js/modules/pierre-bridge.js
+++ b/public/js/modules/pierre-bridge.js
@@ -115,6 +115,10 @@ class PierreBridge {
   // ─── Theme ────────────────────────────────────────────────────────
 
   static detectTheme() {
+    const savedTheme = typeof localStorage !== 'undefined' ? localStorage.getItem('theme') : null;
+    if (savedTheme === 'dark') return 'dark';
+    if (savedTheme === 'light') return 'light';
+    // 'system' or no preference → follow OS
     return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
   }
 

--- a/public/js/modules/pierre-bridge.js
+++ b/public/js/modules/pierre-bridge.js
@@ -115,11 +115,11 @@ class PierreBridge {
   // ─── Theme ────────────────────────────────────────────────────────
 
   static detectTheme() {
-    const savedTheme = typeof localStorage !== 'undefined' ? localStorage.getItem('theme') : null;
+    var savedTheme = typeof localStorage !== 'undefined' ? localStorage.getItem('theme') : null;
     if (savedTheme === 'dark') return 'dark';
     if (savedTheme === 'light') return 'light';
     // 'system' or no preference → follow OS
-    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    return window.__pairReview && window.__pairReview.prefersDark ? window.__pairReview.prefersDark() ? 'dark' : 'light' : (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
   }
 
   getThemeConfig() {

--- a/public/js/pr.js
+++ b/public/js/pr.js
@@ -113,12 +113,8 @@ class PRManager {
     this.expandedFolders = new Set();
     this.expandedSections = new Set();
     const savedTheme = localStorage.getItem('theme') || 'system';
-    if (savedTheme === 'system' && typeof window !== 'undefined' && window.matchMedia) {
-      const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-      this.currentTheme = prefersDark ? 'dark' : 'light';
-    } else if (savedTheme === 'system') {
-      // No matchMedia available (e.g. test environment) — fall back to light
-      this.currentTheme = 'light';
+    if (savedTheme === 'system') {
+      this.currentTheme = window.__pairReview.prefersDark() ? 'dark' : 'light';
     } else {
       this.currentTheme = savedTheme;
     }
@@ -538,10 +534,9 @@ class PRManager {
     }
 
     // Listen for system theme changes and update when preference is 'system'
-    if (typeof window !== 'undefined' && window.matchMedia) {
+    if (typeof window.matchMedia === 'function') {
       window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', (e) => {
-        const savedTheme = localStorage.getItem('theme');
-        if (savedTheme === 'system') {
+        if (localStorage.getItem('theme') === 'system') {
           this.currentTheme = e.matches ? 'dark' : 'light';
           document.documentElement.setAttribute('data-theme', this.currentTheme);
           this.updateThemeIcon();
@@ -7854,13 +7849,8 @@ class PRManager {
   }
 
   toggleTheme() {
-    const savedPreference = localStorage.getItem('theme') || 'system';
-    const nextPreference = savedPreference === 'light' ? 'dark'
-      : savedPreference === 'dark' ? 'system'
-      : 'light';
-    const prefersDark = typeof window !== 'undefined' && window.matchMedia
-      ? window.matchMedia('(prefers-color-scheme: dark)').matches
-      : false;
+    var nextPreference = window.__pairReview.nextTheme(localStorage.getItem('theme') || 'system');
+    var prefersDark = window.__pairReview.prefersDark();
     this.currentTheme = nextPreference === 'system' ? (prefersDark ? 'dark' : 'light') : nextPreference;
     localStorage.setItem('theme', nextPreference);
     document.documentElement.setAttribute('data-theme', this.currentTheme);
@@ -7872,22 +7862,7 @@ class PRManager {
   }
 
   updateThemeIcon() {
-    const themeButton = document.getElementById('theme-toggle');
-    if (!themeButton) return;
-
-    const savedPreference = localStorage.getItem('theme') || 'system';
-
-    if (savedPreference === 'system') {
-      themeButton.innerHTML = `<svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M0 2.75C0 1.784.784 1 1.75 1h12.5c.966 0 1.75.784 1.75 1.75v7.5A1.75 1.75 0 0 1 14.25 12H9.5v1.5h1.75a.75.75 0 0 1 0 1.5h-6.5a.75.75 0 0 1 0-1.5H6.5V12H1.75A1.75 1.75 0 0 1 0 10.25Zm1.75-.25a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h12.5a.25.25 0 0 0 .25-.25v-7.5a.25.25 0 0 0-.25-.25Z"/></svg>`;
-      themeButton.title = 'Theme: System (follows OS)';
-    } else if (savedPreference === 'dark') {
-      themeButton.innerHTML = `<svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M9.598 1.591a.749.749 0 0 1 .785-.175 7.001 7.001 0 1 1-8.967 8.967.75.75 0 0 1 .961-.96 5.5 5.5 0 0 0 7.046-7.046.75.75 0 0 1 .175-.786Z"/></svg>`;
-      themeButton.title = 'Switch to system mode';
-    } else {
-      // Sun icon for light mode (with hollow center)
-      themeButton.innerHTML = `<svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M8 12a4 4 0 1 0 0-8 4 4 0 0 0 0 8Zm0-1.5a2.5 2.5 0 1 1 0-5 2.5 2.5 0 0 1 0 5Zm0-10.5a.75.75 0 0 1 .75.75v1.5a.75.75 0 0 1-1.5 0V.75A.75.75 0 0 1 8 0Zm0 13a.75.75 0 0 1 .75.75v1.5a.75.75 0 0 1-1.5 0v-1.5A.75.75 0 0 1 8 13ZM2.343 2.343a.75.75 0 0 1 1.061 0l1.06 1.061a.75.75 0 0 1-1.06 1.06l-1.06-1.06a.75.75 0 0 1 0-1.06Zm9.193 9.193a.75.75 0 0 1 1.06 0l1.061 1.06a.75.75 0 0 1-1.06 1.061l-1.061-1.06a.75.75 0 0 1 0-1.061ZM16 8a.75.75 0 0 1-.75.75h-1.5a.75.75 0 0 1 0-1.5h1.5A.75.75 0 0 1 16 8ZM3 8a.75.75 0 0 1-.75.75H.75a.75.75 0 0 1 0-1.5h1.5A.75.75 0 0 1 3 8Zm10.657-5.657a.75.75 0 0 1 0 1.061l-1.061 1.06a.75.75 0 1 1-1.06-1.06l1.06-1.06a.75.75 0 0 1 1.06 0Zm-9.193 9.193a.75.75 0 0 1 0 1.06l-1.06 1.061a.75.75 0 0 1-1.061-1.06l1.06-1.061a.75.75 0 0 1 1.061 0Z"/></svg>`;
-      themeButton.title = 'Switch to dark mode';
-    }
+    window.__pairReview.updateThemeIcon(document.getElementById('theme-toggle'));
   }
 
   savePanelStates() {

--- a/public/js/pr.js
+++ b/public/js/pr.js
@@ -112,7 +112,16 @@ class PRManager {
     this.loadingState = false;
     this.expandedFolders = new Set();
     this.expandedSections = new Set();
-    this.currentTheme = localStorage.getItem('theme') || 'light';
+    const savedTheme = localStorage.getItem('theme') || 'light';
+    if (savedTheme === 'system' && typeof window !== 'undefined' && window.matchMedia) {
+      const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+      this.currentTheme = prefersDark ? 'dark' : 'light';
+    } else if (savedTheme === 'system') {
+      // No matchMedia available (e.g. test environment) — fall back to light
+      this.currentTheme = 'light';
+    } else {
+      this.currentTheme = savedTheme;
+    }
     this.suggestionNavigator = null;
     // AI analysis state
     this.isAnalyzing = false;
@@ -526,6 +535,21 @@ class PRManager {
     const themeToggle = document.getElementById('theme-toggle');
     if (themeToggle) {
       themeToggle.addEventListener('click', () => this.toggleTheme());
+    }
+
+    // Listen for system theme changes and update when preference is 'system'
+    if (typeof window !== 'undefined' && window.matchMedia) {
+      window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', (e) => {
+        const savedTheme = localStorage.getItem('theme');
+        if (savedTheme === 'system') {
+          this.currentTheme = e.matches ? 'dark' : 'light';
+          document.documentElement.setAttribute('data-theme', this.currentTheme);
+          this.updateThemeIcon();
+          if (this.pierreBridge) {
+            this.pierreBridge.setTheme(this.currentTheme);
+          }
+        }
+      });
     }
 
     // Analyze button
@@ -7830,8 +7854,15 @@ class PRManager {
   }
 
   toggleTheme() {
-    this.currentTheme = this.currentTheme === 'light' ? 'dark' : 'light';
-    localStorage.setItem('theme', this.currentTheme);
+    const savedPreference = localStorage.getItem('theme') || 'light';
+    const nextPreference = savedPreference === 'light' ? 'dark'
+      : savedPreference === 'dark' ? 'system'
+      : 'light';
+    const prefersDark = typeof window !== 'undefined' && window.matchMedia
+      ? window.matchMedia('(prefers-color-scheme: dark)').matches
+      : false;
+    this.currentTheme = nextPreference === 'system' ? (prefersDark ? 'dark' : 'light') : nextPreference;
+    localStorage.setItem('theme', nextPreference);
     document.documentElement.setAttribute('data-theme', this.currentTheme);
     this.updateThemeIcon();
     // Sync theme with @pierre/diffs instances
@@ -7842,13 +7873,20 @@ class PRManager {
 
   updateThemeIcon() {
     const themeButton = document.getElementById('theme-toggle');
-    if (themeButton) {
-      // Sun icon for light mode (with hollow center), moon icon for dark mode
-      const icon = this.currentTheme === 'light' ?
-        `<svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M8 12a4 4 0 1 0 0-8 4 4 0 0 0 0 8Zm0-1.5a2.5 2.5 0 1 1 0-5 2.5 2.5 0 0 1 0 5Zm0-10.5a.75.75 0 0 1 .75.75v1.5a.75.75 0 0 1-1.5 0V.75A.75.75 0 0 1 8 0Zm0 13a.75.75 0 0 1 .75.75v1.5a.75.75 0 0 1-1.5 0v-1.5A.75.75 0 0 1 8 13ZM2.343 2.343a.75.75 0 0 1 1.061 0l1.06 1.061a.75.75 0 0 1-1.06 1.06l-1.06-1.06a.75.75 0 0 1 0-1.06Zm9.193 9.193a.75.75 0 0 1 1.06 0l1.061 1.06a.75.75 0 0 1-1.06 1.061l-1.061-1.06a.75.75 0 0 1 0-1.061ZM16 8a.75.75 0 0 1-.75.75h-1.5a.75.75 0 0 1 0-1.5h1.5A.75.75 0 0 1 16 8ZM3 8a.75.75 0 0 1-.75.75H.75a.75.75 0 0 1 0-1.5h1.5A.75.75 0 0 1 3 8Zm10.657-5.657a.75.75 0 0 1 0 1.061l-1.061 1.06a.75.75 0 1 1-1.06-1.06l1.06-1.06a.75.75 0 0 1 1.06 0Zm-9.193 9.193a.75.75 0 0 1 0 1.06l-1.06 1.061a.75.75 0 0 1-1.061-1.06l1.06-1.061a.75.75 0 0 1 1.061 0Z"/></svg>` :
-        `<svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M9.598 1.591a.749.749 0 0 1 .785-.175 7.001 7.001 0 1 1-8.967 8.967.75.75 0 0 1 .961-.96 5.5 5.5 0 0 0 7.046-7.046.75.75 0 0 1 .175-.786Z"/></svg>`;
-      themeButton.innerHTML = icon;
-      themeButton.title = `Switch to ${this.currentTheme === 'light' ? 'dark' : 'light'} mode`;
+    if (!themeButton) return;
+
+    const savedPreference = localStorage.getItem('theme') || 'light';
+
+    if (savedPreference === 'system') {
+      themeButton.innerHTML = `<svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M0 2.75C0 1.784.784 1 1.75 1h12.5c.966 0 1.75.784 1.75 1.75v7.5A1.75 1.75 0 0 1 14.25 12H9.5v1.5h1.75a.75.75 0 0 1 0 1.5h-6.5a.75.75 0 0 1 0-1.5H6.5V12H1.75A1.75 1.75 0 0 1 0 10.25Zm1.75-.25a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h12.5a.25.25 0 0 0 .25-.25v-7.5a.25.25 0 0 0-.25-.25Z"/></svg>`;
+      themeButton.title = 'Theme: System (follows OS)';
+    } else if (savedPreference === 'dark') {
+      themeButton.innerHTML = `<svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M9.598 1.591a.749.749 0 0 1 .785-.175 7.001 7.001 0 1 1-8.967 8.967.75.75 0 0 1 .961-.96 5.5 5.5 0 0 0 7.046-7.046.75.75 0 0 1 .175-.786Z"/></svg>`;
+      themeButton.title = 'Switch to system mode';
+    } else {
+      // Sun icon for light mode (with hollow center)
+      themeButton.innerHTML = `<svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M8 12a4 4 0 1 0 0-8 4 4 0 0 0 0 8Zm0-1.5a2.5 2.5 0 1 1 0-5 2.5 2.5 0 0 1 0 5Zm0-10.5a.75.75 0 0 1 .75.75v1.5a.75.75 0 0 1-1.5 0V.75A.75.75 0 0 1 8 0Zm0 13a.75.75 0 0 1 .75.75v1.5a.75.75 0 0 1-1.5 0v-1.5A.75.75 0 0 1 8 13ZM2.343 2.343a.75.75 0 0 1 1.061 0l1.06 1.061a.75.75 0 0 1-1.06 1.06l-1.06-1.06a.75.75 0 0 1 0-1.06Zm9.193 9.193a.75.75 0 0 1 1.06 0l1.061 1.06a.75.75 0 0 1-1.06 1.061l-1.061-1.06a.75.75 0 0 1 0-1.061ZM16 8a.75.75 0 0 1-.75.75h-1.5a.75.75 0 0 1 0-1.5h1.5A.75.75 0 0 1 16 8ZM3 8a.75.75 0 0 1-.75.75H.75a.75.75 0 0 1 0-1.5h1.5A.75.75 0 0 1 3 8Zm10.657-5.657a.75.75 0 0 1 0 1.061l-1.061 1.06a.75.75 0 1 1-1.06-1.06l1.06-1.06a.75.75 0 0 1 1.06 0Zm-9.193 9.193a.75.75 0 0 1 0 1.06l-1.06 1.061a.75.75 0 0 1-1.061-1.06l1.06-1.061a.75.75 0 0 1 1.061 0Z"/></svg>`;
+      themeButton.title = 'Switch to dark mode';
     }
   }
 

--- a/public/js/pr.js
+++ b/public/js/pr.js
@@ -112,7 +112,7 @@ class PRManager {
     this.loadingState = false;
     this.expandedFolders = new Set();
     this.expandedSections = new Set();
-    const savedTheme = localStorage.getItem('theme') || 'light';
+    const savedTheme = localStorage.getItem('theme') || 'system';
     if (savedTheme === 'system' && typeof window !== 'undefined' && window.matchMedia) {
       const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
       this.currentTheme = prefersDark ? 'dark' : 'light';
@@ -7854,7 +7854,7 @@ class PRManager {
   }
 
   toggleTheme() {
-    const savedPreference = localStorage.getItem('theme') || 'light';
+    const savedPreference = localStorage.getItem('theme') || 'system';
     const nextPreference = savedPreference === 'light' ? 'dark'
       : savedPreference === 'dark' ? 'system'
       : 'light';
@@ -7875,7 +7875,7 @@ class PRManager {
     const themeButton = document.getElementById('theme-toggle');
     if (!themeButton) return;
 
-    const savedPreference = localStorage.getItem('theme') || 'light';
+    const savedPreference = localStorage.getItem('theme') || 'system';
 
     if (savedPreference === 'system') {
       themeButton.innerHTML = `<svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M0 2.75C0 1.784.784 1 1.75 1h12.5c.966 0 1.75.784 1.75 1.75v7.5A1.75 1.75 0 0 1 14.25 12H9.5v1.5h1.75a.75.75 0 0 1 0 1.5h-6.5a.75.75 0 0 1 0-1.5H6.5V12H1.75A1.75 1.75 0 0 1 0 10.25Zm1.75-.25a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h12.5a.25.25 0 0 0 .25-.25v-7.5a.25.25 0 0 0-.25-.25Z"/></svg>`;

--- a/public/js/repo-settings.js
+++ b/public/js/repo-settings.js
@@ -158,13 +158,13 @@ class RepoSettingsPage {
     if (!btn) return;
     const pref = localStorage.getItem('theme') || 'system';
     if (pref === 'system') {
-      btn.innerHTML = '<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="3" width="20" height="14" rx="2" ry="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg>';
+      btn.innerHTML = '<svg class="theme-icon-system" viewBox="0 0 16 16" fill="currentColor" width="16" height="16"><path d="M0 2.75C0 1.784.784 1 1.75 1h12.5c.966 0 1.75.784 1.75 1.75v7.5A1.75 1.75 0 0 1 14.25 12H9.5v1.5h1.75a.75.75 0 0 1 0 1.5h-6.5a.75.75 0 0 1 0-1.5H6.5V12H1.75A1.75 1.75 0 0 1 0 10.25Zm1.75-.25a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h12.5a.25.25 0 0 0 .25-.25v-7.5a.25.25 0 0 0-.25-.25Z"/></svg>';
       btn.title = 'Theme: System (follows OS)';
     } else if (pref === 'dark') {
-      btn.innerHTML = '<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>';
+      btn.innerHTML = '<svg class="theme-icon-dark" viewBox="0 0 16 16" fill="currentColor" width="16" height="16"><path d="M9.598 1.591a.749.749 0 0 1 .785-.175 7.001 7.001 0 1 1-8.967 8.967.75.75 0 0 1 .961-.96 5.5 5.5 0 0 0 7.046-7.046.75.75 0 0 1 .175-.786Z"/></svg>';
       btn.title = 'Switch to system mode';
     } else {
-      btn.innerHTML = '<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>';
+      btn.innerHTML = '<svg class="theme-icon-light" viewBox="0 0 16 16" fill="currentColor" width="16" height="16"><path d="M8 12a4 4 0 1 0 0-8 4 4 0 0 0 0 8Zm0-1.5a2.5 2.5 0 1 1 0-5 2.5 2.5 0 0 1 0 5Zm0-10.5a.75.75 0 0 1 .75.75v1.5a.75.75 0 0 1-1.5 0V.75A.75.75 0 0 1 8 0Zm0 13a.75.75 0 0 1 .75.75v1.5a.75.75 0 0 1-1.5 0v-1.5A.75.75 0 0 1 8 13ZM2.343 2.343a.75.75 0 0 1 1.061 0l1.06 1.061a.75.75 0 0 1-1.06 1.06l-1.06-1.06a.75.75 0 0 1 0-1.06Zm9.193 9.193a.75.75 0 0 1 1.06 0l1.061 1.06a.75.75 0 0 1-1.06 1.061l-1.061-1.06a.75.75 0 0 1 0-1.061ZM16 8a.75.75 0 0 1-.75.75h-1.5a.75.75 0 0 1 0-1.5h1.5A.75.75 0 0 1 16 8ZM3 8a.75.75 0 0 1-.75.75H.75a.75.75 0 0 1 0-1.5h1.5A.75.75 0 0 1 3 8Zm10.657-5.657a.75.75 0 0 1 0 1.061l-1.061 1.06a.75.75 0 1 1-1.06-1.06l1.06-1.06a.75.75 0 0 1 1.06 0Zm-9.193 9.193a.75.75 0 0 1 0 1.06l-1.06 1.061a.75.75 0 0 1-1.061-1.06l1.06-1.061a.75.75 0 0 1 1.061 0Z"/></svg>';
       btn.title = 'Switch to dark mode';
     }
   }

--- a/public/js/repo-settings.js
+++ b/public/js/repo-settings.js
@@ -123,7 +123,7 @@ class RepoSettingsPage {
 
   initTheme() {
     // Check for saved theme preference
-    const savedTheme = localStorage.getItem('theme') || 'light';
+    const savedTheme = localStorage.getItem('theme') || 'system';
     const prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
     const theme = savedTheme === 'system' ? (prefersDark ? 'dark' : 'light') : savedTheme;
     document.documentElement.setAttribute('data-theme', theme);
@@ -133,7 +133,7 @@ class RepoSettingsPage {
     const themeToggle = document.getElementById('theme-toggle');
     if (themeToggle) {
       themeToggle.addEventListener('click', () => {
-        const current = localStorage.getItem('theme') || 'light';
+        const current = localStorage.getItem('theme') || 'system';
         const next = current === 'light' ? 'dark' : current === 'dark' ? 'system' : 'light';
         const display = next === 'system' ? (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light') : next;
         document.documentElement.setAttribute('data-theme', display);
@@ -156,7 +156,7 @@ class RepoSettingsPage {
   _updateThemeButtonIcon() {
     const btn = document.getElementById('theme-toggle');
     if (!btn) return;
-    const pref = localStorage.getItem('theme') || 'light';
+    const pref = localStorage.getItem('theme') || 'system';
     if (pref === 'system') {
       btn.innerHTML = '<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="3" width="20" height="14" rx="2" ry="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg>';
       btn.title = 'Theme: System (follows OS)';

--- a/public/js/repo-settings.js
+++ b/public/js/repo-settings.js
@@ -124,17 +124,48 @@ class RepoSettingsPage {
   initTheme() {
     // Check for saved theme preference
     const savedTheme = localStorage.getItem('theme') || 'light';
-    document.documentElement.setAttribute('data-theme', savedTheme);
+    const prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+    const theme = savedTheme === 'system' ? (prefersDark ? 'dark' : 'light') : savedTheme;
+    document.documentElement.setAttribute('data-theme', theme);
+    this._updateThemeButtonIcon();
 
     // Theme toggle button
     const themeToggle = document.getElementById('theme-toggle');
     if (themeToggle) {
       themeToggle.addEventListener('click', () => {
-        const currentTheme = document.documentElement.getAttribute('data-theme');
-        const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', newTheme);
-        localStorage.setItem('theme', newTheme);
+        const current = localStorage.getItem('theme') || 'light';
+        const next = current === 'light' ? 'dark' : current === 'dark' ? 'system' : 'light';
+        const display = next === 'system' ? (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light') : next;
+        document.documentElement.setAttribute('data-theme', display);
+        localStorage.setItem('theme', next);
+        this._updateThemeButtonIcon();
       });
+    }
+
+    // Listen for system theme changes
+    if (window.matchMedia) {
+      window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', (e) => {
+        if (localStorage.getItem('theme') === 'system') {
+          document.documentElement.setAttribute('data-theme', e.matches ? 'dark' : 'light');
+          this._updateThemeButtonIcon();
+        }
+      });
+    }
+  }
+
+  _updateThemeButtonIcon() {
+    const btn = document.getElementById('theme-toggle');
+    if (!btn) return;
+    const pref = localStorage.getItem('theme') || 'light';
+    if (pref === 'system') {
+      btn.innerHTML = '<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="3" width="20" height="14" rx="2" ry="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg>';
+      btn.title = 'Theme: System (follows OS)';
+    } else if (pref === 'dark') {
+      btn.innerHTML = '<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>';
+      btn.title = 'Switch to system mode';
+    } else {
+      btn.innerHTML = '<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>';
+      btn.title = 'Switch to dark mode';
     }
   }
 

--- a/public/js/repo-settings.js
+++ b/public/js/repo-settings.js
@@ -124,7 +124,7 @@ class RepoSettingsPage {
   initTheme() {
     // Check for saved theme preference
     const savedTheme = localStorage.getItem('theme') || 'system';
-    const prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+    const prefersDark = typeof window.matchMedia === 'function' && window.matchMedia('(prefers-color-scheme: dark)').matches;
     const theme = savedTheme === 'system' ? (prefersDark ? 'dark' : 'light') : savedTheme;
     document.documentElement.setAttribute('data-theme', theme);
     this._updateThemeButtonIcon();
@@ -135,7 +135,7 @@ class RepoSettingsPage {
       themeToggle.addEventListener('click', () => {
         const current = localStorage.getItem('theme') || 'system';
         const next = current === 'light' ? 'dark' : current === 'dark' ? 'system' : 'light';
-        const display = next === 'system' ? (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light') : next;
+        const display = next === 'system' ? (typeof window.matchMedia === 'function' && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light') : next;
         document.documentElement.setAttribute('data-theme', display);
         localStorage.setItem('theme', next);
         this._updateThemeButtonIcon();
@@ -143,7 +143,7 @@ class RepoSettingsPage {
     }
 
     // Listen for system theme changes
-    if (window.matchMedia) {
+    if (typeof window.matchMedia === 'function') {
       window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', (e) => {
         if (localStorage.getItem('theme') === 'system') {
           document.documentElement.setAttribute('data-theme', e.matches ? 'dark' : 'light');

--- a/public/js/repo-settings.js
+++ b/public/js/repo-settings.js
@@ -123,9 +123,8 @@ class RepoSettingsPage {
 
   initTheme() {
     // Check for saved theme preference
-    const savedTheme = localStorage.getItem('theme') || 'system';
-    const prefersDark = typeof window.matchMedia === 'function' && window.matchMedia('(prefers-color-scheme: dark)').matches;
-    const theme = savedTheme === 'system' ? (prefersDark ? 'dark' : 'light') : savedTheme;
+    var savedTheme = localStorage.getItem('theme') || 'system';
+    var theme = window.__pairReview.resolveTheme(savedTheme, window.__pairReview.prefersDark());
     document.documentElement.setAttribute('data-theme', theme);
     this._updateThemeButtonIcon();
 
@@ -133,9 +132,9 @@ class RepoSettingsPage {
     const themeToggle = document.getElementById('theme-toggle');
     if (themeToggle) {
       themeToggle.addEventListener('click', () => {
-        const current = localStorage.getItem('theme') || 'system';
-        const next = current === 'light' ? 'dark' : current === 'dark' ? 'system' : 'light';
-        const display = next === 'system' ? (typeof window.matchMedia === 'function' && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light') : next;
+        var current = localStorage.getItem('theme') || 'system';
+        var next = window.__pairReview.nextTheme(current);
+        var display = window.__pairReview.resolveTheme(next, window.__pairReview.prefersDark());
         document.documentElement.setAttribute('data-theme', display);
         localStorage.setItem('theme', next);
         this._updateThemeButtonIcon();
@@ -154,19 +153,7 @@ class RepoSettingsPage {
   }
 
   _updateThemeButtonIcon() {
-    const btn = document.getElementById('theme-toggle');
-    if (!btn) return;
-    const pref = localStorage.getItem('theme') || 'system';
-    if (pref === 'system') {
-      btn.innerHTML = '<svg class="theme-icon-system" viewBox="0 0 16 16" fill="currentColor" width="16" height="16"><path d="M0 2.75C0 1.784.784 1 1.75 1h12.5c.966 0 1.75.784 1.75 1.75v7.5A1.75 1.75 0 0 1 14.25 12H9.5v1.5h1.75a.75.75 0 0 1 0 1.5h-6.5a.75.75 0 0 1 0-1.5H6.5V12H1.75A1.75 1.75 0 0 1 0 10.25Zm1.75-.25a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h12.5a.25.25 0 0 0 .25-.25v-7.5a.25.25 0 0 0-.25-.25Z"/></svg>';
-      btn.title = 'Theme: System (follows OS)';
-    } else if (pref === 'dark') {
-      btn.innerHTML = '<svg class="theme-icon-dark" viewBox="0 0 16 16" fill="currentColor" width="16" height="16"><path d="M9.598 1.591a.749.749 0 0 1 .785-.175 7.001 7.001 0 1 1-8.967 8.967.75.75 0 0 1 .961-.96 5.5 5.5 0 0 0 7.046-7.046.75.75 0 0 1 .175-.786Z"/></svg>';
-      btn.title = 'Switch to system mode';
-    } else {
-      btn.innerHTML = '<svg class="theme-icon-light" viewBox="0 0 16 16" fill="currentColor" width="16" height="16"><path d="M8 12a4 4 0 1 0 0-8 4 4 0 0 0 0 8Zm0-1.5a2.5 2.5 0 1 1 0-5 2.5 2.5 0 0 1 0 5Zm0-10.5a.75.75 0 0 1 .75.75v1.5a.75.75 0 0 1-1.5 0V.75A.75.75 0 0 1 8 0Zm0 13a.75.75 0 0 1 .75.75v1.5a.75.75 0 0 1-1.5 0v-1.5A.75.75 0 0 1 8 13ZM2.343 2.343a.75.75 0 0 1 1.061 0l1.06 1.061a.75.75 0 0 1-1.06 1.06l-1.06-1.06a.75.75 0 0 1 0-1.06Zm9.193 9.193a.75.75 0 0 1 1.06 0l1.061 1.06a.75.75 0 0 1-1.06 1.061l-1.061-1.06a.75.75 0 0 1 0-1.061ZM16 8a.75.75 0 0 1-.75.75h-1.5a.75.75 0 0 1 0-1.5h1.5A.75.75 0 0 1 16 8ZM3 8a.75.75 0 0 1-.75.75H.75a.75.75 0 0 1 0-1.5h1.5A.75.75 0 0 1 3 8Zm10.657-5.657a.75.75 0 0 1 0 1.061l-1.061 1.06a.75.75 0 1 1-1.06-1.06l1.06-1.06a.75.75 0 0 1 1.06 0Zm-9.193 9.193a.75.75 0 0 1 0 1.06l-1.06 1.061a.75.75 0 0 1-1.061-1.06l1.06-1.061a.75.75 0 0 1 1.061 0Z"/></svg>';
-      btn.title = 'Switch to dark mode';
-    }
+    window.__pairReview.updateThemeIcon(document.getElementById('theme-toggle'));
   }
 
   setupEventListeners() {

--- a/public/js/settings.js
+++ b/public/js/settings.js
@@ -138,7 +138,7 @@ class SettingsPage {
   // ─── Theme ────────────────────────────────────────────────────────────────
 
   initTheme() {
-    const savedTheme = localStorage.getItem('theme') || 'light';
+    const savedTheme = localStorage.getItem('theme') || 'system';
     const prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
     const theme = savedTheme === 'system' ? (prefersDark ? 'dark' : 'light') : savedTheme;
     document.documentElement.setAttribute('data-theme', theme);
@@ -147,7 +147,7 @@ class SettingsPage {
     const themeToggle = document.getElementById('theme-toggle');
     if (themeToggle) {
       themeToggle.addEventListener('click', () => {
-        const current = localStorage.getItem('theme') || 'light';
+        const current = localStorage.getItem('theme') || 'system';
         const next = current === 'light' ? 'dark' : current === 'dark' ? 'system' : 'light';
         const display = next === 'system' ? (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light') : next;
         document.documentElement.setAttribute('data-theme', display);
@@ -170,7 +170,7 @@ class SettingsPage {
   _updateThemeButtonIcon() {
     const btn = document.getElementById('theme-toggle');
     if (!btn) return;
-    const pref = localStorage.getItem('theme') || 'light';
+    const pref = localStorage.getItem('theme') || 'system';
     if (pref === 'system') {
       btn.innerHTML = '<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="3" width="20" height="14" rx="2" ry="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg>';
       btn.title = 'Theme: System (follows OS)';

--- a/public/js/settings.js
+++ b/public/js/settings.js
@@ -139,16 +139,47 @@ class SettingsPage {
 
   initTheme() {
     const savedTheme = localStorage.getItem('theme') || 'light';
-    document.documentElement.setAttribute('data-theme', savedTheme);
+    const prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+    const theme = savedTheme === 'system' ? (prefersDark ? 'dark' : 'light') : savedTheme;
+    document.documentElement.setAttribute('data-theme', theme);
+    this._updateThemeButtonIcon();
 
     const themeToggle = document.getElementById('theme-toggle');
     if (themeToggle) {
       themeToggle.addEventListener('click', () => {
-        const current = document.documentElement.getAttribute('data-theme');
-        const next = current === 'dark' ? 'light' : 'dark';
-        document.documentElement.setAttribute('data-theme', next);
+        const current = localStorage.getItem('theme') || 'light';
+        const next = current === 'light' ? 'dark' : current === 'dark' ? 'system' : 'light';
+        const display = next === 'system' ? (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light') : next;
+        document.documentElement.setAttribute('data-theme', display);
         localStorage.setItem('theme', next);
+        this._updateThemeButtonIcon();
       });
+    }
+
+    // Listen for system theme changes
+    if (window.matchMedia) {
+      window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', (e) => {
+        if (localStorage.getItem('theme') === 'system') {
+          document.documentElement.setAttribute('data-theme', e.matches ? 'dark' : 'light');
+          this._updateThemeButtonIcon();
+        }
+      });
+    }
+  }
+
+  _updateThemeButtonIcon() {
+    const btn = document.getElementById('theme-toggle');
+    if (!btn) return;
+    const pref = localStorage.getItem('theme') || 'light';
+    if (pref === 'system') {
+      btn.innerHTML = '<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="3" width="20" height="14" rx="2" ry="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg>';
+      btn.title = 'Theme: System (follows OS)';
+    } else if (pref === 'dark') {
+      btn.innerHTML = '<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>';
+      btn.title = 'Switch to system mode';
+    } else {
+      btn.innerHTML = '<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>';
+      btn.title = 'Switch to dark mode';
     }
   }
 

--- a/public/js/settings.js
+++ b/public/js/settings.js
@@ -138,18 +138,17 @@ class SettingsPage {
   // ─── Theme ────────────────────────────────────────────────────────────────
 
   initTheme() {
-    const savedTheme = localStorage.getItem('theme') || 'system';
-    const prefersDark = typeof window.matchMedia === 'function' && window.matchMedia('(prefers-color-scheme: dark)').matches;
-    const theme = savedTheme === 'system' ? (prefersDark ? 'dark' : 'light') : savedTheme;
+    var savedTheme = localStorage.getItem('theme') || 'system';
+    var theme = window.__pairReview.resolveTheme(savedTheme, window.__pairReview.prefersDark());
     document.documentElement.setAttribute('data-theme', theme);
     this._updateThemeButtonIcon();
 
     const themeToggle = document.getElementById('theme-toggle');
     if (themeToggle) {
       themeToggle.addEventListener('click', () => {
-        const current = localStorage.getItem('theme') || 'system';
-        const next = current === 'light' ? 'dark' : current === 'dark' ? 'system' : 'light';
-        const display = next === 'system' ? (typeof window.matchMedia === 'function' && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light') : next;
+        var current = localStorage.getItem('theme') || 'system';
+        var next = window.__pairReview.nextTheme(current);
+        var display = window.__pairReview.resolveTheme(next, window.__pairReview.prefersDark());
         document.documentElement.setAttribute('data-theme', display);
         localStorage.setItem('theme', next);
         this._updateThemeButtonIcon();
@@ -168,19 +167,7 @@ class SettingsPage {
   }
 
   _updateThemeButtonIcon() {
-    const btn = document.getElementById('theme-toggle');
-    if (!btn) return;
-    const pref = localStorage.getItem('theme') || 'system';
-    if (pref === 'system') {
-      btn.innerHTML = '<svg class="theme-icon-system" viewBox="0 0 16 16" fill="currentColor" width="16" height="16"><path d="M0 2.75C0 1.784.784 1 1.75 1h12.5c.966 0 1.75.784 1.75 1.75v7.5A1.75 1.75 0 0 1 14.25 12H9.5v1.5h1.75a.75.75 0 0 1 0 1.5h-6.5a.75.75 0 0 1 0-1.5H6.5V12H1.75A1.75 1.75 0 0 1 0 10.25Zm1.75-.25a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h12.5a.25.25 0 0 0 .25-.25v-7.5a.25.25 0 0 0-.25-.25Z"/></svg>';
-      btn.title = 'Theme: System (follows OS)';
-    } else if (pref === 'dark') {
-      btn.innerHTML = '<svg class="theme-icon-dark" viewBox="0 0 16 16" fill="currentColor" width="16" height="16"><path d="M9.598 1.591a.749.749 0 0 1 .785-.175 7.001 7.001 0 1 1-8.967 8.967.75.75 0 0 1 .961-.96 5.5 5.5 0 0 0 7.046-7.046.75.75 0 0 1 .175-.786Z"/></svg>';
-      btn.title = 'Switch to system mode';
-    } else {
-      btn.innerHTML = '<svg class="theme-icon-light" viewBox="0 0 16 16" fill="currentColor" width="16" height="16"><path d="M8 12a4 4 0 1 0 0-8 4 4 0 0 0 0 8Zm0-1.5a2.5 2.5 0 1 1 0-5 2.5 2.5 0 0 1 0 5Zm0-10.5a.75.75 0 0 1 .75.75v1.5a.75.75 0 0 1-1.5 0V.75A.75.75 0 0 1 8 0Zm0 13a.75.75 0 0 1 .75.75v1.5a.75.75 0 0 1-1.5 0v-1.5A.75.75 0 0 1 8 13ZM2.343 2.343a.75.75 0 0 1 1.061 0l1.06 1.061a.75.75 0 0 1-1.06 1.06l-1.06-1.06a.75.75 0 0 1 0-1.06Zm9.193 9.193a.75.75 0 0 1 1.06 0l1.061 1.06a.75.75 0 0 1-1.06 1.061l-1.061-1.06a.75.75 0 0 1 0-1.061ZM16 8a.75.75 0 0 1-.75.75h-1.5a.75.75 0 0 1 0-1.5h1.5A.75.75 0 0 1 16 8ZM3 8a.75.75 0 0 1-.75.75H.75a.75.75 0 0 1 0-1.5h1.5A.75.75 0 0 1 3 8Zm10.657-5.657a.75.75 0 0 1 0 1.061l-1.061 1.06a.75.75 0 1 1-1.06-1.06l1.06-1.06a.75.75 0 0 1 1.06 0Zm-9.193 9.193a.75.75 0 0 1 0 1.06l-1.06 1.061a.75.75 0 0 1-1.061-1.06l1.06-1.061a.75.75 0 0 1 1.061 0Z"/></svg>';
-      btn.title = 'Switch to dark mode';
-    }
+    window.__pairReview.updateThemeIcon(document.getElementById('theme-toggle'));
   }
 
   // ─── Data loading ─────────────────────────────────────────────────────────

--- a/public/js/settings.js
+++ b/public/js/settings.js
@@ -139,7 +139,7 @@ class SettingsPage {
 
   initTheme() {
     const savedTheme = localStorage.getItem('theme') || 'system';
-    const prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+    const prefersDark = typeof window.matchMedia === 'function' && window.matchMedia('(prefers-color-scheme: dark)').matches;
     const theme = savedTheme === 'system' ? (prefersDark ? 'dark' : 'light') : savedTheme;
     document.documentElement.setAttribute('data-theme', theme);
     this._updateThemeButtonIcon();
@@ -149,7 +149,7 @@ class SettingsPage {
       themeToggle.addEventListener('click', () => {
         const current = localStorage.getItem('theme') || 'system';
         const next = current === 'light' ? 'dark' : current === 'dark' ? 'system' : 'light';
-        const display = next === 'system' ? (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light') : next;
+        const display = next === 'system' ? (typeof window.matchMedia === 'function' && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light') : next;
         document.documentElement.setAttribute('data-theme', display);
         localStorage.setItem('theme', next);
         this._updateThemeButtonIcon();
@@ -157,7 +157,7 @@ class SettingsPage {
     }
 
     // Listen for system theme changes
-    if (window.matchMedia) {
+    if (typeof window.matchMedia === 'function') {
       window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', (e) => {
         if (localStorage.getItem('theme') === 'system') {
           document.documentElement.setAttribute('data-theme', e.matches ? 'dark' : 'light');

--- a/public/js/settings.js
+++ b/public/js/settings.js
@@ -172,13 +172,13 @@ class SettingsPage {
     if (!btn) return;
     const pref = localStorage.getItem('theme') || 'system';
     if (pref === 'system') {
-      btn.innerHTML = '<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="3" width="20" height="14" rx="2" ry="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg>';
+      btn.innerHTML = '<svg class="theme-icon-system" viewBox="0 0 16 16" fill="currentColor" width="16" height="16"><path d="M0 2.75C0 1.784.784 1 1.75 1h12.5c.966 0 1.75.784 1.75 1.75v7.5A1.75 1.75 0 0 1 14.25 12H9.5v1.5h1.75a.75.75 0 0 1 0 1.5h-6.5a.75.75 0 0 1 0-1.5H6.5V12H1.75A1.75 1.75 0 0 1 0 10.25Zm1.75-.25a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h12.5a.25.25 0 0 0 .25-.25v-7.5a.25.25 0 0 0-.25-.25Z"/></svg>';
       btn.title = 'Theme: System (follows OS)';
     } else if (pref === 'dark') {
-      btn.innerHTML = '<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>';
+      btn.innerHTML = '<svg class="theme-icon-dark" viewBox="0 0 16 16" fill="currentColor" width="16" height="16"><path d="M9.598 1.591a.749.749 0 0 1 .785-.175 7.001 7.001 0 1 1-8.967 8.967.75.75 0 0 1 .961-.96 5.5 5.5 0 0 0 7.046-7.046.75.75 0 0 1 .175-.786Z"/></svg>';
       btn.title = 'Switch to system mode';
     } else {
-      btn.innerHTML = '<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>';
+      btn.innerHTML = '<svg class="theme-icon-light" viewBox="0 0 16 16" fill="currentColor" width="16" height="16"><path d="M8 12a4 4 0 1 0 0-8 4 4 0 0 0 0 8Zm0-1.5a2.5 2.5 0 1 1 0-5 2.5 2.5 0 0 1 0 5Zm0-10.5a.75.75 0 0 1 .75.75v1.5a.75.75 0 0 1-1.5 0V.75A.75.75 0 0 1 8 0Zm0 13a.75.75 0 0 1 .75.75v1.5a.75.75 0 0 1-1.5 0v-1.5A.75.75 0 0 1 8 13ZM2.343 2.343a.75.75 0 0 1 1.061 0l1.06 1.061a.75.75 0 0 1-1.06 1.06l-1.06-1.06a.75.75 0 0 1 0-1.06Zm9.193 9.193a.75.75 0 0 1 1.06 0l1.061 1.06a.75.75 0 0 1-1.06 1.061l-1.061-1.06a.75.75 0 0 1 0-1.061ZM16 8a.75.75 0 0 1-.75.75h-1.5a.75.75 0 0 1 0-1.5h1.5A.75.75 0 0 1 16 8ZM3 8a.75.75 0 0 1-.75.75H.75a.75.75 0 0 1 0-1.5h1.5A.75.75 0 0 1 3 8Zm10.657-5.657a.75.75 0 0 1 0 1.061l-1.061 1.06a.75.75 0 1 1-1.06-1.06l1.06-1.06a.75.75 0 0 1 1.06 0Zm-9.193 9.193a.75.75 0 0 1 0 1.06l-1.06 1.061a.75.75 0 0 1-1.061-1.06l1.06-1.061a.75.75 0 0 1 1.061 0Z"/></svg>';
       btn.title = 'Switch to dark mode';
     }
   }

--- a/public/js/utils/theme.js
+++ b/public/js/utils/theme.js
@@ -1,0 +1,79 @@
+// Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+/**
+ * Shared theme utilities.
+ *
+ * Pure helpers and icon rendering used across all pages.
+ * Exposed on window.__pairReview following the established pattern
+ * (see window.__pairReview.toGraphiteUrl).
+ */
+(function () {
+  'use strict';
+
+  /**
+   * Resolve a stored theme preference to an actual theme value.
+   * @param {string|null|undefined} preference - 'light', 'dark', 'system', or null/undefined
+   * @param {boolean} prefersDark - whether the OS prefers dark mode
+   * @returns {'light'|'dark'} the resolved theme
+   */
+  function resolveTheme(preference, prefersDark) {
+    if (preference === 'light') return 'light';
+    if (preference === 'dark') return 'dark';
+    // 'system' or null/undefined → follow OS preference
+    return prefersDark ? 'dark' : 'light';
+  }
+
+  /**
+   * Get the next theme preference in the cycle.
+   * @param {string} current - 'light', 'dark', or 'system'
+   * @returns {'light'|'dark'|'system'}
+   */
+  function nextTheme(current) {
+    if (current === 'light') return 'dark';
+    if (current === 'dark') return 'system';
+    return 'light'; // 'system' or unknown wraps to light
+  }
+
+  /**
+   * Read the OS dark-mode preference safely.
+   * @returns {boolean}
+   */
+  function prefersDark() {
+    return typeof window.matchMedia === 'function' && window.matchMedia('(prefers-color-scheme: dark)').matches;
+  }
+
+  /**
+   * Render the appropriate icon into a theme toggle button.
+   * @param {HTMLElement} btn - the button element
+   * @param {string} [preference] - 'light', 'dark', or 'system' (reads from localStorage if omitted)
+   */
+  function updateThemeIcon(btn, preference) {
+    if (!btn) return;
+    var pref = preference;
+    if (pref === undefined || pref === null) {
+      pref = (typeof localStorage !== 'undefined' ? localStorage.getItem('theme') : null) || 'system';
+    }
+    if (pref === 'system') {
+      btn.innerHTML = '<svg class="theme-icon-system" viewBox="0 0 16 16" fill="currentColor" width="16" height="16"><path d="M0 2.75C0 1.784.784 1 1.75 1h12.5c.966 0 1.75.784 1.75 1.75v7.5A1.75 1.75 0 0 1 14.25 12H9.5v1.5h1.75a.75.75 0 0 1 0 1.5h-6.5a.75.75 0 0 1 0-1.5H6.5V12H1.75A1.75 1.75 0 0 1 0 10.25Zm1.75-.25a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h12.5a.25.25 0 0 0 .25-.25v-7.5a.25.25 0 0 0-.25-.25Z"/></svg>';
+      btn.title = 'Theme: System (follows OS)';
+    } else if (pref === 'dark') {
+      btn.innerHTML = '<svg class="theme-icon-dark" viewBox="0 0 16 16" fill="currentColor" width="16" height="16"><path d="M9.598 1.591a.749.749 0 0 1 .785-.175 7.001 7.001 0 1 1-8.967 8.967.75.75 0 0 1 .961-.96 5.5 5.5 0 0 0 7.046-7.046.75.75 0 0 1 .175-.786Z"/></svg>';
+      btn.title = 'Switch to system mode';
+    } else {
+      btn.innerHTML = '<svg class="theme-icon-light" viewBox="0 0 16 16" fill="currentColor" width="16" height="16"><path d="M8 12a4 4 0 1 0 0-8 4 4 0 0 0 0 8Zm0-1.5a2.5 2.5 0 1 1 0-5 2.5 2.5 0 0 1 0 5Zm0-10.5a.75.75 0 0 1 .75.75v1.5a.75.75 0 0 1-1.5 0V.75A.75.75 0 0 1 8 0Zm0 13a.75.75 0 0 1 .75.75v1.5a.75.75 0 0 1-1.5 0v-1.5A.75.75 0 0 1 8 13ZM2.343 2.343a.75.75 0 0 1 1.061 0l1.06 1.061a.75.75 0 0 1-1.06 1.06l-1.06-1.06a.75.75 0 0 1 0-1.06Zm9.193 9.193a.75.75 0 0 1 1.06 0l1.061 1.06a.75.75 0 0 1-1.06 1.061l-1.061-1.06a.75.75 0 0 1 0-1.061ZM16 8a.75.75 0 0 1-.75.75h-1.5a.75.75 0 0 1 0-1.5h1.5A.75.75 0 0 1 16 8ZM3 8a.75.75 0 0 1-.75.75H.75a.75.75 0 0 1 0-1.5h1.5A.75.75 0 0 1 3 8Zm10.657-5.657a.75.75 0 0 1 0 1.061l-1.061 1.06a.75.75 0 1 1-1.06-1.06l1.06-1.06a.75.75 0 0 1 1.06 0Zm-9.193 9.193a.75.75 0 0 1 0 1.06l-1.06 1.061a.75.75 0 0 1-1.061-1.06l1.06-1.061a.75.75 0 0 1 1.061 0Z"/></svg>';
+      btn.title = 'Switch to dark mode';
+    }
+  }
+
+  // ---- Expose on window.__pairReview ----
+
+  window.__pairReview = window.__pairReview || {};
+  window.__pairReview.resolveTheme = resolveTheme;
+  window.__pairReview.nextTheme = nextTheme;
+  window.__pairReview.prefersDark = prefersDark;
+  window.__pairReview.updateThemeIcon = updateThemeIcon;
+
+  // Export for unit tests.
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { resolveTheme, nextTheme, prefersDark, updateThemeIcon };
+  }
+})();

--- a/public/local.html
+++ b/public/local.html
@@ -685,6 +685,7 @@
     <script src="/js/repo-links.js"></script>
 
     <!-- PR JavaScript (shared with local mode) -->
+    <script src="/js/utils/theme.js"></script>
     <script src="/js/pr.js"></script>
 
     <!-- Local Mode JavaScript -->

--- a/public/local.html
+++ b/public/local.html
@@ -5,7 +5,9 @@
         // Initialize theme immediately to prevent flash
         (function() {
             const savedTheme = localStorage.getItem('theme') || 'light';
-            document.documentElement.setAttribute('data-theme', savedTheme);
+            const prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+            const theme = savedTheme === 'system' ? (prefersDark ? 'dark' : 'light') : savedTheme;
+            document.documentElement.setAttribute('data-theme', theme);
         })();
         // Fetch chat availability early so PanelGroup sees the correct state
         fetch('/api/config').then(r => r.ok ? r.json() : null).then(config => {

--- a/public/local.html
+++ b/public/local.html
@@ -4,7 +4,7 @@
     <script>
         // Initialize theme immediately to prevent flash
         (function() {
-            const savedTheme = localStorage.getItem('theme') || 'light';
+            const savedTheme = localStorage.getItem('theme') || 'system';
             const prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
             const theme = savedTheme === 'system' ? (prefersDark ? 'dark' : 'light') : savedTheme;
             document.documentElement.setAttribute('data-theme', theme);

--- a/public/pr.html
+++ b/public/pr.html
@@ -486,6 +486,7 @@
     <script src="/js/repo-links.js"></script>
 
     <!-- PR JavaScript -->
+    <script src="/js/utils/theme.js"></script>
     <script src="/js/pr.js"></script>
 </body>
 </html>

--- a/public/pr.html
+++ b/public/pr.html
@@ -5,7 +5,9 @@
         // Initialize theme immediately to prevent flash
         (function() {
             const savedTheme = localStorage.getItem('theme') || 'light';
-            document.documentElement.setAttribute('data-theme', savedTheme);
+            const prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+            const theme = savedTheme === 'system' ? (prefersDark ? 'dark' : 'light') : savedTheme;
+            document.documentElement.setAttribute('data-theme', theme);
         })();
         // Fetch chat availability early so PanelGroup sees the correct state
         fetch('/api/config').then(r => r.ok ? r.json() : null).then(config => {

--- a/public/pr.html
+++ b/public/pr.html
@@ -4,7 +4,7 @@
     <script>
         // Initialize theme immediately to prevent flash
         (function() {
-            const savedTheme = localStorage.getItem('theme') || 'light';
+            const savedTheme = localStorage.getItem('theme') || 'system';
             const prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
             const theme = savedTheme === 'system' ? (prefersDark ? 'dark' : 'light') : savedTheme;
             document.documentElement.setAttribute('data-theme', theme);

--- a/public/repo-settings.html
+++ b/public/repo-settings.html
@@ -5,7 +5,9 @@
         // Initialize theme immediately to prevent flash
         (function() {
             const savedTheme = localStorage.getItem('theme') || 'light';
-            document.documentElement.setAttribute('data-theme', savedTheme);
+            const prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+            const theme = savedTheme === 'system' ? (prefersDark ? 'dark' : 'light') : savedTheme;
+            document.documentElement.setAttribute('data-theme', theme);
         })();
     </script>
     <meta charset="UTF-8">

--- a/public/repo-settings.html
+++ b/public/repo-settings.html
@@ -324,6 +324,7 @@ Examples:
     <script src="/js/utils/tier-icons.js"></script>
     <script src="/js/components/CouncilDropdown.js"></script>
     <script src="/js/components/CouncilCard.js"></script>
+    <script src="/js/utils/theme.js"></script>
     <script src="/js/repo-settings.js"></script>
 </body>
 </html>

--- a/public/repo-settings.html
+++ b/public/repo-settings.html
@@ -4,7 +4,7 @@
     <script>
         // Initialize theme immediately to prevent flash
         (function() {
-            const savedTheme = localStorage.getItem('theme') || 'light';
+            const savedTheme = localStorage.getItem('theme') || 'system';
             const prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
             const theme = savedTheme === 'system' ? (prefersDark ? 'dark' : 'light') : savedTheme;
             document.documentElement.setAttribute('data-theme', theme);

--- a/public/settings.html
+++ b/public/settings.html
@@ -5,7 +5,9 @@
         // Initialize theme immediately to prevent flash
         (function() {
             const savedTheme = localStorage.getItem('theme') || 'light';
-            document.documentElement.setAttribute('data-theme', savedTheme);
+            const prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+            const theme = savedTheme === 'system' ? (prefersDark ? 'dark' : 'light') : savedTheme;
+            document.documentElement.setAttribute('data-theme', theme);
         })();
     </script>
     <meta charset="UTF-8">

--- a/public/settings.html
+++ b/public/settings.html
@@ -140,6 +140,7 @@
     <script src="/js/components/CouncilDropdown.js"></script>
     <script src="/js/components/CouncilCard.js"></script>
     <script src="/js/components/SnippetManager.js"></script>
+    <script src="/js/utils/theme.js"></script>
     <script src="/js/settings.js"></script>
 </body>
 </html>

--- a/public/settings.html
+++ b/public/settings.html
@@ -4,7 +4,7 @@
     <script>
         // Initialize theme immediately to prevent flash
         (function() {
-            const savedTheme = localStorage.getItem('theme') || 'light';
+            const savedTheme = localStorage.getItem('theme') || 'system';
             const prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
             const theme = savedTheme === 'system' ? (prefersDark ? 'dark' : 'light') : savedTheme;
             document.documentElement.setAttribute('data-theme', theme);

--- a/public/setup.html
+++ b/public/setup.html
@@ -5,7 +5,9 @@
         // Initialize theme immediately to prevent flash
         (function() {
             const savedTheme = localStorage.getItem('theme') || 'light';
-            document.documentElement.setAttribute('data-theme', savedTheme);
+            const prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+            const theme = savedTheme === 'system' ? (prefersDark ? 'dark' : 'light') : savedTheme;
+            document.documentElement.setAttribute('data-theme', theme);
         })();
     </script>
     <meta charset="UTF-8">

--- a/public/setup.html
+++ b/public/setup.html
@@ -533,6 +533,7 @@
     <script src="/js/components/UpdateBanner.js"></script>
     <script src="/js/utils/notification-sounds.js"></script>
     <script src="/js/utils/analyze-params.js"></script>
+    <script src="/js/utils/theme.js"></script>
 
     <script>
         // Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0

--- a/public/setup.html
+++ b/public/setup.html
@@ -4,7 +4,7 @@
     <script>
         // Initialize theme immediately to prevent flash
         (function() {
-            const savedTheme = localStorage.getItem('theme') || 'light';
+            const savedTheme = localStorage.getItem('theme') || 'system';
             const prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
             const theme = savedTheme === 'system' ? (prefersDark ? 'dark' : 'light') : savedTheme;
             document.documentElement.setAttribute('data-theme', theme);

--- a/src/settings/registry.js
+++ b/src/settings/registry.js
@@ -44,10 +44,10 @@ const REGISTRY = [
   {
     key: 'theme',
     label: 'Default theme',
-    description: 'Initial theme for the UI. The header toggle still switches themes client-side per session.',
+    description: 'Initial theme for the UI. "system" follows your OS dark/light schedule. The header toggle still switches themes client-side per session.',
     group: 'general',
     type: 'enum',
-    values: ['light', 'dark'],
+    values: ['light', 'dark', 'system'],
     default: 'light',
     editable: true,
     restartRequired: false

--- a/tests/unit/index-open-analyze-buttons.test.js
+++ b/tests/unit/index-open-analyze-buttons.test.js
@@ -227,6 +227,10 @@ describe('Index page Open/Analyze buttons', () => {
     setupGlobals();
 
     // Clear module cache so the IIFE runs fresh each time
+    const themePath = require.resolve('../../public/js/utils/theme.js');
+    delete require.cache[themePath];
+    require('../../public/js/utils/theme.js'); // populates window.__pairReview
+
     const modulePath = require.resolve('../../public/js/index.js');
     delete require.cache[modulePath];
 

--- a/tests/unit/index-tab-persistence.test.js
+++ b/tests/unit/index-tab-persistence.test.js
@@ -207,6 +207,10 @@ describe('Index page tab persistence', () => {
     setupGlobals();
 
     // Clear module cache so the IIFE runs fresh each time
+    const themePath = require.resolve('../../public/js/utils/theme.js');
+    delete require.cache[themePath];
+    require('../../public/js/utils/theme.js'); // populates window.__pairReview
+
     const modulePath = require.resolve('../../public/js/index.js');
     delete require.cache[modulePath];
 

--- a/tests/unit/theme-system.test.js
+++ b/tests/unit/theme-system.test.js
@@ -349,6 +349,42 @@ describe('Landing page theme toggle', () => {
   });
 
   describe('updateThemeIcon', () => {
+    it('shows the monitor icon and correct title for system mode', () => {
+      const exp = setup('system');
+      exp.initTheme();
+      const btn = { innerHTML: '', title: '' };
+      const orig = sandbox.document.getElementById;
+      sandbox.document.getElementById = (id) => id === 'theme-toggle' ? btn : orig(id);
+
+      exp.updateThemeIcon('system');
+      expect(btn.innerHTML).toContain('M0 2.75'); // monitor icon path
+      expect(btn.title).toBe('Theme: System (follows OS)');
+    });
+
+    it('shows the moon icon and correct title for dark mode', () => {
+      const exp = setup('dark');
+      exp.initTheme();
+      const btn = { innerHTML: '', title: '' };
+      const orig = sandbox.document.getElementById;
+      sandbox.document.getElementById = (id) => id === 'theme-toggle' ? btn : orig(id);
+
+      exp.updateThemeIcon('dark');
+      expect(btn.innerHTML).toContain('M9.598 1.591'); // moon icon path
+      expect(btn.title).toBe('Switch to system mode');
+    });
+
+    it('shows the sun icon and correct title for light mode', () => {
+      const exp = setup('light');
+      exp.initTheme();
+      const btn = { innerHTML: '', title: '' };
+      const orig = sandbox.document.getElementById;
+      sandbox.document.getElementById = (id) => id === 'theme-toggle' ? btn : orig(id);
+
+      exp.updateThemeIcon('light');
+      expect(btn.innerHTML).toContain('M8 12a4 4 0'); // sun icon path
+      expect(btn.title).toBe('Switch to dark mode');
+    });
+
     it('icons look the same on all pages', () => {
       const exp = setup('light');
       exp.initTheme();

--- a/tests/unit/theme-system.test.js
+++ b/tests/unit/theme-system.test.js
@@ -228,6 +228,45 @@ describe('Landing page theme toggle', () => {
       expect(sandbox.document.documentElement.getAttribute('data-theme')).toBe('light');
     });
 
+    it('produces visible change on first click with no stored preference and OS dark', () => {
+      // Bug #2: defaulting to 'light' causes invisible clicks for dark-mode users.
+      // With OS dark and no stored preference, the first click should visibly
+      // change the UI (dark → light), not be a no-op.
+      const exp = setup(undefined); // no stored preference
+      sandbox.window._osDark = true;
+      exp.initTheme();
+
+      // Display starts dark (OS is dark)
+      expect(sandbox.document.documentElement.getAttribute('data-theme')).toBe('dark');
+      expect(sandbox.localStorage.getItem('theme')).toBeNull();
+
+      // First click: should produce a visible change (dark → light)
+      exp.toggleTheme();
+      expect(sandbox.document.documentElement.getAttribute('data-theme')).toBe('light');
+      expect(sandbox.localStorage.getItem('theme')).toBe('light');
+    });
+
+    it('produces visible change on first click with no stored preference and OS light', () => {
+      // With OS light, system→light transition is invisible (both = light).
+      // This is the 1-invisible-click case — reduced from 2 with || 'light'.
+      // The first VISIBLE change happens on the second click: light → dark.
+      const exp = setup(undefined);
+      sandbox.window._osDark = false;
+      exp.initTheme();
+
+      expect(sandbox.document.documentElement.getAttribute('data-theme')).toBe('light');
+
+      // First click: saved = 'system' → next = 'light' → both resolve to light (invisible)
+      exp.toggleTheme();
+      expect(sandbox.document.documentElement.getAttribute('data-theme')).toBe('light');
+      expect(sandbox.localStorage.getItem('theme')).toBe('light');
+
+      // Second click: light → dark (visible change)
+      exp.toggleTheme();
+      expect(sandbox.document.documentElement.getAttribute('data-theme')).toBe('dark');
+      expect(sandbox.localStorage.getItem('theme')).toBe('dark');
+    });
+
     it('when OS is dark, "system" resolves to dark', () => {
       const exp = setup('light');
       sandbox.window._osDark = true;
@@ -348,6 +387,9 @@ describe('PR page toggleTheme with system support', () => {
     mgr.currentTheme = 'light';
     mgr.updateThemeIcon = vi.fn();
     mgr.pierreBridge = null;
+
+    // Start with an explicit 'light' preference so the cycle begins there
+    sandbox.localStorage.setItem('theme', 'light');
 
     // light → dark
     mgr.toggleTheme();

--- a/tests/unit/theme-system.test.js
+++ b/tests/unit/theme-system.test.js
@@ -280,6 +280,38 @@ describe('Landing page theme toggle', () => {
   });
 
   describe('matchMedia listener', () => {
+    it('does not throw when window.matchMedia is unavailable', () => {
+      // Regression: the module-level matchMedia listener should be guarded
+      // so index.js doesn't crash in non-browser contexts or test envs.
+      const vm = require('vm');
+      const fs = require('fs');
+      const path = require('path');
+      const code = fs.readFileSync(path.resolve(__dirname, '../../public/js/index.js'), 'utf8');
+
+      const sandbox = {
+        window: { addEventListener() {}, dispatchEvent() {}, location: { href: '' } },
+        // no matchMedia — this is what we're testing
+        document: {
+          documentElement: { setAttribute() {}, getAttribute() { return 'light'; } },
+          getElementById: () => ({ addEventListener() {}, classList: { add() {}, remove() {} } }),
+          addEventListener() {},
+          querySelector: () => null,
+          querySelectorAll: () => [],
+          createElement: () => ({ classList: { add() {} } }),
+          body: { style: {}, appendChild() {} },
+        },
+        localStorage: { getItem() { return null; }, setItem() {} },
+        console,
+        module: { exports: {} },
+        URLSearchParams,
+        fetch: () => Promise.resolve({ ok: true, json: () => Promise.resolve({}) }),
+        navigator: { clipboard: {} },
+      };
+
+      // Should not throw — the matchMedia call must be guarded
+      expect(() => vm.runInNewContext(code, sandbox, { filename: 'index.js' })).not.toThrow();
+    });
+
     it('updates theme when system changes and preference is "system"', () => {
       const exp = setup('system');
       exp.initTheme();

--- a/tests/unit/theme-system.test.js
+++ b/tests/unit/theme-system.test.js
@@ -25,8 +25,7 @@ const INDEX_PATH = '../../public/js/index.js';
 
 function loadExports() {
   delete require.cache[require.resolve(INDEX_PATH)];
-  // getElementById must return a stub with addEventListener so the IIFE
-  // init code at module scope doesn't crash on null.addEventListener.
+
   function el() { return { addEventListener() {}, classList: { add() {}, remove() {} } }; }
   const sandbox = {
     window: { matchMedia: vi.fn(() => ({ matches: false, addEventListener() {} })), addEventListener() {}, dispatchEvent() {}, location: { href: '' }, encodeBase64Utf8: () => '', getRepoStorageKey: () => '' },
@@ -49,6 +48,11 @@ function loadExports() {
   const vm = require('vm');
   const fs = require('fs');
   const path = require('path');
+
+  // Load theme.js in the sandbox first so window.__pairReview is populated.
+  const themeCode = fs.readFileSync(path.resolve(__dirname, '../../public/js/utils/theme.js'), 'utf8');
+  try { vm.runInNewContext(themeCode, sandbox, { filename: 'theme.js' }); } catch (e) { console.error(e.message); }
+
   const code = fs.readFileSync(path.resolve(__dirname, INDEX_PATH), 'utf8');
   try { vm.runInNewContext(code, sandbox, { filename: 'index.js' }); } catch (e) { console.error(e.message); }
   return sandbox.module.exports;
@@ -123,8 +127,6 @@ describe('Landing page theme toggle', () => {
 
   function setup(initialStoredTheme) {
     delete require.cache[require.resolve(INDEX_PATH)];
-
-    // Capture matchMedia listeners to simulate OS theme changes.
     /** @type {Array<Function>} */
     const matchMediaChangeListeners = [];
     let osPrefersDark = false;
@@ -179,6 +181,11 @@ describe('Landing page theme toggle', () => {
     const vm = require('vm');
     const fs = require('fs');
     const path = require('path');
+
+    // Load theme.js in the sandbox first so window.__pairReview is populated.
+    const themeCode = fs.readFileSync(path.resolve(__dirname, '../../public/js/utils/theme.js'), 'utf8');
+    try { vm.runInNewContext(themeCode, sandbox, { filename: 'theme.js' }); } catch (_) {}
+
     const code = fs.readFileSync(path.resolve(__dirname, INDEX_PATH), 'utf8');
     try { vm.runInNewContext(code, sandbox, { filename: 'index.js' }); } catch (_) {}
     return sandbox.module.exports;
@@ -286,7 +293,6 @@ describe('Landing page theme toggle', () => {
       const vm = require('vm');
       const fs = require('fs');
       const path = require('path');
-      const code = fs.readFileSync(path.resolve(__dirname, '../../public/js/index.js'), 'utf8');
 
       const sandbox = {
         window: { addEventListener() {}, dispatchEvent() {}, location: { href: '' } },
@@ -308,7 +314,11 @@ describe('Landing page theme toggle', () => {
         navigator: { clipboard: {} },
       };
 
-      // Should not throw — the matchMedia call must be guarded
+      // Load theme.js first — it has its own guards for missing matchMedia.
+      const themeCode = fs.readFileSync(path.resolve(__dirname, '../../public/js/utils/theme.js'), 'utf8');
+      expect(() => vm.runInNewContext(themeCode, sandbox, { filename: 'theme.js' })).not.toThrow();
+
+      const code = fs.readFileSync(path.resolve(__dirname, '../../public/js/index.js'), 'utf8');
       expect(() => vm.runInNewContext(code, sandbox, { filename: 'index.js' })).not.toThrow();
     });
 
@@ -339,26 +349,26 @@ describe('Landing page theme toggle', () => {
   });
 
   describe('updateThemeIcon', () => {
-    it('renders 16x16 filled icons (not 24x24 stroke)', () => {
+    it('icons look the same on all pages', () => {
       const exp = setup('light');
       exp.initTheme();
       const btn = { innerHTML: '', title: '' };
-      // Stub getElementById so updateThemeIcon writes to our mock button
       const orig = sandbox.document.getElementById;
       sandbox.document.getElementById = (id) => id === 'theme-toggle' ? btn : orig(id);
 
-      exp.updateThemeIcon('system');
-      expect(btn.innerHTML).toContain('width="16"');
-      expect(btn.innerHTML).toContain('height="16"');
-      expect(btn.innerHTML).not.toContain('stroke-width');
-
+      // The landing page icons are the reference.
       exp.updateThemeIcon('dark');
-      expect(btn.innerHTML).toContain('width="16"');
-      expect(btn.innerHTML).not.toContain('stroke-width');
-
+      const landingDark = btn.innerHTML;
       exp.updateThemeIcon('light');
-      expect(btn.innerHTML).toContain('width="16"');
-      expect(btn.innerHTML).not.toContain('stroke-width');
+      const landingLight = btn.innerHTML;
+      exp.updateThemeIcon('system');
+      const landingSystem = btn.innerHTML;
+
+      // All three should use the same SVG structure — only the icon shape differs.
+      // Strip the varying parts (path data, CSS class) and compare the skeleton.
+      const skeleton = (html) => html.replace(/ class="[^"]*"/g, '').replace(/ d="[^"]*"/g, '');
+      expect(skeleton(landingDark)).toBe(skeleton(landingLight));
+      expect(skeleton(landingDark)).toBe(skeleton(landingSystem));
     });
   });
 });
@@ -423,6 +433,11 @@ function loadPRManager() {
   const vm = require('vm');
   const fs = require('fs');
   const path = require('path');
+
+  // Load theme.js in the sandbox first so window.__pairReview is populated.
+  const themeCode = fs.readFileSync(path.resolve(__dirname, '../../public/js/utils/theme.js'), 'utf8');
+  vm.runInNewContext(themeCode, sandbox, { filename: 'theme.js' });
+
   const code = fs.readFileSync(path.resolve(__dirname, PR_PATH), 'utf8');
   vm.runInNewContext(code, sandbox, { filename: 'pr.js' });
 

--- a/tests/unit/theme-system.test.js
+++ b/tests/unit/theme-system.test.js
@@ -337,6 +337,30 @@ describe('Landing page theme toggle', () => {
       expect(sandbox.document.documentElement.getAttribute('data-theme')).toBe('dark');
     });
   });
+
+  describe('updateThemeIcon', () => {
+    it('renders 16x16 filled icons (not 24x24 stroke)', () => {
+      const exp = setup('light');
+      exp.initTheme();
+      const btn = { innerHTML: '', title: '' };
+      // Stub getElementById so updateThemeIcon writes to our mock button
+      const orig = sandbox.document.getElementById;
+      sandbox.document.getElementById = (id) => id === 'theme-toggle' ? btn : orig(id);
+
+      exp.updateThemeIcon('system');
+      expect(btn.innerHTML).toContain('width="16"');
+      expect(btn.innerHTML).toContain('height="16"');
+      expect(btn.innerHTML).not.toContain('stroke-width');
+
+      exp.updateThemeIcon('dark');
+      expect(btn.innerHTML).toContain('width="16"');
+      expect(btn.innerHTML).not.toContain('stroke-width');
+
+      exp.updateThemeIcon('light');
+      expect(btn.innerHTML).toContain('width="16"');
+      expect(btn.innerHTML).not.toContain('stroke-width');
+    });
+  });
 });
 
 // ────────────────────────────────────────────────────────────────────────────

--- a/tests/unit/theme-system.test.js
+++ b/tests/unit/theme-system.test.js
@@ -1,0 +1,391 @@
+// Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+/** @vitest-environment jsdom */
+
+/**
+ * Tests for system theme support (issue #487).
+ *
+ * Adds a "system" option to the theme toggle that follows
+ * `prefers-color-scheme`, cycling: light → dark → system → light.
+ *
+ * The TDD order:
+ * 1. Pure helpers (resolveTheme, nextTheme) — tested first, implemented first
+ * 2. Landing page (index.js) integration — toggle click cycles 3 states,
+ *    matchMedia listener responds when saved = 'system'
+ * 3. PR page (pr.js) — toggleTheme cycles light→dark→system→light
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// ────────────────────────────────────────────────────────────────────────────
+// 1. Pure helpers — resolveTheme  /  nextTheme
+// ────────────────────────────────────────────────────────────────────────────
+
+// We'll require from the index.js exports once implemented.
+const INDEX_PATH = '../../public/js/index.js';
+
+function loadExports() {
+  delete require.cache[require.resolve(INDEX_PATH)];
+  // getElementById must return a stub with addEventListener so the IIFE
+  // init code at module scope doesn't crash on null.addEventListener.
+  function el() { return { addEventListener() {}, classList: { add() {}, remove() {} } }; }
+  const sandbox = {
+    window: { matchMedia: vi.fn(() => ({ matches: false, addEventListener() {} })), addEventListener() {}, dispatchEvent() {}, location: { href: '' }, encodeBase64Utf8: () => '', getRepoStorageKey: () => '' },
+    document: {
+      documentElement: { setAttribute() {}, getAttribute() { return 'light'; } },
+      getElementById: el,
+      addEventListener() {},
+      querySelector: el,
+      querySelectorAll: () => [],
+      createElement: () => ({ classList: { add() {} } }),
+      body: { style: {}, appendChild() {} },
+    },
+    localStorage: { getItem() { return null; }, setItem() {} },
+    console,
+    module: { exports: {} },
+    URLSearchParams,
+    fetch: () => Promise.resolve({ ok: true, json: () => Promise.resolve({}) }),
+    navigator: { clipboard: {} },
+  };
+  const vm = require('vm');
+  const fs = require('fs');
+  const path = require('path');
+  const code = fs.readFileSync(path.resolve(__dirname, INDEX_PATH), 'utf8');
+  try { vm.runInNewContext(code, sandbox, { filename: 'index.js' }); } catch (e) { console.error(e.message); }
+  return sandbox.module.exports;
+}
+
+describe('resolveTheme (pure helper)', () => {
+  // This will fail until resolveTheme is exported from index.js
+  it('is exported from index.js', () => {
+    const exp = loadExports();
+    expect(exp).toHaveProperty('resolveTheme');
+    expect(typeof exp.resolveTheme).toBe('function');
+  });
+
+  it('returns "light" when preference is "light" regardless of system', () => {
+    const { resolveTheme } = loadExports();
+    expect(resolveTheme('light', true)).toBe('light');
+    expect(resolveTheme('light', false)).toBe('light');
+  });
+
+  it('returns "dark" when preference is "dark" regardless of system', () => {
+    const { resolveTheme } = loadExports();
+    expect(resolveTheme('dark', true)).toBe('dark');
+    expect(resolveTheme('dark', false)).toBe('dark');
+  });
+
+  it('returns system-dark when preference is "system" and OS is dark', () => {
+    const { resolveTheme } = loadExports();
+    expect(resolveTheme('system', true)).toBe('dark');
+  });
+
+  it('returns system-light when preference is "system" and OS is light', () => {
+    const { resolveTheme } = loadExports();
+    expect(resolveTheme('system', false)).toBe('light');
+  });
+
+  it('falls back to system when no preference stored (null)', () => {
+    const { resolveTheme } = loadExports();
+    expect(resolveTheme(null, true)).toBe('dark');
+    expect(resolveTheme(null, false)).toBe('light');
+  });
+
+  it('falls back to system when preference is undefined', () => {
+    const { resolveTheme } = loadExports();
+    expect(resolveTheme(undefined, true)).toBe('dark');
+    expect(resolveTheme(undefined, false)).toBe('light');
+  });
+});
+
+describe('nextTheme (pure helper)', () => {
+  it('is exported from index.js', () => {
+    const exp = loadExports();
+    expect(exp).toHaveProperty('nextTheme');
+    expect(typeof exp.nextTheme).toBe('function');
+  });
+
+  it('cycles light → dark → system → light', () => {
+    const { nextTheme } = loadExports();
+    expect(nextTheme('light')).toBe('dark');
+    expect(nextTheme('dark')).toBe('system');
+    expect(nextTheme('system')).toBe('light');
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// 2. Landing page (index.js) toggle click integration
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('Landing page theme toggle', () => {
+  /** @type {import('vm').Context} */
+  let sandbox;
+  let exports;
+
+  function setup(initialStoredTheme) {
+    delete require.cache[require.resolve(INDEX_PATH)];
+
+    // Capture matchMedia listeners to simulate OS theme changes.
+    /** @type {Array<Function>} */
+    const matchMediaChangeListeners = [];
+    let osPrefersDark = false;
+
+    function el() { return { addEventListener() {}, classList: { add() {}, remove() {} } }; }
+
+    sandbox = {
+      window: {
+        matchMedia: vi.fn((query) => ({
+          matches: osPrefersDark,
+          addEventListener: (_event, fn) => matchMediaChangeListeners.push(fn),
+          removeEventListener: () => {},
+        })),
+        addEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+        location: { href: '' },
+        // Allow tests to toggle OS preference
+        set _osDark(v) {
+          osPrefersDark = v;
+          for (const fn of matchMediaChangeListeners) fn({ matches: v });
+        },
+      },
+      document: {
+        documentElement: {
+          _attr: {},
+          setAttribute(name, val) { this._attr[name] = val; },
+          getAttribute(name) { return this._attr[name] || null; },
+        },
+        getElementById: el,
+        addEventListener: vi.fn(),
+        querySelector: el,
+        querySelectorAll: () => [],
+        createElement: () => ({ classList: { add() {} } }),
+        body: { style: {}, appendChild() {} },
+      },
+      localStorage: {
+        _store: {},
+        getItem(key) { return key in this._store ? this._store[key] : null; },
+        setItem(key, val) { this._store[key] = val; },
+      },
+      console,
+      module: { exports: {} },
+      URLSearchParams,
+      fetch: () => Promise.resolve({ ok: true, json: () => Promise.resolve({}) }),
+      navigator: { clipboard: {} },
+    };
+
+    if (initialStoredTheme !== undefined) {
+      sandbox.localStorage.setItem('theme', initialStoredTheme);
+    }
+
+    const vm = require('vm');
+    const fs = require('fs');
+    const path = require('path');
+    const code = fs.readFileSync(path.resolve(__dirname, INDEX_PATH), 'utf8');
+    try { vm.runInNewContext(code, sandbox, { filename: 'index.js' }); } catch (_) {}
+    return sandbox.module.exports;
+  }
+
+  describe('initTheme', () => {
+    it('is exported from index.js', () => {
+      const exp = setup();
+      expect(exp).toHaveProperty('initTheme');
+      expect(typeof exp.initTheme).toBe('function');
+    });
+
+    it('resolves "system" to OS preference on init', () => {
+      const exp = setup('system');
+      exp.initTheme();
+      expect(sandbox.document.documentElement.getAttribute('data-theme')).toBe('light');
+    });
+
+    it('resolves "dark" directly on init', () => {
+      const exp = setup('dark');
+      exp.initTheme();
+      expect(sandbox.document.documentElement.getAttribute('data-theme')).toBe('dark');
+    });
+  });
+
+  describe('toggleTheme', () => {
+    it('is exported from index.js', () => {
+      const exp = setup();
+      expect(exp).toHaveProperty('toggleTheme');
+      expect(typeof exp.toggleTheme).toBe('function');
+    });
+
+    it('cycles light → dark → system → light', () => {
+      const exp = setup('light');
+      exp.initTheme();
+
+      exp.toggleTheme();
+      expect(sandbox.localStorage.getItem('theme')).toBe('dark');
+      expect(sandbox.document.documentElement.getAttribute('data-theme')).toBe('dark');
+
+      exp.toggleTheme();
+      expect(sandbox.localStorage.getItem('theme')).toBe('system');
+      expect(sandbox.document.documentElement.getAttribute('data-theme')).toBe('light'); // OS is light
+
+      exp.toggleTheme();
+      expect(sandbox.localStorage.getItem('theme')).toBe('light');
+      expect(sandbox.document.documentElement.getAttribute('data-theme')).toBe('light');
+    });
+
+    it('when OS is dark, "system" resolves to dark', () => {
+      const exp = setup('light');
+      sandbox.window._osDark = true;
+      exp.initTheme();
+
+      exp.toggleTheme(); // light → dark
+      exp.toggleTheme(); // dark → system → resolves to 'dark' because OS is dark
+      expect(sandbox.document.documentElement.getAttribute('data-theme')).toBe('dark');
+      expect(sandbox.localStorage.getItem('theme')).toBe('system');
+    });
+  });
+
+  describe('matchMedia listener', () => {
+    it('updates theme when system changes and preference is "system"', () => {
+      const exp = setup('system');
+      exp.initTheme();
+
+      // OS was light on init
+      expect(sandbox.document.documentElement.getAttribute('data-theme')).toBe('light');
+
+      // OS switches to dark
+      sandbox.window._osDark = true;
+      expect(sandbox.document.documentElement.getAttribute('data-theme')).toBe('dark');
+
+      // OS switches back to light
+      sandbox.window._osDark = false;
+      expect(sandbox.document.documentElement.getAttribute('data-theme')).toBe('light');
+    });
+
+    it('ignores system changes when user picked light or dark', () => {
+      const exp = setup('dark');
+      exp.initTheme();
+
+      sandbox.window._osDark = false; // OS switches to light
+      // User picked 'dark' — should NOT change
+      expect(sandbox.document.documentElement.getAttribute('data-theme')).toBe('dark');
+    });
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// 3. PR page (pr.js) toggleTheme method
+// ────────────────────────────────────────────────────────────────────────────
+
+const PR_PATH = '../../public/js/pr.js';
+
+function loadPRManager() {
+  delete require.cache[require.resolve(PR_PATH)];
+
+  let osPrefersDark = false;
+  /** @type {Array<Function>} */
+  const matchMediaChangeListeners = [];
+
+  const sandbox = {
+    window: {
+      matchMedia: vi.fn((query) => ({
+        matches: osPrefersDark,
+        addEventListener: (_event, fn) => matchMediaChangeListeners.push(fn),
+        removeEventListener: () => {},
+        get listeners() { return matchMediaChangeListeners; },
+      })),
+      getRepoStorageKey: () => '',
+    },
+    document: {
+      documentElement: {
+        _attr: { 'data-theme': 'light' },
+        setAttribute(name, val) { this._attr[name] = val; },
+        getAttribute(name) { return this._attr[name] || null; },
+      },
+      getElementById: vi.fn(() => ({ addEventListener() {} })),
+      addEventListener: vi.fn(),
+      querySelector: vi.fn(() => null),
+      querySelectorAll: vi.fn(() => []),
+      createElement: vi.fn(() => ({ classList: { add: vi.fn() }, appendChild: vi.fn(), style: {} })),
+      body: { appendChild: vi.fn(), style: {} },
+    },
+    localStorage: {
+      _store: {},
+      getItem(key) { return key in this._store ? this._store[key] : null; },
+      setItem(key, val) { this._store[key] = val; },
+    },
+    fetch: vi.fn(() => Promise.resolve({ ok: false, status: 404, json: () => Promise.resolve({}) })),
+    navigator: { clipboard: {} },
+    setTimeout,
+    clearTimeout,
+    URLSearchParams,
+    console,
+    module: { exports: {} },
+  };
+  // PR.js accesses `window.matchMedia`; since sandbox.window = sandbox,
+  // copy matchMedia up to the sandbox level.
+  sandbox.matchMedia = sandbox.window.matchMedia;
+  sandbox.getRepoStorageKey = sandbox.window.getRepoStorageKey;
+  sandbox.globalThis = sandbox;
+  sandbox.self = sandbox;
+  sandbox.window = sandbox;
+
+  const vm = require('vm');
+  const fs = require('fs');
+  const path = require('path');
+  const code = fs.readFileSync(path.resolve(__dirname, PR_PATH), 'utf8');
+  vm.runInNewContext(code, sandbox, { filename: 'pr.js' });
+
+  return {
+    PRManager: sandbox.module.exports.PRManager,
+    sandbox,
+    setOsDark(v) {
+      osPrefersDark = v;
+      for (const fn of matchMediaChangeListeners) fn({ matches: v });
+    },
+  };
+}
+
+describe('PR page toggleTheme with system support', () => {
+  it('cycles stored preference light → dark → system → light', () => {
+    const { PRManager, sandbox } = loadPRManager();
+    const mgr = Object.create(PRManager.prototype);
+    mgr.currentTheme = 'light';
+    mgr.updateThemeIcon = vi.fn();
+    mgr.pierreBridge = null;
+
+    // light → dark
+    mgr.toggleTheme();
+    expect(sandbox.localStorage.getItem('theme')).toBe('dark');
+
+    // dark → system
+    mgr.toggleTheme();
+    expect(sandbox.localStorage.getItem('theme')).toBe('system');
+
+    // system → light
+    mgr.toggleTheme();
+    expect(sandbox.localStorage.getItem('theme')).toBe('light');
+  });
+
+  it('resolves system to OS preference when toggling to system', () => {
+    const { PRManager, sandbox, setOsDark } = loadPRManager();
+    const mgr = Object.create(PRManager.prototype);
+    mgr.currentTheme = 'dark';
+    mgr.updateThemeIcon = vi.fn();
+    mgr.pierreBridge = null;
+
+    setOsDark(true); // OS is dark
+    sandbox.localStorage.setItem('theme', 'dark'); // start with explicit dark
+    mgr.toggleTheme(); // dark → system
+    expect(sandbox.localStorage.getItem('theme')).toBe('system');
+    // currentTheme should resolve to 'dark' because OS is dark
+    expect(mgr.currentTheme).toBe('dark');
+  });
+
+  it('saves "system" to localStorage when toggled to system', () => {
+    const { PRManager, sandbox } = loadPRManager();
+    const mgr = Object.create(PRManager.prototype);
+    mgr.currentTheme = 'dark';
+    mgr.updateThemeIcon = vi.fn();
+    mgr.pierreBridge = null;
+
+    sandbox.localStorage.setItem('theme', 'dark'); // start with explicit dark
+    mgr.toggleTheme(); // dark → system
+    expect(sandbox.localStorage.getItem('theme')).toBe('system');
+  });
+});


### PR DESCRIPTION
Closes #487

Add a 'system' value to the theme toggle that follows the OS dark/light
schedule via prefers-color-scheme. The toggle cycles through three states:
light → dark → system → light.

### What this does for users

- **System mode follows the OS** — when selected, the theme matches your
  macOS/Windows dark/light schedule and updates in real-time as it changes
- **Visible first click** — first-time visitors always get a visible theme
  change on the first toggle click, regardless of OS mode
- **Works everywhere** — toolbar toggle, global settings page, and config
  file all support 'light', 'dark', and 'system'
- **Consistent look** — the toggle icon (sun, moon, or monitor) looks the
  same on every page