### PR TITLE
fix: hide HTML comments and render sanitized inline HTML in markdown

### DIFF
--- a/.changeset/markdown-inline-html-and-comments.md
+++ b/.changeset/markdown-inline-html-and-comments.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Improve markdown rendering of comments: hide HTML comments (e.g. tracking markers) from the rendered view and render the GitHub-supported inline HTML subset (`<sub>`, `<sup>`, `<kbd>`, `<ins>`, `<del>`, `<mark>`, `<details>`, etc.). Rendered output is now sanitized with DOMPurify against an explicit allowlist, so raw HTML is safe. Raw comment text is still shown when editing a comment.

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "@changesets/cli": "^2.29.8",
     "@playwright/test": "^1.57.0",
     "@vitest/coverage-v8": "^4.0.16",
+    "dompurify": "^3.2.6",
     "esbuild": "^0.27.4",
     "highlight.js": "^11.11.1",
     "jsdom": "^29.0.1",

--- a/plans/render-html-comments-and-inline-html.md
+++ b/plans/render-html-comments-and-inline-html.md
@@ -1,0 +1,112 @@
+# Plan: Hide HTML comments and render GitHub-style inline HTML in markdown
+
+## Context
+
+Pair-review's rendered comments currently show raw HTML comments (`<!-- thread-id:a1b2c3 -->`,
+`<!-- line:35 -->`, etc.) as visible text, and inline HTML tags such as `<sub>` appear as
+literal escaped text instead of rendering. Both symptoms have the same root cause: the single shared
+markdown renderer is configured with `html: false`, which disables **all** HTML handling in
+markdown-it. With that flag off, HTML comments and tags are neither stripped nor interpreted — they
+are escaped and shown verbatim.
+
+Desired outcome (matching GitHub behaviour):
+1. HTML comments are **hidden** in the rendered view (still visible when editing the raw text, which
+   is unaffected because the editor shows source, not rendered output).
+2. A safe subset of inline HTML — `<sub>`, `<sup>`, `<kbd>`, etc. — renders as real elements.
+
+## Approach
+
+Enable `html: true` in markdown-it and pass the rendered output through **DOMPurify** with an
+explicit GitHub-like allowlist. DOMPurify removes comment nodes and dangerous tags/attributes by
+default, so this satisfies both requirements with one well-tested sanitizer rather than a fragile
+hand-rolled regex. Delivery via CDN, matching the sibling markdown-it libraries.
+
+**Safety invariant:** never emit `html: true` output unsanitized. If `window.DOMPurify` is
+unavailable (e.g. offline), fall back to the current `html: false` behaviour (comments visible, tags
+escaped) — degraded but safe. This mirrors the existing guard that only defines `renderMarkdown`
+when `window.markdownit` is present.
+
+## Files to change
+
+### 1. `public/js/utils/markdown.js` (core)
+Refactor for testability (per repo convention: export the real implementation, do not duplicate in
+tests) while preserving the browser-only IIFE path:
+- Extract pure, Node-exportable helpers:
+  - `configureMarkdownIt(markdownit, { emoji })` → returns a configured md instance with
+    `html: true` (plus existing `breaks`, `linkify`, `typographer`, emoji plugin, and the
+    `link_open` target/rel rule).
+  - `sanitizeHtml(purify, html)` → runs DOMPurify with the allowlist below.
+  - `createRenderMarkdown({ md, purify })` → returns the `renderMarkdown(text)` function
+    (try/catch → `escapeHtml` fallback, unchanged contract).
+- Browser IIFE: only enable `html: true` + sanitization when **both** `window.markdownit` and
+  `window.DOMPurify` exist; otherwise build the renderer with `html: false` and no sanitizer (safe
+  fallback). Keep `window.renderMarkdown`, `window.markdownRenderer`, `window.escapeHtmlAttribute`.
+- `module.exports` (Node): `escapeHtmlAttribute` (existing) plus `configureMarkdownIt`,
+  `sanitizeHtml`, `createRenderMarkdown` for unit testing.
+
+**DOMPurify allowlist (GitHub-like set):**
+- `ALLOWED_TAGS`: standard markdown output (`p, a, code, pre, blockquote, ul, ol, li, h1–h6, em,
+  strong, hr, table, thead, tbody, tr, th, td, img, span, br`) **plus** `sub, sup, kbd, ins, del,
+  mark, details, summary, abbr`.
+- `ALLOWED_ATTR`: `href, title, target, rel, src, alt, align, class, start, colspan, rowspan`.
+- Add an `afterSanitizeAttributes` hook to force `target="_blank"` + `rel="noopener noreferrer"` on
+  anchors, so link security survives sanitization regardless of DOMPurify defaults.
+- Comments: removed by DOMPurify default (do not set `ALLOW_COMMENTS`).
+
+### 2. `public/pr.html` and `public/local.html`
+Add a DOMPurify CDN `<script>` (pinned, e.g. `dompurify@3.x`) immediately **before**
+`/js/utils/markdown.js` (after the markdown-it scripts) in both files, so `window.DOMPurify` exists
+when markdown.js runs.
+
+### 3. `package.json`
+Add `dompurify` as a **devDependency**, pinned to the same major as the CDN script, for unit tests.
+(`jsdom` and `markdown-it` are already present.)
+
+### 4. `tests/unit/markdown.test.js` (new)
+Import the real module; wire real `markdown-it` + DOMPurify created over jsdom
+(`createDOMPurify(new JSDOM('').window)`). Cases:
+- HTML comment (own-line block **and** inline) → not present in output / not visible.
+- `<sub>x</sub>`, `<sup>2</sup>`, `<kbd>Ctrl</kbd>` → real elements.
+- XSS regression: `<script>`, `<img onerror=…>`, `javascript:` href → stripped/neutralised.
+- Anchors get `target="_blank" rel="noopener noreferrer"`.
+- Fallback: `createRenderMarkdown` built without a purify → behaves as `html: false` (tags escaped),
+  and empty/null input returns `''`.
+- `escapeHtmlAttribute` still exported and unchanged.
+
+### 5. E2E (via Task tool, per repo rule for frontend changes)
+Add/extend a Playwright spec asserting a rendered comment whose body contains an HTML comment marker
++ `<sub>` shows the subscript and hides the comment. Because both modes share
+`window.renderMarkdown`, one mode exercises the shared path; note parity in the spec.
+
+### 6. `.changeset/*.md`
+`minor` for `@in-the-loop-labs/pair-review`: "Render GitHub-style inline HTML (sub/sup/kbd, …) and
+hide HTML comments in rendered markdown comments."
+
+### 7. README
+Check for a section documenting markdown/comment support; add a one-line note only if such a section
+exists. Likely skip.
+
+## Hazards
+
+- **Blast radius:** `renderMarkdown` is the single renderer behind ~15 call sites across PR **and**
+  Local mode (`pr.js`, `ChatPanel.js`, `AISummaryModal.js`, `file-comment-manager.js`,
+  `comment-manager.js`, `external-comment-manager.js`, `suggestion-manager.js`, `pierre-bridge.js`,
+  `suggestion-ui.js`, `AISummaryModal.js`). Enabling `html: true` changes rendering for **every**
+  markdown surface, not just comments — verify code blocks, tables, emoji, and autolinks still
+  render. Covered by unit tests + E2E.
+- **XSS:** `html: true` without sanitization is an injection hole; comment bodies include
+  AI-generated and GitHub-sourced (untrusted) content. Mitigated by the explicit allowlist, the safe
+  `html: false` fallback when DOMPurify is absent, and XSS regression tests.
+- **Module load path:** markdown.js runs a browser-only IIFE at load keyed on `window.markdownit`.
+  The refactor must keep that path intact while adding Node exports, and must not emit `html: true`
+  output when DOMPurify is missing.
+- **Raw editing unaffected:** comment editors show source text (not rendered), so "visible when
+  editing raw text" is satisfied without extra work.
+
+## Verification
+
+1. `pnpm test` — new `tests/unit/markdown.test.js` plus existing suite green.
+2. `pnpm run test:e2e` (via Task tool) — the new/extended spec passes headless.
+3. Manual: run the app, open a comment containing `<!-- marker -->` and `H<sub>2</sub>O`; confirm the
+   marker is hidden in the rendered view, `H₂O` renders as subscript, and the raw marker reappears
+   when the comment is put into edit mode.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,6 +63,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^4.0.16
         version: 4.1.4(vitest@4.1.4)
