### PR TITLE
fix: keep context entries independent from same-file diff entries

### DIFF
--- a/.changeset/context-entry-independent-collapse.md
+++ b/.changeset/context-entry-independent-collapse.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Fix context entries colliding with a same-file diff entry. The diff panel now applies the "diff wins" rule when rendering context files (a stored context row whose file has entered the diff — via Local-mode scope change, new commits, or PR refresh — is suppressed at the view layer, never deleted, and self-heals when the file leaves the diff). As defense-in-depth, context entries keep collapse/viewed state under context-scoped keys so toggling one never re-expands or re-collapses the other, `findFileElement` resolves only real diff wrappers (never a nested comments zone or a same-path context wrapper), and dismissing a context entry scrubs its scoped state keys so stale viewed/collapsed state cannot resurrect on re-add — including when the removal arrives from another tab via a WebSocket refresh.

--- a/public/js/modules/diff-renderer.js
+++ b/public/js/modules/diff-renderer.js
@@ -273,7 +273,14 @@ class DiffRenderer {
       : filePath;
 
     try {
-      return document.querySelector(`[${attribute}="${escapedValue}"]`);
+      // Scope to `.d2h-file-wrapper` so a nested `.file-comments-zone` (which
+      // also carries data-file-name) can never be returned, and skip context
+      // entries — those are targeted explicitly via `.context-file` selectors
+      // (see PRManager.findContextFileWrapper). No unguarded fallback here:
+      // findFileElement's pathsMatch loop handles rename syntax and
+      // context-only files, and prefers the diff wrapper itself.
+      const selector = `.d2h-file-wrapper[${attribute}="${escapedValue}"]:not(.context-file)`;
+      return document.querySelector(selector);
     } catch {
       return null;
     }
@@ -798,17 +805,22 @@ class DiffRenderer {
     }
 
     // Fall back to normalized iteration so special characters, rename syntax,
-    // and formatted variants still resolve to the rendered wrapper.
+    // and formatted variants still resolve to the rendered wrapper. Prefer a
+    // diff wrapper over a context entry that shares the file path.
     const allFileWrappers = document.querySelectorAll('.d2h-file-wrapper');
+    let contextMatch = null;
     for (const wrapper of allFileWrappers) {
       const fileName = wrapper.dataset.fileName;
       const filePathAttr = wrapper.dataset.filePath;
       if (DiffRenderer.pathsMatch(fileName, filePath) || DiffRenderer.pathsMatch(filePathAttr, filePath)) {
-        return wrapper;
+        if (!wrapper.classList?.contains('context-file')) {
+          return wrapper;
+        }
+        if (!contextMatch) contextMatch = wrapper;
       }
     }
 
-    return null;
+    return contextMatch;
   }
 }
 

--- a/public/js/pr.js
+++ b/public/js/pr.js
@@ -5171,6 +5171,98 @@ class PRManager {
   }
 
   /**
+   * Collapse/viewed state key for a context entry. Context entries share a
+   * file path with a possible diff entry for the same file, so their state
+   * is tracked under a namespaced key to keep the two independent.
+   * @param {string} filePath - Path of the file
+   * @returns {string}
+   */
+  _contextStateKey(filePath) {
+    return `context:${filePath}`;
+  }
+
+  /**
+   * Find the context-entry wrapper for a file path. Unlike findFileElement,
+   * this never resolves to the diff wrapper for the same file.
+   * @param {string} filePath - Path of the file
+   * @returns {Element|null}
+   */
+  findContextFileWrapper(filePath) {
+    return document.querySelector(
+      `.d2h-file-wrapper.context-file[data-file-name="${CSS.escape(filePath)}"]`
+    );
+  }
+
+  /**
+   * Toggle collapse state of a context entry.
+   *
+   * Context entries must not route through toggleFileCollapse: that resolves
+   * by file path, which finds the diff wrapper when the same file also has a
+   * diff entry — collapsing the context entry would expand the viewed diff
+   * instead (#540). Context bodies are built eagerly and are not managed by
+   * the pierre bridge, so no lazy render or bridge sync is needed here.
+   * @param {string} filePath - Path of the file
+   */
+  toggleContextFileCollapse(filePath) {
+    const wrapper = this.findContextFileWrapper(filePath);
+    if (!wrapper) return;
+
+    const key = this._contextStateKey(filePath);
+    const collapsed = wrapper.classList.toggle('collapsed');
+    if (collapsed) {
+      this.collapsedFiles.add(key);
+    } else {
+      this.collapsedFiles.delete(key);
+    }
+
+    const header = wrapper.querySelector('.d2h-file-header');
+    if (header) {
+      window.DiffRenderer.updateFileHeaderState(header, !collapsed);
+    }
+  }
+
+  /**
+   * Toggle viewed state of a context entry, independent of the diff entry
+   * for the same file. Persists through the same viewedFiles storage as
+   * diff entries, under the context-scoped key.
+   * @param {string} filePath - Path of the file
+   * @param {boolean} isViewed - Whether the context entry is now viewed
+   */
+  toggleContextFileViewed(filePath, isViewed) {
+    const wrapper = this.findContextFileWrapper(filePath);
+    const key = this._contextStateKey(filePath);
+    const header = wrapper ? wrapper.querySelector('.d2h-file-header') : null;
+
+    if (isViewed) {
+      this.viewedFiles.add(key);
+      // Auto-collapse when marking as viewed
+      if (wrapper && !wrapper.classList.contains('collapsed')) {
+        wrapper.classList.add('collapsed');
+        this.collapsedFiles.add(key);
+        if (header) {
+          window.DiffRenderer.updateFileHeaderState(header, false);
+        }
+      }
+    } else {
+      this.viewedFiles.delete(key);
+      // Auto-expand when unchecking viewed (match GitHub behavior)
+      if (wrapper && wrapper.classList.contains('collapsed')) {
+        wrapper.classList.remove('collapsed');
+        this.collapsedFiles.delete(key);
+        if (header) {
+          window.DiffRenderer.updateFileHeaderState(header, true);
+        }
+      }
+    }
+
+    // Context entries only get their own sidebar row when the file is not in
+    // the diff; scope to context items so a same-path diff row is untouched.
+    this.updateFileItemViewedState(filePath, isViewed, { contextItem: true });
+
+    this.saveViewedState();
+  }
+
+  /**
    * Build the eye-slash icon wrapper element used to mark a sidebar
    * file row as viewed. Shared by the initial render and in-place updates
    * so the markup and attributes stay in sync.
@@ -5191,12 +5283,16 @@ class PRManager {
    * without re-rendering the whole file list.
    * @param {string} filePath - Path of the file
    * @param {boolean} isViewed - Whether the file is now viewed
+   * @param {Object} [options]
+   * @param {boolean} [options.contextItem=false] - Match the context-entry
+   *   sidebar row instead of the diff row (they can share a file path)
    */
