### PR TITLE
fix: minimize-comments overlays and split-view paint clipping under @pierre/diffs

### DIFF
--- a/.changeset/fix-empty-card-one-sided-split.md
+++ b/.changeset/fix-empty-card-one-sided-split.md
@@ -1,0 +1,15 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Fix: in split (side-by-side) view, comments on entirely added or entirely
+removed files rendered as empty cards — the card border and action buttons
+showed, but the header text and comment body were invisible.
+
+Boxing a one-sided file's lone code column into the split grid made it a real
+box, which activated the vendor's `contain: content` (paint containment). That
+clipped the full-width-stretched annotation card's paint to the column's own
+half, hiding the header and body (which stretch into the adjacent half) while
+the right-aligned buttons stayed visible. The one-sided column CSS now drops
+paint containment (`contain: layout style`) alongside the existing
+`overflow: visible`, so the whole card paints.

--- a/.changeset/fix-minimize-comments-pierre.md
+++ b/.changeset/fix-minimize-comments-pierre.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Fix "Minimize comments" mode under the @pierre/diffs renderer. Line-level indicators and card hiding were dead after the diff migration: AI suggestion cards were never hidden at all, and no per-line indicator appeared for comments, suggestions, or external threads. The minimizer now groups annotation cards by the vendor's stable per-line slot and hides suggestion/comment/external cards, collapsing each annotation row to zero height and floating a single clickable indicator pill over the anchor line's right edge (so minimized comments no longer break up the diff). Expansion state is restored across the renderer's rerenders, and indicators are re-injected after diff-style switches, hunk expansion, and highlight streaming. Works in unified and split view, including one-sided (entirely-added/removed) files.

--- a/public/css/pr.css
+++ b/public/css/pr.css
@@ -1686,7 +1686,11 @@ body:not(.tour-active) .d2h-file-wrapper tr,
 body:not(.tour-active) .ai-suggestion,
 body:not(.tour-active) .file-comment-card,
 body:not(.tour-active) .user-comment-row,
-body:not(.tour-active) .external-comment-row {
+body:not(.tour-active) .external-comment-row,
+/* Minimize mode: navigation scrolls to the vendor annotation wrapper
+   (CommentMinimizer.findDiffRowFor returns it), which is not one of the card
+   elements above — give it the same offset so it clears the sticky toolbar. */
+body:not(.tour-active) #diff-container [data-annotation-slot] {
   scroll-margin-top: var(--diff-scroll-offset);
 }
 