+      dompurify:
+        specifier: ^3.2.6
+        version: 3.4.12
       esbuild:
         specifier: ^0.27.4
         version: 0.27.7
@@ -727,6 +730,9 @@ packages:
   '@types/responselike@1.0.3':
     resolution: {integrity: sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==}
 
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
@@ -1104,6 +1110,9 @@ packages:
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
+
+  dompurify@3.4.12:
+    resolution: {integrity: sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==}
 
   dot-prop@5.3.0:
     resolution: {integrity: sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==}
@@ -3293,6 +3302,9 @@ snapshots:
     dependencies:
       '@types/node': 25.6.0
 
+  '@types/trusted-types@2.0.7':
+    optional: true
+
   '@types/unist@3.0.3': {}
 
   '@ungap/structured-clone@1.3.0': {}
@@ -3680,6 +3692,10 @@ snapshots:
   dir-glob@3.0.1:
     dependencies:
       path-type: 4.0.0
+
+  dompurify@3.4.12:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   dot-prop@5.3.0:
     dependencies:

--- a/public/js/utils/markdown.js
+++ b/public/js/utils/markdown.js
@@ -1,7 +1,12 @@
 // Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
 /**
- * Safe markdown renderer for comments
- * Uses markdown-it with security settings to prevent XSS
+ * Safe markdown renderer for comments.
+ *
+ * Uses markdown-it to render markdown and DOMPurify to sanitize the result.
+ * Enabling raw HTML (`html: true`) lets us render the GitHub-supported inline
+ * HTML subset (e.g. <sub>, <sup>, <kbd>) and lets DOMPurify strip HTML comments
+ * (e.g. tracking markers) from the rendered view. DOMPurify is what keeps this
+ * safe from XSS — it must be present before we enable raw HTML.
  */
 
 /**
@@ -21,82 +26,214 @@ function escapeHtmlAttribute(text) {
     .replace(/'/g, '&#39;');
 }
 
-// Browser-only code: markdown rendering requires markdown-it library
-if (typeof window !== 'undefined' && window.markdownit) {
-  (function() {
-    // Initialize markdown-it with safe defaults
-    const md = window.markdownit({
-      html: false,        // Disable HTML tags to prevent XSS
-      xhtmlOut: false,    // Don't use self-closing tags
-      breaks: true,       // Convert \n to <br>
-      langPrefix: 'language-',  // CSS class prefix for code blocks
-      linkify: true,      // Auto-convert URLs to links
-      typographer: true   // Enable smartquotes and other typographic replacements
-    });
+/**
+ * GitHub-like allowlist for inline HTML permitted in comment bodies.
+ * Standard markdown output tags plus the safe inline subset GitHub renders.
+ */
+const ALLOWED_TAGS = [
+  // Standard markdown output
+  'p', 'a', 'code', 'pre', 'blockquote',
+  'ul', 'ol', 'li',
+  'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
+  'em', 'strong', 's', 'hr', 'br', 'span',
+  'table', 'thead', 'tbody', 'tr', 'th', 'td',
+  'img',
+  // GitHub-supported inline HTML subset
+  'sub', 'sup', 'kbd', 'ins', 'del', 'mark',
+  'details', 'summary', 'abbr'
+];
 
