### PR TITLE
fix: make review summary textarea resizable

### DIFF
--- a/.changeset/resizable-review-summary.md
+++ b/.changeset/resizable-review-summary.md
@@ -1,0 +1,9 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Make the Submit Review modal's summary textarea genuinely resizable. It already
+had `resize: vertical`, but a `max-height: 150px` cap limited it to ~3 visible
+lines with an inner scrollbar, so the drag handle did almost nothing. The cap is
+raised to `60vh` (and the default `min-height` bumped to 90px); the modal body
+scrolls beyond that.

--- a/public/css/pr.css
+++ b/public/css/pr.css
@@ -5225,8 +5225,8 @@ div.external-comment-row {
   border: 1px solid #d1d9e0;
   border-radius: 6px;
   resize: vertical;
-  min-height: 60px;
-  max-height: 150px;
+  min-height: 90px;
+  max-height: 60vh;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
 }
 


### PR DESCRIPTION
The Submit Review modal's summary textarea had resize: vertical but was capped at max-height: 150px, limiting it to ~3 lines with an inner scrollbar so the drag handle was effectively useless. Raise the cap to 60vh and bump the default min-height to 90px; the modal body scrolls beyond that.

https://github.com/user-attachments/assets/b00de48e-b8da-4243-a0b4-5daa0800df17

