### PR TITLE
fix: make dark-mode tour bar opaque so diff content does not bleed through

### DIFF
--- a/.changeset/tour-bar-opaque-dark.md
+++ b/.changeset/tour-bar-opaque-dark.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+fix: make the dark-mode tour bar opaque so diff content no longer bleeds through the sticky header

--- a/public/css/pr.css
+++ b/public/css/pr.css
@@ -13528,7 +13528,10 @@ body.tour-active .d2h-file-header {
 }
 
 [data-theme="dark"] .tour-bar {
-  background: rgba(187, 128, 9, 0.22);
+  /* The bar is sticky, so diff content scrolls beneath it — the amber wash
+     must be layered over an opaque base or that content bleeds through. */
+  background: linear-gradient(rgba(187, 128, 9, 0.22), rgba(187, 128, 9, 0.22)),
+              var(--color-bg-primary, #0d1117);
   border-bottom-color: #bb8009;
   color: #e3b341;
   box-shadow: 0 2px 12px rgba(0, 0, 0, 0.40);


### PR DESCRIPTION
## Summary
- The sticky `.tour-bar` header in dark mode used `background: rgba(187, 128, 9, 0.22)` — a 22% alpha amber wash with no opaque base — so diff text scrolling beneath it bled through.
- Fix layers the same amber wash over the opaque theme background (`var(--color-bg-primary, #0d1117)`) via a `linear-gradient` stack, keeping the exact same rendered color while eliminating bleed. Light mode was already opaque (`#fef3c7`).
- Adds a patch changeset.

## Testing
- All 14 tour E2E tests pass (`pnpm run test:e2e -- tour.spec.js`), covering both PR mode and Local mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)