-    // Enable emoji shortcode support (e.g., :smile: -> 😄)
-    if (window.markdownitEmoji) {
-      md.use(window.markdownitEmoji);
-    }
+const ALLOWED_ATTR = [
+  'href', 'title', 'target', 'rel',
+  'src', 'alt', 'align', 'class',
+  'start', 'colspan', 'rowspan'
+];
 
-    // Configure link rendering to open in new tab and add security
-    const defaultLinkRender = md.renderer.rules.link_open || function(tokens, idx, options, env, self) {
-      return self.renderToken(tokens, idx, options);
-    };
+/**
+ * Configure a markdown-it instance with the project's rendering options.
+ * Raw HTML is enabled here; sanitization happens separately via DOMPurify.
+ * @param {function} markdownit - the markdown-it factory (window.markdownit)
+ * @param {object} [opts]
+ * @param {boolean} [opts.html=true] - allow raw HTML tokens
+ * @param {object} [opts.emoji] - markdown-it-emoji plugin (optional)
+ * @returns {object} configured markdown-it instance
+ */
+function configureMarkdownIt(markdownit, opts = {}) {
+  const html = opts.html !== undefined ? opts.html : true;
 
-    md.renderer.rules.link_open = function(tokens, idx, options, env, self) {
-      const token = tokens[idx];
-      token.attrPush(['target', '_blank']);
-      token.attrPush(['rel', 'noopener noreferrer']);
-      return defaultLinkRender(tokens, idx, options, env, self);
-    };
+  const md = markdownit({
+    html,               // Allow raw HTML; DOMPurify sanitizes the output
+    xhtmlOut: false,    // Don't use self-closing tags
+    breaks: true,       // Convert \n to <br>
+    langPrefix: 'language-',  // CSS class prefix for code blocks
+    linkify: true,      // Auto-convert URLs to links
+    typographer: true   // Enable smartquotes and other typographic replacements
+  });
 
-    /**
-     * Escape HTML characters (fallback for when markdown rendering fails)
-     * NOTE: This only escapes <, >, and &. It does NOT escape quotes.
-     * Use escapeHtmlAttribute() when placing content in HTML attributes.
-     * @param {string} text - Text to escape
-     * @returns {string} Escaped text
-     */
-    function escapeHtml(text) {
-      if (!text) return '';
-      const div = document.createElement('div');
-      div.textContent = text;
-      return div.innerHTML;
-    }
+  // Enable emoji shortcode support (e.g., :smile: -> 😄)
+  if (opts.emoji) {
+    md.use(opts.emoji);
+  }
 
-    /**
-     * Render markdown to safe HTML
-     * @param {string} text - Markdown text to render
-     * @returns {string} Safe HTML output
-     */
-    function renderMarkdown(text) {
-      if (!text) return '';
+  // Configure link rendering to open in new tab and add security.
+  // (DOMPurify's afterSanitizeAttributes hook re-applies these as a backstop.)
+  const defaultLinkRender = md.renderer.rules.link_open || function(tokens, idx, options, env, self) {
+    return self.renderToken(tokens, idx, options);
+  };
 
-      try {
-        // Render markdown to HTML
-        return md.render(text);
-      } catch (error) {
-        console.error('Markdown rendering error:', error);
-        // Fall back to escaped text if rendering fails
-        return escapeHtml(text);
-      }
-    }
+  md.renderer.rules.link_open = function(tokens, idx, options, env, self) {
+    const token = tokens[idx];
+    token.attrPush(['target', '_blank']);
+    token.attrPush(['rel', 'noopener noreferrer']);
+    return defaultLinkRender(tokens, idx, options, env, self);
+  };
 
-    // Export functions to global scope
-    window.renderMarkdown = renderMarkdown;
-
-    // Also export markdown instance for advanced usage if needed
-    window.markdownRenderer = md;
-  })();
+  return md;
 }
 
