### PR TITLE
feat: draft the review summary with AI from the Submit Review modal

### DIFF
--- a/.changeset/draft-review-summary-with-ai.md
+++ b/.changeset/draft-review-summary-with-ai.md
@@ -1,0 +1,12 @@
+---
+"@in-the-loop-labs/pair-review": minor
+---
+
+Add "Draft with AI" to the Submit Review modal. A new link next to "Copy AI
+summary" opens the chat panel in a fresh conversation tab to draft the review
+summary, seeded with your current summary text (if any) plus the PR/review
+context. The chat's action bar
+then shows a "Use as review summary" button (mirroring the findings-chat
+"Create comment" action) that pulls the AI's latest reply back into the summary
+field, preserving the selected review type. The link is hidden for Draft reviews
+(whose body is not sent) and when no chat panel is available.

--- a/public/css/pr.css
+++ b/public/css/pr.css
@@ -10254,8 +10254,16 @@ body.resizing * {
   margin-bottom: 6px;
 }
 
+/* Review Summary action links (Draft with AI, Copy AI summary) */
+.review-summary-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
 /* Copy AI summary link styling */
-.copy-ai-summary-link {
+.copy-ai-summary-link,
+.draft-with-ai-link {
   font-size: 12px;
   color: var(--color-accent-emphasis, #0969da);
   text-decoration: none;
@@ -10263,12 +10271,18 @@ body.resizing * {
   transition: opacity var(--transition-fast);
 }
 
-.copy-ai-summary-link:hover {
+.copy-ai-summary-link:hover,
+.draft-with-ai-link:hover {
   text-decoration: underline;
   opacity: 0.8;
 }
 
-[data-theme="dark"] .copy-ai-summary-link {
+.draft-with-ai-link {
+  cursor: pointer;
+}
+
+[data-theme="dark"] .copy-ai-summary-link,
+[data-theme="dark"] .draft-with-ai-link {
   color: #58a6ff;
 }
 
@@ -11729,6 +11743,18 @@ body.resizing * {
 }
 
 .chat-panel__action-btn--create-comment:hover:not(:disabled) {
+  background: var(--color-accent-hover, #388bfd);
+  border-color: var(--color-accent-hover, #388bfd);
+  color: #ffffff;
+}
+
+.chat-panel__action-btn--use-summary {
+  background: var(--color-accent-primary, #2f81f7);
+  border-color: var(--color-accent-primary, #2f81f7);
+  color: #ffffff;
+}
+
+.chat-panel__action-btn--use-summary:hover:not(:disabled) {
   background: var(--color-accent-hover, #388bfd);
   border-color: var(--color-accent-hover, #388bfd);
   color: #ffffff;

--- a/public/js/components/ChatPanel.js
+++ b/public/js/components/ChatPanel.js
@@ -856,6 +856,12 @@ class ChatPanel {
             </svg>
             Create comment
           </button>
+          <button class="chat-panel__action-btn chat-panel__action-btn--use-summary" style="display: none;" title="Use the latest AI reply as your review summary">
+            <svg viewBox="0 0 16 16" fill="currentColor" width="12" height="12">
+              <path d="M13.78 4.22a.75.75 0 0 1 0 1.06l-7.25 7.25a.75.75 0 0 1-1.06 0L2.22 9.28a.751.751 0 0 1 .018-1.042.751.751 0 0 1 1.042-.018L6 10.94l6.72-6.72a.75.75 0 0 1 1.06 0Z"/>
+            </svg>
+            Use as review summary
+          </button>
           <button class="chat-panel__action-bar-dismiss" title="Dismiss shortcuts">
             ${DISMISS_ICON}
           </button>
@@ -909,6 +915,7 @@ class ChatPanel {
     this.dismissSuggestionBtn = this.container.querySelector('.chat-panel__action-btn--dismiss-suggestion');
     this.dismissCommentBtn = this.container.querySelector('.chat-panel__action-btn--dismiss-comment');
     this.createCommentBtn = this.container.querySelector('.chat-panel__action-btn--create-comment');
+    this.useSummaryBtn = this.container.querySelector('.chat-panel__action-btn--use-summary');
     this.actionBarDismissBtn = this.container.querySelector('.chat-panel__action-bar-dismiss');
     this.providerPickerEl = this.container.querySelector('.chat-panel__provider-picker');
     this.providerPickerBtn = this.container.querySelector('.chat-panel__provider-picker-btn');
@@ -955,6 +962,7 @@ class ChatPanel {
     this.dismissSuggestionBtn.addEventListener('click', () => this._handleDismissSuggestionClick());
     this.dismissCommentBtn.addEventListener('click', () => this._handleDismissCommentClick());
     this.createCommentBtn.addEventListener('click', () => this._handleCreateCommentClick());
+    this.useSummaryBtn.addEventListener('click', () => this._handleUseSummaryClick());
     this.actionBarDismissBtn.addEventListener('click', () => this._handleActionBarDismiss());
 
     // New-content pill: click to scroll to bottom
@@ -4339,6 +4347,72 @@ class ChatPanel {
   }
 
   /**
+   * Return the raw markdown content of the most recent assistant message in
+   * the active tab, or null when there is none. Used by ReviewModal to pull a
+   * drafted review summary back into the Submit Review modal.
+   * @returns {string|null}
+   */
+  getLastAssistantMessage() {
+    const tab = this._getActiveTab();
+    if (!tab || !Array.isArray(tab.messages)) return null;
+    for (let i = tab.messages.length - 1; i >= 0; i--) {
+      const msg = tab.messages[i];
+      if (msg && msg.role === 'assistant' && msg.content) return msg.content;
+    }
+    return null;
+  }
+
+  /**
+   * Open the chat panel and ask the agent to draft a PR review summary,
+   * seeding it with the user's current summary text (if any) so it refines
+   * rather than starts over. Driven by the "Draft with AI" affordance in the
+   * Submit Review modal.
+   * @param {{currentSummary?: string}} [options]
+   */
+  async startSummaryDraft({ currentSummary = '' } = {}) {
+    await this.open();
+    // Draft in a dedicated fresh tab (like the "New conversation" button) so
+    // the summary session is isolated from whatever chat is currently active
+    // and repeated invocations don't stack duplicate prompts in one tab.
+    await this._openNewTab();
+    // Mark this tab as a review-summary drafting session so the action bar
+    // exposes "Use as review summary" (mirrors the suggestion/comment/line
+    // context sources). The button stays disabled until the reply finishes
+    // streaming, since _updateActionButtons re-runs on stream start/end.
+    this._contextSource = 'review-summary';
+    this._contextItemId = null;
+    this._updateActionButtons();
+    if (!this.inputEl) return;
+    this.inputEl.value = ChatPanel.buildSummaryDraftPrompt(currentSummary);
+    this.sendMessage();
+  }
+
+  /**
+   * Build the prompt sent to the agent when drafting a review summary. Pure so
+   * it can be unit-tested without a live panel.
+   * @param {string} [currentSummary]
+   * @returns {string}
+   */
+  static buildSummaryDraftPrompt(currentSummary = '') {
+    const trimmed = (currentSummary || '').trim();
+    const base = [
+      'Draft a short review summary for this pull request, written in my voice as the reviewer, for the review body.',
+      '',
+      'This is a code review, not a PR description. Follow these rules strictly:',
+      '- Do NOT describe what the PR does, summarize the diff, or mention file/line counts or a list of changes.',
+      '- Do NOT repeat anything already covered in my line-level comments — the author reads those inline. Synthesize the overall takeaway instead.',
+      '- Give my overall assessment and recommendation, plus at most one or two cross-cutting themes not already raised inline.',
+      '- Be terse and specific: a few sentences, or 2–3 tight bullets at most. No praise padding, no generic filler.',
+      '',
+      'Return only the summary text (Markdown), with no preamble.',
+    ].join('\n');
+    if (trimmed) {
+      return `${base}\n\nHere is my current draft to refine (keep what works, tighten the rest):\n\n${trimmed}`;
+    }
+    return base;
+  }
+
+  /**
    * Create a copy-to-clipboard button for an assistant message bubble.
    * @param {string} rawContent - Raw markdown to copy
    * @returns {HTMLButtonElement}
@@ -5163,9 +5237,10 @@ class ChatPanel {
     const hasSuggestion = this._contextSource === 'suggestion' && this._contextItemId;
     const hasComment = this._contextSource === 'user' && this._contextItemId;
     const hasLine = this._contextSource === 'line';
+    const hasSummaryDraft = this._contextSource === 'review-summary';
 
     // Show the bar only if at least one button is relevant
-    const showBar = hasSuggestion || hasComment || hasLine;
+    const showBar = hasSuggestion || hasComment || hasLine || hasSummaryDraft;
     this.actionBar.style.display = showBar ? '' : 'none';
     this.adoptBtn.style.display = hasSuggestion ? '' : 'none';
     this.dismissSuggestionBtn.style.display = hasSuggestion ? '' : 'none';
@@ -5173,6 +5248,11 @@ class ChatPanel {
     this.dismissCommentBtn.style.display = hasComment ? '' : 'none';
     this.createCommentBtn.style.display = hasLine ? '' : 'none';
     this.createCommentBtn.disabled = this.isStreaming;
+    this.useSummaryBtn.style.display = hasSummaryDraft ? '' : 'none';
+    // Enabled only once a reply exists AND streaming has finished. This keeps
+    // it disabled right after "Draft with AI" (nothing to use yet) and while
+    // the draft streams; it enables when the first reply lands.
+    this.useSummaryBtn.disabled = this.isStreaming || !this.getLastAssistantMessage();
 
     // Disable while streaming
     this.adoptBtn.disabled = this.isStreaming;
@@ -5261,6 +5341,26 @@ class ChatPanel {
     };
     this.inputEl.value = 'Based on our conversation, please create a review comment for this code.';
     this.sendMessage();
+  }
+
+  /**
+   * Handle click on "Use as review summary" button. Sends the latest assistant
+   * message back to the Submit Review modal (client-side, no agent round-trip)
+   * and clears the review-summary context so the button hides.
+   */
+  _handleUseSummaryClick() {
+    if (this.isStreaming) return;
+    const draft = this.getLastAssistantMessage();
+    if (!draft) {
+      window.toast?.showWarning?.('No draft yet — wait for the AI to respond, then try again.');
+      return;
+    }
+    this._contextSource = null;
+    this._contextItemId = null;
+    this._updateActionButtons();
+    if (window.reviewModal && typeof window.reviewModal.applyDraftedSummary === 'function') {
+      window.reviewModal.applyDraftedSummary(draft);
+    }
   }
 
   /**

--- a/public/js/components/ChatPanel.js
+++ b/public/js/components/ChatPanel.js
@@ -4404,12 +4404,38 @@ class ChatPanel {
       '- Give my overall assessment and recommendation, plus at most one or two cross-cutting themes not already raised inline.',
       '- Be terse and specific: a few sentences, or 2–3 tight bullets at most. No praise padding, no generic filler.',
       '',
-      'Return only the summary text (Markdown), with no preamble.',
+      'Put the finished summary — and nothing else — inside a single fenced code block tagged `markdown`:',
+      '',
+      '```markdown',
+      '<your summary here>',
+      '```',
+      '',
+      'Only the contents of that block are used as my review summary, so keep any thinking, preamble, or narration outside it.',
     ].join('\n');
     if (trimmed) {
       return `${base}\n\nHere is my current draft to refine (keep what works, tighten the rest):\n\n${trimmed}`;
     }
     return base;
+  }
+
+  /**
+   * Extract the drafted review summary from a raw assistant reply.
+   * `buildSummaryDraftPrompt` asks the agent to wrap the summary in a fenced
+   * ```markdown block; tool-using agents also emit process narration ("I'll
+   * review the diff…", "Now let me check…") outside it. Return only the block
+   * contents when present, otherwise the trimmed raw text so older replies (or
+   * an agent that ignores the fence) still fall back to the whole message.
+   * @param {string|null} raw
+   * @returns {string|null}
+   */
+  static extractDraftedSummary(raw) {
+    if (typeof raw !== 'string') return raw;
+    const fenceRe = /```(?:markdown|md)[^\n]*\n([\s\S]*?)```/gi;
+    let match;
+    let last = null;
+    while ((match = fenceRe.exec(raw)) !== null) last = match[1];
+    if (last !== null && last.trim()) return last.trim();
+    return raw.trim();
   }
 
   /**
@@ -5350,7 +5376,7 @@ class ChatPanel {
    */
   _handleUseSummaryClick() {
     if (this.isStreaming) return;
-    const draft = this.getLastAssistantMessage();
+    const draft = ChatPanel.extractDraftedSummary(this.getLastAssistantMessage());
     if (!draft) {
       window.toast?.showWarning?.('No draft yet — wait for the AI to respond, then try again.');
       return;

--- a/public/js/components/ReviewModal.js
+++ b/public/js/components/ReviewModal.js
@@ -74,7 +74,10 @@ class ReviewModal {
             <div class="review-summary-section">
               <div class="review-label-row">
                 <label for="review-body-modal" class="review-label">Review Summary</label>
-                <a href="#" class="copy-ai-summary-link" id="copy-ai-summary-link" style="display: none;">Copy AI summary</a>
+                <span class="review-summary-actions">
+                  <a href="#" class="draft-with-ai-link" id="draft-with-ai-link" style="display: none;">✨ Draft with AI</a>
+                  <a href="#" class="copy-ai-summary-link" id="copy-ai-summary-link" style="display: none;">Copy AI summary</a>
+                </span>
               </div>
               <textarea
                 class="review-body-textarea"
@@ -188,11 +191,15 @@ class ReviewModal {
       }
     });
 
-    // Handle copy AI summary link (delegated since modal is recreated)
+    // Handle copy AI summary / draft-with-AI links (delegated since modal is recreated)
     document.addEventListener('click', (e) => {
       if (e.target.closest('#copy-ai-summary-link')) {
         e.preventDefault();
         window.reviewModal?.appendAISummary();
+      }
+      if (e.target.closest('#draft-with-ai-link')) {
+        e.preventDefault();
+        window.reviewModal?.handleDraftWithAI();
       }
     });
 
@@ -236,6 +243,9 @@ class ReviewModal {
         toggle.classList.remove('disabled');
       }
     }
+
+    // Drafting a summary makes no sense for DRAFT reviews (no body is sent).
+    this.updateDraftWithAILink();
   }
 
   /**
@@ -283,6 +293,8 @@ class ReviewModal {
 
     // Update AI summary link visibility
     this.updateAISummaryLink();
+    // Update Draft-with-AI link visibility
+    this.updateDraftWithAILink();
 
     // Apply the configured remote-host display name + icon (resolves
     // asynchronously after the modal HTML was built).
@@ -663,6 +675,91 @@ class ReviewModal {
     if (window.toast) {
       window.toast.showSuccess('AI summary added to review');
     }
+  }
+
+  /**
+   * Show the "Draft with AI" link only when a chat panel is available and the
+   * selected review type includes a body (i.e. not DRAFT, whose body GitHub
+   * ignores). Mirrors updateAISummaryLink's visibility handling.
+   */
+  updateDraftWithAILink() {
+    const link = this.modal?.querySelector('#draft-with-ai-link');
+    if (!link) return;
+
+    const selectedOption = this.modal?.querySelector('input[name="review-event"]:checked');
+    const isDraft = selectedOption?.value === 'DRAFT';
+    const chatAvailable = typeof window !== 'undefined'
+      && !!window.chatPanel
+      && typeof window.chatPanel.startSummaryDraft === 'function';
+
+    link.style.display = (chatAvailable && !isDraft) ? 'inline' : 'none';
+  }
+
+  /**
+   * Open the chat panel to draft the review summary. Hides the modal so the
+   * side-by-side chat panel is usable; the chat's action bar then shows a
+   * "Use as review summary" button (like the findings-chat "Create comment"
+   * action) which calls applyDraftedSummary() to bring the draft back. The
+   * current summary text (if any) is handed to the chat so the agent refines
+   * rather than starting from scratch.
+   */
+  async handleDraftWithAI() {
+    if (this.isSubmitting) return;
+
+    const chatPanel = (typeof window !== 'undefined') ? window.chatPanel : null;
+    if (!chatPanel || typeof chatPanel.startSummaryDraft !== 'function') {
+      window.toast?.showWarning?.('Chat is not available for drafting.');
+      return;
+    }
+
+    const textarea = this.modal?.querySelector('#review-body-modal');
+    const currentSummary = (textarea?.value || '').trim();
+
+    // Hide the modal so the chat panel is interactive; the chat's action-bar
+    // "Use as review summary" button re-opens it via applyDraftedSummary().
+    this.hide();
+
+    try {
+      await chatPanel.startSummaryDraft({ currentSummary });
+    } catch (err) {
+      console.error('[ReviewModal] Failed to start summary draft:', err);
+      window.toast?.showError?.('Could not start the drafting chat.');
+    }
+  }
+
+  /**
+   * Put a drafted summary into the review summary field and re-open the modal.
+   * Called by ChatPanel's "Use as review summary" action. Re-displays without
+   * running show()'s form reset, preserving the selected review type. Falls
+   * back to reading the chat's latest reply when no text is passed.
+   *
+   * @param {string} [text] - Draft summary text to insert
+   */
+  applyDraftedSummary(text) {
+    const draft = (typeof text === 'string' && text)
+      ? text
+      : (typeof window !== 'undefined' ? window.chatPanel?.getLastAssistantMessage?.() : null);
+    if (!draft) {
+      window.toast?.showWarning?.('No draft yet — wait for the AI to respond, then try again.');
+      return;
+    }
+
+    const textarea = this.modal?.querySelector('#review-body-modal');
+    if (textarea) {
+      textarea.value = draft;
+    }
+
+    // Re-display without show()'s reset so the injected draft and the selected
+    // review type both survive.
+    if (this.modal) {
+      this.modal.style.display = 'flex';
+      this.isVisible = true;
+      if (textarea && typeof textarea.focus === 'function') {
+        setTimeout(() => textarea.focus(), 50);
+      }
+    }
+
+    window.toast?.showSuccess?.('Draft added to review summary');
   }
 
   /**

--- a/tests/unit/chat-panel.test.js
+++ b/tests/unit/chat-panel.test.js
@@ -920,13 +920,31 @@ describe('ChatPanel', () => {
       expect(global.window.reviewModal.applyDraftedSummary).not.toHaveBeenCalled();
       expect(global.window.toast.showWarning).toHaveBeenCalled();
     });
+
+    it('extracts only the fenced markdown block from a narrated reply', () => {
+      const tab = attachActiveTab(chatPanel);
+      tab.messages.push({
+        role: 'assistant',
+        content: "I'll review the diff.\nNow let me check the lifecycle.\n\n```markdown\nApprove — one nit: guard the null path.\n```",
+      });
+      chatPanel._contextSource = 'review-summary';
+      chatPanel.isStreaming = false;
+      global.window.reviewModal = { applyDraftedSummary: vi.fn() };
+
+      chatPanel._handleUseSummaryClick();
+
+      // Only the block contents reach the modal — not the surrounding narration.
+      expect(global.window.reviewModal.applyDraftedSummary)
+        .toHaveBeenCalledWith('Approve — one nit: guard the null path.');
+    });
   });
 
   describe('buildSummaryDraftPrompt', () => {
-    it('returns a base prompt with no preamble instruction when no draft is given', () => {
+    it('asks for the summary inside a fenced markdown block and omits the refine section when no draft is given', () => {
       const prompt = ChatPanel.buildSummaryDraftPrompt('');
       expect(prompt).toContain('review summary');
-      expect(prompt).toContain('no preamble');
+      expect(prompt).toContain('```markdown');
+      expect(prompt.toLowerCase()).toContain('narration');
       expect(prompt).not.toContain('current draft');
     });
 
@@ -947,6 +965,35 @@ describe('ChatPanel', () => {
       expect(prompt).toContain('my existing text');
       // Whitespace is trimmed before embedding.
       expect(prompt).not.toContain('  my existing text  ');
+    });
+  });
+
+  describe('extractDraftedSummary', () => {
+    it('returns only the fenced markdown block, dropping process narration around it', () => {
+      const raw = [
+        "I'll review the PR changes and existing comments to synthesize a summary.",
+        'Now let me check the lifecycle concerns.',
+        '',
+        '```markdown',
+        'Clean, well-scoped change. One nit: guard the null path.',
+        '```',
+      ].join('\n');
+
+      expect(ChatPanel.extractDraftedSummary(raw))
+        .toBe('Clean, well-scoped change. One nit: guard the null path.');
+    });
+
+    it('takes the last markdown block when several are present', () => {
+      const raw = '```markdown\nfirst\n```\nmore narration\n```markdown\nfinal summary\n```';
+      expect(ChatPanel.extractDraftedSummary(raw)).toBe('final summary');
+    });
+
+    it('falls back to the trimmed raw text when no fenced block is present', () => {
+      expect(ChatPanel.extractDraftedSummary('  just a plain reply  ')).toBe('just a plain reply');
+    });
+
+    it('passes through a null reply', () => {
+      expect(ChatPanel.extractDraftedSummary(null)).toBeNull();
     });
   });
 

--- a/tests/unit/chat-panel.test.js
+++ b/tests/unit/chat-panel.test.js
@@ -94,6 +94,7 @@ function createMockElement(tag = 'div', overrides = {}) {
       if (selector === '.chat-panel__action-btn--dismiss-suggestion') return elementRegistry['chat-dismiss-suggestion-btn'] || null;
       if (selector === '.chat-panel__action-btn--dismiss-comment') return elementRegistry['chat-dismiss-comment-btn'] || null;
       if (selector === '.chat-panel__action-btn--create-comment') return elementRegistry['chat-create-comment-btn'] || null;
+      if (selector === '.chat-panel__action-btn--use-summary') return elementRegistry['chat-use-summary-btn'] || null;
       if (selector === '.chat-panel__action-bar-dismiss') return elementRegistry['chat-action-bar-dismiss'] || null;
       if (selector === '.chat-panel__resize-handle') return elementRegistry['chat-resize-handle'] || null;
       if (selector === '.chat-panel__empty') return elementRegistry['chat-empty'] || null;
@@ -161,6 +162,7 @@ function buildElementRegistry() {
     'chat-dismiss-suggestion-btn': createMockElement('button'),
     'chat-dismiss-comment-btn': createMockElement('button'),
     'chat-create-comment-btn': createMockElement('button'),
+    'chat-use-summary-btn': createMockElement('button'),
     'chat-action-bar-dismiss': createMockElement('button'),
     'chat-resize-handle': createMockElement('div'),
     'chat-empty': createMockElement('div'),
@@ -193,6 +195,7 @@ function buildElementRegistry() {
   elementRegistry['chat-dismiss-suggestion-btn'].style = { display: 'none' };
   elementRegistry['chat-dismiss-comment-btn'].style = { display: 'none' };
   elementRegistry['chat-create-comment-btn'].style = { display: 'none' };
+  elementRegistry['chat-use-summary-btn'].style = { display: 'none' };
   elementRegistry['chat-provider-dropdown'].style = { display: 'none' };
   elementRegistry['chat-session-dropdown'].style = { display: 'none' };
   elementRegistry['chat-new-content-pill'].style = { display: 'none' };
@@ -359,6 +362,7 @@ function createChatPanel() {
       '.chat-panel__action-btn--dismiss-suggestion': reg['chat-dismiss-suggestion-btn'],
       '.chat-panel__action-btn--dismiss-comment': reg['chat-dismiss-comment-btn'],
       '.chat-panel__action-btn--create-comment': reg['chat-create-comment-btn'],
+      '.chat-panel__action-btn--use-summary': reg['chat-use-summary-btn'],
       '.chat-panel__action-bar-dismiss': reg['chat-action-bar-dismiss'],
       '.chat-panel__resize-handle': reg['chat-resize-handle'],
       '.chat-panel__provider-picker': reg['chat-provider-picker'],
@@ -776,6 +780,173 @@ describe('ChatPanel', () => {
       expect(chatPanel._contextItemId).toBeNull();
       expect(chatPanel._contextLineMeta).toBeNull();
       expect(chatPanel.actionBar.style.display).toBe('none');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Review summary drafting (Draft with AI)
+  // -----------------------------------------------------------------------
+  describe('getLastAssistantMessage', () => {
+    it('returns the most recent assistant message content', () => {
+      const tab = attachActiveTab(chatPanel);
+      tab.messages.push(
+        { role: 'user', content: 'draft a summary' },
+        { role: 'assistant', content: 'first draft' },
+        { role: 'user', content: 'make it shorter' },
+        { role: 'assistant', content: 'shorter draft' },
+      );
+
+      expect(chatPanel.getLastAssistantMessage()).toBe('shorter draft');
+    });
+
+    it('returns null when there is no assistant message', () => {
+      const tab = attachActiveTab(chatPanel);
+      tab.messages.push({ role: 'user', content: 'hello' });
+
+      expect(chatPanel.getLastAssistantMessage()).toBeNull();
+    });
+
+    it('returns null when there is no active tab', () => {
+      clearActiveTab(chatPanel);
+      expect(chatPanel.getLastAssistantMessage()).toBeNull();
+    });
+  });
+
+  describe('startSummaryDraft', () => {
+    it('opens a fresh tab, sets review-summary context, shows the button, and sends the prompt', async () => {
+      const openSpy = vi.spyOn(chatPanel, 'open').mockResolvedValue(undefined);
+      const newTabSpy = vi.spyOn(chatPanel, '_openNewTab').mockResolvedValue(undefined);
+      const sendSpy = vi.spyOn(chatPanel, 'sendMessage').mockResolvedValue(undefined);
+      chatPanel.isStreaming = false;
+
+      await chatPanel.startSummaryDraft({ currentSummary: 'keep this bit' });
+
+      expect(openSpy).toHaveBeenCalled();
+      // Draft goes into a dedicated fresh tab, not the currently active one.
+      expect(newTabSpy).toHaveBeenCalled();
+      expect(chatPanel._contextSource).toBe('review-summary');
+      expect(chatPanel.actionBar.style.display).toBe('');
+      expect(chatPanel.useSummaryBtn.style.display).toBe('');
+      expect(chatPanel.inputEl.value).toBe(ChatPanel.buildSummaryDraftPrompt('keep this bit'));
+      expect(chatPanel.inputEl.value).toContain('keep this bit');
+      expect(sendSpy).toHaveBeenCalled();
+    });
+
+    it('works with no current summary', async () => {
+      vi.spyOn(chatPanel, 'open').mockResolvedValue(undefined);
+      vi.spyOn(chatPanel, '_openNewTab').mockResolvedValue(undefined);
+      const sendSpy = vi.spyOn(chatPanel, 'sendMessage').mockResolvedValue(undefined);
+
+      await chatPanel.startSummaryDraft();
+
+      expect(chatPanel.inputEl.value).toBe(ChatPanel.buildSummaryDraftPrompt(''));
+      expect(sendSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('_updateActionButtons (review-summary context)', () => {
+    it('shows only the Use as review summary button, enabled once a reply exists', () => {
+      chatPanel._getActiveTab().messages.push({ role: 'assistant', content: 'the draft' });
+      chatPanel._contextSource = 'review-summary';
+      chatPanel._contextItemId = null;
+      chatPanel.isStreaming = false;
+
+      chatPanel._updateActionButtons();
+
+      expect(chatPanel.actionBar.style.display).toBe('');
+      expect(chatPanel.useSummaryBtn.style.display).toBe('');
+      expect(chatPanel.useSummaryBtn.disabled).toBe(false);
+      expect(chatPanel.adoptBtn.style.display).toBe('none');
+      expect(chatPanel.createCommentBtn.style.display).toBe('none');
+    });
+
+    it('stays shown but disabled until the first reply arrives', () => {
+      // review-summary context, not streaming, but no assistant reply yet.
+      chatPanel._contextSource = 'review-summary';
+      chatPanel.isStreaming = false;
+
+      chatPanel._updateActionButtons();
+
+      expect(chatPanel.useSummaryBtn.style.display).toBe('');
+      expect(chatPanel.useSummaryBtn.disabled).toBe(true);
+    });
+
+    it('disables the button while streaming (draft not complete)', () => {
+      chatPanel._getActiveTab().messages.push({ role: 'assistant', content: 'partial' });
+      chatPanel._contextSource = 'review-summary';
+      chatPanel.isStreaming = true;
+
+      chatPanel._updateActionButtons();
+
+      expect(chatPanel.useSummaryBtn.disabled).toBe(true);
+    });
+  });
+
+  describe('_handleUseSummaryClick', () => {
+    it('sends the latest assistant message to the review modal and clears context', () => {
+      const tab = attachActiveTab(chatPanel);
+      tab.messages.push({ role: 'assistant', content: 'the drafted summary' });
+      chatPanel._contextSource = 'review-summary';
+      chatPanel.isStreaming = false;
+      global.window.reviewModal = { applyDraftedSummary: vi.fn() };
+
+      chatPanel._handleUseSummaryClick();
+
+      expect(global.window.reviewModal.applyDraftedSummary).toHaveBeenCalledWith('the drafted summary');
+      expect(chatPanel._contextSource).toBeNull();
+      expect(chatPanel.useSummaryBtn.style.display).toBe('none');
+    });
+
+    it('does nothing while streaming', () => {
+      const tab = attachActiveTab(chatPanel);
+      tab.messages.push({ role: 'assistant', content: 'partial' });
+      chatPanel.isStreaming = true;
+      global.window.reviewModal = { applyDraftedSummary: vi.fn() };
+
+      chatPanel._handleUseSummaryClick();
+
+      expect(global.window.reviewModal.applyDraftedSummary).not.toHaveBeenCalled();
+    });
+
+    it('warns when there is no assistant reply yet', () => {
+      const tab = attachActiveTab(chatPanel);
+      tab.messages.push({ role: 'user', content: 'draft it' });
+      chatPanel.isStreaming = false;
+      global.window.reviewModal = { applyDraftedSummary: vi.fn() };
+      global.window.toast = { showWarning: vi.fn() };
+
+      chatPanel._handleUseSummaryClick();
+
+      expect(global.window.reviewModal.applyDraftedSummary).not.toHaveBeenCalled();
+      expect(global.window.toast.showWarning).toHaveBeenCalled();
+    });
+  });
+
+  describe('buildSummaryDraftPrompt', () => {
+    it('returns a base prompt with no preamble instruction when no draft is given', () => {
+      const prompt = ChatPanel.buildSummaryDraftPrompt('');
+      expect(prompt).toContain('review summary');
+      expect(prompt).toContain('no preamble');
+      expect(prompt).not.toContain('current draft');
+    });
+
+    it('frames it as a review, not a PR description, and pushes for brevity', () => {
+      const prompt = ChatPanel.buildSummaryDraftPrompt('');
+      // Must steer away from PR-description / diff-restatement output.
+      expect(prompt).toContain('not a PR description');
+      expect(prompt).toMatch(/do not.*(describe what the pr does|summarize the diff)/i);
+      // Must avoid duplicating line-level comments.
+      expect(prompt).toContain('line-level comments');
+      // Must push for terseness.
+      expect(prompt.toLowerCase()).toMatch(/terse|short|few sentences/);
+    });
+
+    it('embeds the current draft when provided', () => {
+      const prompt = ChatPanel.buildSummaryDraftPrompt('  my existing text  ');
+      expect(prompt).toContain('current draft to refine');
+      expect(prompt).toContain('my existing text');
+      // Whitespace is trimmed before embedding.
+      expect(prompt).not.toContain('  my existing text  ');
     });
   });
 

--- a/tests/unit/review-modal.test.js
+++ b/tests/unit/review-modal.test.js
@@ -129,6 +129,11 @@ function createTestReviewModal() {
   textarea.id = 'review-body-modal';
   textarea.value = '';
 
+  // Create a persistent Draft-with-AI link element
+  const draftWithAILink = createMockElement('a');
+  draftWithAILink.id = 'draft-with-ai-link';
+  draftWithAILink.style = { display: 'none' };
+
   // Create assisted-by checkbox and toggle
   const assistedByCheckbox = createMockElement('input');
   assistedByCheckbox.type = 'checkbox';
@@ -183,6 +188,7 @@ function createTestReviewModal() {
     if (sel === '#review-error-message') return createMockElement('div');
     if (sel === '#large-review-warning') return createMockElement('div');
     if (sel === '#copy-ai-summary-link') return createMockElement('a');
+    if (sel === '#draft-with-ai-link') return draftWithAILink;
     return null;
   });
 
@@ -208,7 +214,8 @@ function createTestReviewModal() {
     pendingDraftLink,
     draftRadioInput,
     draftTypeLabel,
-    draftTypeOption
+    draftTypeOption,
+    draftWithAILink
   };
 }
 
@@ -601,6 +608,114 @@ describe('ReviewModal', () => {
       expect(ReviewModal.resolveDraftPrUrl(null, null)).toBeNull();
       expect(ReviewModal.resolveDraftPrUrl({}, {})).toBeNull();
       expect(ReviewModal.resolveDraftPrUrl(undefined, undefined)).toBeNull();
+    });
+  });
+});
+
+describe('ReviewModal — Draft with AI', () => {
+  describe('updateDraftWithAILink', () => {
+    it('shows the link when a chat panel is available and review type is not DRAFT', () => {
+      const { modal, draftWithAILink } = createTestReviewModal();
+      global.window.chatPanel = { startSummaryDraft: vi.fn() };
+
+      modal.updateDraftWithAILink();
+
+      expect(draftWithAILink.style.display).toBe('inline');
+    });
+
+    it('hides the link when no chat panel is available', () => {
+      const { modal, draftWithAILink } = createTestReviewModal();
+      global.window.chatPanel = null;
+
+      modal.updateDraftWithAILink();
+
+      expect(draftWithAILink.style.display).toBe('none');
+    });
+
+    it('hides the link when DRAFT review type is selected (no body is sent)', () => {
+      const { modal, modalContainer, draftWithAILink } = createTestReviewModal();
+      global.window.chatPanel = { startSummaryDraft: vi.fn() };
+
+      // Override the checked radio to report DRAFT.
+      const originalQS = modalContainer.querySelector;
+      modalContainer.querySelector = vi.fn().mockImplementation((sel) => {
+        if (sel === 'input[name="review-event"]:checked') {
+          const radio = createMockElement('input');
+          radio.value = 'DRAFT';
+          return radio;
+        }
+        if (sel === '#draft-with-ai-link') return draftWithAILink;
+        return originalQS(sel);
+      });
+
+      modal.updateDraftWithAILink();
+
+      expect(draftWithAILink.style.display).toBe('none');
+    });
+  });
+
+  describe('handleDraftWithAI', () => {
+    it('hides the modal and hands the current summary to the chat panel', async () => {
+      const { modal, modalContainer, textarea } = createTestReviewModal();
+      textarea.value = 'my current summary';
+      const startSummaryDraft = vi.fn().mockResolvedValue(undefined);
+      global.window.chatPanel = { startSummaryDraft };
+
+      await modal.handleDraftWithAI();
+
+      expect(modalContainer.style.display).toBe('none');
+      expect(modal.isVisible).toBe(false);
+      expect(startSummaryDraft).toHaveBeenCalledWith({ currentSummary: 'my current summary' });
+    });
+
+    it('warns and does nothing when the chat panel is unavailable', async () => {
+      const { modal, modalContainer } = createTestReviewModal();
+      global.window.chatPanel = null;
+      global.window.toast = { showWarning: vi.fn() };
+
+      await modal.handleDraftWithAI();
+
+      expect(global.window.toast.showWarning).toHaveBeenCalled();
+      // Modal was never hidden.
+      expect(modalContainer.style.display).not.toBe('none');
+    });
+  });
+
+  describe('applyDraftedSummary', () => {
+    it('inserts the passed draft text and reopens the modal', () => {
+      const { modal, modalContainer, textarea } = createTestReviewModal();
+      global.window.toast = { showSuccess: vi.fn() };
+
+      modal.applyDraftedSummary('# Summary\nLooks good.');
+
+      expect(textarea.value).toBe('# Summary\nLooks good.');
+      expect(modalContainer.style.display).toBe('flex');
+      expect(modal.isVisible).toBe(true);
+      expect(global.window.toast.showSuccess).toHaveBeenCalled();
+    });
+
+    it('falls back to the chat panel\u2019s latest reply when no text is passed', () => {
+      const { modal, textarea } = createTestReviewModal();
+      global.window.chatPanel = { getLastAssistantMessage: vi.fn().mockReturnValue('fallback draft') };
+      global.window.toast = { showSuccess: vi.fn() };
+
+      modal.applyDraftedSummary();
+
+      expect(textarea.value).toBe('fallback draft');
+      expect(modal.isVisible).toBe(true);
+    });
+
+    it('warns and does not reopen when there is no draft', () => {
+      const { modal, textarea } = createTestReviewModal();
+      textarea.value = 'untouched';
+      global.window.chatPanel = { getLastAssistantMessage: vi.fn().mockReturnValue(null) };
+      global.window.toast = { showWarning: vi.fn() };
+
+      modal.applyDraftedSummary();
+
+      expect(textarea.value).toBe('untouched');
+      expect(global.window.toast.showWarning).toHaveBeenCalled();
+      expect(modal.isVisible).toBe(false);
     });
   });
 });


### PR DESCRIPTION
Add a 'Draft with AI' link next to 'Copy AI summary' in the Submit Review modal. It hides the modal, opens the chat panel seeded with the current summary text and PR context, and shows a floating bar to pull the AI's latest reply back into the summary field (preserving the selected review type) or return unchanged.

ChatPanel gains three small additive methods: getLastAssistantMessage(), startSummaryDraft({currentSummary}), and a pure static buildSummaryDraftPrompt(). The link is hidden for Draft reviews and when no chat panel is available.

https://github.com/user-attachments/assets/4f15a428-8709-4234-979a-d38ec4930046

