### PR TITLE
Disable background pool fetches when skip_bulk_fetch is enabled

### DIFF
--- a/.changeset/calm-pools-rest.md
+++ b/.changeset/calm-pools-rest.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Honor `skip_bulk_fetch` when scheduling periodic worktree pool fetches.

--- a/config.example.json
+++ b/config.example.json
@@ -283,7 +283,7 @@
   },
 
   "repos": {
-    "_comment": "Repository configurations (renamed from 'monorepos'; the old key still works). 'path' points to an existing local clone. 'checkout_script' runs after worktree creation. 'reset_script' runs when switching a pool worktree to a new PR. 'load_skills' controls whether AI providers load environment-level skills (default: true). 'skip_bulk_fetch' opts out of the unconditional `git fetch <remote> --prune` during refresh (default: false); the targeted base-SHA and PR-head ref fetches still run. Useful for very large monorepos where bulk fetching all refs/tags is prohibitively slow.",
+    "_comment": "Repository configurations (renamed from 'monorepos'; the old key still works). 'path' points to an existing local clone. 'checkout_script' runs after worktree creation. 'reset_script' runs when switching a pool worktree to a new PR. 'load_skills' controls whether AI providers load environment-level skills (default: true). 'skip_bulk_fetch' opts out of the unconditional `git fetch <remote> --prune` during refresh and periodic pool background fetching (default: false); the targeted base-SHA and PR-head ref fetches still run. Useful for very large monorepos where bulk fetching all refs/tags is prohibitively slow.",
     "owner/repo": {
       "path": "~/path/to/monorepo",
       "checkout_script": "my-repo-checkout $BASE_SHA $HEAD_BRANCH",

--- a/src/config.js
+++ b/src/config.js
@@ -1412,10 +1412,11 @@ function getRepoResetScript(config, repository) {
 }
 
 /**
- * Gets whether updateWorktree should skip the bulk `git fetch <remote> --prune`
+ * Gets whether broad fetches should be skipped during worktree refresh and
+ * periodic pool background fetching. Targeted base-SHA and PR-head fetches continue.
  * @param {Object} config - Configuration object from loadConfig()
  * @param {string} repository - Repository in "owner/repo" format
- * @returns {boolean} - true if the bulk fetch should be skipped (default: false)
+ * @returns {boolean} - true if broad fetches should be skipped (default: false)
  */
 function getRepoSkipBulkFetch(config, repository) {
   const repoConfig = getRepoConfig(config, repository);

--- a/src/main.js
+++ b/src/main.js
@@ -1,7 +1,7 @@
 // Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
 const fs = require('fs');
 const { v4: uuidv4 } = require('uuid');
-const { loadConfig, getConfigDir, showWelcomeMessage, resolveDbName, resolveRepoOptions, resolvePoolConfig, getRepoResetScript, resolveLoadSkills, buildCouncilProviderOverrides } = require('./config');
+const { loadConfig, getConfigDir, showWelcomeMessage, resolveDbName, resolveRepoOptions, resolvePoolConfig, getRepoResetScript, getRepoSkipBulkFetch, resolveLoadSkills, buildCouncilProviderOverrides } = require('./config');
 const { initializeDatabase, run, queryOne, query, migrateExistingWorktrees, WorktreeRepository, ReviewRepository, RepoSettingsRepository, GitHubReviewRepository, WorktreePoolRepository, CouncilRepository, CommentRepository, AnalysisRunRepository } = require('./database');
 const { PRArgumentParser } = require('./github/parser');
 const { GitHubClient } = require('./github/client');
@@ -2652,10 +2652,14 @@ async function handleActionReview(args, config, db, flags = {}, poolLifecycle = 
  */
 const POOL_FETCH_TICK_MS = 60 * 1000; // Check every minute
 
-function startPoolBackgroundFetches(db, config) {
+function startPoolBackgroundFetches(
+  db,
+  config,
+  { createGit = simpleGit, schedule = setInterval } = {}
+) {
   let fetchInProgress = false;
 
-  const timer = setInterval(async () => {
+  const timer = schedule(async () => {
     if (fetchInProgress) return;
     fetchInProgress = true;
     try {
@@ -2676,6 +2680,13 @@ function startPoolBackgroundFetches(db, config) {
         const repoSettings = allRepoSettings.find(r => r.repository.toLowerCase() === repoName.toLowerCase()) || null;
         const { poolSize, poolFetchIntervalMinutes } = resolvePoolConfig(config, repoName, repoSettings);
         if (!poolSize || !poolFetchIntervalMinutes) continue;
+
+        if (getRepoSkipBulkFetch(config, repoName)) {
+          logger.debug(
+            `Background fetch disabled for ${repoName}: skip_bulk_fetch enabled`
+          );
+          continue;
+        }
 
         const intervalMs = poolFetchIntervalMinutes * 60 * 1000;
         const worktrees = await poolRepo.findAllForFetch(repoName);
@@ -2709,7 +2720,7 @@ function startPoolBackgroundFetches(db, config) {
 
             logger.info(`Background fetch starting for ${repoName} pool worktree ${entry.id}`);
             try {
-              const git = simpleGit(entry.path, { timeout: { block: 300000 } });
+              const git = createGit(entry.path, { timeout: { block: 300000 } });
               const remotes = await git.getRemotes();
               const remote = remotes.find(r => r.name === 'origin') || remotes[0];
               if (remote) await fetchNoTags(git, ['--prune', remote.name]);
@@ -2788,4 +2799,4 @@ if (require.main === module) {
   main();
 }
 
-module.exports = { main, parseArgs, detectPRFromGitHubEnvironment, printCouncilList, handleHeadlessAnalysis, handleHeadlessDelegated, runHeadlessAnalysis, buildHeadlessJson, buildHeadlessErrorJson, resolveCliInstructions };
+module.exports = { main, parseArgs, detectPRFromGitHubEnvironment, printCouncilList, handleHeadlessAnalysis, handleHeadlessDelegated, runHeadlessAnalysis, buildHeadlessJson, buildHeadlessErrorJson, resolveCliInstructions, startPoolBackgroundFetches };

--- a/tests/unit/pool-background-fetch.test.js
+++ b/tests/unit/pool-background-fetch.test.js
@@ -1,0 +1,114 @@
+// Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { WorktreePoolRepository } = require('../../src/database');
+const { startPoolBackgroundFetches } = require('../../src/main');
+const logger = require('../../src/utils/logger');
+const { createTestDatabase, closeTestDatabase } = require('../utils/schema');
+
+const REPOSITORY = 'owner/repo';
+const POOL_ID = 'pool-background-fetch';
+
+describe('startPoolBackgroundFetches', () => {
+  let db;
+  let tempDir;
+  let getRemotes;
+  let fetch;
+  let createGit;
+  let schedule;
+  let runScheduledTick;
+  let errorSpy;
+
+  beforeEach(async () => {
+    db = createTestDatabase();
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pair-review-pool-fetch-'));
+    await new WorktreePoolRepository(db).create({
+      id: POOL_ID,
+      repository: REPOSITORY,
+      path: tempDir,
+    });
+    getRemotes = vi.fn().mockResolvedValue([{ name: 'origin' }]);
+    fetch = vi.fn().mockResolvedValue(undefined);
+    createGit = vi.fn(() => ({ getRemotes, fetch }));
+    schedule = vi.fn((callback) => {
+      runScheduledTick = callback;
+      return { unref: vi.fn() };
+    });
+    errorSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    try {
+      errorSpy?.mockRestore();
+    } finally {
+      try {
+        if (db?.open) closeTestDatabase(db);
+      } finally {
+        if (tempDir) fs.rmSync(tempDir, { recursive: true, force: true });
+      }
+    }
+  });
+
+  function configWithSkipBulkFetch(skipBulkFetch) {
+    return {
+      repos: {
+        [REPOSITORY]: {
+          pool_size: 1,
+          pool_fetch_interval_minutes: 60,
+          skip_bulk_fetch: skipBulkFetch,
+        },
+      },
+    };
+  }
+
+  function getPoolRow() {
+    return db.prepare('SELECT last_fetched_at FROM worktree_pool WHERE id = ?').get(POOL_ID);
+  }
+
+  function getRepoSettingsRow() {
+    return db.prepare(
+      'SELECT pool_fetch_started_at, pool_fetch_finished_at FROM repo_settings WHERE repository = ?'
+    ).get(REPOSITORY);
+  }
+
+  it('skips due pool fetches when skip_bulk_fetch is enabled', async () => {
+    startPoolBackgroundFetches(
+      db,
+      configWithSkipBulkFetch(true),
+      { createGit, schedule }
+    );
+    await runScheduledTick();
+
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(createGit).not.toHaveBeenCalled();
+    expect(getRemotes).not.toHaveBeenCalled();
+    expect(fetch).not.toHaveBeenCalled();
+    expect(getPoolRow().last_fetched_at).toBeNull();
+    expect(getRepoSettingsRow()).toBeUndefined();
+  });
+
+  it('fetches due pool worktrees when skip_bulk_fetch is disabled', async () => {
+    startPoolBackgroundFetches(
+      db,
+      configWithSkipBulkFetch(false),
+      { createGit, schedule }
+    );
+    await runScheduledTick();
+
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(createGit).toHaveBeenCalledOnce();
+    expect(createGit).toHaveBeenCalledWith(tempDir, {
+      timeout: { block: 300000 },
+    });
+    expect(getRemotes).toHaveBeenCalledOnce();
+    expect(fetch).toHaveBeenCalledWith(['--no-tags', '--prune', 'origin']);
+    expect(getPoolRow().last_fetched_at).not.toBeNull();
+    expect(getRepoSettingsRow()).toEqual({
+      pool_fetch_started_at: expect.any(String),
+      pool_fetch_finished_at: expect.any(String),
+    });
+  });
+});


### PR DESCRIPTION
## Why is this needed?

On large repos, the [pool scheduler](https://github.com/in-the-loop-labs/pair-review/blob/73946b1c9c66360b701d9fdc5e87006848a291cd/src/main.js#L2653-L2727) currently triggers an infinite fetch loop, which consumes substantial disk space on user's computers (~300GB in my case).

That loop occurs when the following conditions are met:

1. the `git fetch --no-tags --prune origin` timeout fires after Git writes a pack
2. the [fetch timeout](https://github.com/in-the-loop-labs/pair-review/blob/73946b1c9c66360b701d9fdc5e87006848a291cd/src/main.js#L2712-L2715) fires before the fetch succeeds

When these conditions are met, the lease is realased but `last_fetched_at` isn't updated, thereby causing the next tick to see the same entry as due and to start the fetch again.

As an immediate mitigation, this PR applies the `skip_bulk_fetch` flag for background pool refreshes (in addition to it already being applied on foreground refreshes).

### Longer term follow-up

This PR disables periodic broad fetches only for repositories with `skip_bulk_fetch: true`. Hence, the issues is fixed only for explicitly configured repositories. A more resilient follow-up could add bounded retry backoff after repeated failures, keeping `last_fetched_at` success-only and tracking attempts separately, for example with `last_fetch_attempt_at`.

## Manual Validation

This exercises the production scheduler tick with an in-memory database and injected Git client, proving the skip path performs no Git or lease work while the enabled path still completes the existing fetch and lease lifecycle.

<details>
<summary>Manual validation script</summary>

```bash
node <<'NODE'
const assert = require('assert');
const fs = require('fs');
const os = require('os');
const path = require('path');
const logger = require('./src/utils/logger');
const { WorktreePoolRepository } = require('./src/database');
const { startPoolBackgroundFetches } = require('./src/main');
const { createTestDatabase, closeTestDatabase } = require('./tests/utils/schema');

logger.debug = () => {};
logger.info = () => {};
logger.warn = () => {};

const db = createTestDatabase();
const skippedPath = fs.mkdtempSync(path.join(os.tmpdir(), 'pair-review-skipped-'));
const enabledPath = fs.mkdtempSync(path.join(os.tmpdir(), 'pair-review-enabled-'));

(async () => {
  try {
    const pool = new WorktreePoolRepository(db);
    await pool.create({ id: 'pool-skipped', repository: 'owner/skipped', path: skippedPath });
    await pool.create({ id: 'pool-enabled', repository: 'owner/enabled', path: enabledPath });

    const gitPaths = [];
    const fetchCalls = [];
    const createGit = (worktreePath) => {
      gitPaths.push(worktreePath);
      return {
        getRemotes: async () => [{ name: 'origin' }],
        fetch: async (args) => fetchCalls.push(args),
      };
    };
    let runScheduledTick;
    const schedule = (callback) => {
      runScheduledTick = callback;
      return { unref() {} };
    };

    startPoolBackgroundFetches(db, {
      repos: {
        'owner/skipped': {
          pool_size: 1,
          pool_fetch_interval_minutes: 60,
          skip_bulk_fetch: true,
        },
        'owner/enabled': {
          pool_size: 1,
          pool_fetch_interval_minutes: 60,
          skip_bulk_fetch: false,
        },
      },
    }, { createGit, schedule });
    await runScheduledTick();

    const skippedPool = db.prepare(
      'SELECT last_fetched_at FROM worktree_pool WHERE id = ?'
    ).get('pool-skipped');
    const enabledPool = db.prepare(
      'SELECT last_fetched_at FROM worktree_pool WHERE id = ?'
    ).get('pool-enabled');
    const skippedLease = db.prepare(
      'SELECT pool_fetch_started_at FROM repo_settings WHERE repository = ?'
    ).get('owner/skipped');
    const enabledLease = db.prepare(
      'SELECT pool_fetch_started_at, pool_fetch_finished_at FROM repo_settings WHERE repository = ?'
    ).get('owner/enabled');

    assert.deepStrictEqual(gitPaths, [enabledPath]);
    assert.deepStrictEqual(fetchCalls, [['--no-tags', '--prune', 'origin']]);
    assert.strictEqual(skippedPool.last_fetched_at, null);
    assert.strictEqual(skippedLease, undefined);
    assert.ok(enabledPool.last_fetched_at);
    assert.ok(enabledLease.pool_fetch_started_at);
    assert.ok(enabledLease.pool_fetch_finished_at);

    console.log('Skipped Git client: not created');
    console.log('Skipped lease row: absent');
    console.log(`Fetch arguments: ${JSON.stringify(fetchCalls[0])}`);
    console.log('Fetched timestamp: recorded');
    console.log('Lease start: recorded');
    console.log('Lease finish: recorded');
    console.log('Manual validation passed');
  } finally {
    closeTestDatabase(db);
    fs.rmSync(skippedPath, { recursive: true, force: true });
    fs.rmSync(enabledPath, { recursive: true, force: true });
  }
})().catch((error) => {
  console.error(error);
  process.exitCode = 1;
});
NODE
```

</details>

I got:

```text
Skipped Git client: not created
Skipped lease row: absent
Fetch arguments: ["--no-tags","--prune","origin"]
Fetched timestamp: recorded
Lease start: recorded
Lease finish: recorded
Manual validation passed
```

This confirms opted-out repositories are skipped before Git-client creation and lease acquisition, while enabled repositories preserve the broad-fetch arguments, fetched timestamp, and lease start/finish behavior.