-// Export escapeHtmlAttribute to window (browser) regardless of markdown-it availability
+/**
+ * Sanitize rendered HTML with DOMPurify using the project allowlist.
+ * Removes HTML comments (default) and dangerous tags/attributes, converts
+ * markdown-it's table-alignment inline style into the allowlisted `align`
+ * attribute (so arbitrary inline styles never need to be permitted), forces
+ * safe link attributes on anchors, and scopes `class` to markdown code
+ * language hints only.
+ * @param {object} purify - a configured DOMPurify instance
+ * @param {string} html - HTML to sanitize
+ * @returns {string} sanitized HTML
+ */
+function sanitizeHtml(purify, html) {
+  // Hooks are registered idempotently (removed then re-added) so repeated
+  // sanitize() calls on the same instance don't stack duplicates.
+
+  // markdown-it encodes table column alignment as an inline `text-align` style.
+  // Convert it to the allowlisted `align` attribute BEFORE sanitization so we
+  // never have to permit arbitrary inline styles (which could hide or cover
+  // review UI via position/z-index/display). The `style` attribute itself is
+  // then dropped by the allowlist.
+  purify.removeHook('beforeSanitizeAttributes');
+  purify.addHook('beforeSanitizeAttributes', function (node) {
+    const tag = node.tagName;
+    if (tag === 'TH' || tag === 'TD') {
+      const align = node.style && node.style.textAlign;
+      if (align === 'left' || align === 'center' || align === 'right') {
+        node.setAttribute('align', align);
+      }
+    }
+  });
+
+  purify.removeHook('afterSanitizeAttributes');
+  purify.addHook('afterSanitizeAttributes', function (node) {
+    const tag = node.tagName;
+    // Force safe rel/target on links regardless of DOMPurify version defaults.
+    if (tag === 'A' && node.getAttribute('href')) {
+      node.setAttribute('target', '_blank');
+      node.setAttribute('rel', 'noopener noreferrer');
+    }
+    // Scope `class` to expected markdown output: only `language-*` on code/pre.
+    // Stops rendered repo content from reusing layout-sensitive app classes.
+    if (node.hasAttribute('class')) {
+      const kept =
+        tag === 'CODE' || tag === 'PRE'
+          ? node.getAttribute('class').split(/\s+/).filter((c) => /^language-[\w-]+$/.test(c))
+          : [];
+      if (kept.length) {
+        node.setAttribute('class', kept.join(' '));
+      } else {
+        node.removeAttribute('class');
+      }
+    }
+  });
+
+  return purify.sanitize(html, {
+    ALLOWED_TAGS,
+    ALLOWED_ATTR,
+    ALLOW_DATA_ATTR: false,
+  });
+}
+
+/**
+ * Create the renderMarkdown function.
+ * When a DOMPurify instance is provided, the markdown-it output is sanitized
+ * (safe to enable raw HTML). Without it, callers should pass an md configured
+ * with `html: false` so no unsanitized HTML is ever emitted.
+ * @param {object} config
+ * @param {object} config.md - configured markdown-it instance
+ * @param {object} [config.purify] - DOMPurify instance (optional)
+ * @param {function} [config.escape] - fallback escaper for render errors
+ * @returns {function(string): string} renderMarkdown
+ */
+function createRenderMarkdown(config) {
+  const { md, purify, escape } = config;
+  const fallbackEscape = escape || ((text) => escapeHtmlAttribute(text));
+
+  return function renderMarkdown(text) {
+    if (!text) return '';
+
+    try {
+      const rendered = md.render(text);
+      return purify ? sanitizeHtml(purify, rendered) : rendered;
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error('Markdown rendering error:', error);
+      // Fall back to escaped text if rendering fails
+      return fallbackEscape(text);
+    }
+  };
+}
+
+/**
+ * Wire the markdown renderer onto a window/global object.
+ * Raw HTML is only enabled when a DOMPurify instance is present to sanitize it;
+ * otherwise we fall back to html:false so unsanitized HTML is never emitted.
+ * Defines `win.renderMarkdown` and `win.markdownRenderer`. No-op without
+ * `win.markdownit`.
+ * @param {object} win - a window-like object (expects markdownit, optionally
+ *   DOMPurify, markdownitEmoji, and document)
+ */
+function initMarkdownGlobals(win) {
+  if (!win || !win.markdownit) return;
+
+  /**
+   * Escape HTML characters (fallback for when markdown rendering fails).
+   * NOTE: This only escapes <, >, and &. It does NOT escape quotes.
+   * Use escapeHtmlAttribute() when placing content in HTML attributes.
+   */
+  function escapeHtml(text) {
+    if (!text) return '';
+    const div = win.document.createElement('div');
+    div.textContent = text;
+    return div.innerHTML;
+  }
+
+  // Only enable raw HTML when DOMPurify is available to sanitize it.
+  const purify = win.DOMPurify || null;
+  const md = configureMarkdownIt(win.markdownit, {
+    html: !!purify,
+    emoji: win.markdownitEmoji || undefined
+  });
+
+  win.renderMarkdown = createRenderMarkdown({ md, purify, escape: escapeHtml });
+  // Also expose the markdown instance for advanced usage if needed.
+  win.markdownRenderer = md;
+}
+
+// Browser-only code: markdown rendering requires the markdown-it library.
 if (typeof window !== 'undefined') {
+  initMarkdownGlobals(window);
+  // Export escapeHtmlAttribute regardless of markdown-it availability.
   window.escapeHtmlAttribute = escapeHtmlAttribute;
 }
 
 // Export for Node.js testing
 if (typeof module !== 'undefined' && module.exports) {
-  module.exports = { escapeHtmlAttribute };
+  module.exports = {
+    escapeHtmlAttribute,
+    configureMarkdownIt,
+    sanitizeHtml,
+    createRenderMarkdown,
+    initMarkdownGlobals,
+    ALLOWED_TAGS,
+    ALLOWED_ATTR
+  };
 }