-  updateFileItemViewedState(filePath, isViewed) {
+  updateFileItemViewedState(filePath, isViewed, { contextItem = false } = {}) {
     const items = document.querySelectorAll('.file-item');
     let item = null;
     for (const candidate of items) {
-      if (candidate.dataset.path === filePath) {
+      if (candidate.dataset.path === filePath &&
+          candidate.classList.contains('context-file-item') === contextItem) {
         item = candidate;
         break;
       }
@@ -7664,7 +7760,10 @@ class PRManager {
 
     if (file.generated) item.classList.add('generated');
     if (file.contextFile) item.classList.add('context-file-item');
-    if (this.viewedFiles && this.viewedFiles.has(file.fullPath)) {
+    // Context entries track viewed state under a context-scoped key so they
+    // stay independent of a diff entry for the same file.
+    const viewedKey = file.contextFile ? this._contextStateKey(file.fullPath) : file.fullPath;
+    if (this.viewedFiles && this.viewedFiles.has(viewedKey)) {
       item.classList.add('viewed');
       const viewedIcon = this._createViewedIcon();
       item.insertBefore(viewedIcon, item.firstChild);
@@ -8652,6 +8751,10 @@ class PRManager {
     const reviewId = this.currentPR?.id;
     if (!reviewId) return;
 
+    // Capture before anything reassigns this.contextFiles — needed to scrub
+    // context-scoped state for rows deleted remotely (peer tab / WebSocket).
+    const previousFiles = this.contextFiles || [];
+
     try {
       const response = await fetch(`/api/reviews/${reviewId}/context-files`);
       if (!response.ok) return;
@@ -8690,9 +8793,18 @@ class PRManager {
         }
       }
 
-      // Add only new context files
+      // Add only new context files. "Diff wins": a stored context row whose
+      // file has since entered the diff (Local-mode scope change, new commits,
+      // PR refresh) is suppressed at the view layer — never rendered as a
+      // duplicate wrapper, never deleted from the DB. renderDiff is a full
+      // clear-and-rebuild that resets contextFiles and re-runs this method,
+      // so a file leaving the diff self-heals back to a context wrapper.
+      // Mirrors the add-time guards (ensureContextFile, the POST route) and
+      // the sidebar merge (mergeFileListWithContext).
+      const diffPaths = new Set((this.diffFiles || []).map(f => f.file));
       let newFilesRendered = false;
       for (const cf of newFiles) {
+        if (diffPaths.has(cf.file)) continue;
         if (!oldIds.has(cf.id)) {
           await this.renderContextFile(cf);
           newFilesRendered = true;
@@ -8700,6 +8812,13 @@ class PRManager {
       }
 
       this.contextFiles = newFiles;
+
+      // Scrub context-scoped viewed/collapsed keys for paths whose entries all
+      // disappeared in this refresh. Without this, a delete arriving via the
+      // WebSocket path leaves orphaned `context:` keys on peer tabs: re-adding
+      // the file renders it pre-viewed/pre-collapsed, and a later
+      // saveViewedState() writes the orphan back into shared storage.
+      this._scrubRemovedContextState(previousFiles);
 
       // Rebuild sidebar with context files interleaved in natural path order
       this.rebuildFileListWithContext();
@@ -8902,7 +9021,7 @@ class PRManager {
     chevronBtn.innerHTML = window.DiffRenderer.CHEVRON_DOWN_ICON;
     chevronBtn.addEventListener('click', (e) => {
       e.stopPropagation();
-      this.toggleFileCollapse(contextFile.file);
+      this.toggleContextFileCollapse(contextFile.file);
     });
     header.appendChild(chevronBtn);
 
@@ -8924,10 +9043,10 @@ class PRManager {
     const viewedCheckbox = document.createElement('input');
     viewedCheckbox.type = 'checkbox';
     viewedCheckbox.className = 'file-viewed-checkbox';
-    viewedCheckbox.checked = this.viewedFiles.has(contextFile.file);
+    viewedCheckbox.checked = this.viewedFiles.has(this._contextStateKey(contextFile.file));
     viewedCheckbox.addEventListener('change', (e) => {
       e.stopPropagation();
-      this.toggleFileViewed(contextFile.file, viewedCheckbox.checked);
+      this.toggleContextFileViewed(contextFile.file, viewedCheckbox.checked);
     });
     viewedLabel.appendChild(viewedCheckbox);
     viewedLabel.appendChild(document.createTextNode('Viewed'));
@@ -9006,7 +9125,7 @@ class PRManager {
           e.target.closest('.context-file-dismiss')) {
         return;
       }
-      this.toggleFileCollapse(contextFile.file);
+      this.toggleContextFileCollapse(contextFile.file);
     });
 
     wrapper.appendChild(header);
@@ -9027,6 +9146,14 @@ class PRManager {
     fileBody.appendChild(table);
     wrapper.appendChild(fileBody);
 
+    // Apply context-scoped collapse/viewed state (independent of any diff
+    // entry for the same file) — mirrors renderFileDiff's initial state.
+    const contextKey = this._contextStateKey(contextFile.file);
+    if (this.viewedFiles.has(contextKey) || this.collapsedFiles.has(contextKey)) {
+      wrapper.classList.add('collapsed');
+      window.DiffRenderer.updateFileHeaderState(header, false);
+    }
+
     // Insert in sorted path order among existing file wrappers
     const allWrappers = [...diffContainer.querySelectorAll('.d2h-file-wrapper')];
     const insertBefore = allWrappers.find(w => w.dataset.fileName > contextFile.file);
@@ -9038,12 +9165,50 @@ class PRManager {
   }
 
   /**
+   * Scrub context-scoped viewed/collapsed keys for context entries that no
+   * longer have any row for their path in the current this.contextFiles.
+   * Persists via saveViewedState() only when a viewed key was actually
+   * removed, so WebSocket-driven refreshes don't POST on every event.
+   * Idempotent: re-running with the same input is a no-op.
+   *
+   * Note: the "diff wins" guard in loadContextFiles only suppresses rendering;
+   * suppressed rows remain in this.contextFiles, so they are correctly treated
+   * as still present here and never scrubbed.
+   *
+   * @param {Array<{file: string}>} previousContextFiles - Context rows that
+   *   existed before the refresh/delete (candidates for scrubbing)
+   */
+  _scrubRemovedContextState(previousContextFiles) {
+    if (!previousContextFiles || previousContextFiles.length === 0) return;
+
+    const remainingPaths = new Set((this.contextFiles || []).map(cf => cf.file));
+    let viewedRemoved = false;
+    for (const prev of previousContextFiles) {
+      if (!prev || remainingPaths.has(prev.file)) continue;
+      const key = this._contextStateKey(prev.file);
+      this.collapsedFiles?.delete(key);
+      if (this.viewedFiles?.delete(key)) {
+        viewedRemoved = true;
+      }
+    }
+    if (viewedRemoved) {
+      this.saveViewedState();
+    }
+  }
+
+  /**
    * Remove a context file by ID.
    * @param {number} contextFileId
    */
   async removeContextFile(contextFileId) {
     const reviewId = this.currentPR?.id;
     if (!reviewId) return;
+
+    // Capture the row before loadContextFiles refreshes this.contextFiles —
+    // afterwards the deleted ID is gone and the file path with it.
+    const removed = (this.contextFiles || []).find(
+      cf => String(cf.id) === String(contextFileId)
+    );
 
     try {
       const resp = await fetch(`/api/reviews/${reviewId}/context-files/${contextFileId}`, {
@@ -9056,6 +9221,13 @@ class PRManager {
       }
       // Refresh immediately — WebSocket self-echo is suppressed by the client ID filter
       await this.loadContextFiles();
+
+      // Defense-in-depth: loadContextFiles already scrubs based on its own
+      // previous-files snapshot, but scrub the captured row explicitly too —
+      // the helper's remaining-paths check makes double-scrubbing harmless.
+      if (removed) {
+        this._scrubRemovedContextState([removed]);
+      }
     } catch (error) {
       console.error('Error removing context file:', error);
     }

--- a/tests/unit/context-entry-collapse.test.js
+++ b/tests/unit/context-entry-collapse.test.js
@@ -1,0 +1,473 @@
+// Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+// @vitest-environment jsdom
+/**
+ * Regression tests for issue #540: Context entry controls must collapse
+ * independently from a same-file diff entry.
+ *
+ * When an LLM chat brings in a section of a file that is ALSO changed in the
+ * PR, the diff panel shows two wrappers with the same data-file-name: the
+ * diff entry and the `.context-file` entry. Collapse/viewed actions on the
+ * context entry must target the context wrapper (via context-scoped state
+ * keys), never the diff wrapper — and vice versa.
+ *
+ * Shared by PR mode and Local mode: Local mode reuses PRManager's
+ * renderContextFile/toggle* methods and only patches viewed-state persistence,
+ * so these tests cover both modes.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const { DiffRenderer } = require('../../public/js/modules/diff-renderer.js');
+const { PRManager } = require('../../public/js/pr.js');
+
+// jsdom exposes CSS.escape via window; make sure the global exists for code
+// that references bare `CSS`.
+if (typeof globalThis.CSS === 'undefined' || typeof globalThis.CSS.escape !== 'function') {
+  globalThis.CSS = window.CSS && typeof window.CSS.escape === 'function'
+    ? window.CSS
+    : { escape: (s) => String(s).replace(/[^a-zA-Z0-9_\-]/g, (c) => `\\${c}`) };
+}
+
+const FILE = 'src/app.js';
+
+function buildWrapper(file, { context = false } = {}) {
+  const wrapper = document.createElement('div');
+  wrapper.className = context ? 'd2h-file-wrapper context-file' : 'd2h-file-wrapper';
+  wrapper.dataset.fileName = file;
+
+  const header = document.createElement('div');
+  header.className = context ? 'd2h-file-header context-file-header' : 'd2h-file-header';
+
+  const chevron = document.createElement('button');
+  chevron.className = 'file-collapse-toggle';
+  chevron.title = 'Collapse file';
+  header.appendChild(chevron);
+  wrapper.appendChild(header);
+
+  // Production wrappers nest a comments zone that ALSO carries
+  // data-file-name (FileCommentManager.createFileCommentsZone) — file
+  // lookups must never resolve to it.
+  const commentsZone = document.createElement('div');
+  commentsZone.className = 'file-comments-zone';
+  commentsZone.dataset.fileName = file;
+  wrapper.appendChild(commentsZone);
+
+  const body = document.createElement('div');
+  body.className = 'd2h-file-body';
+  wrapper.appendChild(body);
+
+  return wrapper;
+}
+
+function createManager() {
+  const manager = Object.create(PRManager.prototype);
+  manager.collapsedFiles = new Set();
+  manager.viewedFiles = new Set();
+  manager.saveViewedState = vi.fn();
+  manager.ensureFileBodyRendered = vi.fn().mockResolvedValue(undefined);
+  manager.pierreBridge = null;
+  return manager;
+}
+
+describe('context entry collapse independence (#540)', () => {
+  let manager, diffWrapper, contextWrapper;
+
+  beforeEach(() => {
+    document.body.innerHTML = '<div id="diff-container"></div>';
+    window.DiffRenderer = DiffRenderer;
+
+    manager = createManager();
+    diffWrapper = buildWrapper(FILE);
+    contextWrapper = buildWrapper(FILE, { context: true });
+    const container = document.getElementById('diff-container');
+    container.appendChild(diffWrapper);
+    container.appendChild(contextWrapper);
+  });
+
+  describe('DiffRenderer.findFileElement', () => {
+    beforeEach(() => {
+      // Put the context wrapper FIRST in document order. A naive first-match
+      // lookup would return it, so these assertions exercise the preference
+      // logic itself rather than passing by DOM position.
+      document.getElementById('diff-container').insertBefore(contextWrapper, diffWrapper);
+    });
+
+    it('prefers the diff wrapper when a context entry precedes it in the DOM', () => {
+      expect(DiffRenderer.findFileElement(FILE)).toBe(diffWrapper);
+    });
+
+    it('still resolves the context wrapper when the file has no diff entry', () => {
+      diffWrapper.remove();
+      expect(DiffRenderer.findFileElement(FILE)).toBe(contextWrapper);
+    });
+
+    it('never resolves to a nested comments zone that carries data-file-name', () => {
+      diffWrapper.remove();
+      const result = DiffRenderer.findFileElement(FILE);
+      expect(result).toBe(contextWrapper);
+      expect(result.classList.contains('file-comments-zone')).toBe(false);
+    });
+
+    it('prefers the diff wrapper in the partial-match fallback too', () => {
+      // Force the fallback path: query by a suffix of the stored path, with
+      // the context wrapper still first in document order.
+      expect(DiffRenderer.findFileElement('app.js')).toBe(diffWrapper);
+    });
+  });
+
+  describe('toggleContextFileCollapse', () => {
+    it('collapses the context entry without expanding a viewed (collapsed) diff', () => {
+      // Reproduce the issue: diff is marked viewed (collapsed), then the user
+      // collapses the context entry for the same file.
+      diffWrapper.classList.add('collapsed');
+      manager.viewedFiles.add(FILE);
+      manager.collapsedFiles.add(FILE);
+
+      manager.toggleContextFileCollapse(FILE);
+
+      expect(contextWrapper.classList.contains('collapsed')).toBe(true);
+      expect(diffWrapper.classList.contains('collapsed')).toBe(true);
+      // Diff-scoped state is untouched
+      expect(manager.collapsedFiles.has(FILE)).toBe(true);
+      expect(manager.collapsedFiles.has(`context:${FILE}`)).toBe(true);
+    });
+
+    it('expands a collapsed context entry and updates its chevron', () => {
+      manager.toggleContextFileCollapse(FILE);
+      expect(contextWrapper.classList.contains('collapsed')).toBe(true);
+      expect(contextWrapper.querySelector('.file-collapse-toggle').title).toBe('Expand file');
+
+      manager.toggleContextFileCollapse(FILE);
+      expect(contextWrapper.classList.contains('collapsed')).toBe(false);
+      expect(contextWrapper.querySelector('.file-collapse-toggle').title).toBe('Collapse file');
+      expect(manager.collapsedFiles.has(`context:${FILE}`)).toBe(false);
+    });
+
+    it('is a no-op when no context wrapper exists', () => {
+      contextWrapper.remove();
+      expect(() => manager.toggleContextFileCollapse(FILE)).not.toThrow();
+      expect(diffWrapper.classList.contains('collapsed')).toBe(false);
+    });
+  });
+
+  describe('toggleContextFileViewed', () => {
+    it('marks the context entry viewed and collapses it, leaving the diff alone', () => {
+      manager.toggleContextFileViewed(FILE, true);
+
+      expect(contextWrapper.classList.contains('collapsed')).toBe(true);
+      expect(diffWrapper.classList.contains('collapsed')).toBe(false);
+      expect(manager.viewedFiles.has(`context:${FILE}`)).toBe(true);
+      // The plain path key (diff entry) is untouched
+      expect(manager.viewedFiles.has(FILE)).toBe(false);
+      expect(manager.saveViewedState).toHaveBeenCalled();
+    });
+
+    it('unchecking viewed expands the context entry only', () => {
+      manager.toggleContextFileViewed(FILE, true);
+      diffWrapper.classList.add('collapsed');
+
+      manager.toggleContextFileViewed(FILE, false);
+
+      expect(contextWrapper.classList.contains('collapsed')).toBe(false);
+      expect(manager.viewedFiles.has(`context:${FILE}`)).toBe(false);
+      // Diff stays collapsed — context actions never touch it
+      expect(diffWrapper.classList.contains('collapsed')).toBe(true);
+    });
+
+    it('only updates the context sidebar row, never a same-path diff row', () => {
+      const diffItem = document.createElement('a');
+      diffItem.className = 'file-item';
+      diffItem.dataset.path = FILE;
+      const contextItem = document.createElement('a');
+      contextItem.className = 'file-item context-file-item';
+      contextItem.dataset.path = FILE;
+      document.body.append(diffItem, contextItem);
+
+      manager.toggleContextFileViewed(FILE, true);
+
+      expect(diffItem.classList.contains('viewed')).toBe(false);
+      expect(contextItem.classList.contains('viewed')).toBe(true);
+    });
+  });
+
+  describe('diff entry actions leave the context entry alone', () => {
+    it('toggleFileViewed collapses the diff wrapper, not the context wrapper', async () => {
+      await manager.toggleFileViewed(FILE, true);
+
+      expect(diffWrapper.classList.contains('collapsed')).toBe(true);
+      expect(contextWrapper.classList.contains('collapsed')).toBe(false);
+      expect(manager.viewedFiles.has(FILE)).toBe(true);
+      expect(manager.viewedFiles.has(`context:${FILE}`)).toBe(false);
+    });
+
+    it('toggleFileCollapse toggles the diff wrapper, not the context wrapper', async () => {
+      await manager.toggleFileCollapse(FILE);
+
+      expect(diffWrapper.classList.contains('collapsed')).toBe(true);
+      expect(contextWrapper.classList.contains('collapsed')).toBe(false);
+    });
+  });
+
+  describe('renderContextFile', () => {
+    function renderableManager() {
+      manager.fetchFileContent = vi.fn().mockResolvedValue({ lines: ['a', 'b', 'c'] });
+      manager._buildContextChunkTbody = vi.fn(() => {
+        const tbody = document.createElement('tbody');
+        tbody.className = 'context-chunk';
+        return tbody;
+      });
+      manager.fileCommentManager = null;
+      return manager;
+    }
+
+    beforeEach(() => {
+      // renderContextFile builds its own context wrapper
+      contextWrapper.remove();
+      renderableManager();
+    });
+
+    it('does not render the viewed checkbox checked from the diff entry state', async () => {
+      manager.viewedFiles.add(FILE); // diff marked viewed
+
+      await manager.renderContextFile({ id: 1, file: FILE, line_start: 1, line_end: 3 });
+
+      const wrapper = document.querySelector('.d2h-file-wrapper.context-file');
+      expect(wrapper).not.toBeNull();
+      expect(wrapper.querySelector('.file-viewed-checkbox').checked).toBe(false);
+      expect(wrapper.classList.contains('collapsed')).toBe(false);
+    });
+
+    it('renders collapsed and checked when the context entry itself is viewed', async () => {
+      manager.viewedFiles.add(`context:${FILE}`);
+
+      await manager.renderContextFile({ id: 1, file: FILE, line_start: 1, line_end: 3 });
+
+      const wrapper = document.querySelector('.d2h-file-wrapper.context-file');
+      expect(wrapper.querySelector('.file-viewed-checkbox').checked).toBe(true);
+      expect(wrapper.classList.contains('collapsed')).toBe(true);
+    });
+
+    it('chevron click toggles the context wrapper only', async () => {
+      await manager.renderContextFile({ id: 1, file: FILE, line_start: 1, line_end: 3 });
+
+      const wrapper = document.querySelector('.d2h-file-wrapper.context-file');
+      wrapper.querySelector('.file-collapse-toggle').click();
+
+      expect(wrapper.classList.contains('collapsed')).toBe(true);
+      expect(diffWrapper.classList.contains('collapsed')).toBe(false);
+    });
+
+    it('viewed checkbox change routes to context-scoped viewed state', async () => {
+      await manager.renderContextFile({ id: 1, file: FILE, line_start: 1, line_end: 3 });
+
+      const wrapper = document.querySelector('.d2h-file-wrapper.context-file');
+      const checkbox = wrapper.querySelector('.file-viewed-checkbox');
+      checkbox.checked = true;
+      checkbox.dispatchEvent(new window.Event('change', { bubbles: true }));
+
+      expect(wrapper.classList.contains('collapsed')).toBe(true);
+      expect(manager.viewedFiles.has(`context:${FILE}`)).toBe(true);
+      expect(manager.viewedFiles.has(FILE)).toBe(false);
+      expect(diffWrapper.classList.contains('collapsed')).toBe(false);
+    });
+  });
+
+  describe('loadContextFiles "diff wins" guard', () => {
+    beforeEach(() => {
+      manager.currentPR = { id: 1 };
+      manager.contextFiles = [];
+      manager.renderContextFile = vi.fn().mockResolvedValue(undefined);
+      manager.rebuildFileListWithContext = vi.fn();
+      manager.loadUserComments = vi.fn().mockResolvedValue(undefined);
+    });
+
+    function stubContextFilesResponse(rows) {
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ contextFiles: rows }),
+      });
+    }
+
+    it('suppresses rendering a context row whose file is now in the diff', async () => {
+      manager.diffFiles = [{ file: FILE }];
+      const inDiff = { id: 1, file: FILE, line_start: 1, line_end: 10 };
+      const outside = { id: 2, file: 'src/other.js', line_start: 1, line_end: 10 };
+      stubContextFilesResponse([inDiff, outside]);
+
+      await manager.loadContextFiles();
+
+      expect(manager.renderContextFile).toHaveBeenCalledTimes(1);
+      expect(manager.renderContextFile).toHaveBeenCalledWith(outside);
+      // The DB row is only suppressed at the view layer, never dropped
+      expect(manager.contextFiles).toEqual([inDiff, outside]);
+    });
+
+    it('renders the same row again once its file leaves the diff', async () => {
+      manager.diffFiles = [];
+      const row = { id: 1, file: FILE, line_start: 1, line_end: 10 };
+      stubContextFilesResponse([row]);
+
+      await manager.loadContextFiles();
+
+      expect(manager.renderContextFile).toHaveBeenCalledWith(row);
+    });
+  });
+
+  describe('loadContextFiles remote-delete context-key scrub', () => {
+    // A peer tab deleting a context file reaches this tab via the
+    // review:context_files_changed WebSocket event -> loadContextFiles().
+    // That path must scrub the `context:` viewed/collapsed keys too, or the
+    // orphaned state resurrects on re-add and round-trips back into shared
+    // storage via saveViewedState().
+    beforeEach(() => {
+      manager.currentPR = { id: 1 };
+      manager.diffFiles = [];
+      manager.renderContextFile = vi.fn().mockResolvedValue(undefined);
+      manager.rebuildFileListWithContext = vi.fn();
+      manager.loadUserComments = vi.fn().mockResolvedValue(undefined);
+    });
+
+    function stubContextFilesResponse(rows) {
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ contextFiles: rows }),
+      });
+    }
+
+    it('scrubs viewed and collapsed keys when a peer tab deleted the last entry for a path', async () => {
+      manager.contextFiles = [{ id: 5, file: FILE, line_start: 1, line_end: 10 }];
+      manager.viewedFiles.add(`context:${FILE}`);
+      manager.collapsedFiles.add(`context:${FILE}`);
+      stubContextFilesResponse([]);
+
+      await manager.loadContextFiles();
+
+      expect(manager.viewedFiles.has(`context:${FILE}`)).toBe(false);
+      expect(manager.collapsedFiles.has(`context:${FILE}`)).toBe(false);
+      expect(manager.saveViewedState).toHaveBeenCalled();
+    });
+
+    it('keeps the keys while another entry for the same path remains in the response', async () => {
+      manager.contextFiles = [
+        { id: 5, file: FILE, line_start: 1, line_end: 10 },
+        { id: 6, file: FILE, line_start: 20, line_end: 30 },
+      ];
+      manager.viewedFiles.add(`context:${FILE}`);
+      manager.collapsedFiles.add(`context:${FILE}`);
+      stubContextFilesResponse([{ id: 6, file: FILE, line_start: 20, line_end: 30 }]);
+
+      await manager.loadContextFiles();
+
+      expect(manager.viewedFiles.has(`context:${FILE}`)).toBe(true);
+      expect(manager.collapsedFiles.has(`context:${FILE}`)).toBe(true);
+      expect(manager.saveViewedState).not.toHaveBeenCalled();
+    });
+
+    it('does not persist when only the in-memory collapsed key existed', async () => {
+      manager.contextFiles = [{ id: 5, file: FILE, line_start: 1, line_end: 10 }];
+      manager.collapsedFiles.add(`context:${FILE}`);
+      stubContextFilesResponse([]);
+
+      await manager.loadContextFiles();
+
+      expect(manager.collapsedFiles.has(`context:${FILE}`)).toBe(false);
+      expect(manager.saveViewedState).not.toHaveBeenCalled();
+    });
+
+    it('does not scrub a row suppressed by the diff-wins guard but still present in the response', async () => {
+      // The row's file entered the diff: rendering is suppressed, but the DB
+      // row still exists — its context-scoped state must survive.
+      manager.diffFiles = [{ file: FILE }];
+      const row = { id: 5, file: FILE, line_start: 1, line_end: 10 };
+      manager.contextFiles = [row];
+      manager.viewedFiles.add(`context:${FILE}`);
+      manager.collapsedFiles.add(`context:${FILE}`);
+      stubContextFilesResponse([row]);
+
+      await manager.loadContextFiles();
+
+      expect(manager.viewedFiles.has(`context:${FILE}`)).toBe(true);
+      expect(manager.collapsedFiles.has(`context:${FILE}`)).toBe(true);
+      expect(manager.saveViewedState).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('removeContextFile context-key scrub', () => {
+    beforeEach(() => {
+      manager.currentPR = { id: 1 };
+      globalThis.fetch = vi.fn().mockResolvedValue({ ok: true });
+    });
+
+    it('scrubs context-scoped keys when the last entry for a path is removed', async () => {
+      manager.contextFiles = [{ id: 5, file: FILE }];
+      manager.viewedFiles.add(`context:${FILE}`);
+      manager.collapsedFiles.add(`context:${FILE}`);
+      manager.loadContextFiles = vi.fn().mockImplementation(async () => {
+        manager.contextFiles = [];
+      });
+
+      await manager.removeContextFile(5);
+
+      expect(manager.viewedFiles.has(`context:${FILE}`)).toBe(false);
+      expect(manager.collapsedFiles.has(`context:${FILE}`)).toBe(false);
+      expect(manager.saveViewedState).toHaveBeenCalled();
+    });
+
+    it('keeps the keys while other entries for the same path remain', async () => {
+      manager.contextFiles = [{ id: 5, file: FILE }, { id: 6, file: FILE }];
+      manager.viewedFiles.add(`context:${FILE}`);
+      manager.loadContextFiles = vi.fn().mockImplementation(async () => {
+        manager.contextFiles = [{ id: 6, file: FILE }];
+      });
+
+      await manager.removeContextFile(5);
+
+      expect(manager.viewedFiles.has(`context:${FILE}`)).toBe(true);
+      expect(manager.saveViewedState).not.toHaveBeenCalled();
+    });
+
+    it('does not persist when only the in-memory collapsed key existed', async () => {
+      manager.contextFiles = [{ id: 5, file: FILE }];
+      manager.collapsedFiles.add(`context:${FILE}`);
+      manager.loadContextFiles = vi.fn().mockImplementation(async () => {
+        manager.contextFiles = [];
+      });
+
+      await manager.removeContextFile(5);
+
+      expect(manager.collapsedFiles.has(`context:${FILE}`)).toBe(false);
+      expect(manager.saveViewedState).not.toHaveBeenCalled();
+    });
+
+    it('does not scrub keys when the DELETE fails', async () => {
+      manager.contextFiles = [{ id: 5, file: FILE }];
+      manager.viewedFiles.add(`context:${FILE}`);
+      manager.loadContextFiles = vi.fn();
+      globalThis.fetch = vi.fn().mockResolvedValue({ ok: false, status: 500 });
+
+      await manager.removeContextFile(5);
+
+      expect(manager.viewedFiles.has(`context:${FILE}`)).toBe(true);
+      expect(manager.loadContextFiles).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('renderFileItem viewed key scoping', () => {
+    it('a context sidebar row reads the context-scoped viewed key', () => {
+      manager.viewedFiles.add(FILE); // diff viewed only
+
+      const item = manager.renderFileItem({
+        name: 'app.js', fullPath: FILE, status: 'modified',
+        contextFile: true, contextId: 7, lineStart: 1,
+      });
+      expect(item.classList.contains('viewed')).toBe(false);
+
+      manager.viewedFiles.add(`context:${FILE}`);
+      const viewedItem = manager.renderFileItem({
+        name: 'app.js', fullPath: FILE, status: 'modified',
+        contextFile: true, contextId: 7, lineStart: 1,
+      });
+      expect(viewedItem.classList.contains('viewed')).toBe(true);
+    });
+  });
+});

--- a/tests/unit/file-item-viewed-indicator.test.js
+++ b/tests/unit/file-item-viewed-indicator.test.js
@@ -70,12 +70,20 @@ describe('file-item viewed indicator', () => {
       expect(item.querySelector('.file-viewed-icon-wrapper')).toBeNull();
     });
 
-    it('marks context files as viewed when their path is in viewedFiles', () => {
-      const manager = createManager(['src/app.js']);
+    it('marks context files as viewed via their context-scoped key', () => {
+      const manager = createManager(['context:src/app.js']);
       const item = manager.renderFileItem(makeFile({ contextFile: true }));
 
       expect(item.classList.contains('viewed')).toBe(true);
       expect(item.querySelector('.file-viewed-icon-wrapper')).not.toBeNull();
+    });
+
+    it('does not mark a context file viewed from the diff entry key (#540)', () => {
+      const manager = createManager(['src/app.js']);
+      const item = manager.renderFileItem(makeFile({ contextFile: true }));
+
+      expect(item.classList.contains('viewed')).toBe(false);
+      expect(item.querySelector('.file-viewed-icon-wrapper')).toBeNull();
     });
 
     it('handles missing viewedFiles set without throwing', () => {


### PR DESCRIPTION
Fixes #540

## Problem

When a file has both a diff entry and an LLM chat context entry, the two shared identity by file path. Collapsing the context entry resolved to the diff wrapper and re-expanded a viewed diff; marking the context entry Viewed toggled the diff's persisted state instead of its own.

## Fix (layered)

**Root cause — "diff wins" at the render layer:** `loadContextFiles` now skips rendering any stored context row whose file is currently in the diff. The rule already existed at add time (`ensureContextFile`, the POST route) and in the sidebar merge (`mergeFileListWithContext`); the diff panel was the only unguarded gate. Suppression is view-only — the DB row survives, and since `renderDiff` is a full clear-and-rebuild, a file entering the diff (Local-mode scope change, new commits, PR refresh) and later leaving it self-heals in both directions.

**Defense-in-depth for duplicates that still slip through:**
- Context entries track collapse/viewed state under context-scoped keys (`context:<path>`) via dedicated `toggleContextFileCollapse` / `toggleContextFileViewed` methods that target the `.context-file` wrapper directly — toggling one entry never touches the other's state, in either direction.
- `findFileElement` resolves only real `.d2h-file-wrapper` diff wrappers: never a nested `.file-comments-zone` (which also carries `data-file-name`) and never a same-path context wrapper, while context-only files still resolve through the `pathsMatch` fallback.
- Removing a context entry scrubs its scoped state keys once no rows remain for the path — both on the initiating tab (`removeContextFile`) and on peer tabs receiving the delete via WebSocket refresh (`loadContextFiles` diffs its previous snapshot) — so stale viewed/collapsed state cannot resurrect on re-add, and orphaned keys never round-trip through `saveViewedState`.

Both modes are covered by construction: Local mode reuses these shared `PRManager` methods and only patches viewed-state persistence, which serializes the namespaced keys transparently.

## Hazards audited

- `updateFileList` sets `this.diffFiles` immediately before `renderDiff` in both PR mode and Local mode, so the render guard always sees fresh diff paths.
- All four `loadContextFiles` callers checked against the new scrub: `renderDiff` (resets `contextFiles` first — no scrub), `ensureContextFile` range expansion (evicts the path from the snapshot first — no scrub mid-expansion), WebSocket handlers (the fixed path), `removeContextFile` (idempotent double-scrub).
- Tour flows expand/collapse via `toggleFileCollapse` on diff and context-only wrappers; `findFileElement`'s fallback still resolves context-only wrappers, and the preference change only applies when both wrappers exist — where the diff was always the intended target.
- Nothing in the codebase sets `data-file-path` on any element, so scoping that lookup branch is behavior-neutral.

## Tests

- New `tests/unit/context-entry-collapse.test.js` (27 tests): the exact issue repro (viewed diff + context collapse), viewed independence both directions, DOM-order-proof `findFileElement` preference (context wrapper inserted before the diff wrapper so a revert fails the suite), nested comments-zone shape, the diff-wins guard (suppress/keep-row/re-render), and all scrub branches including the remote-delete path driving the real `loadContextFiles`.
- One existing test in `file-item-viewed-indicator.test.js` encoded the buggy shared-key behavior; updated, plus a regression case.
- Full suites green: 7726 unit, 1361 integration. E2E: 390 passed; the 2 failures (`gutter-buttons` pointer-leave, `comment-crud` multi-line) were verified as pre-existing flakes — the latter reproduced identically on `origin/main` without this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)