@@ -7649,29 +7653,32 @@ body.resizing * {
    Comment Minimize Mode
    -------------------------------------------------------------------------- */
 
-/* When minimize mode is active, hide all inline comment, suggestion, and
-   external-comment rows */
-.comments-minimized .user-comment-row,
-.comments-minimized .ai-suggestion-row,
-.comments-minimized .external-comment-row {
+/* When minimize mode is active, hide the inline comment, suggestion and
+   external-comment cards anchored to diff lines. Under @pierre/diffs each card
+   is slotted inside a vendor `[data-annotation-slot]` wrapper below its line;
+   scoping the hide to those wrappers leaves file-comments-zone cards and
+   AI-panel cards (which are NOT inside a slot wrapper) untouched. */
+#diff-container.comments-minimized [data-annotation-slot] > .user-comment-row,
+#diff-container.comments-minimized [data-annotation-slot] > .ai-suggestion,
+#diff-container.comments-minimized [data-annotation-slot] > .external-comment-row {
   display: none;
 }
 
-/* Per-line expansion override — clicking an indicator reveals that line's rows */
-.comments-minimized .user-comment-row.comment-expanded,
-.comments-minimized .ai-suggestion-row.comment-expanded,
-.comments-minimized .external-comment-row.comment-expanded {
-  display: table-row;
+/* Per-line expansion override — clicking an indicator reveals that line's cards */
+#diff-container.comments-minimized [data-annotation-slot] > .user-comment-row.comment-expanded,
+#diff-container.comments-minimized [data-annotation-slot] > .ai-suggestion.comment-expanded,
+#diff-container.comments-minimized [data-annotation-slot] > .external-comment-row.comment-expanded {
+  display: block;
 }
 
-/* File-level external comments live in the always-visible file-comments-zone,
-   not on a diff line. They have no per-line indicator to reveal them (the
-   minimizer's line scan skips zone cards, and its file-header indicator counts
-   only .file-comment-card), so the blanket .external-comment-row hide above
-   must not apply to cards inside a zone — keep them visible when minimized.
-   Higher specificity (three classes) wins over the two-class hide rule. */
-.comments-minimized .file-comments-zone .external-comment-row {
-  display: block;
+/* A collapsed annotation row must add ZERO vertical space so it doesn't read
+   as a "collapsed comment" breaking up the diff. The hidden card already gives
+   the wrapper 0 height; we only make it a positioning context so the indicator
+   pill can float OVER the anchor code line above (annotations render below
+   their anchor line). The vendor annotation cell defaults to min-height:0 with
+   no padding/row-gap, so the row genuinely collapses. */
+#diff-container.comments-minimized [data-annotation-slot]:has(> .comment-indicator) {
+  position: relative;
 }
 
 /* When minimize mode is active, hide file-level comment cards */
@@ -7758,12 +7765,17 @@ body.resizing * {
   border-width: 2px;
 }
 
-/* Indicator button on the right edge of diff code cells */
+/* Line-level indicator — a small pill floated over the right edge of the
+   anchor code line. It lives in the light-DOM `[data-annotation-slot]` wrapper
+   (a zero-height positioning context, see above) and is absolutely positioned
+   so it contributes no layout height: `bottom: 100%` lifts it out of the
+   zero-height row up onto the anchor line directly above. */
 .comment-indicator {
   position: absolute;
-  right: 4px;
-  top: 50%;
-  transform: translateY(-50%);
+  right: 8px;
+  bottom: 100%;
+  transform: translateY(50%); /* straddle the line's lower edge, matching legacy */
+  z-index: 3; /* above line content (annotation cell is z-index:2); below sticky headers (4) */
   display: inline-flex;
   align-items: center;
   gap: 3px;
@@ -7772,12 +7784,12 @@ body.resizing * {
   border-radius: 12px;
   background: var(--color-bg-secondary);
   cursor: pointer;
+  pointer-events: auto;
   font-size: 11px;
   line-height: 1;
   color: var(--color-text-secondary);
-  opacity: 1;
+  flex-shrink: 0;
   transition: background 0.15s ease, box-shadow 0.15s ease, border-color 0.15s ease;
-  z-index: 2; /* must be below sticky file headers (z-index: 4) */
 }
 
 .comment-indicator:hover {

--- a/public/js/modules/comment-minimizer.js
+++ b/public/js/modules/comment-minimizer.js
@@ -2,16 +2,29 @@
 /**
  * CommentMinimizer - Manages "minimize comments" mode for the diff view.
  *
- * When active, all inline comment rows (.user-comment-row, .ai-suggestion-row,
- * and .external-comment-row) are hidden via CSS class. Small indicator
- * buttons are injected on the right edge of each diff line that has
- * comments, showing a person icon (user comments), sparkles icon (AI
- * suggestions), or chat-bubble icon (external review comments).
+ * When active, all inline comment cards (.user-comment-row), AI suggestion
+ * cards (.ai-suggestion) and external review threads (.external-comment-row)
+ * anchored to diff lines are hidden via CSS. A single small clickable
+ * indicator is injected for each diff line that has hidden cards, showing a
+ * person icon (user comments), AI-comment icon (adopted suggestions),
+ * sparkles icon (AI suggestions) or chat-bubble icon (external comments),
+ * with a count badge when a line holds more than one card.
  *
  * File-level comments (.file-comment-card inside .file-comments-zone) are also
  * hidden, with an indicator button injected into the file header bar.
  *
- * Clicking an indicator toggles visibility of that line's or file's comments.
+ * Clicking an indicator toggles visibility of that line's or file's cards.
+ *
+ * ── @pierre/diffs rendering ──────────────────────────────────────────────
+ * Diff lines are shadow-DOM elements owned by the vendor renderer; annotation
+ * cards live in the LIGHT DOM, each wrapped by the vendor in a
+ * `<div data-annotation-slot slot="annotation-{side}-{lineNumber}">` that is a
+ * child of the file's `<diffs-container>` host and projected into the matching
+ * shadow annotation cell. All cards anchored to the same line+side share the
+ * same `slot` value, so we group by `{fileName}\0{slot}` — a STABLE string key
+ * that survives the vendor's card-recreating rerenders (element identity does
+ * NOT survive them). The line-level indicator is injected into the first
+ * wrapper of each group (light DOM, so page CSS reaches it).
  */
 
 class CommentMinimizer {
@@ -29,10 +42,18 @@ class CommentMinimizer {
 
   constructor() {
     this._active = false;
-    // Track which diff lines have been expanded by the user (Set of diff row elements)
+    // Diff lines the user has expanded, keyed by the STABLE string
+    // `${fileName}\0${slot}` (see class doc). NOT element references — the
+    // vendor recreates annotation wrappers on every rerender.
     this._expandedLines = new Set();
-    // Track which file-comments-zones have been expanded (Set of zone elements)
+    // Files whose file-level zone has been expanded (Set of zone elements —
+    // zones are pr.js light DOM, not vendor-managed, so they persist).
     this._expandedFiles = new Set();
+    // MutationObserver that re-injects indicators after vendor rerenders
+    // (diffStyle switch, hunk expansion, worker-highlight streaming, lazy file
+    // render) that are NOT followed by an explicit refreshIndicators() call.
+    this._observer = null;
+    this._refreshScheduled = false;
   }
 
   /** @returns {boolean} Whether minimize mode is active */
@@ -55,7 +76,9 @@ class CommentMinimizer {
     if (minimized) {
       diffContainer.classList.add('comments-minimized');
       this.refreshIndicators();
+      this._startObserving();
     } else {
+      this._stopObserving();
       diffContainer.classList.remove('comments-minimized');
       this._removeAllIndicators();
       // Remove any per-line expansion overrides
@@ -66,118 +89,163 @@ class CommentMinimizer {
   }
 
   /**
-   * Rebuild all indicator buttons on diff lines.
+   * Rebuild all indicator buttons on diff lines and file headers.
    * Call this after comments or suggestions are added/removed/re-rendered.
+   * Idempotent: starts by removing every existing indicator.
    */
   refreshIndicators() {
     if (!this._active) return;
 
-    this._removeAllIndicators();
+    // The vendor recreates annotation wrappers as we inject indicators; pause
+    // the observer so our own DOM writes don't re-trigger a refresh loop.
+    this._stopObserving();
+    try {
+      this._removeAllIndicators();
 
-    // Find all comment, suggestion, and external-comment rows currently in the DOM
-    const commentRows = document.querySelectorAll('.user-comment-row');
-    const suggestionRows = document.querySelectorAll('.ai-suggestion-row');
-    const externalRows = document.querySelectorAll('.external-comment-row');
+      // Line-level: group the vendor annotation wrappers by file + slot.
+      for (const group of this._buildLineGroups().values()) {
+        this._injectLineIndicator(group);
+      }
 
-    // Build a map: diff row element → indicator info entry
-    const lineMap = new Map();
+      // File-level indicators (pr.js light DOM — unchanged path).
+      this._refreshFileIndicators();
+    } finally {
+      if (this._active) this._startObserving();
+    }
+  }
+
+  /**
+   * Build a map of line-level groups keyed by `${fileName}\0${slot}`.
+   * Each group aggregates the hidden cards anchored to one line+side and keeps
+   * references to their vendor wrappers (`[data-annotation-slot]`).
+   * @returns {Map<string, {key: string, wrappers: HTMLElement[], info: Object}>}
+   * @private
+   */
+  _buildLineGroups() {
+    const groups = new Map();
     const newEntry = () => ({
       hasUser: false, hasAI: false, hasAdopted: false, hasExternal: false,
       userCount: 0, aiCount: 0, adoptedCount: 0, externalCount: 0
     });
 
-    for (const row of commentRows) {
-      const diffRow = this._findDiffRowFor(row);
-      if (!diffRow) continue;
-      const entry = lineMap.get(diffRow) || newEntry();
-      if (row.querySelector('.adopted-comment')) {
-        entry.hasAdopted = true;
-        entry.adoptedCount++;
-      } else {
-        entry.hasUser = true;
-        entry.userCount++;
-      }
-      lineMap.set(diffRow, entry);
-    }
+    const wrappers = document.querySelectorAll('#diff-container [data-annotation-slot]');
+    for (const wrapper of wrappers) {
+      const card = this._cardOf(wrapper);
+      if (!card) continue;
 
-    for (const row of suggestionRows) {
-      const diffRow = this._findDiffRowFor(row);
-      if (!diffRow) continue;
-      const entry = lineMap.get(diffRow) || newEntry();
-      // Count non-adopted suggestion divs only — adopted ones are already
-      // represented by the adopted comment row (avoid double-counting)
-      const allSuggestions = row.querySelectorAll('.ai-suggestion');
-      let activeCount = 0;
-      for (const s of allSuggestions) {
-        if (!s.dataset?.hiddenForAdoption) {
-          activeCount++;
+      const isComment = card.classList.contains('user-comment-row');
+      const isSuggestion = card.classList.contains('ai-suggestion');
+      const isExternal = card.classList.contains('external-comment-row');
+      // Skip comment forms, tour stops, hunk summaries — those stay visible.
+      if (!isComment && !isSuggestion && !isExternal) continue;
+
+      const key = this._lineKeyFor(wrapper);
+      if (!key) continue;
+
+      let group = groups.get(key);
+      if (!group) {
+        group = { key, wrappers: [], info: newEntry() };
+        groups.set(key, group);
+      }
+      group.wrappers.push(wrapper);
+      const info = group.info;
+
+      if (isComment) {
+        // Adopted AI suggestions render with an inner `.adopted-comment` card.
+        if (card.querySelector('.adopted-comment')) {
+          info.hasAdopted = true;
+          info.adoptedCount++;
+        } else {
+          info.hasUser = true;
+          info.userCount++;
         }
+      } else if (isSuggestion) {
+        // A suggestion hidden for adoption is already represented by its
+        // adopted comment card — don't double-count it. The flag is a string:
+        // 'true' when adopted, and suggestion-ui.js writes the literal 'false'
+        // on runtime restore, so compare against 'true' (not truthiness) or a
+        // restored suggestion would be wrongly dropped from the count.
+        if (card.dataset?.hiddenForAdoption !== 'true') {
+          info.hasAI = true;
+          info.aiCount++;
+        }
+      } else {
+        // External thread: count root + replies so the badge matches the
+        // total the thread card itself shows.
+        const bubbles = card.querySelectorAll('.external-comment');
+        info.hasExternal = true;
+        info.externalCount += (bubbles.length || 1);
       }
-      if (activeCount > 0) {
-        entry.hasAI = true;
-        entry.aiCount += activeCount;
-      }
-      lineMap.set(diffRow, entry);
     }
 
-    for (const row of externalRows) {
-      const diffRow = this._findDiffRowFor(row);
-      if (!diffRow) continue;
-      const entry = lineMap.get(diffRow) || newEntry();
-      // Count root + replies — each .external-comment is one bubble in the
-      // thread card and the reviewer should see the same total here that
-      // the thread itself shows.
-      const bubbles = row.querySelectorAll('.external-comment');
-      const bubbleCount = bubbles.length || 1;
-      entry.hasExternal = true;
-      entry.externalCount += bubbleCount;
-      lineMap.set(diffRow, entry);
-    }
-
-    // Inject line-level indicators
-    for (const [diffRow, info] of lineMap) {
-      this._injectIndicator(diffRow, info);
-    }
-
-    // Scan file-comments-zones and inject file-header indicators
-    this._refreshFileIndicators();
+    return groups;
   }
 
   /**
-   * Walk backward from a comment/suggestion/external row to find its parent
-   * diff line. Skips other comment/suggestion/external rows and
-   * context-expand rows.
-   * @param {HTMLElement} row
+   * The annotation card element inside a vendor `[data-annotation-slot]`
+   * wrapper (the element returned by PierreBridge's renderAnnotation).
+   * @param {HTMLElement} wrapper
    * @returns {HTMLElement|null}
+   * @private
    */
-  _findDiffRowFor(row) {
-    let prev = row.previousElementSibling;
-    while (prev) {
-      if (
-        !prev.classList.contains('user-comment-row') &&
-        !prev.classList.contains('ai-suggestion-row') &&
-        !prev.classList.contains('external-comment-row') &&
-        !prev.classList.contains('comment-form-row') &&
-        !prev.classList.contains('context-expand-row')
-      ) {
-        return prev;
-      }
-      prev = prev.previousElementSibling;
-    }
-    return null;
+  _cardOf(wrapper) {
+    return wrapper.firstElementChild || null;
   }
 
   /**
-   * Inject an indicator button into a diff line's code cell.
-   * @param {HTMLElement} diffRow - The diff table row
-   * @param {Object} info - { hasUser, hasAI, hasAdopted, userCount, aiCount, adoptedCount }
+   * Stable grouping key for a vendor annotation wrapper: the owning file plus
+   * the vendor slot name (`annotation-{side}-{lineNumber}`). Wrappers on the
+   * same line+side share a slot, so they share a key.
+   * @param {HTMLElement} wrapper
+   * @returns {string|null}
+   * @private
    */
-  _injectIndicator(diffRow, info) {
-    const codeCell = diffRow.querySelector('.d2h-code-line-ctn');
-    if (!codeCell) return;
+  _lineKeyFor(wrapper) {
+    const slot = wrapper.getAttribute('slot');
+    if (!slot) return null;
+    const fileWrapper = wrapper.closest('.d2h-file-wrapper');
+    const file = fileWrapper?.dataset?.fileName || '';
+    return `${file}\0${slot}`;
+  }
 
-    // Don't double-inject
-    if (codeCell.querySelector('.comment-indicator')) return;
+  /**
+   * All vendor annotation wrappers that share a group key (a line+side).
+   * @param {string} key
+   * @returns {HTMLElement[]}
+   * @private
+   */
+  _wrappersForKey(key) {
+    const out = [];
+    for (const wrapper of document.querySelectorAll('#diff-container [data-annotation-slot]')) {
+      if (this._lineKeyFor(wrapper) === key) out.push(wrapper);
+    }
+    return out;
+  }
+
+  /**
+   * Inject a single indicator button for a line group into the first wrapper,
+   * and sync the group's expanded/collapsed card visibility.
+   * @param {{key: string, wrappers: HTMLElement[], info: Object}} group
+   * @private
+   */
+  _injectLineIndicator(group) {
+    const first = group.wrappers[0];
+    if (!first) return;
+
+    // Nothing to represent — e.g. the line's only card is a suggestion hidden
+    // for adoption (represented by its adopted comment elsewhere). Injecting
+    // here would produce an empty button with no icon, count, or title.
+    const info = group.info;
+    const total = info.userCount + info.adoptedCount + info.aiCount + info.externalCount;
+    if (total === 0) return;
+
+    // Sync card visibility to the persisted expanded state (survives rerenders
+    // because the state is keyed by the stable group key).
+    const expanded = this._expandedLines.has(group.key);
+    this._applyExpanded(group.wrappers, expanded);
+
+    // Don't double-inject.
+    if (first.querySelector(':scope > .comment-indicator')) return;
 
     const btn = document.createElement('button');
     btn.className = 'comment-indicator';
@@ -202,7 +270,6 @@ class CommentMinimizer {
       icons.push(`<span class="indicator-icon indicator-external" title="${info.externalCount} external comment${info.externalCount !== 1 ? 's' : ''}">${CommentMinimizer.EXTERNAL_ICON}</span>`);
     }
 
-    const total = info.userCount + info.adoptedCount + info.aiCount + info.externalCount;
     const countBadge = total > 1 ? `<span class="indicator-count">${total}</span>` : '';
 
     btn.innerHTML = icons.join('') + countBadge;
@@ -214,118 +281,81 @@ class CommentMinimizer {
     if (info.externalCount) totalLabel.push(`${info.externalCount} external comment${info.externalCount !== 1 ? 's' : ''}`);
     btn.title = totalLabel.join(', ');
 
-    // Check if this line was previously expanded. Re-applying
-    // `.comment-expanded` to the (possibly rebuilt) comment rows is
-    // important: when an external-comment refresh tears down and rebuilds
-    // `.external-comment-row` elements, the new rows have no expanded
-    // class even though the indicator button is still marked expanded.
-    // Without this step the indicator says "open" but the rows stay
-    // hidden via the `.comments-minimized` display: none rule.
-    if (this._expandedLines.has(diffRow)) {
+    if (expanded) {
       btn.classList.add('expanded');
-      this._getCommentRowsFor(diffRow).forEach(row => row.classList.add('comment-expanded'));
     }
 
-    // Click handler: toggle this line's comments
+    // Click handler toggles this line's cards. Closes over the current
+    // wrappers; a rerender replaces both wrappers and handler together.
     btn.addEventListener('click', (e) => {
       e.stopPropagation();
       e.preventDefault();
-      this._toggleLineComments(diffRow, btn);
+      this._toggleLineComments(group.key, btn);
     });
 
-    // Make the code cell position:relative for absolute positioning of the indicator
-    codeCell.style.position = 'relative';
-    codeCell.appendChild(btn);
+    first.appendChild(btn);
   }
 
   /**
-   * Toggle visibility of comment/suggestion rows for a specific diff line.
-   * @param {HTMLElement} diffRow
+   * Show or hide the cards of a line group by toggling `.comment-expanded` on
+   * each wrapper's card element.
+   * @param {HTMLElement[]} wrappers
+   * @param {boolean} expanded
+   * @private
+   */
+  _applyExpanded(wrappers, expanded) {
+    for (const wrapper of wrappers) {
+      const card = this._cardOf(wrapper);
+      if (card) card.classList.toggle('comment-expanded', expanded);
+    }
+  }
+
+  /**
+   * Toggle visibility of the cards for one line group.
+   * @param {string} key - The stable group key
    * @param {HTMLElement} btn - The indicator button
+   * @private
    */
-  _toggleLineComments(diffRow, btn) {
-    const isExpanded = this._expandedLines.has(diffRow);
-
-    if (isExpanded) {
-      // Collapse: remove .comment-expanded from this line's rows
-      this._expandedLines.delete(diffRow);
+  _toggleLineComments(key, btn) {
+    const wrappers = this._wrappersForKey(key);
+    if (this._expandedLines.has(key)) {
+      this._expandedLines.delete(key);
       btn.classList.remove('expanded');
-      this._getCommentRowsFor(diffRow).forEach(row => row.classList.remove('comment-expanded'));
+      this._applyExpanded(wrappers, false);
     } else {
-      // Expand: add .comment-expanded to this line's rows
-      this._expandedLines.add(diffRow);
+      this._expandedLines.add(key);
       btn.classList.add('expanded');
-      this._getCommentRowsFor(diffRow).forEach(row => row.classList.add('comment-expanded'));
+      this._applyExpanded(wrappers, true);
     }
   }
 
   /**
-   * Get all comment/suggestion rows that belong to a diff line.
-   * Walks forward from the diff row, collecting adjacent comment/suggestion rows.
-   * @param {HTMLElement} diffRow
-   * @returns {HTMLElement[]}
-   */
-  _getCommentRowsFor(diffRow) {
-    const rows = [];
-    let next = diffRow.nextElementSibling;
-    while (next) {
-      if (
-        next.classList.contains('user-comment-row') ||
-        next.classList.contains('ai-suggestion-row') ||
-        next.classList.contains('external-comment-row')
-      ) {
-        rows.push(next);
-      } else if (
-        next.classList.contains('comment-form-row') ||
-        next.classList.contains('context-expand-row')
-      ) {
-        // Skip these but keep looking
-        next = next.nextElementSibling;
-        continue;
-      } else {
-        // Hit another diff line — stop
-        break;
-      }
-      next = next.nextElementSibling;
-    }
-    return rows;
-  }
-
-  /**
-   * Find the parent diff row for a given comment/suggestion element.
-   * Public wrapper around _findDiffRowFor that first locates the containing
-   * comment/suggestion row from any child element.
-   * @param {HTMLElement} element - Any element inside (or equal to) a comment/suggestion row
-   * @returns {HTMLElement|null} The parent diff row, or null
+   * Find the vendor annotation wrapper (`[data-annotation-slot]`) that holds a
+   * given card element. Used by navigation callers as a stable scroll anchor;
+   * returns null for elements not slotted onto a diff line (callers fall back
+   * to the element itself).
+   * @param {HTMLElement} element - A card element (or a child of one)
+   * @returns {HTMLElement|null}
    */
   findDiffRowFor(element) {
-    const commentRow = element.closest('.user-comment-row, .ai-suggestion-row, .external-comment-row') || element;
-    if (
-      !commentRow.classList.contains('user-comment-row') &&
-      !commentRow.classList.contains('ai-suggestion-row') &&
-      !commentRow.classList.contains('external-comment-row')
-    ) {
-      return null;
-    }
-    return this._findDiffRowFor(commentRow);
+    return element?.closest?.('[data-annotation-slot]') || null;
   }
 
   // TODO: expose via API route so chat can programmatically expand findings when discussing them
   /**
-   * Expand comments for a given element so it becomes visible when minimized.
-   * Call this before scrolling to a comment/suggestion row that may be hidden.
-   * @param {HTMLElement} element - The target comment/suggestion element (or row)
+   * Expand the comments for a given element so it becomes visible when
+   * minimized. Call this before scrolling to a card that may be hidden.
+   * @param {HTMLElement} element - The target card element (or a child of one)
    */
   expandForElement(element) {
-    if (!this._active) return;
+    if (!this._active || !element) return;
 
-    // Check if this element is inside a file-comments-zone (file-level comment)
+    // File-level comment inside a file-comments-zone.
     const zone = element.closest('.file-comments-zone');
     if (zone) {
       if (this._expandedFiles.has(zone)) return; // already expanded
       this._expandedFiles.add(zone);
       zone.classList.add('file-comments-expanded');
-      // Update the file-header indicator button
       const wrapper = zone.closest('.d2h-file-wrapper');
       const btn = wrapper?.querySelector('.d2h-file-header .file-comment-indicator');
       if (btn) {
@@ -334,29 +364,18 @@ class CommentMinimizer {
       return;
     }
 
-    // Line-level: find the containing comment/suggestion row
-    const commentRow = element.closest('.user-comment-row, .ai-suggestion-row, .external-comment-row') || element;
-    if (
-      !commentRow.classList.contains('user-comment-row') &&
-      !commentRow.classList.contains('ai-suggestion-row') &&
-      !commentRow.classList.contains('external-comment-row')
-    ) {
-      return;
-    }
+    // Line-level: resolve the containing vendor annotation wrapper.
+    const annotationWrapper = element.closest('[data-annotation-slot]');
+    if (!annotationWrapper) return;
+    const key = this._lineKeyFor(annotationWrapper);
+    if (!key) return;
 
-    // Find the parent diff row for this comment row
-    const diffRow = this._findDiffRowFor(commentRow);
-    if (!diffRow) return;
+    this._expandedLines.add(key);
+    const wrappers = this._wrappersForKey(key);
+    this._applyExpanded(wrappers, true);
 
-    // Already expanded — nothing to do
-    if (this._expandedLines.has(diffRow)) return;
-
-    // Expand all comment rows for this diff line
-    this._expandedLines.add(diffRow);
-    this._getCommentRowsFor(diffRow).forEach(row => row.classList.add('comment-expanded'));
-
-    // Update the indicator button's expanded state
-    const btn = diffRow.querySelector('.d2h-code-line-ctn .comment-indicator');
+    // Mark the indicator (injected into the group's first wrapper) as expanded.
+    const btn = wrappers[0]?.querySelector(':scope > .comment-indicator');
     if (btn) {
       btn.classList.add('expanded');
     }
@@ -486,6 +505,46 @@ class CommentMinimizer {
   _removeAllIndicators() {
     document.querySelectorAll('.comment-indicator').forEach(btn => btn.remove());
     document.querySelectorAll('.file-comment-indicator').forEach(btn => btn.remove());
+  }
+
+  // ---------------------------------------------------------------------------
+  // Rerender resilience
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Observe the diff container for the vendor's card-recreating rerenders and
+   * re-inject indicators. Debounced via rAF and idempotent (refreshIndicators
+   * clears first). Paused during our own refresh so injecting indicators does
+   * not loop. No-op without a DOM (tests may run headless without MutationObserver).
+   * @private
+   */
+  _startObserving() {
+    if (this._observer || typeof MutationObserver === 'undefined') return;
+    const container = document.getElementById('diff-container');
+    if (!container) return;
+    this._observer = new MutationObserver(() => this._onDomMutation());
+    this._observer.observe(container, { childList: true, subtree: true });
+  }
+
+  /** Stop observing the diff container. @private */
+  _stopObserving() {
+    if (this._observer) {
+      this._observer.disconnect();
+      this._observer = null;
+    }
+  }
+
+  /** Debounced reaction to diff-container mutations. @private */
+  _onDomMutation() {
+    if (!this._active || this._refreshScheduled) return;
+    this._refreshScheduled = true;
+    const raf = (typeof requestAnimationFrame === 'function')
+      ? requestAnimationFrame
+      : (fn) => setTimeout(fn, 16);
+    raf(() => {
+      this._refreshScheduled = false;
+      if (this._active) this.refreshIndicators();
+    });
   }
 }
 

--- a/public/js/modules/pierre-bridge.js
+++ b/public/js/modules/pierre-bridge.js
@@ -2438,13 +2438,28 @@ class PierreBridge {
       grid-column: 2;
       border-left: 1px solid var(--diffs-bg);
     }
-    /* The vendor's [data-code] ships overflow: scroll clip. Unlike the
-       split layout (display:contents columns — no clipping box), this
-       one-sided code is a real box and would clip the stretched cards
-       below. Lines wrap in wrap mode, so visible is safe there. */
+    /* The vendor's [data-code] ships overflow: scroll clip AND
+       contain: content. Both must be neutralized here, for different reasons:
+         - overflow: scroll clip is a scroll/clip box that would clip the
+           stretched cards; reset to visible (lines wrap in wrap mode, so
+           there is nothing to scroll).
+         - contain: content implies contain: PAINT, which clips descendant
+           paint to the code column's own border box REGARDLESS of overflow.
+           The .pr-annotation-fullwidth cards below reach past this box (a
+           right-half card sits at margin-left: calc(-100% - 2g)), so paint
+           containment would hide their left portion — header text and body —
+           while the right-aligned action buttons, which fall inside the box,
+           still paint (the "empty card" bug). Drop paint containment; keep
+           layout+style containment (cheap, no visual effect) so the vendor's
+           perf intent is mostly preserved.
+       Two-sided split columns escape both: they are display: contents and
+       generate no box, so neither overflow nor contain has anything to clip —
+       which is why this only bites one-sided (single) files, whose columns
+       ARE real boxes (display: grid children, above). */
     [data-diff-type='single'][data-overflow='wrap'] > [data-deletions],
     [data-diff-type='single'][data-overflow='wrap'] > [data-additions] {
       overflow: visible;
+      contain: layout style;
     }
     /* One-sided file: every card is lone, stretch across both halves.
        Geometry (g = the file's own gutter, published by

--- a/tests/e2e/comment-minimize.spec.js
+++ b/tests/e2e/comment-minimize.spec.js
@@ -1,0 +1,257 @@
+// Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+/**
+ * E2E: Minimize Comments mode under the @pierre/diffs renderer.
+ *
+ * Regression coverage for the minimize feature after the @pierre/diffs
+ * migration. Diff lines are shadow-DOM elements and annotation cards live in
+ * the light DOM inside vendor `[data-annotation-slot]` wrappers. The minimizer
+ * must, when enabled:
+ *   - hide inline user-comment AND AI-suggestion cards (the suggestion case
+ *     regressed — bare `.ai-suggestion` had no `-row` wrapper so the old hide
+ *     rules and the old line scan both missed it),
+ *   - collapse the annotation row to ZERO height and float a single indicator
+ *     pill over the anchor code line (so it doesn't read as a collapsed
+ *     comment breaking up the diff),
+ *   - reveal that line's cards again when the indicator is clicked,
+ * and remove every indicator when disabled. The one-sided (entirely-added)
+ * split case is exercised too — its column carries paint-free containment and
+ * its annotation cell is fullwidth-stretched, both of which the overlay must
+ * survive.
+ */
+
+import { test, expect } from './fixtures.js';
+import { waitForDiffToRender, seedAISuggestions, openCommentFormOnLine, waitForDiffType } from './helpers.js';
+
+// A line-level annotation card slotted below a diff line (excludes
+// file-comments-zone cards, which are not inside a slot wrapper).
+const SLOTTED_SUGGESTION = '#diff-container [data-annotation-slot] > .ai-suggestion';
+const SLOTTED_COMMENT = '#diff-container [data-annotation-slot] > .user-comment-row';
+const LINE_INDICATOR = '#diff-container [data-annotation-slot] .comment-indicator';
+
+/** Enable/disable "Minimize comments" via the diff-options gear dropdown. */
+async function setMinimize(page, enabled) {
+  await page.locator('#diff-options-btn').click();
+  const checkbox = page.locator('label:has-text("Minimize comments") input[type="checkbox"]');
+  await expect(checkbox).toBeVisible();
+  if (enabled) {
+    await checkbox.check();
+  } else {
+    await checkbox.uncheck();
+  }
+  // Close the popover so it can't intercept later clicks.
+  await page.keyboard.press('Escape');
+  const container = page.locator('#diff-container');
+  if (enabled) {
+    await expect(container).toHaveClass(/comments-minimized/, { timeout: 3000 });
+  } else {
+    await expect(container).not.toHaveClass(/comments-minimized/, { timeout: 3000 });
+  }
+}
+
+test.describe('Minimize comments (pierre renderer)', () => {
+  test.afterEach(async ({ page }) => {
+    // The worker DB is shared across spec files (fullyParallel: false), so both
+    // user comments AND seeded AI suggestions must be swept — GET /comments does
+    // not return source='ai' rows, so they need the dedicated delete route.
+    await page.evaluate(async () => {
+      const resp = await fetch('/api/reviews/1/comments?includeDismissed=true');
+      const data = await resp.json();
+      for (const c of (data.comments || [])) {
+        await fetch(`/api/reviews/1/comments/${c.id}`, { method: 'DELETE' });
+      }
+      // fetch only rejects on network errors, so assert resp.ok ourselves.
+      const aiResp = await fetch('/api/reviews/1/ai-suggestions', { method: 'DELETE' });
+      if (!aiResp.ok) throw new Error(`AI cleanup failed: ${aiResp.status}`);
+    });
+  });
+
+  test('hides suggestion + comment cards behind line indicators and toggles them back', async ({ page }) => {
+    await page.goto('/pr/test-owner/test-repo/1');
+    await waitForDiffToRender(page);
+
+    // A real AI suggestion rendered inline in the diff.
+    await seedAISuggestions(page);
+    const suggestion = page.locator(SLOTTED_SUGGESTION).first();
+    await expect(suggestion).toBeVisible();
+
+    // A real user comment rendered inline in the diff.
+    await openCommentFormOnLine(page, 0);
+    const textarea = page.locator('.user-comment-form textarea');
+    await textarea.fill('Minimize me');
+    await page.locator('.save-comment-btn').click();
+    await expect(page.locator('.user-comment-form')).toBeHidden({ timeout: 5000 });
+    const comment = page.locator(SLOTTED_COMMENT).first();
+    await expect(comment).toBeVisible();
+
+    // --- Enable minimize ---
+    await setMinimize(page, true);
+
+    // Both card types are now hidden (the suggestion is the regression case).
+    await expect(suggestion).toBeHidden();
+    await expect(comment).toBeHidden();
+
+    // At least one line indicator is visible.
+    const indicators = page.locator(LINE_INDICATOR);
+    await expect(indicators.first()).toBeVisible();
+    const indicatorCount = await indicators.count();
+    expect(indicatorCount).toBeGreaterThan(0);
+
+    // The collapsed annotation row must add ZERO height — the pill is an
+    // absolutely-positioned overlay, so the wrapper contributes no layout box.
+    // This is the crux of the "don't break up the diff" fix.
+    const wrapperHeight = await page
+      .locator('#diff-container [data-annotation-slot]:has(> .comment-indicator)')
+      .first()
+      .evaluate((el) => el.getBoundingClientRect().height);
+    expect(wrapperHeight).toBe(0);
+
+    // The wrapper is the scroll anchor for AI-panel navigation
+    // (CommentMinimizer.findDiffRowFor returns it). It must carry a non-zero
+    // scroll-margin-top so scrollIntoView lands it below the sticky toolbar
+    // instead of flush under it.
+    const scrollMargin = await page
+      .locator('#diff-container [data-annotation-slot]:has(> .comment-indicator)')
+      .first()
+      .evaluate((el) => parseFloat(getComputedStyle(el).scrollMarginTop));
+    expect(scrollMargin).toBeGreaterThan(0);
+
+    // --- Click the indicator on the suggestion's line: its card reappears ---
+    const suggestionIndicator = page
+      .locator('#diff-container [data-annotation-slot]:has(> .ai-suggestion) .comment-indicator')
+      .first();
+    await expect(suggestionIndicator).toBeVisible();
+    await suggestionIndicator.click();
+    await expect(suggestion).toBeVisible();
+
+    // --- Disable minimize: indicators gone, cards visible again ---
+    await setMinimize(page, false);
+    await expect(page.locator(LINE_INDICATOR)).toHaveCount(0);
+    await expect(suggestion).toBeVisible();
+    await expect(comment).toBeVisible();
+  });
+
+  test('AI-panel navigation lands a minimized suggestion below the sticky toolbar', async ({ page }) => {
+    await page.goto('/pr/test-owner/test-repo/1');
+    await waitForDiffToRender(page);
+    await seedAISuggestions(page);
+
+    await setMinimize(page, true);
+
+    // Open the AI panel and navigate to the first finding — this drives
+    // expandForElement + scroll-to-wrapper, the path that regressed under the
+    // sticky toolbar without scroll-margin on the wrapper.
+    await page.evaluate(() => window.aiPanel?.expand());
+    await page.waitForSelector('.finding-item', { timeout: 5000 });
+    await page.locator('.finding-item').first().click();
+
+    // The navigated card is expanded and visible; its top must sit at/below the
+    // sticky toolbar's bottom (not hidden underneath it). Poll while the smooth
+    // scroll settles.
+    const expandedCard = page
+      .locator('#diff-container [data-annotation-slot] > .ai-suggestion.comment-expanded')
+      .first();
+    await expect(expandedCard).toBeVisible();
+    await expect
+      .poll(async () => {
+        return page.evaluate(() => {
+          const toolbar = document.querySelector('.diff-toolbar');
+          const card = document.querySelector(
+            '#diff-container [data-annotation-slot] > .ai-suggestion.comment-expanded'
+          );
+          if (!toolbar || !card) return -1;
+          const toolbarBottom = toolbar.getBoundingClientRect().bottom;
+          const cardTop = card.getBoundingClientRect().top;
+          // Positive margin = card is fully below the sticky toolbar.
+          return Math.round(cardTop - toolbarBottom);
+        });
+      }, { timeout: 5000 })
+      .toBeGreaterThanOrEqual(0);
+  });
+
+  // An entirely-added file renders as a one-sided `data-diff-type="single"` pre
+  // in split view. Its code column carries `contain: layout style` and its
+  // annotation cell is fullwidth-stretched — the overlay pill must still float
+  // over the anchor line at zero row height and stay clickable there.
+  test('overlays the indicator on a one-sided (entirely-added) file in split view', async ({ page }) => {
+    const ADDED_FILE = 'src/added.js';
+    const REF_FILE = 'src/utils.js';
+    const ONE_SIDED_DIFF = [
+      // Two-sided reference so split layout has a host that settles.
+      'diff --git a/src/utils.js b/src/utils.js',
+      '--- a/src/utils.js',
+      '+++ b/src/utils.js',
+      '@@ -1,3 +1,3 @@',
+      ' // Utility functions',
+      '-const old = 1;',
+      '+const updated = 2;',
+      ' module.exports = {};',
+      // Entirely-added file → one-sided "single" pre in split.
+      'diff --git a/src/added.js b/src/added.js',
+      'new file mode 100644',
+      'index 0000000..abcdef1',
+      '--- /dev/null',
+      '+++ b/src/added.js',
+      '@@ -0,0 +1,4 @@',
+      '+// Brand new module',
+      '+function created() {',
+      '+  return 42;',
+      '+}',
+      ''
+    ].join('\n');
+    const CHANGED_FILES = [
+      { file: 'src/utils.js', additions: 1, deletions: 1 },
+      { file: 'src/added.js', additions: 4, deletions: 0 }
+    ];
+
+    await page.route('**/api/pr/*/*/*/diff', (route) =>
+      route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({ diff: ONE_SIDED_DIFF, changed_files: CHANGED_FILES })
+      })
+    );
+    // Keep the pure-add render one-sided (see split-view.spec.js rationale).
+    await page.route('**/api/reviews/*/file-contents/**', (route) =>
+      route.fulfill({ contentType: 'application/json', body: JSON.stringify({ tooLarge: true }) })
+    );
+
+    await page.goto('/pr/test-owner/test-repo/1');
+    await waitForDiffToRender(page);
+
+    // Seed a comment on the added file (RIGHT/additions side, line 2).
+    await page.evaluate(async () => {
+      await fetch('/api/reviews/1/comments', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ file: 'src/added.js', line_start: 2, line_end: 2, side: 'RIGHT', body: 'one-sided overlay' })
+      });
+    });
+    await page.reload();
+    await waitForDiffToRender(page);
+
+    const addedWrapper = `.d2h-file-wrapper[data-file-name="${ADDED_FILE}"]`;
+    const comment = page.locator(`${addedWrapper} [data-annotation-slot] > .user-comment-row`).first();
+    await expect(comment).toBeVisible();
+
+    // Switch to split (gate on the two-sided reference file flipping).
+    await page.locator('#diff-options-btn').click();
+    await page.locator('.diff-view-option[data-diff-view="split"]').click();
+    await page.keyboard.press('Escape');
+    await waitForDiffType(page, 'split', 5000, { fileName: REF_FILE });
+
+    await setMinimize(page, true);
+
+    // Card hidden, indicator floats over the line at zero row height.
+    await expect(comment).toBeHidden();
+    const indicator = page.locator(`${addedWrapper} [data-annotation-slot] .comment-indicator`).first();
+    await expect(indicator).toBeVisible();
+    const wrapperHeight = await page
+      .locator(`${addedWrapper} [data-annotation-slot]:has(> .comment-indicator)`)
+      .first()
+      .evaluate((el) => el.getBoundingClientRect().height);
+    expect(wrapperHeight).toBe(0);
+
+    // The overlaid pill is clickable where it visually sits → card reappears.
+    await indicator.click();
+    await expect(comment).toBeVisible();
+  });
+});

--- a/tests/e2e/split-view.spec.js
+++ b/tests/e2e/split-view.spec.js
@@ -641,6 +641,88 @@ test.describe('Split diff view — one-sided files (PR mode)', () => {
     }, ADDED_FILE);
     expect(u.ratio).toBeGreaterThan(0.9);
   });
+
+  /**
+   * PAINT-level regression for the "empty card" bug: a full-width-stretched
+   * annotation card on a one-sided file must actually PAINT its header text and
+   * body, not merely lay them out at the right coordinates.
+   *
+   * The boxing above makes the one-sided `code[data-<side>]` a real box, which
+   * activates the vendor's `code { contain: content }` — and `contain: content`
+   * implies `contain: PAINT`, which clips descendant paint to that box
+   * regardless of `overflow`. A `.pr-annotation-fullwidth` card reaches LEFT out
+   * of its box (margin-left: calc(-100% - 2g)), so paint containment hid its
+   * header text + body while the right-aligned action buttons (inside the box)
+   * still painted — the geometry stayed correct, so a getBoundingClientRect
+   * assertion could not see it. ANNOTATION_CSS drops paint containment
+   * (`contain: layout style`) on these columns; this test guards that.
+   *
+   * The probe is a shadow-piercing hit-test at the card's header + body text
+   * coordinates: `elementFromPoint` (recursed through shadow roots) resolves to
+   * the actual text element only when that region is painted/hit-testable. Under
+   * paint containment the point lies outside the code column's box and resolves
+   * elsewhere, so `insideComment` is false.
+   */
+  test('paints the header text and body of a stretched one-sided card (not just its box)', async ({ page }) => {
+    await mockOneSidedDiff(page);
+    await page.goto(PR_PATH);
+    await waitForDiffToRender(page);
+    await page.waitForSelector(`.d2h-file-wrapper[data-file-name="${ADDED_FILE}"]`);
+
+    const body = `Paint check ${Date.now()} — this header and body must be visible.`;
+    // Line 2 of the added file is an addition (RIGHT side).
+    await seedComment(page, 1, { file: ADDED_FILE, line: 2, side: 'RIGHT', body });
+    await page.reload();
+    await waitForDiffToRender(page);
+    await expect(page.locator('.user-comment-body', { hasText: body })).toBeVisible();
+
+    await switchToSplit(page);
+    await expectAnnotationInSplitColumn(page, { text: body, column: 'additions' });
+    // The stretch class lands on a rAF after render — gate on it before probing.
+    await expect.poll(async () => (await singleCardMetrics(page, ADDED_FILE, body))?.hasFullwidthClass, {
+      timeout: 5000
+    }).toBe(true);
+
+    // Shadow-piercing hit-test at the card's header-left and body text. Both sit
+    // in the LEFT portion of the stretched card — the region paint containment
+    // clipped — so a resolve to an element inside .user-comment proves paint.
+    const paint = await page.evaluate(async (file) => {
+      // Ensure a paint has occurred after the fullwidth class was applied.
+      await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
+      const pierce = (x, y) => {
+        let el = document.elementFromPoint(x, y);
+        while (el && el.shadowRoot) {
+          const inner = el.shadowRoot.elementFromPoint(x, y);
+          if (!inner || inner === el) break;
+          el = inner;
+        }
+        return el;
+      };
+      const scope = document.querySelector(`.d2h-file-wrapper[data-file-name="${file}"]`);
+      const headerLeft = scope.querySelector('.user-comment-header-left');
+      const bodyEl = scope.querySelector('.user-comment-body');
+      const probe = (el) => {
+        const r = el.getBoundingClientRect();
+        // A few px in from the element's left edge, at its vertical centre.
+        const hit = pierce(r.left + 4, r.top + r.height / 2);
+        return {
+          insideComment: !!(hit && hit.closest && hit.closest('.user-comment')),
+          left: Math.round(r.left)
+        };
+      };
+      return {
+        header: probe(headerLeft),
+        body: probe(bodyEl)
+      };
+    }, ADDED_FILE);
+
+    // Both the header text and the body must actually paint (be hit-testable),
+    // even though they lie in the stretched card's left half, outside the code
+    // column's own box. Under the paint-containment bug these points resolve to
+    // an element outside .user-comment (the clipped-away region), failing here.
+    expect(paint.header.insideComment).toBe(true);
+    expect(paint.body.insideComment).toBe(true);
+  });
 });
 
 /**

--- a/tests/unit/comment-minimizer.test.js
+++ b/tests/unit/comment-minimizer.test.js
@@ -1,1514 +1,718 @@
 // Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+// @vitest-environment jsdom
+
 /**
- * Unit tests for CommentMinimizer
+ * Unit tests for CommentMinimizer against the @pierre/diffs DOM.
  *
- * Tests the minimize-comments mode for the diff view, including:
- * - _findDiffRowFor: backward walk to find parent diff row
- * - _getCommentRowsFor: forward walk to collect comment/suggestion rows
- * - refreshIndicators: lineMap building with correct counts
- * - Toggle expand/collapse: _expandedLines Set and CSS classes
- * - findDiffRowFor (public): locates diff row from child element
- * - expandForElement: expands comments and updates indicator state
- * - File-level: _refreshFileIndicators, _toggleFileComments, expandForElement for file cards
+ * Under @pierre/diffs, diff lines are shadow-DOM elements and annotation cards
+ * live in the LIGHT DOM, each wrapped by the vendor in a
+ * `<div data-annotation-slot slot="annotation-{side}-{lineNumber}">` that is a
+ * child of the file's `<diffs-container>` host. Cards on the same line+side
+ * share a slot value; the minimizer groups by `{fileName}\0{slot}`.
  *
- * IMPORTANT: These tests import the actual CommentMinimizer class from
- * production code to ensure tests verify real behavior.
+ * These tests build that real structure in jsdom and import the actual
+ * CommentMinimizer class (never duplicating production code). They cover:
+ * - grouping/aggregation counts and per-type icons (user/adopted/AI/external)
+ * - suggestions hidden for adoption are not double-counted
+ * - per-file scoping (same slot name in two files → two independent lines)
+ * - toggle expand/collapse by clicking the indicator
+ * - expandForElement (line-level and file-level)
+ * - stable-key expansion surviving a simulated vendor rerender
+ * - minimize-off cleanup
+ * - file-level indicators (unchanged path)
+ * - findDiffRowFor contract
+ * - the mutation-driven re-injection debounce
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
-// Ensure global.window exists before importing production code (which assigns to window.CommentMinimizer)
-global.window = global.window || {};
-
 const { CommentMinimizer } = require('../../public/js/modules/comment-minimizer.js');
 
 // ---------------------------------------------------------------------------
-// DOM Helpers
+// DOM builders — mirror the real light-DOM structure the vendor produces.
 // ---------------------------------------------------------------------------
 
+/** Create (or reuse) the #diff-container root. */
+function diffContainer() {
+  let el = document.getElementById('diff-container');
+  if (!el) {
+    el = document.createElement('div');
+    el.id = 'diff-container';
+    document.body.appendChild(el);
+  }
+  return el;
+}
+
 /**
- * Build a linked list of table rows (simulating <tbody> children).
- * Each entry is { classes: [...], children: { '.selector': element } }.
- * Returns the array of row objects with previousElementSibling / nextElementSibling set.
+ * Create a `.d2h-file-wrapper` with a `<diffs-container>` host and (optionally)
+ * a file header + file-comments-zone, appended to #diff-container.
+ * @returns {{wrapper: Element, host: Element, header: Element, zone: Element}}
  */
-function buildRows(specs) {
-  const rows = specs.map((spec) => {
-    const classSet = new Set(spec.classes || []);
-    const childElements = spec.children || {};
-    const innerHTML = spec.innerHTML || '';
+function makeFile(fileName, { withZone = false } = {}) {
+  const wrapper = document.createElement('div');
+  wrapper.className = 'd2h-file-wrapper';
+  wrapper.dataset.fileName = fileName;
 
-    const row = {
-      _tag: 'tr',
-      _spec: spec,
-      classList: {
-        contains(cls) { return classSet.has(cls); },
-        add(cls) { classSet.add(cls); },
-        remove(cls) { classSet.delete(cls); },
-        _set: classSet,
-      },
-      querySelector(selector) {
-        if (childElements[selector]) return childElements[selector];
-        // Search children by class match (simple .class selector)
-        if (selector.startsWith('.')) {
-          const cls = selector.slice(1);
-          for (const child of Object.values(childElements)) {
-            if (child && child.classList && child.classList.contains(cls)) {
-              return child;
-            }
-          }
-        }
-        return null;
-      },
-      querySelectorAll(selector) {
-        const cls = selector.startsWith('.') ? selector.slice(1) : null;
-        if (!cls) return [];
-        const matches = [];
-        for (const child of Object.values(childElements)) {
-          if (child && child.classList && child.classList.contains(cls)) {
-            matches.push(child);
-          }
-        }
-        return matches;
-      },
-      innerHTML,
-      previousElementSibling: null,
-      nextElementSibling: null,
-      closest(selector) {
-        // CommentMinimizer uses closest('.user-comment-row, .ai-suggestion-row')
-        const selectors = selector.split(',').map(s => s.trim());
-        for (const s of selectors) {
-          if (s.startsWith('.') && classSet.has(s.slice(1))) {
-            return row;
-          }
-        }
-        return null;
-      },
-    };
-    return row;
-  });
+  const header = document.createElement('div');
+  header.className = 'd2h-file-header';
+  const commentBtn = document.createElement('button');
+  commentBtn.className = 'file-header-comment-btn';
+  header.appendChild(commentBtn);
+  wrapper.appendChild(header);
 
-  // Wire up sibling links
-  for (let i = 0; i < rows.length; i++) {
-    rows[i].previousElementSibling = i > 0 ? rows[i - 1] : null;
-    rows[i].nextElementSibling = i < rows.length - 1 ? rows[i + 1] : null;
+  let zone = null;
+  if (withZone) {
+    zone = document.createElement('div');
+    zone.className = 'file-comments-zone';
+    zone.dataset.fileName = fileName;
+    wrapper.appendChild(zone);
   }
 
-  return rows;
+  const host = document.createElement('diffs-container');
+  // Attach a shadow root so the structure matches production, even though the
+  // minimizer only reads the light DOM.
+  host.attachShadow({ mode: 'open' });
+  wrapper.appendChild(host);
+
+  diffContainer().appendChild(wrapper);
+  return { wrapper, host, header, zone };
 }
 
 /**
- * Build a simple mock element that can act as a code cell (.d2h-code-line-ctn).
+ * Slot an annotation card into a host, wrapped in the vendor
+ * `[data-annotation-slot]` div (as @pierre/diffs does).
+ * @param {Element} host - the <diffs-container>
+ * @param {string} side - 'additions' | 'deletions'
+ * @param {number} lineNumber
+ * @param {Element} card - the annotation card element
+ * @returns {Element} the vendor wrapper
  */
-function buildCodeCell() {
-  const children = [];
-  return {
-    style: {},
-    children,
-    classList: {
-      _set: new Set(['d2h-code-line-ctn']),
-      contains(cls) { return this._set.has(cls); },
-      add(cls) { this._set.add(cls); },
-      remove(cls) { this._set.delete(cls); },
-    },
-    appendChild(child) { children.push(child); },
-    querySelector(selector) {
-      if (selector === '.comment-indicator') {
-        return children.find(c => c.className === 'comment-indicator') || null;
-      }
-      return null;
-    },
-  };
+function slotCard(host, side, lineNumber, card) {
+  const wrapper = document.createElement('div');
+  wrapper.dataset.annotationSlot = '';
+  wrapper.setAttribute('slot', `annotation-${side}-${lineNumber}`);
+  wrapper.appendChild(card);
+  host.appendChild(wrapper);
+  return wrapper;
 }
 
-/**
- * Build a mock button element with classList support.
- */
-function buildMockButton(className = '') {
-  return {
-    className,
-    classList: {
-      _set: new Set(),
-      add(c) { this._set.add(c); },
-      remove(c) { this._set.delete(c); },
-      contains(c) { return this._set.has(c); },
-    },
-  };
+function userCommentCard({ adopted = false } = {}) {
+  const card = document.createElement('div');
+  card.className = 'user-comment-row';
+  card.dataset.commentId = String(Math.floor(Math.random() * 1e6));
+  const inner = document.createElement('div');
+  inner.className = adopted ? 'user-comment adopted-comment comment-ai-origin' : 'user-comment comment-user-origin';
+  inner.textContent = 'a comment';
+  card.appendChild(inner);
+  return card;
 }
 
-/**
- * Build a mock element that can act as a child inside a comment row.
- * Uses closest() to walk up to the provided parentRow.
- */
-function buildChildElement(parentRow) {
-  return {
-    closest(selector) {
-      const selectors = selector.split(',').map(s => s.trim());
-      for (const s of selectors) {
-        if (s.startsWith('.') && parentRow.classList.contains(s.slice(1))) {
-          return parentRow;
-        }
-      }
-      return null;
-    },
-    classList: {
-      _set: new Set(),
-      contains(cls) { return this._set.has(cls); },
-    },
-  };
+// `hiddenForAdoption` mirrors the real string dataset: undefined (load-time,
+// visible), 'true' (adopted → hidden), or 'false' (runtime-restored → visible,
+// written literally by suggestion-ui.js).
+function suggestionCard({ hiddenForAdoption } = {}) {
+  const card = document.createElement('div');
+  card.className = 'ai-suggestion ai-type-bug';
+  card.dataset.suggestionId = String(Math.floor(Math.random() * 1e6));
+  if (hiddenForAdoption !== undefined) card.dataset.hiddenForAdoption = String(hiddenForAdoption);
+  card.textContent = 'a suggestion';
+  return card;
 }
 
-// ---------------------------------------------------------------------------
-// Global DOM mock
-// ---------------------------------------------------------------------------
+function externalCard({ bubbles = 1 } = {}) {
+  const card = document.createElement('div');
+  card.className = 'external-comment-row';
+  card.dataset.threadId = String(Math.floor(Math.random() * 1e6));
+  const thread = document.createElement('div');
+  thread.className = 'external-comment-thread';
+  for (let i = 0; i < bubbles; i++) {
+    const bubble = document.createElement('div');
+    bubble.className = 'external-comment';
+    thread.appendChild(bubble);
+  }
+  card.appendChild(thread);
+  return card;
+}
 
-let diffContainer;
-let allIndicators;
+/** Add a file-level card to a zone. */
+function fileCommentCard(zone, type, { adopted = false, collapsed = false } = {}) {
+  const card = document.createElement('div');
+  card.className = 'file-comment-card ' + type;
+  if (adopted) card.classList.add('adopted-comment');
+  if (collapsed) card.classList.add('collapsed');
+  zone.appendChild(card);
+  return card;
+}
 
+/** All line-level indicators currently in the DOM. */
+function lineIndicators() {
+  return [...document.querySelectorAll('#diff-container .comment-indicator')];
+}
+
+// The real MutationObserver would fire async refreshes that leak across tests
+// (a prior test's minimizer mutating a later test's DOM). Stub it to a no-op —
+// the debounce/scheduling logic is covered directly via _onDomMutation below.
+let RealMutationObserver;
 beforeEach(() => {
-  global.window = global.window || {};
-  allIndicators = [];
-  diffContainer = {
-    classList: {
-      _set: new Set(),
-      add(cls) { this._set.add(cls); },
-      remove(cls) { this._set.delete(cls); },
-      contains(cls) { return this._set.has(cls); },
-    },
+  document.body.innerHTML = '';
+  window.prManager = undefined;
+  RealMutationObserver = global.MutationObserver;
+  global.MutationObserver = class {
+    observe() {}
+    disconnect() {}
+    takeRecords() { return []; }
   };
-
-  global.document = {
-    getElementById: vi.fn((id) => {
-      if (id === 'diff-container') return diffContainer;
-      return null;
-    }),
-    querySelectorAll: vi.fn((selector) => {
-      // Default: return empty arrays — tests override via vi.fn().mockReturnValue(...)
-      return [];
-    }),
-    createElement: vi.fn((tag) => {
-      const el = {
-        _tag: tag,
-        className: '',
-        type: '',
-        innerHTML: '',
-        title: '',
-        classList: {
-          _set: new Set(),
-          add(cls) { this._set.add(cls); },
-          remove(cls) { this._set.delete(cls); },
-          contains(cls) { return this._set.has(cls); },
-        },
-        addEventListener: vi.fn(),
-        style: {},
-      };
-      allIndicators.push(el);
-      return el;
-    }),
-  };
+  window.MutationObserver = global.MutationObserver;
 });
 
 afterEach(() => {
   vi.restoreAllMocks();
-  delete global.document;
-  delete global.window;
+  document.body.innerHTML = '';
+  global.MutationObserver = RealMutationObserver;
+  window.MutationObserver = RealMutationObserver;
 });
 
 // ===========================================================================
-// Tests
+// Line-level grouping / aggregation
 // ===========================================================================
 
-describe('CommentMinimizer', () => {
-  // -------------------------------------------------------------------------
-  // _findDiffRowFor
-  // -------------------------------------------------------------------------
-  describe('_findDiffRowFor', () => {
-    it('should return the immediate previous sibling when it is a diff row', () => {
-      const rows = buildRows([
-        { classes: ['d2h-cntx'] },          // diff row
-        { classes: ['user-comment-row'] },   // comment row
-      ]);
+describe('CommentMinimizer — line-level grouping', () => {
+  it('injects one indicator per line with a person icon for a user comment', () => {
+    const { host } = makeFile('a.js');
+    slotCard(host, 'additions', 10, userCommentCard());
 
-      const cm = new CommentMinimizer();
-      const result = cm._findDiffRowFor(rows[1]);
-      expect(result).toBe(rows[0]);
-    });
+    const cm = new CommentMinimizer();
+    cm.setMinimized(true);
 
-    it('should skip comment rows to find the diff row', () => {
-      const rows = buildRows([
-        { classes: ['d2h-cntx'] },
-        { classes: ['user-comment-row'] },
-        { classes: ['user-comment-row'] },
-      ]);
-
-      const cm = new CommentMinimizer();
-      expect(cm._findDiffRowFor(rows[2])).toBe(rows[0]);
-    });
-
-    it('should skip suggestion rows to find the diff row', () => {
-      const rows = buildRows([
-        { classes: ['d2h-ins'] },
-        { classes: ['ai-suggestion-row'] },
-        { classes: ['ai-suggestion-row'] },
-        { classes: ['user-comment-row'] },
-      ]);
-
-      const cm = new CommentMinimizer();
-      expect(cm._findDiffRowFor(rows[3])).toBe(rows[0]);
-    });
-
-    it('should skip form rows to find the diff row', () => {
-      const rows = buildRows([
-        { classes: ['d2h-del'] },
-        { classes: ['comment-form-row'] },
-        { classes: ['ai-suggestion-row'] },
-      ]);
-
-      const cm = new CommentMinimizer();
-      expect(cm._findDiffRowFor(rows[2])).toBe(rows[0]);
-    });
-
-    it('should skip context-expand rows to find the diff row', () => {
-      const rows = buildRows([
-        { classes: ['d2h-cntx'] },
-        { classes: ['context-expand-row'] },
-        { classes: ['user-comment-row'] },
-      ]);
-
-      const cm = new CommentMinimizer();
-      expect(cm._findDiffRowFor(rows[2])).toBe(rows[0]);
-    });
-
-    it('should skip mixed intermediate rows (comment, form, expand, suggestion)', () => {
-      const rows = buildRows([
-        { classes: ['d2h-cntx'] },
-        { classes: ['user-comment-row'] },
-        { classes: ['comment-form-row'] },
-        { classes: ['context-expand-row'] },
-        { classes: ['ai-suggestion-row'] },
-        { classes: ['user-comment-row'] },
-      ]);
-
-      const cm = new CommentMinimizer();
-      expect(cm._findDiffRowFor(rows[5])).toBe(rows[0]);
-    });
-
-    it('should return null when no diff row is found', () => {
-      const rows = buildRows([
-        { classes: ['user-comment-row'] },
-        { classes: ['ai-suggestion-row'] },
-      ]);
-
-      const cm = new CommentMinimizer();
-      expect(cm._findDiffRowFor(rows[1])).toBeNull();
-    });
+    const indicators = lineIndicators();
+    expect(indicators).toHaveLength(1);
+    const btn = indicators[0];
+    expect(btn.innerHTML).toContain('indicator-user');
+    expect(btn.innerHTML).not.toContain('indicator-ai');
+    expect(btn.title).toBe('1 comment');
   });
 
-  // -------------------------------------------------------------------------
-  // _getCommentRowsFor
-  // -------------------------------------------------------------------------
-  describe('_getCommentRowsFor', () => {
-    it('should collect adjacent user-comment-row siblings', () => {
-      const rows = buildRows([
-        { classes: ['d2h-cntx'] },
-        { classes: ['user-comment-row'] },
-        { classes: ['user-comment-row'] },
-        { classes: ['d2h-cntx'] },
-      ]);
+  it('uses the adopted icon for an adopted comment card', () => {
+    const { host } = makeFile('a.js');
+    slotCard(host, 'additions', 10, userCommentCard({ adopted: true }));
 
-      const cm = new CommentMinimizer();
-      const result = cm._getCommentRowsFor(rows[0]);
-      expect(result).toHaveLength(2);
-      expect(result[0]).toBe(rows[1]);
-      expect(result[1]).toBe(rows[2]);
-    });
+    const cm = new CommentMinimizer();
+    cm.setMinimized(true);
 
-    it('should collect adjacent ai-suggestion-row siblings', () => {
-      const rows = buildRows([
-        { classes: ['d2h-cntx'] },
-        { classes: ['ai-suggestion-row'] },
-        { classes: ['ai-suggestion-row'] },
-        { classes: ['d2h-cntx'] },
-      ]);
-
-      const cm = new CommentMinimizer();
-      const result = cm._getCommentRowsFor(rows[0]);
-      expect(result).toHaveLength(2);
-      expect(result[0]).toBe(rows[1]);
-      expect(result[1]).toBe(rows[2]);
-    });
-
-    it('should collect mixed comment and suggestion rows', () => {
-      const rows = buildRows([
-        { classes: ['d2h-cntx'] },
-        { classes: ['user-comment-row'] },
-        { classes: ['ai-suggestion-row'] },
-        { classes: ['d2h-cntx'] },
-      ]);
-
-      const cm = new CommentMinimizer();
-      const result = cm._getCommentRowsFor(rows[0]);
-      expect(result).toHaveLength(2);
-      expect(result[0]).toBe(rows[1]);
-      expect(result[1]).toBe(rows[2]);
-    });
-
-    it('should skip comment-form-row but continue collecting', () => {
-      const rows = buildRows([
-        { classes: ['d2h-cntx'] },
-        { classes: ['user-comment-row'] },
-        { classes: ['comment-form-row'] },
-        { classes: ['ai-suggestion-row'] },
-        { classes: ['d2h-cntx'] },
-      ]);
-
-      const cm = new CommentMinimizer();
-      const result = cm._getCommentRowsFor(rows[0]);
-      expect(result).toHaveLength(2);
-      expect(result[0]).toBe(rows[1]);
-      expect(result[1]).toBe(rows[3]);
-    });
-
-    it('should skip context-expand-row but continue collecting', () => {
-      const rows = buildRows([
-        { classes: ['d2h-cntx'] },
-        { classes: ['ai-suggestion-row'] },
-        { classes: ['context-expand-row'] },
-        { classes: ['user-comment-row'] },
-        { classes: ['d2h-cntx'] },
-      ]);
-
-      const cm = new CommentMinimizer();
-      const result = cm._getCommentRowsFor(rows[0]);
-      expect(result).toHaveLength(2);
-      expect(result[0]).toBe(rows[1]);
-      expect(result[1]).toBe(rows[3]);
-    });
-
-    it('should stop at the next diff row', () => {
-      const rows = buildRows([
-        { classes: ['d2h-cntx'] },
-        { classes: ['user-comment-row'] },
-        { classes: ['d2h-ins'] },
-        { classes: ['user-comment-row'] },
-      ]);
-
-      const cm = new CommentMinimizer();
-      const result = cm._getCommentRowsFor(rows[0]);
-      expect(result).toHaveLength(1);
-      expect(result[0]).toBe(rows[1]);
-    });
-
-    it('should return empty array when no comment rows follow', () => {
-      const rows = buildRows([
-        { classes: ['d2h-cntx'] },
-        { classes: ['d2h-ins'] },
-      ]);
-
-      const cm = new CommentMinimizer();
-      const result = cm._getCommentRowsFor(rows[0]);
-      expect(result).toHaveLength(0);
-    });
-
-    it('should return empty array when diff row is the last row', () => {
-      const rows = buildRows([
-        { classes: ['d2h-cntx'] },
-      ]);
-
-      const cm = new CommentMinimizer();
-      const result = cm._getCommentRowsFor(rows[0]);
-      expect(result).toHaveLength(0);
-    });
+    const btn = lineIndicators()[0];
+    expect(btn.innerHTML).toContain('indicator-adopted');
+    expect(btn.innerHTML).not.toContain('indicator-user');
+    expect(btn.title).toBe('1 adopted comment');
   });
 
-  // -------------------------------------------------------------------------
-  // refreshIndicators - lineMap counts
-  // -------------------------------------------------------------------------
-  describe('refreshIndicators', () => {
-    /** Set up document.querySelectorAll to return the given rows by selector. */
-    function mockQuerySelectorAll(commentRows, suggestionRows, externalRows = []) {
-      global.document.querySelectorAll = vi.fn((selector) => {
-        if (selector === '.user-comment-row') return commentRows;
-        if (selector === '.ai-suggestion-row') return suggestionRows;
-        if (selector === '.external-comment-row') return externalRows;
-        if (selector === '.comment-indicator') return [];
-        if (selector === '.comment-expanded') return [];
-        return [];
-      });
+  it('uses the sparkles icon for an AI suggestion card', () => {
+    const { host } = makeFile('a.js');
+    slotCard(host, 'additions', 10, suggestionCard());
+
+    const cm = new CommentMinimizer();
+    cm.setMinimized(true);
+
+    const btn = lineIndicators()[0];
+    expect(btn.innerHTML).toContain('indicator-ai');
+    expect(btn.title).toBe('1 suggestion');
+  });
+
+  it('does not count a suggestion hidden for adoption', () => {
+    const { host } = makeFile('a.js');
+    // Adopted comment + its now-hidden originating suggestion, same line.
+    slotCard(host, 'additions', 10, suggestionCard({ hiddenForAdoption: true }));
+    slotCard(host, 'additions', 10, userCommentCard({ adopted: true }));
+
+    const cm = new CommentMinimizer();
+    cm.setMinimized(true);
+
+    const btn = lineIndicators()[0];
+    expect(btn.innerHTML).toContain('indicator-adopted');
+    expect(btn.innerHTML).not.toContain('indicator-ai');
+    expect(btn.title).toBe('1 adopted comment');
+  });
+
+  it('counts a runtime-restored suggestion whose flag is the string "false"', () => {
+    // Regression: `!dataset.hiddenForAdoption` treated the literal 'false'
+    // string as truthy and dropped a restored suggestion from the count.
+    const { host } = makeFile('a.js');
+    slotCard(host, 'additions', 10, suggestionCard({ hiddenForAdoption: 'false' }));
+
+    const cm = new CommentMinimizer();
+    cm.setMinimized(true);
+
+    const btn = lineIndicators()[0];
+    expect(btn.innerHTML).toContain('indicator-ai');
+    expect(btn.title).toBe('1 suggestion');
+  });
+
+  it('injects no indicator when a line\'s only card is hidden for adoption', () => {
+    // The suggestion is represented by its adopted comment elsewhere; with no
+    // other card on the line the group has zero counts and must not produce an
+    // empty (icon-less, title-less) button.
+    const { host } = makeFile('a.js');
+    slotCard(host, 'additions', 10, suggestionCard({ hiddenForAdoption: 'true' }));
+
+    const cm = new CommentMinimizer();
+    cm.setMinimized(true);
+
+    expect(lineIndicators()).toHaveLength(0);
+  });
+
+  it('uses the external chat icon and counts thread bubbles', () => {
+    const { host } = makeFile('a.js');
+    slotCard(host, 'deletions', 4, externalCard({ bubbles: 3 }));
+
+    const cm = new CommentMinimizer();
+    cm.setMinimized(true);
+
+    const btn = lineIndicators()[0];
+    expect(btn.innerHTML).toContain('indicator-external');
+    expect(btn.innerHTML).toContain('<span class="indicator-count">3</span>');
+    expect(btn.title).toBe('3 external comments');
+  });
+
+  it('aggregates mixed card types on the same line into one indicator', () => {
+    const { host } = makeFile('a.js');
+    slotCard(host, 'additions', 10, userCommentCard());
+    slotCard(host, 'additions', 10, userCommentCard({ adopted: true }));
+    slotCard(host, 'additions', 10, suggestionCard());
+    slotCard(host, 'additions', 10, externalCard({ bubbles: 1 }));
+
+    const cm = new CommentMinimizer();
+    cm.setMinimized(true);
+
+    const indicators = lineIndicators();
+    expect(indicators).toHaveLength(1);
+    const btn = indicators[0];
+    expect(btn.innerHTML).toContain('indicator-user');
+    expect(btn.innerHTML).toContain('indicator-adopted');
+    expect(btn.innerHTML).toContain('indicator-ai');
+    expect(btn.innerHTML).toContain('indicator-external');
+    // 1 user + 1 adopted + 1 AI + 1 external = 4
+    expect(btn.innerHTML).toContain('<span class="indicator-count">4</span>');
+    expect(btn.title).toBe('1 comment, 1 adopted comment, 1 suggestion, 1 external comment');
+  });
+
+  it('separates cards on different lines and different sides', () => {
+    const { host } = makeFile('a.js');
+    slotCard(host, 'additions', 10, userCommentCard());
+    slotCard(host, 'additions', 20, suggestionCard());
+    slotCard(host, 'deletions', 10, externalCard());
+
+    const cm = new CommentMinimizer();
+    cm.setMinimized(true);
+
+    // Three distinct line+side groups → three indicators.
+    expect(lineIndicators()).toHaveLength(3);
+  });
+
+  it('scopes grouping per file so identical slot names do not merge', () => {
+    const a = makeFile('a.js');
+    const b = makeFile('b.js');
+    slotCard(a.host, 'additions', 10, userCommentCard());
+    slotCard(b.host, 'additions', 10, suggestionCard());
+
+    const cm = new CommentMinimizer();
+    cm.setMinimized(true);
+
+    // Same slot string "annotation-additions-10" but different files.
+    expect(lineIndicators()).toHaveLength(2);
+  });
+
+  it('ignores comment forms / tour stops (non-minimized annotations)', () => {
+    const { host } = makeFile('a.js');
+    const form = document.createElement('div');
+    form.className = 'user-comment-form';
+    slotCard(host, 'additions', 10, form);
+
+    const cm = new CommentMinimizer();
+    cm.setMinimized(true);
+
+    expect(lineIndicators()).toHaveLength(0);
+  });
+});
+
+// ===========================================================================
+// Toggle expand / collapse
+// ===========================================================================
+
+describe('CommentMinimizer — expand/collapse', () => {
+  it('shows and hides a line group when the indicator is clicked', () => {
+    const { host } = makeFile('a.js');
+    const w1 = slotCard(host, 'additions', 10, userCommentCard());
+    const w2 = slotCard(host, 'additions', 10, suggestionCard());
+
+    const cm = new CommentMinimizer();
+    cm.setMinimized(true);
+
+    const card1 = w1.firstElementChild;
+    const card2 = w2.firstElementChild;
+    expect(card1.classList.contains('comment-expanded')).toBe(false);
+
+    const btn = lineIndicators()[0];
+    btn.click();
+    expect(btn.classList.contains('expanded')).toBe(true);
+    expect(card1.classList.contains('comment-expanded')).toBe(true);
+    expect(card2.classList.contains('comment-expanded')).toBe(true);
+
+    btn.click();
+    expect(btn.classList.contains('expanded')).toBe(false);
+    expect(card1.classList.contains('comment-expanded')).toBe(false);
+    expect(card2.classList.contains('comment-expanded')).toBe(false);
+  });
+
+  it('tracks expanded lines independently', () => {
+    const { host } = makeFile('a.js');
+    slotCard(host, 'additions', 10, userCommentCard());
+    slotCard(host, 'additions', 20, userCommentCard());
+
+    const cm = new CommentMinimizer();
+    cm.setMinimized(true);
+
+    const [b1, b2] = lineIndicators();
+    b1.click();
+    expect(cm._expandedLines.size).toBe(1);
+    b2.click();
+    expect(cm._expandedLines.size).toBe(2);
+    b1.click();
+    expect(cm._expandedLines.size).toBe(1);
+  });
+});
+
+// ===========================================================================
+// Stable-key expansion survives a vendor rerender
+// ===========================================================================
+
+describe('CommentMinimizer — rerender resilience', () => {
+  it('re-applies expansion after the vendor recreates the cards', () => {
+    const { host } = makeFile('a.js');
+    slotCard(host, 'additions', 10, userCommentCard());
+
+    const cm = new CommentMinimizer();
+    cm.setMinimized(true);
+
+    // User expands the line.
+    lineIndicators()[0].click();
+    expect(cm._expandedLines.size).toBe(1);
+
+    // Simulate a vendor rerender: every [data-annotation-slot] wrapper (and its
+    // card + our injected indicator) is destroyed and rebuilt fresh — no
+    // .comment-expanded, no indicator. Element identity does NOT survive.
+    host.innerHTML = '';
+    const rebuilt = slotCard(host, 'additions', 10, userCommentCard());
+    expect(rebuilt.firstElementChild.classList.contains('comment-expanded')).toBe(false);
+
+    // The minimizer's stable string key survives, so a refresh restores state.
+    cm.refreshIndicators();
+
+    const btn = lineIndicators()[0];
+    expect(btn.classList.contains('expanded')).toBe(true);
+    expect(rebuilt.firstElementChild.classList.contains('comment-expanded')).toBe(true);
+  });
+
+  it('does not duplicate indicators across refreshes', () => {
+    const { host } = makeFile('a.js');
+    slotCard(host, 'additions', 10, userCommentCard());
+
+    const cm = new CommentMinimizer();
+    cm.setMinimized(true);
+    cm.refreshIndicators();
+    cm.refreshIndicators();
+
+    expect(lineIndicators()).toHaveLength(1);
+  });
+});
+
+// ===========================================================================
+// findDiffRowFor
+// ===========================================================================
+
+describe('CommentMinimizer — findDiffRowFor', () => {
+  it('returns the vendor annotation wrapper for a slotted card', () => {
+    const { host } = makeFile('a.js');
+    const card = userCommentCard();
+    const wrapper = slotCard(host, 'additions', 10, card);
+
+    const cm = new CommentMinimizer();
+    expect(cm.findDiffRowFor(card)).toBe(wrapper);
+    // Also from a descendant of the card.
+    expect(cm.findDiffRowFor(card.firstElementChild)).toBe(wrapper);
+  });
+
+  it('returns null for an element not slotted onto a diff line', () => {
+    const loose = document.createElement('div');
+    document.body.appendChild(loose);
+
+    const cm = new CommentMinimizer();
+    expect(cm.findDiffRowFor(loose)).toBeNull();
+  });
+});
+
+// ===========================================================================
+// expandForElement
+// ===========================================================================
+
+describe('CommentMinimizer — expandForElement', () => {
+  it('expands the whole line group for a line-level card', () => {
+    const { host } = makeFile('a.js');
+    const w1 = slotCard(host, 'additions', 10, userCommentCard());
+    const w2 = slotCard(host, 'additions', 10, suggestionCard());
+
+    const cm = new CommentMinimizer();
+    cm.setMinimized(true);
+
+    cm.expandForElement(w2.firstElementChild);
+
+    expect(cm._expandedLines.size).toBe(1);
+    expect(w1.firstElementChild.classList.contains('comment-expanded')).toBe(true);
+    expect(w2.firstElementChild.classList.contains('comment-expanded')).toBe(true);
+    expect(lineIndicators()[0].classList.contains('expanded')).toBe(true);
+  });
+
+  it('is a no-op when not active', () => {
+    const { host } = makeFile('a.js');
+    const card = userCommentCard();
+    slotCard(host, 'additions', 10, card);
+
+    const cm = new CommentMinimizer();
+    cm.expandForElement(card);
+
+    expect(cm._expandedLines.size).toBe(0);
+    expect(card.classList.contains('comment-expanded')).toBe(false);
+  });
+
+  it('is a no-op for an element with no annotation wrapper', () => {
+    const loose = document.createElement('div');
+    const cm = new CommentMinimizer();
+    cm._active = true;
+    cm.expandForElement(loose);
+    expect(cm._expandedLines.size).toBe(0);
+  });
+
+  it('expands a file-comments-zone for a file-level element', () => {
+    const { zone } = makeFile('a.js', { withZone: true });
+    const card = fileCommentCard(zone, 'user-comment');
+
+    const cm = new CommentMinimizer();
+    cm.setMinimized(true);
+
+    cm.expandForElement(card);
+    expect(cm._expandedFiles.has(zone)).toBe(true);
+    expect(zone.classList.contains('file-comments-expanded')).toBe(true);
+    // File-header indicator is marked expanded.
+    const indicator = document.querySelector('.d2h-file-header .file-comment-indicator');
+    expect(indicator.classList.contains('expanded')).toBe(true);
+  });
+});
+
+// ===========================================================================
+// setMinimized cleanup
+// ===========================================================================
+
+describe('CommentMinimizer — setMinimized', () => {
+  it('adds the container class and injects indicators when enabled', () => {
+    const { host } = makeFile('a.js');
+    slotCard(host, 'additions', 10, userCommentCard());
+
+    const cm = new CommentMinimizer();
+    cm.setMinimized(true);
+
+    expect(cm.active).toBe(true);
+    expect(diffContainer().classList.contains('comments-minimized')).toBe(true);
+    expect(lineIndicators()).toHaveLength(1);
+  });
+
+  it('removes the class, indicators and expansion overrides when disabled', () => {
+    const { host } = makeFile('a.js');
+    const w = slotCard(host, 'additions', 10, userCommentCard());
+
+    const cm = new CommentMinimizer();
+    cm.setMinimized(true);
+    lineIndicators()[0].click();
+    expect(w.firstElementChild.classList.contains('comment-expanded')).toBe(true);
+
+    cm.setMinimized(false);
+
+    expect(cm.active).toBe(false);
+    expect(diffContainer().classList.contains('comments-minimized')).toBe(false);
+    expect(lineIndicators()).toHaveLength(0);
+    expect(w.firstElementChild.classList.contains('comment-expanded')).toBe(false);
+    expect(cm._expandedLines.size).toBe(0);
+  });
+});
+
+// ===========================================================================
+// File-level indicators (unchanged path)
+// ===========================================================================
+
+describe('CommentMinimizer — file-level indicators', () => {
+  function fileIndicator() {
+    return document.querySelector('.d2h-file-header .file-comment-indicator');
+  }
+
+  it('injects a file-header indicator for a zone with user comments', () => {
+    const { zone } = makeFile('a.js', { withZone: true });
+    fileCommentCard(zone, 'user-comment');
+
+    const cm = new CommentMinimizer();
+    cm.setMinimized(true);
+
+    const btn = fileIndicator();
+    expect(btn).toBeTruthy();
+    expect(btn.innerHTML).toContain('indicator-user');
+    expect(btn.title).toBe('1 file comment');
+  });
+
+  it('shows combined counts and skips collapsed cards', () => {
+    const { zone } = makeFile('a.js', { withZone: true });
+    fileCommentCard(zone, 'ai-suggestion', { collapsed: true }); // ignored
+    fileCommentCard(zone, 'user-comment', { adopted: true });
+    fileCommentCard(zone, 'ai-suggestion');
+    fileCommentCard(zone, 'user-comment');
+
+    const cm = new CommentMinimizer();
+    cm.setMinimized(true);
+
+    const btn = fileIndicator();
+    expect(btn.innerHTML).toContain('indicator-user');
+    expect(btn.innerHTML).toContain('indicator-adopted');
+    expect(btn.innerHTML).toContain('indicator-ai');
+    // 1 user + 1 adopted + 1 AI = 3 (collapsed AI not counted)
+    expect(btn.innerHTML).toContain('<span class="indicator-count">3</span>');
+  });
+
+  it('inserts the indicator before the file-header comment button', () => {
+    const { zone, header } = makeFile('a.js', { withZone: true });
+    fileCommentCard(zone, 'user-comment');
+
+    const cm = new CommentMinimizer();
+    cm.setMinimized(true);
+
+    const kids = [...header.children];
+    const indicatorIdx = kids.findIndex(c => c.classList.contains('file-comment-indicator'));
+    const btnIdx = kids.findIndex(c => c.classList.contains('file-header-comment-btn'));
+    expect(indicatorIdx).toBeGreaterThanOrEqual(0);
+    expect(indicatorIdx).toBeLessThan(btnIdx);
+  });
+
+  it('toggles file comments when the indicator is clicked', () => {
+    const { zone } = makeFile('a.js', { withZone: true });
+    fileCommentCard(zone, 'user-comment');
+
+    const cm = new CommentMinimizer();
+    cm.setMinimized(true);
+
+    const btn = fileIndicator();
+    btn.click();
+    expect(cm._expandedFiles.has(zone)).toBe(true);
+    expect(zone.classList.contains('file-comments-expanded')).toBe(true);
+    btn.click();
+    expect(cm._expandedFiles.has(zone)).toBe(false);
+    expect(zone.classList.contains('file-comments-expanded')).toBe(false);
+  });
+
+  it('does not inject an indicator for an empty zone', () => {
+    makeFile('a.js', { withZone: true });
+
+    const cm = new CommentMinimizer();
+    cm.setMinimized(true);
+
+    expect(fileIndicator()).toBeNull();
+  });
+
+  it('clears file-level expansion state and indicators when disabled', () => {
+    const { zone } = makeFile('a.js', { withZone: true });
+    fileCommentCard(zone, 'user-comment');
+
+    const cm = new CommentMinimizer();
+    cm.setMinimized(true);
+    fileIndicator().click();
+    expect(cm._expandedFiles.size).toBe(1);
+    expect(zone.classList.contains('file-comments-expanded')).toBe(true);
+
+    cm.setMinimized(false);
+
+    expect(cm._expandedFiles.size).toBe(0);
+    expect(document.querySelector('.file-comments-expanded')).toBeNull();
+    expect(document.querySelector('.file-comment-indicator')).toBeNull();
+  });
+});
+
+// ===========================================================================
+// Mutation-driven re-injection
+// ===========================================================================
+
+describe('CommentMinimizer — mutation observer', () => {
+  it('debounces a refresh in response to DOM mutations', () => {
+    const { host } = makeFile('a.js');
+    slotCard(host, 'additions', 10, userCommentCard());
+
+    const cm = new CommentMinimizer();
+    cm._active = true;
+    const refreshSpy = vi.spyOn(cm, 'refreshIndicators');
+
+    // Stub rAF so we control when the debounced refresh runs.
+    let queued = null;
+    const rafStub = vi.spyOn(window, 'requestAnimationFrame').mockImplementation((fn) => {
+      queued = fn;
+      return 1;
+    });
+
+    // Two mutations before the frame fires → one scheduled refresh.
+    cm._onDomMutation();
+    cm._onDomMutation();
+    expect(refreshSpy).not.toHaveBeenCalled();
+    expect(rafStub).toHaveBeenCalledTimes(1);
+
+    queued();
+    expect(refreshSpy).toHaveBeenCalledTimes(1);
+
+    // After the frame, a new mutation schedules again.
+    cm._onDomMutation();
+    expect(rafStub).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not schedule when inactive', () => {
+    const cm = new CommentMinimizer();
+    cm._active = false;
+    const rafStub = vi.spyOn(window, 'requestAnimationFrame');
+    cm._onDomMutation();
+    expect(rafStub).not.toHaveBeenCalled();
+  });
+
+  it('_startObserving watches #diff-container and routes the callback to _onDomMutation', () => {
+    makeFile('a.js');
+
+    // A controlled MutationObserver that captures the constructor callback and
+    // observe() arguments (the beforeEach no-op stub can't assert either).
+    let capturedCb;
+    let observeArgs;
+    const prev = global.MutationObserver;
+    global.MutationObserver = class {
+      constructor(cb) { capturedCb = cb; }
+      observe(target, opts) { observeArgs = { target, opts }; }
+      disconnect() {}
+    };
+    window.MutationObserver = global.MutationObserver;
+
+    try {
+      const cm = new CommentMinimizer();
+      cm._active = true;
+      const onMutation = vi.spyOn(cm, '_onDomMutation').mockImplementation(() => {});
+
+      cm._startObserving();
+
+      expect(observeArgs.target).toBe(document.getElementById('diff-container'));
+      expect(observeArgs.opts).toEqual({ childList: true, subtree: true });
+
+      // The constructor callback must reach _onDomMutation with `this` intact —
+      // guards against a refactor to a bare `this._onDomMutation` method ref.
+      capturedCb([], {});
+      expect(onMutation).toHaveBeenCalledTimes(1);
+    } finally {
+      global.MutationObserver = prev;
+      window.MutationObserver = prev;
     }
-
-    it('should inject indicator for a user-comment-only line', () => {
-      const codeCell = buildCodeCell();
-      const rows = buildRows([
-        { classes: ['d2h-cntx'], children: { '.d2h-code-line-ctn': codeCell } },
-        { classes: ['user-comment-row'] },
-      ]);
-
-      mockQuerySelectorAll([rows[1]], []);
-
-      const cm = new CommentMinimizer();
-      cm._active = true;
-      cm.refreshIndicators();
-
-      // An indicator button should have been appended
-      expect(codeCell.children.length).toBe(1);
-      const btn = codeCell.children[0];
-      expect(btn.className).toBe('comment-indicator');
-      // Should contain person icon, not sparkles
-      expect(btn.innerHTML).toContain('indicator-user');
-      expect(btn.innerHTML).not.toContain('indicator-ai');
-      expect(btn.title).toBe('1 comment');
-    });
-
-    it('should inject indicator for an AI-suggestion-only line', () => {
-      // Build suggestion row with one .ai-suggestion child div
-      const suggestionDiv = {
-        classList: { _set: new Set(['ai-suggestion']), contains(c) { return this._set.has(c); } },
-      };
-      const codeCell = buildCodeCell();
-      const rows = buildRows([
-        { classes: ['d2h-cntx'], children: { '.d2h-code-line-ctn': codeCell } },
-        {
-          classes: ['ai-suggestion-row'],
-          children: { '.ai-suggestion': suggestionDiv },
-        },
-      ]);
-      // Override querySelectorAll on the suggestion row to return 1 item
-      rows[1].querySelectorAll = (selector) => {
-        if (selector === '.ai-suggestion') return [suggestionDiv];
-        return [];
-      };
-
-      mockQuerySelectorAll([], [rows[1]]);
-
-      const cm = new CommentMinimizer();
-      cm._active = true;
-      cm.refreshIndicators();
-
-      expect(codeCell.children.length).toBe(1);
-      const btn = codeCell.children[0];
-      expect(btn.innerHTML).toContain('indicator-ai');
-      expect(btn.innerHTML).not.toContain('indicator-user');
-      expect(btn.title).toBe('1 suggestion');
-    });
-
-    it('should inject indicator for an adopted-comment-only line', () => {
-      // Build user-comment-row that contains an .adopted-comment div
-      const adoptedDiv = {
-        classList: { _set: new Set(['adopted-comment']), contains(c) { return this._set.has(c); } },
-      };
-      const codeCell = buildCodeCell();
-      const rows = buildRows([
-        { classes: ['d2h-cntx'], children: { '.d2h-code-line-ctn': codeCell } },
-        {
-          classes: ['user-comment-row'],
-          children: { '.adopted-comment': adoptedDiv },
-        },
-      ]);
-
-      mockQuerySelectorAll([rows[1]], []);
-
-      const cm = new CommentMinimizer();
-      cm._active = true;
-      cm.refreshIndicators();
-
-      expect(codeCell.children.length).toBe(1);
-      const btn = codeCell.children[0];
-      expect(btn.innerHTML).toContain('indicator-adopted');
-      expect(btn.innerHTML).not.toContain('indicator-user');
-      expect(btn.title).toBe('1 adopted comment');
-    });
-
-    it('should combine counts for mixed comment types on the same diff line', () => {
-      const adoptedDiv = {
-        classList: { _set: new Set(['adopted-comment']), contains(c) { return this._set.has(c); } },
-      };
-      const suggestionDiv = {
-        classList: { _set: new Set(['ai-suggestion']), contains(c) { return this._set.has(c); } },
-      };
-      const codeCell = buildCodeCell();
-
-      const rows = buildRows([
-        { classes: ['d2h-cntx'], children: { '.d2h-code-line-ctn': codeCell } },
-        { classes: ['user-comment-row'] },                                       // plain user comment
-        { classes: ['user-comment-row'], children: { '.adopted-comment': adoptedDiv } },  // adopted
-        { classes: ['ai-suggestion-row'], children: { '.ai-suggestion': suggestionDiv } }, // AI
-      ]);
-      rows[3].querySelectorAll = (selector) => {
-        if (selector === '.ai-suggestion') return [suggestionDiv];
-        return [];
-      };
-
-      mockQuerySelectorAll([rows[1], rows[2]], [rows[3]]);
-
-      const cm = new CommentMinimizer();
-      cm._active = true;
-      cm.refreshIndicators();
-
-      expect(codeCell.children.length).toBe(1);
-      const btn = codeCell.children[0];
-      // All three types present
-      expect(btn.innerHTML).toContain('indicator-user');
-      expect(btn.innerHTML).toContain('indicator-adopted');
-      expect(btn.innerHTML).toContain('indicator-ai');
-      // Total = 1 user + 1 adopted + 1 AI = 3
-      expect(btn.innerHTML).toContain('<span class="indicator-count">3</span>');
-      expect(btn.title).toBe('1 comment, 1 adopted comment, 1 suggestion');
-    });
-
-    it('should count multiple AI suggestions within a single suggestion row', () => {
-      const s1 = {
-        classList: { _set: new Set(['ai-suggestion']), contains(c) { return this._set.has(c); } },
-      };
-      const s2 = {
-        classList: { _set: new Set(['ai-suggestion']), contains(c) { return this._set.has(c); } },
-      };
-      const codeCell = buildCodeCell();
-
-      const rows = buildRows([
-        { classes: ['d2h-cntx'], children: { '.d2h-code-line-ctn': codeCell } },
-        { classes: ['ai-suggestion-row'] },
-      ]);
-      rows[1].querySelectorAll = (selector) => {
-        if (selector === '.ai-suggestion') return [s1, s2];
-        return [];
-      };
-
-      mockQuerySelectorAll([], [rows[1]]);
-
-      const cm = new CommentMinimizer();
-      cm._active = true;
-      cm.refreshIndicators();
-
-      const btn = codeCell.children[0];
-      expect(btn.title).toBe('2 suggestions');
-    });
-
-    it('should be a no-op when not active', () => {
-      mockQuerySelectorAll([], []);
-
-      const cm = new CommentMinimizer();
-      cm._active = false;
-      cm.refreshIndicators();
-
-      // querySelectorAll should not have been called for comment rows
-      expect(global.document.querySelectorAll).not.toHaveBeenCalledWith('.user-comment-row');
-    });
-
-    it('should not inject indicators when comment row has no parent diff row', () => {
-      // Comment row is first — no previous sibling
-      const rows = buildRows([
-        { classes: ['user-comment-row'] },
-      ]);
-
-      mockQuerySelectorAll([rows[0]], []);
-
-      const cm = new CommentMinimizer();
-      cm._active = true;
-      cm.refreshIndicators();
-
-      // createElement should not have been called (no indicator injected)
-      expect(global.document.createElement).not.toHaveBeenCalled();
-    });
-
-    it('should not throw when diff row has no codeCell', () => {
-      // Diff row without .d2h-code-line-ctn child
-      const rows = buildRows([
-        { classes: ['d2h-cntx'] },
-        { classes: ['user-comment-row'] },
-      ]);
-
-      mockQuerySelectorAll([rows[1]], []);
-
-      const cm = new CommentMinimizer();
-      cm._active = true;
-
-      // Should not throw
-      expect(() => cm.refreshIndicators()).not.toThrow();
-      // No indicator created since there is no codeCell
-      expect(global.document.createElement).not.toHaveBeenCalled();
-    });
-
-    it('should not create duplicate indicators when called twice', () => {
-      const codeCell = buildCodeCell();
-      const rows = buildRows([
-        { classes: ['d2h-cntx'], children: { '.d2h-code-line-ctn': codeCell } },
-        { classes: ['user-comment-row'] },
-      ]);
-
-      mockQuerySelectorAll([rows[1]], []);
-
-      const cm = new CommentMinimizer();
-      cm._active = true;
-      cm.refreshIndicators();
-      cm.refreshIndicators();
-
-      // Only one indicator should exist — refreshIndicators removes old ones first
-      expect(codeCell.children.length).toBe(1);
-    });
-
-    it('should add expanded class to indicator when diff line is in _expandedLines', () => {
-      const codeCell = buildCodeCell();
-      const rows = buildRows([
-        { classes: ['d2h-cntx'], children: { '.d2h-code-line-ctn': codeCell } },
-        { classes: ['user-comment-row'] },
-      ]);
-
-      mockQuerySelectorAll([rows[1]], []);
-
-      const cm = new CommentMinimizer();
-      cm._active = true;
-      cm._expandedLines.add(rows[0]);
-      cm.refreshIndicators();
-
-      const btn = codeCell.children[0];
-      expect(btn.classList.contains('expanded')).toBe(true);
-    });
-
-    it('should re-apply .comment-expanded to rebuilt rows on refresh when the diff line is in _expandedLines', () => {
-      // Regression: external-comment refresh tears down and rebuilds
-      // `.external-comment-row` elements. The rebuilt rows have no
-      // expanded class. _injectIndicator was setting btn.expanded based
-      // on _expandedLines but never re-applying `.comment-expanded` to
-      // the new rows, leaving the indicator "open" while the rows stayed
-      // hidden by the `.comments-minimized .external-comment-row` rule.
-      const codeCell = buildCodeCell();
-      // Fresh external-comment-row after rebuild — has NO comment-expanded yet.
-      const rebuiltExternal = {
-        classList: {
-          _set: new Set(['external-comment-row']),
-          add(c) { this._set.add(c); },
-          remove(c) { this._set.delete(c); },
-          contains(c) { return this._set.has(c); },
-        },
-      };
-      // The thread bubble children so the indicator path still works.
-      const bubble = {
-        classList: { _set: new Set(['external-comment']), contains(c) { return this._set.has(c); } },
-      };
-      const rows = buildRows([
-        { classes: ['d2h-cntx'], children: { '.d2h-code-line-ctn': codeCell } },
-      ]);
-      // Wire rebuiltExternal as a sibling of rows[0] using the same shape buildRows uses.
-      rebuiltExternal.previousElementSibling = rows[0];
-      rebuiltExternal.nextElementSibling = null;
-      rows[0].nextElementSibling = rebuiltExternal;
-      rebuiltExternal.querySelectorAll = (selector) => {
-        if (selector === '.external-comment') return [bubble];
-        return [];
-      };
-
-      mockQuerySelectorAll([], [], [rebuiltExternal]);
-
-      const cm = new CommentMinimizer();
-      cm._active = true;
-      // User had previously expanded this line — the Set survives the rebuild,
-      // even though .comment-expanded has been wiped from the rebuilt rows.
-      cm._expandedLines.add(rows[0]);
-      cm.refreshIndicators();
-
-      // Indicator button reflects "expanded"
-      const btn = codeCell.children[0];
-      expect(btn.classList.contains('expanded')).toBe(true);
-      // Rebuilt row must regain .comment-expanded so it becomes visible
-      // again via the `.comments-minimized .external-comment-row.comment-expanded`
-      // display: table-row override.
-      expect(rebuiltExternal.classList.contains('comment-expanded')).toBe(true);
-    });
-
-    it('should inject an external-comment indicator and count the bubbles in the thread card', () => {
-      // Regression: external-comment-row was previously excluded from the
-      // minimizer. The row stayed visible while user/AI rows were hidden,
-      // and no indicator counted toward the per-line badge total.
-      const bubble1 = {
-        classList: { _set: new Set(['external-comment']), contains(c) { return this._set.has(c); } },
-      };
-      const bubble2 = {
-        classList: { _set: new Set(['external-comment']), contains(c) { return this._set.has(c); } },
-      };
-      const bubble3 = {
-        classList: { _set: new Set(['external-comment']), contains(c) { return this._set.has(c); } },
-      };
-      const codeCell = buildCodeCell();
-
-      const rows = buildRows([
-        { classes: ['d2h-cntx'], children: { '.d2h-code-line-ctn': codeCell } },
-        { classes: ['external-comment-row'] },
-      ]);
-      rows[1].querySelectorAll = (selector) => {
-        if (selector === '.external-comment') return [bubble1, bubble2, bubble3];
-        return [];
-      };
-
-      mockQuerySelectorAll([], [], [rows[1]]);
-
-      const cm = new CommentMinimizer();
-      cm._active = true;
-      cm.refreshIndicators();
-
-      expect(codeCell.children.length).toBe(1);
-      const btn = codeCell.children[0];
-      expect(btn.innerHTML).toContain('indicator-external');
-      // The thread card has 3 bubbles (root + 2 replies); the count reflects that.
-      expect(btn.innerHTML).toContain('<span class="indicator-count">3</span>');
-      expect(btn.title).toBe('3 external comments');
-    });
-
-    it('mixes external counts into the total alongside user/AI rows', () => {
-      const externalBubble = {
-        classList: { _set: new Set(['external-comment']), contains(c) { return this._set.has(c); } },
-      };
-      const codeCell = buildCodeCell();
-
-      const rows = buildRows([
-        { classes: ['d2h-cntx'], children: { '.d2h-code-line-ctn': codeCell } },
-        { classes: ['user-comment-row'] },
-        { classes: ['external-comment-row'] },
-      ]);
-      rows[2].querySelectorAll = (selector) => {
-        if (selector === '.external-comment') return [externalBubble];
-        return [];
-      };
-
-      mockQuerySelectorAll([rows[1]], [], [rows[2]]);
-
-      const cm = new CommentMinimizer();
-      cm._active = true;
-      cm.refreshIndicators();
-
-      const btn = codeCell.children[0];
-      expect(btn.innerHTML).toContain('indicator-user');
-      expect(btn.innerHTML).toContain('indicator-external');
-      // 1 user + 1 external = 2
-      expect(btn.innerHTML).toContain('<span class="indicator-count">2</span>');
-      expect(btn.title).toBe('1 comment, 1 external comment');
-    });
-  });
-
-  // -------------------------------------------------------------------------
-  // Toggle expand/collapse
-  // -------------------------------------------------------------------------
-  describe('toggle expand/collapse', () => {
-    it('should expand then collapse comment rows via _toggleLineComments', () => {
-      const codeCell = buildCodeCell();
-      const rows = buildRows([
-        { classes: ['d2h-cntx'], children: { '.d2h-code-line-ctn': codeCell } },
-        { classes: ['user-comment-row'] },
-        { classes: ['ai-suggestion-row'] },
-      ]);
-
-      const cm = new CommentMinimizer();
-      const btn = buildMockButton();
-
-      // Expand
-      cm._toggleLineComments(rows[0], btn);
-      expect(cm._expandedLines.has(rows[0])).toBe(true);
-      expect(btn.classList.contains('expanded')).toBe(true);
-      expect(rows[1].classList.contains('comment-expanded')).toBe(true);
-      expect(rows[2].classList.contains('comment-expanded')).toBe(true);
-
-      // Collapse
-      cm._toggleLineComments(rows[0], btn);
-      expect(cm._expandedLines.has(rows[0])).toBe(false);
-      expect(btn.classList.contains('expanded')).toBe(false);
-      expect(rows[1].classList.contains('comment-expanded')).toBe(false);
-      expect(rows[2].classList.contains('comment-expanded')).toBe(false);
-    });
-
-    it('should track multiple expanded lines independently', () => {
-      const cell1 = buildCodeCell();
-      const cell2 = buildCodeCell();
-      const rows = buildRows([
-        { classes: ['d2h-cntx'], children: { '.d2h-code-line-ctn': cell1 } },
-        { classes: ['user-comment-row'] },
-        { classes: ['d2h-ins'], children: { '.d2h-code-line-ctn': cell2 } },
-        { classes: ['ai-suggestion-row'] },
-      ]);
-
-      const cm = new CommentMinimizer();
-      const btn1 = buildMockButton();
-      const btn2 = buildMockButton();
-
-      cm._toggleLineComments(rows[0], btn1);
-      cm._toggleLineComments(rows[2], btn2);
-
-      expect(cm._expandedLines.size).toBe(2);
-
-      // Collapse only the first
-      cm._toggleLineComments(rows[0], btn1);
-      expect(cm._expandedLines.has(rows[0])).toBe(false);
-      expect(cm._expandedLines.has(rows[2])).toBe(true);
-    });
-  });
-
-  // -------------------------------------------------------------------------
-  // setMinimized
-  // -------------------------------------------------------------------------
-  describe('setMinimized', () => {
-    it('should add comments-minimized class and refresh when enabled', () => {
-      const codeCell = buildCodeCell();
-      const rows = buildRows([
-        { classes: ['d2h-cntx'], children: { '.d2h-code-line-ctn': codeCell } },
-        { classes: ['user-comment-row'] },
-      ]);
-
-      global.document.querySelectorAll = vi.fn((selector) => {
-        if (selector === '.user-comment-row') return [rows[1]];
-        if (selector === '.ai-suggestion-row') return [];
-        if (selector === '.comment-indicator') return [];
-        if (selector === '.comment-expanded') return [];
-        return [];
-      });
-
-      const cm = new CommentMinimizer();
-      cm.setMinimized(true);
-
-      expect(cm.active).toBe(true);
-      expect(diffContainer.classList.contains('comments-minimized')).toBe(true);
-      // Indicator should have been injected
-      expect(codeCell.children.length).toBe(1);
-    });
-
-    it('should remove comments-minimized class and indicators when disabled', () => {
-      const mockIndicator1 = { remove: vi.fn() };
-      const mockIndicator2 = { remove: vi.fn() };
-      global.document.querySelectorAll = vi.fn((selector) => {
-        if (selector === '.comment-indicator') return [mockIndicator1, mockIndicator2];
-        if (selector === '.comment-expanded') return [];
-        return [];
-      });
-
-      const cm = new CommentMinimizer();
-      cm._active = true;
-      diffContainer.classList.add('comments-minimized');
-
-      cm.setMinimized(false);
-
-      expect(cm.active).toBe(false);
-      expect(diffContainer.classList.contains('comments-minimized')).toBe(false);
-      expect(mockIndicator1.remove).toHaveBeenCalled();
-      expect(mockIndicator2.remove).toHaveBeenCalled();
-    });
-
-    it('should clear _expandedLines when toggling', () => {
-      global.document.querySelectorAll = vi.fn(() => []);
-
-      const cm = new CommentMinimizer();
-      cm._expandedLines.add('fake-row');
-
-      cm.setMinimized(true);
-      expect(cm._expandedLines.size).toBe(0);
-    });
-  });
-
-  // -------------------------------------------------------------------------
-  // findDiffRowFor (public)
-  // -------------------------------------------------------------------------
-  describe('findDiffRowFor', () => {
-    it('should locate the diff row from a child element inside a comment row', () => {
-      const rows = buildRows([
-        { classes: ['d2h-cntx'] },
-        { classes: ['user-comment-row'] },
-      ]);
-
-      // Build child element that closest() resolves to the comment row
-      const child = buildChildElement(rows[1]);
-
-      const cm = new CommentMinimizer();
-      expect(cm.findDiffRowFor(child)).toBe(rows[0]);
-    });
-
-    it('should locate the diff row from a child element inside a suggestion row', () => {
-      const rows = buildRows([
-        { classes: ['d2h-ins'] },
-        { classes: ['ai-suggestion-row'] },
-      ]);
-
-      const child = buildChildElement(rows[1]);
-
-      const cm = new CommentMinimizer();
-      expect(cm.findDiffRowFor(child)).toBe(rows[0]);
-    });
-
-    it('should return null if element is not inside a comment or suggestion row', () => {
-      const rows = buildRows([
-        { classes: ['d2h-cntx'] },
-      ]);
-
-      // A child that is not inside a comment/suggestion row
-      const unrelated = {
-        closest() { return null; },
-        classList: {
-          _set: new Set(),
-          contains(cls) { return this._set.has(cls); },
-        },
-      };
-
-      const cm = new CommentMinimizer();
-      expect(cm.findDiffRowFor(unrelated)).toBeNull();
-    });
-
-    it('should skip intermediate rows between the comment row and diff row', () => {
-      const rows = buildRows([
-        { classes: ['d2h-cntx'] },
-        { classes: ['comment-form-row'] },
-        { classes: ['ai-suggestion-row'] },
-        { classes: ['user-comment-row'] },
-      ]);
-
-      const child = buildChildElement(rows[3]);
-
-      const cm = new CommentMinimizer();
-      expect(cm.findDiffRowFor(child)).toBe(rows[0]);
-    });
-  });
-
-  // -------------------------------------------------------------------------
-  // expandForElement
-  // -------------------------------------------------------------------------
-  describe('expandForElement', () => {
-    it('should expand comments for a given element and update indicator button', () => {
-      const indicatorBtn = buildMockButton('comment-indicator');
-      const codeCell = buildCodeCell();
-      codeCell.children.push(indicatorBtn);
-
-      const rows = buildRows([
-        { classes: ['d2h-cntx'], children: { '.d2h-code-line-ctn': codeCell } },
-        { classes: ['user-comment-row'] },
-        { classes: ['ai-suggestion-row'] },
-      ]);
-
-      // Wire up the diff row's querySelector to find the indicator inside codeCell
-      rows[0].querySelector = (selector) => {
-        if (selector === '.d2h-code-line-ctn .comment-indicator') return indicatorBtn;
-        if (selector === '.d2h-code-line-ctn') return codeCell;
-        return null;
-      };
-
-      const child = buildChildElement(rows[1]);
-
-      const cm = new CommentMinimizer();
-      cm._active = true;
-      cm.expandForElement(child);
-
-      // Should have expanded
-      expect(cm._expandedLines.has(rows[0])).toBe(true);
-      expect(rows[1].classList.contains('comment-expanded')).toBe(true);
-      expect(rows[2].classList.contains('comment-expanded')).toBe(true);
-      expect(indicatorBtn.classList.contains('expanded')).toBe(true);
-    });
-
-    it('should be a no-op when not active', () => {
-      const rows = buildRows([
-        { classes: ['d2h-cntx'] },
-        { classes: ['user-comment-row'] },
-      ]);
-
-      const child = buildChildElement(rows[1]);
-
-      const cm = new CommentMinimizer();
-      cm._active = false;
-      cm.expandForElement(child);
-
-      expect(cm._expandedLines.size).toBe(0);
-      expect(rows[1].classList.contains('comment-expanded')).toBe(false);
-    });
-
-    it('should be a no-op if element is not inside a comment/suggestion row', () => {
-      const unrelated = {
-        closest() { return null; },
-        classList: {
-          _set: new Set(),
-          contains(cls) { return this._set.has(cls); },
-        },
-      };
-
-      const cm = new CommentMinimizer();
-      cm._active = true;
-      cm.expandForElement(unrelated);
-
-      expect(cm._expandedLines.size).toBe(0);
-    });
-
-    it('should not re-expand if already expanded', () => {
-      const rows = buildRows([
-        { classes: ['d2h-cntx'] },
-        { classes: ['user-comment-row'] },
-      ]);
-
-      const child = buildChildElement(rows[1]);
-
-      const cm = new CommentMinimizer();
-      cm._active = true;
-
-      // Pre-expand
-      cm._expandedLines.add(rows[0]);
-
-      // Should exit early — comment-expanded should NOT be added because the
-      // early return prevents the forEach call
-      cm.expandForElement(child);
-
-      expect(cm._expandedLines.has(rows[0])).toBe(true);
-      // The row's class was not modified (no add call)
-      expect(rows[1].classList.contains('comment-expanded')).toBe(false);
-    });
-
-    it('should handle missing indicator button gracefully', () => {
-      const codeCell = buildCodeCell();
-      const rows = buildRows([
-        { classes: ['d2h-cntx'], children: { '.d2h-code-line-ctn': codeCell } },
-        { classes: ['user-comment-row'] },
-      ]);
-
-      // No indicator button exists — querySelector returns null
-      rows[0].querySelector = (selector) => {
-        if (selector === '.d2h-code-line-ctn .comment-indicator') return null;
-        if (selector === '.d2h-code-line-ctn') return codeCell;
-        return null;
-      };
-
-      const child = buildChildElement(rows[1]);
-
-      const cm = new CommentMinimizer();
-      cm._active = true;
-
-      // Should not throw
-      cm.expandForElement(child);
-
-      expect(cm._expandedLines.has(rows[0])).toBe(true);
-      expect(rows[1].classList.contains('comment-expanded')).toBe(true);
-    });
-  });
-
-  // -------------------------------------------------------------------------
-  // File-level comment minimization
-  // -------------------------------------------------------------------------
-  describe('file-level comments', () => {
-    /**
-     * Build a mock file-comment-card element.
-     * @param {'user-comment'|'ai-suggestion'} type
-     * @param {Object} opts - { adopted: boolean }
-     */
-    function buildFileCommentCard(type, opts = {}) {
-      const classes = new Set(['file-comment-card', type]);
-      if (opts.adopted) classes.add('adopted-comment');
-      if (opts.collapsed) classes.add('collapsed');
-      return {
-        classList: {
-          _set: classes,
-          contains(cls) { return this._set.has(cls); },
-          add(cls) { this._set.add(cls); },
-          remove(cls) { this._set.delete(cls); },
-        },
-      };
-    }
-
-    /**
-     * Build a mock file-comments-zone with cards inside it, wrapped in a
-     * .d2h-file-wrapper with a .d2h-file-header.
-     * Returns { zone, header, wrapper, cards }.
-     */
-    function buildFileCommentsStructure(cardSpecs) {
-      const cards = cardSpecs.map(spec => buildFileCommentCard(spec.type, spec));
-
-      const zoneClasses = new Set(['file-comments-zone']);
-      const zone = {
-        classList: {
-          _set: zoneClasses,
-          contains(cls) { return this._set.has(cls); },
-          add(cls) { this._set.add(cls); },
-          remove(cls) { this._set.delete(cls); },
-        },
-        querySelectorAll(selector) {
-          if (selector === '.file-comment-card') return cards;
-          return [];
-        },
-        closest(selector) {
-          if (selector === '.d2h-file-wrapper') return wrapper;
-          if (selector === '.file-comments-zone') return zone;
-          return null;
-        },
-        dataset: { fileName: 'test.js' },
-      };
-
-      const headerChildren = [];
-      const headerClasses = new Set(['d2h-file-header']);
-      const commentBtn = { className: 'file-header-comment-btn' };
-      headerChildren.push(commentBtn);
-
-      const header = {
-        classList: {
-          _set: headerClasses,
-          contains(cls) { return this._set.has(cls); },
-        },
-        querySelector(selector) {
-          if (selector === '.file-comment-indicator') {
-            return headerChildren.find(c => c.className === 'file-comment-indicator') || null;
-          }
-          if (selector === '.file-header-comment-btn') return commentBtn;
-          if (selector === '.d2h-file-header .file-comment-indicator') {
-            return headerChildren.find(c => c.className === 'file-comment-indicator') || null;
-          }
-          return null;
-        },
-        appendChild(child) { headerChildren.push(child); },
-        insertBefore(child, ref) {
-          const idx = headerChildren.indexOf(ref);
-          if (idx >= 0) headerChildren.splice(idx, 0, child);
-          else headerChildren.push(child);
-        },
-        _children: headerChildren,
-      };
-
-      const wrapper = {
-        classList: {
-          _set: new Set(['d2h-file-wrapper']),
-          contains(cls) { return this._set.has(cls); },
-        },
-        querySelector(selector) {
-          if (selector === '.d2h-file-header') return header;
-          if (selector === '.d2h-file-header .file-comment-indicator') {
-            return headerChildren.find(c => c.className === 'file-comment-indicator') || null;
-          }
-          return null;
-        },
-      };
-
-      return { zone, header, wrapper, cards, commentBtn };
-    }
-
-    /**
-     * Build a child element that resolves closest() to a file-comments-zone.
-     */
-    function buildFileCommentChild(zone) {
-      return {
-        closest(selector) {
-          if (selector === '.file-comments-zone') return zone;
-          if (selector === '.d2h-file-wrapper') return zone.closest('.d2h-file-wrapper');
-          // Not a line-level comment/suggestion row
-          if (selector.includes('user-comment-row') || selector.includes('ai-suggestion-row')) return null;
-          return null;
-        },
-        classList: {
-          _set: new Set(),
-          contains(cls) { return this._set.has(cls); },
-        },
-      };
-    }
-
-    /**
-     * Set up document.querySelectorAll to return file-comments zones and empty
-     * line-level results. Accepts an array of zones.
-     */
-    function mockFileQuerySelectorAll(zones) {
-      global.document.querySelectorAll = vi.fn((selector) => {
-        if (selector === '.file-comments-zone') return zones;
-        if (selector === '.user-comment-row') return [];
-        if (selector === '.ai-suggestion-row') return [];
-        if (selector === '.comment-indicator') return [];
-        if (selector === '.file-comment-indicator') return [];
-        if (selector === '.comment-expanded') return [];
-        if (selector === '.file-comments-expanded') return [];
-        return [];
-      });
-    }
-
-    describe('_refreshFileIndicators', () => {
-      it('should inject file-header indicator for zone with user comments', () => {
-        const { zone, header } = buildFileCommentsStructure([
-          { type: 'user-comment' },
-        ]);
-
-        mockFileQuerySelectorAll([zone]);
-
-        const cm = new CommentMinimizer();
-        cm._active = true;
-        cm.refreshIndicators();
-
-        // Indicator should have been inserted before the comment button
-        const indicator = header._children.find(c => c.className === 'file-comment-indicator');
-        expect(indicator).toBeTruthy();
-        expect(indicator.innerHTML).toContain('indicator-user');
-        expect(indicator.title).toBe('1 file comment');
-      });
-
-      it('should inject file-header indicator for zone with AI suggestions', () => {
-        const { zone, header } = buildFileCommentsStructure([
-          { type: 'ai-suggestion' },
-          { type: 'ai-suggestion' },
-        ]);
-
-        mockFileQuerySelectorAll([zone]);
-
-        const cm = new CommentMinimizer();
-        cm._active = true;
-        cm.refreshIndicators();
-
-        const indicator = header._children.find(c => c.className === 'file-comment-indicator');
-        expect(indicator).toBeTruthy();
-        expect(indicator.innerHTML).toContain('indicator-ai');
-        expect(indicator.title).toBe('2 suggestions');
-      });
-
-      it('should inject file-header indicator for zone with adopted suggestions', () => {
-        const { zone, header } = buildFileCommentsStructure([
-          { type: 'user-comment', adopted: true },
-        ]);
-
-        mockFileQuerySelectorAll([zone]);
-
-        const cm = new CommentMinimizer();
-        cm._active = true;
-        cm.refreshIndicators();
-
-        const indicator = header._children.find(c => c.className === 'file-comment-indicator');
-        expect(indicator).toBeTruthy();
-        expect(indicator.innerHTML).toContain('indicator-adopted');
-        expect(indicator.title).toBe('1 adopted');
-      });
-
-      it('should show combined counts for mixed file comment types', () => {
-        const { zone, header } = buildFileCommentsStructure([
-          { type: 'user-comment' },
-          { type: 'user-comment' },
-          { type: 'ai-suggestion' },
-          { type: 'user-comment', adopted: true },
-        ]);
-
-        mockFileQuerySelectorAll([zone]);
-
-        const cm = new CommentMinimizer();
-        cm._active = true;
-        cm.refreshIndicators();
-
-        const indicator = header._children.find(c => c.className === 'file-comment-indicator');
-        expect(indicator).toBeTruthy();
-        expect(indicator.innerHTML).toContain('indicator-user');
-        expect(indicator.innerHTML).toContain('indicator-ai');
-        expect(indicator.innerHTML).toContain('indicator-adopted');
-        // Total = 2 user + 1 AI + 1 adopted = 4
-        expect(indicator.innerHTML).toContain('<span class="indicator-count">4</span>');
-        expect(indicator.title).toBe('2 file comments, 1 adopted, 1 suggestion');
-      });
-
-      it('should skip collapsed cards (adopted/dismissed originals)', () => {
-        const { zone, header } = buildFileCommentsStructure([
-          { type: 'ai-suggestion', collapsed: true },  // dismissed or adopted original
-          { type: 'user-comment', adopted: true },      // adopted comment card
-          { type: 'ai-suggestion' },                     // active suggestion
-        ]);
-
-        mockFileQuerySelectorAll([zone]);
-
-        const cm = new CommentMinimizer();
-        cm._active = true;
-        cm.refreshIndicators();
-
-        const indicator = header._children.find(c => c.className === 'file-comment-indicator');
-        expect(indicator).toBeTruthy();
-        // Collapsed AI suggestion should not be counted
-        expect(indicator.innerHTML).toContain('indicator-adopted');
-        expect(indicator.innerHTML).toContain('indicator-ai');
-        expect(indicator.innerHTML).not.toContain('indicator-user');
-        // Total = 1 adopted + 1 AI = 2 (not 3)
-        expect(indicator.innerHTML).toContain('<span class="indicator-count">2</span>');
-        expect(indicator.title).toBe('1 adopted, 1 suggestion');
-      });
-
-      it('should not inject indicator for empty zone', () => {
-        const { zone, header } = buildFileCommentsStructure([]);
-
-        mockFileQuerySelectorAll([zone]);
-
-        const cm = new CommentMinimizer();
-        cm._active = true;
-        cm.refreshIndicators();
-
-        const indicator = header._children.find(c => c.className === 'file-comment-indicator');
-        expect(indicator).toBeUndefined();
-      });
-
-      it('should not inject indicator when all cards are collapsed', () => {
-        const { zone, header } = buildFileCommentsStructure([
-          { type: 'ai-suggestion', collapsed: true },
-          { type: 'ai-suggestion', collapsed: true },
-        ]);
-
-        mockFileQuerySelectorAll([zone]);
-
-        const cm = new CommentMinimizer();
-        cm._active = true;
-        cm.refreshIndicators();
-
-        const indicator = header._children.find(c => c.className === 'file-comment-indicator');
-        expect(indicator).toBeUndefined();
-      });
-
-      it('should insert indicator before file-header-comment-btn', () => {
-        const { zone, header, commentBtn } = buildFileCommentsStructure([
-          { type: 'user-comment' },
-        ]);
-
-        mockFileQuerySelectorAll([zone]);
-
-        const cm = new CommentMinimizer();
-        cm._active = true;
-        cm.refreshIndicators();
-
-        // The indicator should come before the comment button in the children array
-        const indicatorIdx = header._children.findIndex(c => c.className === 'file-comment-indicator');
-        const commentBtnIdx = header._children.indexOf(commentBtn);
-        expect(indicatorIdx).toBeLessThan(commentBtnIdx);
-      });
-
-      it('should restore expanded class on indicator when zone is in _expandedFiles', () => {
-        const { zone, header } = buildFileCommentsStructure([
-          { type: 'user-comment' },
-        ]);
-
-        mockFileQuerySelectorAll([zone]);
-
-        const cm = new CommentMinimizer();
-        cm._active = true;
-        cm._expandedFiles.add(zone);
-        cm.refreshIndicators();
-
-        const indicator = header._children.find(c => c.className === 'file-comment-indicator');
-        expect(indicator.classList.contains('expanded')).toBe(true);
-      });
-    });
-
-    describe('_toggleFileComments', () => {
-      it('should expand then collapse file comments', () => {
-        const { zone } = buildFileCommentsStructure([
-          { type: 'user-comment' },
-        ]);
-
-        const cm = new CommentMinimizer();
-        const btn = buildMockButton();
-
-        // Expand
-        cm._toggleFileComments(zone, btn);
-        expect(cm._expandedFiles.has(zone)).toBe(true);
-        expect(btn.classList.contains('expanded')).toBe(true);
-        expect(zone.classList.contains('file-comments-expanded')).toBe(true);
-
-        // Collapse
-        cm._toggleFileComments(zone, btn);
-        expect(cm._expandedFiles.has(zone)).toBe(false);
-        expect(btn.classList.contains('expanded')).toBe(false);
-        expect(zone.classList.contains('file-comments-expanded')).toBe(false);
-      });
-    });
-
-    describe('expandForElement (file-level)', () => {
-      it('should expand file-comments-zone for element inside it', () => {
-        const { zone, wrapper } = buildFileCommentsStructure([
-          { type: 'user-comment' },
-        ]);
-
-        const child = buildFileCommentChild(zone);
-
-        const cm = new CommentMinimizer();
-        cm._active = true;
-        cm.expandForElement(child);
-
-        expect(cm._expandedFiles.has(zone)).toBe(true);
-        expect(zone.classList.contains('file-comments-expanded')).toBe(true);
-      });
-
-      it('should update file-header indicator button when expanding', () => {
-        const { zone, header, wrapper } = buildFileCommentsStructure([
-          { type: 'user-comment' },
-        ]);
-
-        // Simulate indicator already injected in the header
-        const indicatorBtn = buildMockButton('file-comment-indicator');
-        header._children.push(indicatorBtn);
-
-        const child = buildFileCommentChild(zone);
-
-        const cm = new CommentMinimizer();
-        cm._active = true;
-        cm.expandForElement(child);
-
-        expect(indicatorBtn.classList.contains('expanded')).toBe(true);
-      });
-
-      it('should not re-expand if zone is already expanded', () => {
-        const { zone } = buildFileCommentsStructure([
-          { type: 'user-comment' },
-        ]);
-
-        const child = buildFileCommentChild(zone);
-
-        const cm = new CommentMinimizer();
-        cm._active = true;
-        cm._expandedFiles.add(zone);
-
-        // Should exit early — class should NOT be added again
-        cm.expandForElement(child);
-
-        expect(cm._expandedFiles.has(zone)).toBe(true);
-        // Zone class was added during the pre-expand setup, not by expandForElement
-        expect(zone.classList.contains('file-comments-expanded')).toBe(false);
-      });
-    });
-
-    describe('setMinimized (file-level state)', () => {
-      it('should clear _expandedFiles when toggling', () => {
-        global.document.querySelectorAll = vi.fn(() => []);
-
-        const cm = new CommentMinimizer();
-        cm._expandedFiles.add('fake-zone');
-
-        cm.setMinimized(true);
-        expect(cm._expandedFiles.size).toBe(0);
-      });
-
-      it('should remove file-comments-expanded classes when disabling', () => {
-        const expandedZone = {
-          classList: {
-            _set: new Set(['file-comments-expanded']),
-            remove(cls) { this._set.delete(cls); },
-            contains(cls) { return this._set.has(cls); },
-          },
-        };
-
-        global.document.querySelectorAll = vi.fn((selector) => {
-          if (selector === '.comment-indicator') return [];
-          if (selector === '.file-comment-indicator') return [];
-          if (selector === '.comment-expanded') return [];
-          if (selector === '.file-comments-expanded') return [expandedZone];
-          return [];
-        });
-
-        const cm = new CommentMinimizer();
-        cm._active = true;
-        diffContainer.classList.add('comments-minimized');
-
-        cm.setMinimized(false);
-
-        expect(expandedZone.classList.contains('file-comments-expanded')).toBe(false);
-      });
-    });
-
-    describe('_removeAllIndicators (file-level)', () => {
-      it('should remove both line-level and file-level indicators', () => {
-        const lineIndicator = { remove: vi.fn() };
-        const fileIndicator = { remove: vi.fn() };
-
-        global.document.querySelectorAll = vi.fn((selector) => {
-          if (selector === '.comment-indicator') return [lineIndicator];
-          if (selector === '.file-comment-indicator') return [fileIndicator];
-          return [];
-        });
-
-        const cm = new CommentMinimizer();
-        cm._removeAllIndicators();
-
-        expect(lineIndicator.remove).toHaveBeenCalled();
-        expect(fileIndicator.remove).toHaveBeenCalled();
-      });
-    });
   });
 });


### PR DESCRIPTION
## Summary

Two regressions from the @pierre/diffs migration, both in the diff annotation layer:

### 1. Minimize Comments restored (as zero-height line overlays)

The minimize feature was never adapted to the pierre renderer — diff lines moved into shadow DOM and comment cards became slotted light-DOM annotations, so every line-level selector (`.d2h-code-line-ctn`, sibling walks, `.ai-suggestion-row`) silently matched nothing. Suggestions weren't even hidden, since pierre renders them without the `-row` wrapper. The old unit suite faked the legacy table DOM, so it stayed green throughout.

The line-level path is reworked against the pierre DOM:
- Cards group by the vendor's stable per-line slot key (`annotation-{side}-{line}`); expansion state is keyed by strings so it survives vendor rerenders (which recreate all light-DOM annotation elements).
- Indicators render as **zero-height overlay pills** floating at the anchor line's right edge — no row is inserted into the diff flow (the vendor's annotation cell has no intrinsic min-height, so hiding the card collapses the row to exactly 0px, asserted in E2E).
- A debounced MutationObserver re-injects indicators after vendor rerenders that bypass `refreshIndicators()` (diff-style switch, hunk expansion, highlight streaming).
- Also fixes a timing-dependent `hiddenForAdoption` comparison (literal string `'false'` vs truthiness), guards against empty indicator buttons, and gives annotation slot wrappers the nav `scroll-margin-top` so AI-panel navigation doesn't land under the sticky toolbar.
- File-level indicators unchanged.

Known cosmetic limit: in split view, a deletions-side (LEFT) comment's pill anchors at the diff's far right rather than the left column's edge, because the annotation cell is fullwidth-stretched. Additions-side is exact.

### 2. Split view: empty comment cards on entirely added/removed files

The vendor stylesheet sets `contain: content` — which includes **paint containment** — on every code column. Boxing a one-sided file's lone column into half of the split grid (c03feac7) made it a real box, so full-width-stretched annotation cards (which reach past the column via a negative margin) had their left portion paint-clipped regardless of `overflow: visible`. Only the right-aligned action buttons painted, leaving an apparently empty card. Two-sided columns escape because `display: contents` generates no box.

Fixed with `contain: layout style` on one-sided columns (drops only the paint keyword, keeps the vendor's perf containment). The regression test asserts paint via shadow-piercing hit-tests, since bounding-rect assertions pass even while text is clipped.

## Testing

- `tests/unit/comment-minimizer.test.js` rewritten against a real pierre shadow-DOM structure (32 tests), including expansion surviving simulated rerenders, observer wiring, and file-level cleanup.
- New `tests/e2e/comment-minimize.spec.js`: minimize toggling in unified + one-sided split, zero-height assertion, overlaid-pill clickability, AI-panel navigation on a minimized diff, AI-suggestion DB cleanup.
- `tests/e2e/split-view.spec.js`: new paint-level regression test, verified failing with the fix reverted.
- Full suites green: 23 E2E across both specs, full unit run passing.

Two changesets included (both patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)