--- a/public/local.html
+++ b/public/local.html
@@ -566,6 +566,8 @@
     <!-- Markdown-it Library for rendering markdown in comments -->
     <script src="https://cdn.jsdelivr.net/npm/markdown-it@13.0.2/dist/markdown-it.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/markdown-it-emoji@2.0.2/dist/markdown-it-emoji.min.js"></script>
+    <!-- DOMPurify sanitizes rendered markdown HTML (must load before markdown.js) -->
+    <script src="https://cdn.jsdelivr.net/npm/dompurify@3.2.6/dist/purify.min.js"></script>
 
     <!-- Markdown renderer utility -->
     <script src="/js/utils/markdown.js"></script>

--- a/public/pr.html
+++ b/public/pr.html
@@ -371,6 +371,8 @@
     <!-- Markdown-it Library for rendering markdown in comments -->
     <script src="https://cdn.jsdelivr.net/npm/markdown-it@13.0.2/dist/markdown-it.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/markdown-it-emoji@2.0.2/dist/markdown-it-emoji.min.js"></script>
+    <!-- DOMPurify sanitizes rendered markdown HTML (must load before markdown.js) -->
+    <script src="https://cdn.jsdelivr.net/npm/dompurify@3.2.6/dist/purify.min.js"></script>
 
     <!-- Markdown renderer utility -->
     <script src="/js/utils/markdown.js"></script>

--- a/tests/e2e/markdown-rendering.spec.js
+++ b/tests/e2e/markdown-rendering.spec.js
@@ -1,0 +1,93 @@
+// Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+/**
+ * E2E Tests: Markdown Rendering (html:true + DOMPurify)
+ *
+ * Verifies, through the real browser + server, that the shared markdown
+ * renderer (window.renderMarkdown) now:
+ *   - renders the GitHub-supported inline HTML subset (e.g. <sub>) as real
+ *     elements instead of visible escaped text, and
+ *   - strips HTML comment markers (e.g. <!-- thread-id:... -->) so they are
+ *     not shown in the rendered comment body.
+ *
+ * markdown-it is configured with html:true and the output is sanitized with
+ * DOMPurify (both loaded via CDN <script> in public/pr.html before
+ * /js/utils/markdown.js). This affects ALL comment rendering, so it is exercised
+ * here through the real comment-creation flow used by comment-crud.spec.js.
+ *
+ * The test server is started via global-setup.js with pre-seeded test data.
+ */
+
+import { test, expect } from './fixtures.js';
+import { waitForDiffToRender, openCommentFormOnLine } from './helpers.js';
+
+// Helper to clean up all user comments (call via API to ensure clean state).
+// Mirrors the cleanupAllComments pattern in comment-crud.spec.js.
+async function cleanupAllComments(page) {
+  await page.evaluate(async () => {
+    const commentsResponse = await fetch('/api/reviews/1/comments?includeDismissed=true');
+    const data = await commentsResponse.json();
+    const comments = data.comments || [];
+    for (const comment of comments) {
+      await fetch(`/api/reviews/1/comments/${comment.id}`, { method: 'DELETE' });
+    }
+  });
+}
+
+// Create a user comment on the first diff line with the given body and return
+// the rendered comment body locator (the element produced by renderMarkdown).
+async function createComment(page, body) {
+  await openCommentFormOnLine(page, 0);
+  const textarea = page.locator('.user-comment-form textarea');
+  await expect(textarea).toBeVisible();
+  await textarea.fill(body);
+  await page.locator('.save-comment-btn').click();
+  await expect(page.locator('.user-comment-form')).not.toBeVisible({ timeout: 5000 });
+  const commentRow = page.locator('.user-comment-row').first();
+  await expect(commentRow).toBeVisible({ timeout: 5000 });
+  return commentRow.locator('.user-comment-body').first();
+}
+
+test.describe('Markdown Rendering (html:true + DOMPurify)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/pr/test-owner/test-repo/1');
+    await waitForDiffToRender(page);
+    await cleanupAllComments(page);
+  });
+
+  test.afterEach(async ({ page }) => {
+    await cleanupAllComments(page);
+  });
+
+  test('renders GitHub inline HTML like <sub> as a real element', async ({ page }) => {
+    const commentBody = await createComment(page, 'Water formula: H<sub>2</sub>O');
+
+    // The <sub> must render as a real element (not escaped text) inside the body.
+    const subEl = commentBody.locator('sub');
+    await expect(subEl).toBeVisible({ timeout: 5000 });
+    await expect(subEl).toHaveText('2');
+
+    // Sanity: the rendered body must NOT contain the escaped tag as literal text,
+    // which is what the old escape-only renderer would have produced.
+    await expect(commentBody).not.toContainText('<sub>');
+  });
+
+  test('strips HTML comment markers from the rendered body', async ({ page }) => {
+    const marker = 'thread-id:abc123';
+    const commentBody = await createComment(
+      page,
+      `Visible comment text. <!-- ${marker} -->`
+    );
+
+    // The visible text still renders.
+    await expect(commentBody).toContainText('Visible comment text.');
+
+    // The HTML comment marker must be stripped from the rendered output: neither
+    // the marker payload nor the comment delimiter should appear as text or HTML.
+    await expect(commentBody).not.toContainText('thread-id');
+    await expect(commentBody).not.toContainText('<!--');
+
+    const innerHTML = await commentBody.evaluate((el) => el.innerHTML);
+    expect(innerHTML).not.toContain('thread-id');
+    expect(innerHTML).not.toContain('<!--');
+  });
+});

--- a/tests/unit/markdown.test.js
+++ b/tests/unit/markdown.test.js
@@ -1,0 +1,308 @@
+// Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, beforeAll } from 'vitest';
+
+const markdownit = require('markdown-it');
+const createDOMPurify = require('dompurify');
+const { JSDOM } = require('jsdom');
+
+const {
+  escapeHtmlAttribute,
+  configureMarkdownIt,
+  createRenderMarkdown,
+  sanitizeHtml,
+  initMarkdownGlobals,
+  ALLOWED_TAGS,
+  ALLOWED_ATTR,
+} = require('../../public/js/utils/markdown.js');
+
+/**
+ * Build the sanitized renderer the browser uses (html:true + DOMPurify),
+ * using the real markdown-it and a DOMPurify instance backed by jsdom —
+ * i.e. the actual production code paths, never a duplicate.
+ */
+function buildRenderer() {
+  const purify = createDOMPurify(new JSDOM('').window);
+  const md = configureMarkdownIt(markdownit, { html: true });
+  return createRenderMarkdown({ md, purify });
+}
+
+/**
+ * Build the safe fallback renderer used when DOMPurify is unavailable
+ * (html:false, no sanitizer).
+ */
+function buildFallbackRenderer() {
+  const md = configureMarkdownIt(markdownit, { html: false });
+  return createRenderMarkdown({ md });
+}
+
+describe('renderMarkdown (sanitized, html enabled)', () => {
+  let render;
+  beforeAll(() => {
+    render = buildRenderer();
+  });
+
+  describe('HTML comments', () => {
+    it('strips block-level HTML comments (e.g. tracking markers)', () => {
+      const html = render('Hello\n\n<!-- thread-id:abc123 -->\n\nWorld');
+      expect(html).not.toContain('<!--');
+      expect(html).not.toContain('thread-id');
+      expect(html).toContain('Hello');
+      expect(html).toContain('World');
+    });
+
+    it('strips inline HTML comments', () => {
+      const html = render('Line one <!-- line-ref:35 --> still here');
+      expect(html).not.toContain('<!--');
+      expect(html).not.toContain('line-ref');
+      expect(html).toContain('Line one');
+      expect(html).toContain('still here');
+    });
+
+    it('strips multiple consecutive comment markers', () => {
+      const body =
+        'text\n\n<!-- track-thread:x -->\n<!-- track-review-head:y -->\n<!-- track-review-base:z -->';
+      const html = render(body);
+      expect(html).not.toContain('<!--');
+      expect(html).not.toContain('track-');
+      expect(html).toContain('text');
+    });
+  });
+
+  describe('GitHub-style inline HTML', () => {
+    it('renders <sub> as a real subscript element', () => {
+      expect(render('H<sub>2</sub>O')).toContain('<sub>2</sub>');
+    });
+
+    it('renders <sup> as a real superscript element', () => {
+      expect(render('x<sup>2</sup>')).toContain('<sup>2</sup>');
+    });
+
+    it('renders <kbd>', () => {
+      expect(render('Press <kbd>Ctrl</kbd>')).toContain('<kbd>Ctrl</kbd>');
+    });
+
+    it('renders <ins>, <del>, <mark>', () => {
+      const html = render('<ins>added</ins> <del>removed</del> <mark>note</mark>');
+      expect(html).toContain('<ins>added</ins>');
+      expect(html).toContain('<del>removed</del>');
+      expect(html).toContain('<mark>note</mark>');
+    });
+  });
+
+  describe('XSS protection', () => {
+    it('removes <script> tags', () => {
+      const html = render('before <script>alert(1)</script> after');
+      expect(html).not.toContain('<script');
+      expect(html).not.toContain('alert(1)');
+    });
+
+    it('strips event-handler attributes and dangerous tags', () => {
+      const html = render('<img src="x" onerror="alert(1)">');
+      expect(html).not.toContain('onerror');
+      expect(html).not.toContain('alert(1)');
+    });
+
+    it('does not emit an anchor for a javascript: markdown link', () => {
+      // markdown-it's validateLink refuses dangerous schemes, so no <a> is produced.
+      const html = render('[click](javascript:alert(1))');
+      expect(html).not.toMatch(/href\s*=\s*["']?\s*javascript:/i);
+      expect(html).not.toContain('<a ');
+    });
+
+    it('strips the javascript: scheme from raw HTML anchors', () => {
+      // Exercises DOMPurify's scheme filtering on passed-through HTML.
+      const html = render('<a href="javascript:alert(1)">x</a>');
+      expect(html).not.toContain('javascript:');
+    });
+
+    it('does not allow arbitrary tags outside the allowlist', () => {
+      const html = render('<iframe src="https://evil.example"></iframe>');
+      expect(html).not.toContain('<iframe');
+    });
+  });
+
+  describe('link safety', () => {
+    it('adds target=_blank and rel=noopener noreferrer to links', () => {
+      const html = render('[GitHub](https://github.com)');
+      expect(html).toContain('target="_blank"');
+      expect(html).toContain('rel="noopener noreferrer"');
+      expect(html).toContain('href="https://github.com"');
+    });
+  });
+
+  describe('standard markdown still works', () => {
+    it('renders bold, code, and lists', () => {
+      expect(render('**bold**')).toContain('<strong>bold</strong>');
+      expect(render('`code`')).toContain('<code>code</code>');
+      expect(render('- a\n- b')).toContain('<li>a</li>');
+    });
+
+    it('renders tables', () => {
+      const html = render('| a | b |\n| - | - |\n| 1 | 2 |');
+      expect(html).toContain('<table>');
+      expect(html).toContain('<td>1</td>');
+    });
+
+    it('renders strikethrough as <s>', () => {
+      expect(render('~~gone~~')).toContain('<s>gone</s>');
+    });
+
+    it('preserves table column alignment as align attribute (no inline style)', () => {
+      const html = render('| a | b |\n| :-: | --: |\n| 1 | 2 |');
+      expect(html).toContain('align="center"');
+      expect(html).toContain('align="right"');
+      expect(html).not.toContain('style=');
+      expect(html).not.toContain('text-align');
+    });
+  });
+
+  describe('layout-injection protection', () => {
+    it('strips layout-changing inline styles', () => {
+      const html = render(
+        '<p style="position:fixed;top:0;z-index:99999;display:none">overlay</p>'
+      );
+      expect(html).toContain('overlay');
+      expect(html).not.toContain('style=');
+      expect(html).not.toContain('position');
+      expect(html).not.toContain('z-index');
+      expect(html).not.toContain('display:none');
+    });
+  });
+
+  describe('class scoping', () => {
+    it('keeps the language class on fenced code blocks', () => {
+      const html = render('```js\nconst x = 1;\n```');
+      expect(html).toContain('class="language-js"');
+    });
+
+    it('strips class from non-code raw elements', () => {
+      const html = render('<span class="app-toolbar danger">hi</span>');
+      expect(html).toContain('<span');
+      expect(html).toContain('hi');
+      expect(html).not.toContain('app-toolbar');
+      expect(html).not.toContain('class=');
+    });
+
+    it('filters code classes down to language-* only', () => {
+      const html = render('<code class="language-js sneaky-overlay">x</code>');
+      expect(html).toContain('language-js');
+      expect(html).not.toContain('sneaky-overlay');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('returns empty string for empty input', () => {
+      expect(render('')).toBe('');
+    });
+
+    it('returns empty string for null/undefined', () => {
+      expect(render(null)).toBe('');
+      expect(render(undefined)).toBe('');
+    });
+  });
+});
+
+describe('renderMarkdown fallback (no DOMPurify, html disabled)', () => {
+  let render;
+  beforeAll(() => {
+    render = buildFallbackRenderer();
+  });
+
+  it('escapes raw HTML tags instead of rendering them (safe degraded mode)', () => {
+    const html = render('<sub>2</sub>');
+    expect(html).not.toContain('<sub>');
+    expect(html).toContain('&lt;sub&gt;');
+  });
+
+  it('escapes script tags', () => {
+    const html = render('<script>alert(1)</script>');
+    expect(html).not.toContain('<script');
+  });
+
+  it('still renders standard markdown', () => {
+    expect(render('**bold**')).toContain('<strong>bold</strong>');
+  });
+
+  it('returns empty string for empty input', () => {
+    expect(render('')).toBe('');
+  });
+});
+
+describe('sanitizeHtml', () => {
+  it('applies the allowlist and removes comments', () => {
+    const purify = createDOMPurify(new JSDOM('').window);
+    const out = sanitizeHtml(
+      purify,
+      '<sub>x</sub><script>alert(1)</script><!-- marker -->'
+    );
+    expect(out).toContain('<sub>x</sub>');
+    expect(out).not.toContain('<script');
+    expect(out).not.toContain('<!--');
+  });
+});
+
+describe('exported allowlists', () => {
+  it('includes the GitHub inline HTML subset', () => {
+    for (const tag of ['sub', 'sup', 'kbd', 'ins', 'del', 'mark', 'details', 'summary']) {
+      expect(ALLOWED_TAGS).toContain(tag);
+    }
+  });
+
+  it('permits link attributes', () => {
+    expect(ALLOWED_ATTR).toContain('href');
+    expect(ALLOWED_ATTR).toContain('target');
+    expect(ALLOWED_ATTR).toContain('rel');
+  });
+});
+
+describe('initMarkdownGlobals (browser wiring)', () => {
+  /**
+   * Build a window-like object mirroring what the browser exposes when
+   * markdown.js runs, optionally including DOMPurify.
+   */
+  function makeWindow({ withPurify }) {
+    const dom = new JSDOM('');
+    const win = dom.window;
+    win.markdownit = markdownit;
+    if (withPurify) {
+      win.DOMPurify = createDOMPurify(win);
+    }
+    return win;
+  }
+
+  it('defines a sanitizing renderer when DOMPurify is present', () => {
+    const win = makeWindow({ withPurify: true });
+    initMarkdownGlobals(win);
+    expect(typeof win.renderMarkdown).toBe('function');
+    expect(win.renderMarkdown('H<sub>2</sub>O')).toContain('<sub>2</sub>');
+    expect(win.renderMarkdown('x <!-- thread-id:z -->')).not.toContain('<!--');
+  });
+
+  it('falls back to escaping raw HTML when DOMPurify is absent (safe degraded mode)', () => {
+    const win = makeWindow({ withPurify: false });
+    initMarkdownGlobals(win);
+    expect(typeof win.renderMarkdown).toBe('function');
+    const html = win.renderMarkdown('<sub>2</sub>');
+    expect(html).not.toContain('<sub>');
+    expect(html).toContain('&lt;sub&gt;');
+  });
+
+  it('is a no-op when markdownit is unavailable', () => {
+    const dom = new JSDOM('');
+    initMarkdownGlobals(dom.window);
+    expect(dom.window.renderMarkdown).toBeUndefined();
+  });
+});
+
+describe('escapeHtmlAttribute', () => {
+  it('escapes all attribute-special characters', () => {
+    expect(escapeHtmlAttribute(`<>&"'`)).toBe('&lt;&gt;&amp;&quot;&#39;');
+  });
+
+  it('returns empty string for falsy input', () => {
+    expect(escapeHtmlAttribute('')).toBe('');
+    expect(escapeHtmlAttribute(null)).toBe('');
+    expect(escapeHtmlAttribute(undefined)).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary

The shared markdown renderer (`public/js/utils/markdown.js`) ran markdown-it with `html: false`, which turned off **all** HTML handling. As a result, HTML comments were shown as visible escaped text, and GitHub-style inline HTML (`<sub>`, `<sup>`, `<kbd>`, …) never rendered.

This change enables `html: true` and sanitizes the output with **DOMPurify** against an explicit allowlist:

- **HTML comments are hidden** in the rendered view (stripped by DOMPurify). Raw comment text is still shown when editing.
- **GitHub inline HTML subset renders** (`sub`, `sup`, `kbd`, `ins`, `del`, `mark`, `s`, `details`, `summary`, …) as real elements.
- **Safe by construction** — every surface routes through DOMPurify; if the DOMPurify CDN fails to load, the renderer falls back to the previous safe `html: false` behavior.

Single shared renderer, so this applies to both PR and Local mode.

## Security hardening

- **No inline `style`** — table column alignment is preserved by converting markdown-it's `text-align` metadata to the allowlisted `align` attribute *before* sanitization. This avoids permitting arbitrary CSS (which could overlay/hide review UI via `position`/`z-index`/`display`).
- **`class` scoped** to `language-*` on `code`/`pre` only, so rendered repo content can't reuse layout-sensitive app classes.
- Links get `target="_blank" rel="noopener noreferrer"`.

## Tests

- **35 unit tests** (`tests/unit/markdown.test.js`): comment stripping, inline HTML, XSS regressions (`<script>`, `onerror`, `javascript:`, `<iframe>`), table alignment via `align`, layout-injection stripping, class scoping, the safe fallback path, and browser wiring. All green.
- **E2E spec** (`tests/e2e/markdown-rendering.spec.js`) covering `<sub>` rendering and comment stripping through the real browser + server.

## Changeset

`patch` — display-rendering fix.