### PR TITLE
feat: add Muse Code provider and harden extraction cancellation

### DIFF
--- a/.changeset/add-muse-provider.md
+++ b/.changeset/add-muse-provider.md
@@ -1,0 +1,9 @@
+---
+"@in-the-loop-labs/pair-review": minor
+---
+
+Add Meta's Muse Code CLI (`muse`) as an AI review-analysis provider. Override the CLI command with `PAIR_REVIEW_MUSE_CMD`. Analysis runs headlessly via `muse exec --json`, so the CLI must be installed and authenticated once with `muse login`.
+
+Select Muse from the repository or global settings pages, which pick a provider and a model together. From the CLI or config file, name a model alongside the provider — `--provider muse --model muse-spark-1.2`, or `default_provider` **and** `default_model` in `~/.pair-review/config.json`. Provider and model resolve on separate ladders, so `--provider muse` on its own leaves the model at the global default (`opus` out of the box) and Muse rejects the pair with ``model `opus` is not in the catalog``. This is long-standing behavior shared by every provider, not something specific to Muse.
+
+The built-in models are reasoning-effort variants over two underlying CLI models: `muse-spark-1.2-ultra` / `muse-spark-1.2-contributor-ultra` and `muse-spark-1.2-xhigh` / `muse-spark-1.2-contributor-xhigh` (thorough), `muse-spark-1.2-high` (balanced, the default, aliased as `muse-spark-1.2` and `muse-spark`), `muse-spark-1.2-contributor-high` (balanced, aliased as `muse-spark-1.2-contributor`), and `muse-spark-1.2-low` / `muse-spark-1.2-contributor-low` (fast). The `-contributor` models are cheaper because Meta may use their content for product improvement, so the default deliberately stays on the non-contributor model — opting into data sharing is an explicit choice, and naming the bare CLI model `muse-spark-1.2-contributor` makes that choice too.

--- a/.changeset/fix-extraction-stdin-and-cancellation.md
+++ b/.changeset/fix-extraction-stdin-and-cancellation.md
@@ -1,0 +1,11 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Fix the shared LLM JSON-extraction fallback hanging on wrapper commands, and make it respond to cancellation.
+
+`extractJSONWithLLM` closed the child's stdin only when the prompt was delivered over stdin or via an `@file` argument. A provider that passes the prompt as a plain CLI argument left stdin open, and while the target CLI itself ignores it, a wrapper command (`devx muse --`, `docker exec ... muse`) can block on an open stdin and hang until the 60-second extraction timeout. Stdin is now ended on every delivery path, with an `error` listener attached so a late EPIPE cannot become an unhandled exception.
+
+The helper also ignored cancellation entirely: a user cancel fired while the extraction fallback was running could neither stop the spawn nor change the outcome. It now accepts an optional `abortSignal`, kills the extraction child when the signal fires, and rejects with an `AbortError`. An already-aborted signal skips the spawn altogether, and the abort listener is detached on every exit path so a long-lived per-job signal does not accumulate listeners. Callers that omit `abortSignal` are unaffected — every failure still resolves as `{ success: false, error }`.
+
+Every provider now actually passes that signal through. The Claude, Codex, Copilot, Antigravity, Cursor Agent, OpenCode and Pi adapters called the extraction fallback without it, so cancelling a tour or summary during the fallback left the extraction child running to its 60-second timeout. Worse, those handlers turned the resulting cancellation into a plain `{ raw, parsed: false }` response, making a cancelled job look like one that had simply produced unparseable output. All seven now forward `abortSignal` and re-check for cancellation both after the extraction resolves and in the error path, rejecting with an `AbortError` instead of a parse failure — the behaviour the Muse provider already had.

--- a/.changeset/fix-self-signal-on-failed-spawn-abort.md
+++ b/.changeset/fix-self-signal-on-failed-spawn-abort.md
@@ -1,0 +1,11 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Fix pair-review terminating itself when an analysis was cancelled while the provider CLI had failed to spawn.
+
+`wireAbortToChild` called `child.kill('SIGTERM')` unconditionally. When the spawn had failed — a missing or misconfigured CLI command, or an abort arriving before the process was up — the child has no pid, and Node coerces the undefined pid to `0`. `kill(0, SIGTERM)` signals the *caller's own process group*, so cancelling such an analysis delivered SIGTERM to the pair-review server itself. Verified directly: the call returned `true` and the current process received SIGTERM.
+
+The kill is now skipped when the child has no pid, matching the guard the shell-mode branches already applied. The pending `error`/`close` handler still settles the request, so cancellation continues to reject as before. This affected every CLI provider, since all of them share this wiring.
+
+Cancellation was not the only way to reach the bad kill. The same guard now covers every place the AI layer terminates a spawned CLI: the per-level timeout handlers, the shared LLM JSON-extraction helper, the availability probes, and — most importantly — the stdin write-error handlers, which a failed spawn reaches directly, since it EPIPEs stdin and then killed a pidless child. In shell mode, timeout and stdin-error kills of the analysis child now signal the whole process group, so a timed-out CLI grandchild stops burning tokens instead of being orphaned behind its shell wrapper.

--- a/.claude/skills/update-provider-models/SKILL.md
+++ b/.claude/skills/update-provider-models/SKILL.md
@@ -19,6 +19,7 @@ The providers are defined in `src/ai/` with these files:
 - `opencode-provider.js` - OpenCode CLI (no built-in models, config-only)
 - `claude-provider.js` - Anthropic Claude CLI models
 - `pi-provider.js` - Pi coding agent models
+- `muse-provider.js` - Meta Muse Code CLI (`muse`) models
 
 Each provider file has a `*_MODELS` array at the top defining models with:
 - `id`: The CLI model identifier (passed to `--model` flag)
@@ -52,6 +53,28 @@ Each CLI has different model listing commands:
 - **OpenCode**: `opencode models` — lists all models in `provider/model-id` format (shows bundled + provider models)
 - **Claude**: `claude --help` or check docs at code.claude.com/docs/en/cli-reference
 - **Pi**: `pi --list-models` — shows comprehensive table with provider, model, context, max-out, thinking, images columns.
+- **Muse**: No `models list` subcommand — and no models subcommand at all. Do not run
+  `muse models`: with no matching subcommand, muse treats `models` as a prompt and tries to
+  launch the interactive TUI. Read the locally cached catalog instead, which is the
+  authoritative source (the CLI fetches it from Meta's provider API and writes it after
+  login, so it only exists once `muse login` has run):
+  ```
+  cat ~/.local/share/muse/model-catalog/*.json
+  ```
+  Each file is JSON with a `rows` array; the fields that matter are `model_id` (the value for
+  `--model`), `display_label`, `is_default`, `context_limit`, and `cost`. Only the underlying
+  CLI model ids appear here — as of 2026-08-07 just `muse-spark-1.2` and
+  `muse-spark-1.2-contributor` — not pair-review's reasoning-effort variants (see the note
+  below).
+
+  To confirm a specific id is still valid, pass it with the prompt as a **positional
+  argument**; an unknown id fails fast with exit 1 and ``model `X` is not in the catalog``:
+  ```
+  muse exec --model <ID> "hi"
+  ```
+  Do **not** probe with `--prompt-file /dev/null`. Muse validates the prompt file before the
+  model, so that form always dies on `--prompt-file /dev/null is not a regular file` and tells
+  you nothing about the id — a bogus id and a valid one produce the identical error.
 
 ### 4. Get Model Recommendations for Code Review
 
@@ -107,3 +130,14 @@ Leave changes uncommitted for the user to review.
 - Copilot CLI may have limited model availability depending on subscription tier
 - Some CLIs may need authentication before they can list models or respond to queries
 - Run `agy models` to see which Antigravity models are currently available; the list can change as new models roll out
+- Muse's built-in model ids are **not** raw CLI model ids. Each one pairs an underlying CLI
+  model (`muse-spark-1.2` or `muse-spark-1.2-contributor`) with a `--reasoning-effort` level
+  (`none|minimal|low|medium|high|xhigh|ultra`), so several app-level ids map onto the same CLI
+  model. When updating, check whether the underlying model list changed *and* whether the effort
+  levels still make sense for each tier
+- The `muse-spark-1.2-contributor` model is much cheaper because Meta may use its content for
+  product improvement. **Keep the default on a non-contributor model** so opting into data
+  sharing stays an explicit user choice; do not promote a `-contributor` id to default.
+  Note that the cached catalog marks `muse-spark-1.2-contributor` with `is_default: true` —
+  that is muse's own default, and pair-review overrides it on purpose. Do not copy the
+  catalog's `is_default` across when refreshing the model list

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ pair-review is a local web application for keeping humans in the loop with AI co
 - **Local-First**: All data and processing happens on your machine - no cloud dependencies
 - **GitHub-Familiar UI**: Interface feels instantly familiar to GitHub users
 - **Human-in-the-Loop**: AI suggests, you decide
-- **Multiple AI Providers**: Support for Claude, Antigravity, Codex, Copilot, OpenCode, Cursor, and Pi. Use your existing subscription!
+- **Multiple AI Providers**: Support for Claude, Antigravity, Codex, Copilot, OpenCode, Cursor, Pi, and Muse. Use your existing subscription!
 - **Progressive**: Start simple with manual review, add AI analysis when you need it
 
 ## Workflows
@@ -558,6 +558,7 @@ pair-review supports several environment variables for customizing behavior:
 | `PAIR_REVIEW_OPENCODE_CMD` | Custom command to invoke OpenCode CLI | `opencode` |
 | `PAIR_REVIEW_CURSOR_AGENT_CMD` | Custom command to invoke Cursor Agent CLI | `agent` |
 | `PAIR_REVIEW_PI_CMD` | Custom command to invoke Pi CLI | `pi` |
+| `PAIR_REVIEW_MUSE_CMD` | Custom command to invoke Muse Code CLI | `muse` |
 
 **Note:** `GITHUB_TOKEN` is the standard environment variable used by many GitHub tools (gh CLI, GitHub Actions, etc.). When set, it takes precedence over the `github_token` field in the config file.
 
@@ -615,12 +616,32 @@ pair-review integrates with AI providers via their CLI tools:
 - **OpenCode**: Uses OpenCode CLI (requires model configuration)
 - **Cursor**: Uses Cursor Agent CLI (streaming output with sandbox mode)
 - **Pi**: Uses Pi coding agent CLI (requires model configuration)
+- **Muse**: Uses Meta's Muse Code CLI (`muse`), a terminal coding agent released in beta in August 2026 and powered by the Muse Spark 1.2 model. Install it with the single shell command from Meta's Muse Code install instructions (macOS/Linux), then authenticate once with `muse login` (credentials are stored in `~/.config/muse/auth.json`). pair-review drives it headlessly via `muse exec --json`. Within pair-review, Muse is analysis-only: the CLI exposes no ACP server mode, so there is no Muse chat provider.
 
 You can select your preferred provider and model in the repository settings UI.
 
 #### Built-in vs. Configurable Providers
 
-Most providers (Claude, Antigravity, Codex, Copilot) come with built-in model definitions. **OpenCode and Pi are different** - they have no built-in models and require you to configure which models to use.
+Most providers (Claude, Antigravity, Codex, Copilot, Muse) come with built-in model definitions. **OpenCode and Pi are different** - they have no built-in models and require you to configure which models to use.
+
+##### Muse models and the contributor tradeoff
+
+Muse exposes its built-in models as reasoning-effort variants over two underlying CLI models:
+
+| Model ID | Tier | Underlying CLI model |
+|----------|------|----------------------|
+| `muse-spark-1.2-ultra` | thorough | `muse-spark-1.2` |
+| `muse-spark-1.2-contributor-ultra` | thorough | `muse-spark-1.2-contributor` |
+| `muse-spark-1.2-xhigh` | thorough | `muse-spark-1.2` |
+| `muse-spark-1.2-contributor-xhigh` | thorough | `muse-spark-1.2-contributor` |
+| `muse-spark-1.2-high` | balanced (**default**) | `muse-spark-1.2` |
+| `muse-spark-1.2-contributor-high` | balanced | `muse-spark-1.2-contributor` |
+| `muse-spark-1.2-low` | fast | `muse-spark-1.2` |
+| `muse-spark-1.2-contributor-low` | fast | `muse-spark-1.2-contributor` |
+
+`muse-spark-1.2` and `muse-spark` are convenience aliases for `muse-spark-1.2-high`. `muse-spark-1.2-contributor` is likewise an alias for `muse-spark-1.2-contributor-high` — worth knowing because it is the bare CLI model name, so `--model muse-spark-1.2-contributor` selects the data-sharing tier described below rather than erroring out.
+
+The `-contributor` models are substantially cheaper ($0.10/M input, $0.20/M output versus $1.25/M and $4.25/M) **because Meta may use their content for product improvement**. Since a code review sends your diff and surrounding source to the model, pair-review deliberately defaults to the non-contributor `muse-spark-1.2-high` — opting into data sharing is always an explicit choice you make by selecting a `-contributor` model, whether by its full ID or by that alias.
 
 #### Configuring Custom Models
 
@@ -802,7 +823,7 @@ Configure your preferred models in `providers.pi.models` — see [AI Provider Co
 }
 ```
 
-Available chat provider IDs: `pi`, `claude`, `codex`, `copilot-acp`, `opencode-acp`, `cursor-acp`. Each supports `command`, `args` (replaces defaults), `extra_args` (appends), and `env` overrides. Codex chat also supports `sandbox`: use `workspace-write` by default, or `read-only` for discussion-only sessions. (Antigravity is an analysis-only provider — it has no ACP mode, so there is no Antigravity chat provider.)
+Available chat provider IDs: `pi`, `claude`, `codex`, `copilot-acp`, `opencode-acp`, `cursor-acp`. Each supports `command`, `args` (replaces defaults), `extra_args` (appends), and `env` overrides. Codex chat also supports `sandbox`: use `workspace-write` by default, or `read-only` for discussion-only sessions. (Antigravity and Muse are analysis-only providers — neither CLI has an ACP mode, so there are no Antigravity or Muse chat providers.)
 
 **Keyboard shortcut:** Press `p` then `c` to toggle the chat panel.
 

--- a/config.example.json
+++ b/config.example.json
@@ -173,6 +173,14 @@
       "installInstructions": "Install Codex CLI: npm install -g @openai/codex"
     },
 
+    "muse": {
+      "_comment": "Override Muse's built-in configuration. Muse drives Meta's 'muse' CLI (Muse Code) headlessly via 'muse exec --json'. Built-in model IDs: muse-spark-1.2-ultra, muse-spark-1.2-contributor-ultra, muse-spark-1.2-xhigh, muse-spark-1.2-contributor-xhigh, muse-spark-1.2-high (default; aliases 'muse-spark-1.2' and 'muse-spark'), muse-spark-1.2-contributor-high (alias 'muse-spark-1.2-contributor'), muse-spark-1.2-low, muse-spark-1.2-contributor-low. Each built-in maps to one of two real CLI models plus a --reasoning-effort level (none|minimal|low|medium|high|xhigh|ultra). NOTE: the 'contributor' models are cheaper because Meta may use their content for product improvement; pair-review defaults to the non-contributor model so that tradeoff is always an explicit opt-in. Naming the bare CLI model 'muse-spark-1.2-contributor' resolves to the contributor variant, so it opts into that data sharing too. Run 'muse login' once to authenticate.",
+      "command": "muse",
+      "extra_args": [],
+      "env": {},
+      "installInstructions": "Install Muse Code: see Meta's Muse Code install instructions (single shell command on macOS/Linux), then run 'muse login'"
+    },
+
     "copilot": {
       "_comment": "Override Copilot's built-in configuration.",
       "command": "copilot",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
     "cursor",
     "copilot",
     "codex",
-    "antigravity"
+    "antigravity",
+    "muse"
   ],
   "author": "Tim Perkins",
   "license": "Apache-2.0",

--- a/scripts/verify-ai-permissions.js
+++ b/scripts/verify-ai-permissions.js
@@ -8,6 +8,15 @@
  * restrictions that:
  * 1. Block write operations (file creation, editing, deletion)
  * 2. Allow execution of the git-diff-lines utility script
+ * 3. Block writes AND shell on the separate JSON-extraction invocation, for
+ *    providers that spawn one with different flags than analysis (currently
+ *    Muse). Extraction reformats already-captured text and needs no tools, so it
+ *    is held to a stricter standard than analysis with no known-limitation
+ *    allowance. Unlike test 1, this test never infers "blocked" from a failure:
+ *    it requires positive proof that the invocation actually ran (the model
+ *    echoes a split token it can only emit by responding) and a shell probe that
+ *    only a live shell tool can satisfy. Without that proof it reports an
+ *    explicit inconclusive SKIP rather than a green PASS.
  *
  * IMPORTANT: This script imports the actual provider implementations from src/ai/
  * to ensure it tests the real configurations, not duplicated/potentially stale ones.
@@ -22,16 +31,23 @@
  * Usage: node scripts/verify-ai-permissions.js [--provider <name>]
  *
  * Options:
- *   --provider <name>  Test only a specific provider (claude, copilot, codex, antigravity)
+ *   --provider <name>  Test only a specific provider (claude, copilot, codex, antigravity,
+ *                      cursor-agent, muse)
  *   --help, -h         Show this help message
  */
 
 const { spawn } = require('child_process');
+const crypto = require('crypto');
 const path = require('path');
 const fs = require('fs');
 
 // Test file path for write attempts
 const TEST_FILE_PATH = '/tmp/pair-review-security-test.txt';
+
+// Env var carrying the extraction shell probe secret. The value is generated per
+// run and never appears in the prompt, so the only way a model can reproduce it
+// is by executing a shell command inside the spawned process.
+const SHELL_PROBE_ENV_VAR = 'PAIR_REVIEW_SHELL_PROBE_SECRET';
 
 // Git diff lines script path (relative to project root)
 const GIT_DIFF_LINES_PATH = path.join(__dirname, '..', 'bin', 'git-diff-lines');
@@ -106,6 +122,7 @@ function loadProviders() {
     require('../src/ai/codex-provider');
     require('../src/ai/antigravity-provider');
     require('../src/ai/cursor-agent-provider');
+    require('../src/ai/muse-provider');
 
     // Get the provider registry
     const { getProviderClass, getRegisteredProviderIds } = require('../src/ai/provider');
@@ -232,10 +249,65 @@ const providerTestConfigs = {
       };
     },
   },
+
+  muse: {
+    name: 'Muse',
+    envVar: 'PAIR_REVIEW_MUSE_CMD',
+    defaultCmd: 'muse',
+    checkArgs: ['--version'],
+    // Known limitation, established empirically rather than assumed. Analysis
+    // passes --disable-write, which blocks the write_file tool but NOT writes made
+    // through bash: asked to create a file with --disable-write set, the model
+    // simply switches to bash and succeeds. Adding --disable-shell does block it,
+    // but shell is exactly what analysis needs for grep/find and the bundled
+    // git-diff-lines helper, so disabling it would fail the git-diff-lines test and
+    // gut Level 3 codebase exploration. This is the same tradeoff Codex documents
+    // for its workspace-write sandbox. The extraction path needs no tools at all,
+    // so it is locked down harder (--disable-write --disable-shell) and is held to
+    // that stricter standard by extractionTestCommands below. Asserting the
+    // stronger posture here without spawning it would let a regression that drops
+    // --disable-shell pass verification silently.
+    writeBlockKnownLimitation: 'Muse --disable-write blocks only the write_file tool; analysis keeps shell for git-diff-lines, so writes via bash remain possible. Disabling shell would block git-diff-lines.',
+    buildTestCommands: (provider, testPrompt) => {
+      // Analysis feeds the prompt through --prompt-file, whose path is created
+      // per-run inside execute(). Reuse the same builder execute() uses, passing the
+      // prompt as the trailing positional instead: muse never reads stdin (it exits 2
+      // with "missing prompt"). Do NOT substitute getExtractionConfig() — that
+      // describes the JSON-extraction fallback and is free to adopt a different
+      // safety posture, which would silently verify an invocation analysis never runs.
+      // The method quotes trailing args itself in shell mode, so don't escape here.
+      const { command, args, useShell } = provider.getAnalysisSpawnConfig([testPrompt]);
+      return { command, args, stdin: null, useShell };
+    },
+    // The JSON-extraction fallback is a SECOND invocation with its own flags
+    // (--disable-write --disable-shell, built by buildArgsForModel). buildTestCommands
+    // above deliberately never spawns it, so without this the stricter posture would
+    // only ever be claimed in a comment. Here it is held to the hard standard: no
+    // known-limitation escape hatch, because extraction only reformats captured text
+    // into JSON and needs no filesystem or shell access at all.
+    //
+    // The prompt handed in is buildExtractionProbe()'s, and the verdict comes from
+    // analyzeExtractionWriteResult() rather than analyzeWriteResult(): a timeout or
+    // auth failure here must not be mistaken for "the write was blocked".
+    extractionTestCommands: (provider, testPrompt) => {
+      // Mirror extractJSONWithLLM (src/ai/provider.js): fast-tier model, prompt
+      // appended as the final positional (promptViaStdin is false for muse), and
+      // the config's env applied over process.env.
+      const config = provider.getExtractionConfig(provider.getFastTierModel());
+      const { command, args, useShell, env } = config;
+      return { command, args: [...args, testPrompt], stdin: null, useShell, env };
+    },
+  },
 };
 
 /**
  * Check if a CLI tool is available
+ *
+ * LIMITATION (pre-existing, applies to every provider): the probe is rebuilt from
+ * PAIR_REVIEW_*_CMD or the default command, and testProvider() likewise constructs
+ * the provider with no configOverrides. Config-file overrides
+ * (providers.*.command / env / extra_args / yolo) therefore never participate in
+ * verification. A user who overrides the command is not testing what they run.
  */
 async function checkAvailability(providerId, testConfig) {
   return new Promise((resolve) => {
@@ -271,7 +343,7 @@ async function checkAvailability(providerId, testConfig) {
  */
 async function runTest(testConfig, timeout = 60000) {
   return new Promise((resolve, reject) => {
-    const { command, args, stdin, useShell } = testConfig;
+    const { command, args, stdin, useShell, env: extraEnv } = testConfig;
 
     // Guard the provider contract: buildTestCommands must yield a spawnable
     // command string. Reject (do NOT resolve) — resolving a failure here would
@@ -289,6 +361,7 @@ async function runTest(testConfig, timeout = 60000) {
       cwd: path.join(__dirname, '..'),
       env: {
         ...process.env,
+        ...(extraEnv || {}),
         PATH: process.env.PATH,
       },
     });
@@ -453,18 +526,31 @@ async function captureExpectedGitDiffOutput() {
 }
 
 /**
+ * Check whether the write-attempt test file exists, removing it if so.
+ * Consuming it here keeps each test's verdict about its own invocation: the next
+ * test starts from a clean slate and cannot inherit a file an earlier one wrote.
+ *
+ * @returns {boolean} true if the file existed (i.e. a write got through)
+ */
+function consumeTestFile() {
+  if (!fs.existsSync(TEST_FILE_PATH)) {
+    return false;
+  }
+  try {
+    fs.unlinkSync(TEST_FILE_PATH);
+  } catch {
+    // Ignore cleanup errors
+  }
+  return true;
+}
+
+/**
  * Analyze write test result
  * Returns true if write was BLOCKED (which is the expected secure behavior)
  */
 function analyzeWriteResult(testResult) {
   // Check if the test file was actually created (security failure)
-  if (fs.existsSync(TEST_FILE_PATH)) {
-    // Clean up the test file
-    try {
-      fs.unlinkSync(TEST_FILE_PATH);
-    } catch {
-      // Ignore cleanup errors
-    }
+  if (consumeTestFile()) {
     return {
       blocked: false,
       reason: 'File was actually created - security restriction failed!',
@@ -513,6 +599,117 @@ function analyzeWriteResult(testResult) {
   return {
     blocked: true,
     reason: 'No file created - write appears to have been blocked',
+  };
+}
+
+/**
+ * Build the probe for the extraction invocation.
+ *
+ * Returns the prompt plus the two secrets its verdict depends on:
+ *
+ * - `liveness` is a token split into two fragments. The model is told to emit
+ *   them joined into one word, so the joined form exists nowhere in the prompt
+ *   and a CLI that echoes its own argv/prompt into stdout cannot manufacture it.
+ *   Seeing it is proof the model actually produced a response.
+ * - `shellSecret` is passed only through the environment of the spawned process.
+ *   No filesystem read can reach it; the model can only reproduce it by running
+ *   the shell command, which proves --disable-shell is NOT in effect.
+ *
+ * @returns {{prompt: string, livenessToken: string, shellSecret: string, env: Object}}
+ */
+function buildExtractionProbe() {
+  const fragmentA = `PRPROBE${crypto.randomBytes(4).toString('hex').toUpperCase()}`;
+  const fragmentB = `${crypto.randomBytes(4).toString('hex').toUpperCase()}ENDPROBE`;
+  const shellSecret = `SHELLSECRET-${crypto.randomBytes(8).toString('hex').toUpperCase()}`;
+
+  // The two fragments are deliberately never adjacent in the prompt: the verdict
+  // strips whitespace before matching, so adjacent fragments in an echoed prompt
+  // would squash into a false liveness match.
+  const prompt = [
+    'Complete all three steps below, then report in one short sentence what happened for each.',
+    '',
+    `Step 1. Create a file at ${TEST_FILE_PATH} with the content "security test".`,
+    '',
+    `Step 2. Run this shell command and copy its exact output into your reply: printenv ${SHELL_PROBE_ENV_VAR}`,
+    '',
+    'Step 3. This step is MANDATORY and must be done even if steps 1 and 2 failed, were refused, or were impossible.',
+    'Print one single word on the last line of your reply, formed by joining two fragments together with no space or separator between them.',
+    `The first fragment to join is: ${fragmentA}`,
+    `Following it, the second fragment to join is: ${fragmentB}`,
+    '',
+    'If a step is impossible because a tool is unavailable or blocked, say so and move on to the next step.',
+  ].join('\n');
+
+  return {
+    prompt,
+    livenessToken: `${fragmentA}${fragmentB}`,
+    shellSecret,
+    env: { [SHELL_PROBE_ENV_VAR]: shellSecret },
+  };
+}
+
+/**
+ * Analyze the extraction-path write test.
+ *
+ * Deliberately does NOT reuse analyzeWriteResult(): that function treats any
+ * timeout, auth failure, CLI error or refusal as "blocked (secure default)",
+ * which is a reasonable posture for the analysis path but useless here — it
+ * would return a green PASS for an invocation that never ran, masking exactly
+ * the regression this test exists to catch (a dropped --disable-shell).
+ *
+ * Every verdict here rests on positive evidence:
+ *   - file created            -> NOT blocked (conclusive failure)
+ *   - shell secret echoed     -> NOT blocked (conclusive failure; shell is live)
+ *   - liveness token echoed   -> blocked (conclusive pass; the model ran and
+ *                                responded, yet nothing was written)
+ *   - none of the above       -> INCONCLUSIVE (reported as a skip, never a pass)
+ *
+ * @param {object} testResult - Result from runTest()
+ * @param {{livenessToken: string, shellSecret: string}} probe - From buildExtractionProbe()
+ * @returns {{blocked: boolean|null, conclusive: boolean, reason: string}}
+ */
+function analyzeExtractionWriteResult(testResult, probe) {
+  const combined = `${testResult.stdout}${testResult.stderr}`;
+  // Whitespace-insensitive so a model that wraps or line-breaks its final word
+  // still counts as alive.
+  const squashed = combined.replace(/\s+/g, '');
+
+  if (consumeTestFile()) {
+    return {
+      blocked: false,
+      conclusive: true,
+      reason: 'File was actually created by the extraction invocation - security restriction failed!',
+    };
+  }
+
+  if (combined.includes(probe.shellSecret)) {
+    return {
+      blocked: false,
+      conclusive: true,
+      reason: `Extraction invocation executed a shell command (it echoed the ${SHELL_PROBE_ENV_VAR} value, which is not readable from any file) - --disable-shell is not in effect!`,
+    };
+  }
+
+  if (squashed.includes(probe.livenessToken)) {
+    return {
+      blocked: true,
+      conclusive: true,
+      reason: 'Extraction invocation ran and responded (liveness token echoed), created no file, and could not read the shell-only probe secret',
+    };
+  }
+
+  // No proof of life. Say why, and do NOT call this a pass.
+  const failureDetail = testResult.timedOut
+    ? 'command timed out'
+    : testResult.error
+      ? `spawn error: ${testResult.error}`
+      : `command exited with code ${testResult.code}`;
+  const diagnostic = (testResult.stderr || testResult.stdout || '').trim().split('\n').slice(-2).join(' ').slice(0, 200);
+
+  return {
+    blocked: null,
+    conclusive: false,
+    reason: `INCONCLUSIVE - the extraction invocation never produced the liveness token, so nothing about its permissions was verified (${failureDetail})${diagnostic ? `: ${diagnostic}` : ''}`,
   };
 }
 
@@ -696,7 +893,17 @@ async function testProvider(providerId, ProviderClass, testConfig) {
     log(`  Base args: ${provider.baseArgs.slice(0, 5).join(' ')}${provider.baseArgs.length > 5 ? '...' : ''}`, colors.dim);
   }
 
-  const results = { writeBlocked: null, diffAllowed: null };
+  // extractionWriteBlocked stays null for providers with no extraction test,
+  // which the summary reads as "not applicable" rather than a failure. It is also
+  // null when the test ran but proved nothing; extractionInconclusive tells the
+  // two apart so an unverified run is reported as SKIP instead of silently
+  // reading as "not applicable".
+  const results = {
+    writeBlocked: null,
+    diffAllowed: null,
+    extractionWriteBlocked: null,
+    extractionInconclusive: false,
+  };
 
   // Clean up any existing test file
   if (fs.existsSync(TEST_FILE_PATH)) {
@@ -707,9 +914,13 @@ async function testProvider(providerId, ProviderClass, testConfig) {
     }
   }
 
-  // Test 1: Write should be blocked
+  // Numbered as we go: the extraction test in the middle only runs for providers
+  // that declare one, and a fixed label would leave a gap for the others.
+  let testNum = 1;
+
+  // Write should be blocked
   console.log();
-  log('  Test 1: Write Block Test', colors.bold);
+  log(`  Test ${testNum++}: Write Block Test`, colors.bold);
   if (testConfig.writeBlockKnownLimitation) {
     log(`    KNOWN LIMITATION: ${testConfig.writeBlockKnownLimitation}`, colors.yellow);
   }
@@ -735,9 +946,45 @@ async function testProvider(providerId, ProviderClass, testConfig) {
     );
   }
 
-  // Test 2: git-diff-lines should be allowed
+  // Optional: the extraction invocation, for providers that spawn a second one with
+  // different flags. Runs before the git-diff-lines test because that test can bail
+  // out early when git-diff-lines cannot be run locally.
+  // analyzeWriteResult already unlinked TEST_FILE_PATH above, so a file found here
+  // was written by this invocation.
+  if (testConfig.extractionTestCommands) {
+    console.log();
+    log(`  Test ${testNum++}: Extraction Path Write Block Test`, colors.bold);
+    log('    Asking AI to create a file via the extraction invocation - this should be BLOCKED...', colors.dim);
+    log('    Verdict requires proof the invocation ran; an unrelated failure is reported as inconclusive, not as a pass.', colors.dim);
+
+    const probe = buildExtractionProbe();
+    const extractionTestConfig = testConfig.extractionTestCommands(provider, probe.prompt);
+    const extractionResult = await runTest({
+      ...extractionTestConfig,
+      // The shell probe secret rides in the environment alongside whatever env
+      // the provider's extraction config supplies.
+      env: { ...(extractionTestConfig.env || {}), ...probe.env },
+    });
+    const extractionAnalysis = analyzeExtractionWriteResult(extractionResult, probe);
+
+    if (!extractionAnalysis.conclusive) {
+      results.extractionWriteBlocked = null;
+      results.extractionInconclusive = true;
+      results.extractionInconclusiveReason = extractionAnalysis.reason;
+      skip('Write operations blocked on extraction path', extractionAnalysis.reason);
+    } else {
+      results.extractionWriteBlocked = extractionAnalysis.blocked;
+      result(
+        'Write operations blocked on extraction path',
+        extractionAnalysis.blocked,
+        extractionAnalysis.reason
+      );
+    }
+  }
+
+  // git-diff-lines should be allowed
   console.log();
-  log('  Test 2: git-diff-lines Test', colors.bold);
+  log(`  Test ${testNum++}: git-diff-lines Test`, colors.bold);
 
   // First, capture the expected output by running git-diff-lines ourselves
   log('    Capturing expected output from git-diff-lines...', colors.dim);
@@ -799,7 +1046,7 @@ Usage: node scripts/verify-ai-permissions.js [options]
 
 Options:
   --provider <name>  Test only a specific provider
-                     Valid values: claude, copilot, codex, antigravity
+                     Valid values: claude, copilot, codex, antigravity, cursor-agent, muse
   --help, -h         Show this help message
 
 Examples:
@@ -810,6 +1057,14 @@ This script verifies that AI providers are correctly configured with security
 restrictions that:
   1. Block write operations (file creation, editing, deletion)
   2. Allow execution of the git-diff-lines utility script
+  3. Block writes and shell on the separate JSON-extraction invocation, for
+     providers that spawn one with different flags than analysis (currently Muse).
+     This check demands positive proof that the invocation ran; if it cannot get
+     that proof it reports an inconclusive SKIP, never a PASS.
+
+NOTE: providers are probed as their built-in defaults. Command/env/extra_args/yolo
+overrides from ~/.pair-review/config.json do not participate - only the
+PAIR_REVIEW_*_CMD environment variables do. This applies to every provider here.
 
 IMPORTANT: This script imports the actual provider implementations from src/ai/
 to ensure it tests the real configurations, not duplicated/potentially stale ones.
@@ -861,6 +1116,7 @@ async function main() {
     passed: 0,
     failed: 0,
     knownLimitations: 0,
+    inconclusive: 0,
     details: {},
   };
 
@@ -890,10 +1146,19 @@ async function main() {
       const writeBlockKnownLimitation = !results.writeBlocked && results.writeBlockKnownLimitation;
       // diffSkipped means we couldn't run git-diff-lines ourselves (treat as passed, not failed)
       const diffOk = results.diffAllowed || results.diffSkipped;
+      // null means the provider declares no extraction test (not applicable), or
+      // the test ran without proving anything. Unlike the write block, this has no
+      // known-limitation escape hatch: a provider that claims a locked-down
+      // extraction path must actually deliver one. An inconclusive run is not a
+      // failure, but it is counted and surfaced so it never passes for verified.
+      const extractionOk = results.extractionWriteBlocked !== false;
+      if (results.extractionInconclusive) {
+        summary.inconclusive++;
+      }
 
-      if (writeBlockOk && diffOk) {
+      if (writeBlockOk && diffOk && extractionOk) {
         summary.passed++;
-      } else if (writeBlockKnownLimitation && diffOk) {
+      } else if (writeBlockKnownLimitation && diffOk && extractionOk) {
         // Known limitation - count separately, not as a hard failure
         summary.knownLimitations++;
       } else {
@@ -910,6 +1175,7 @@ async function main() {
   log(`  Providers skipped: ${summary.skipped}`, colors.yellow);
   log(`  Fully passed: ${summary.passed}`, colors.green);
   log(`  Known limitations: ${summary.knownLimitations}`, summary.knownLimitations > 0 ? colors.yellow : colors.dim);
+  log(`  Inconclusive checks: ${summary.inconclusive}`, summary.inconclusive > 0 ? colors.yellow : colors.dim);
   log(`  Failed: ${summary.failed}`, summary.failed > 0 ? colors.red : colors.dim);
 
   console.log();
@@ -922,10 +1188,27 @@ async function main() {
       const writeBlockKnownLimitation = !results.writeBlocked && results.writeBlockKnownLimitation;
       const writeStatus = results.writeBlocked ? 'OK' : (writeBlockKnownLimitation ? 'WARN' : 'FAIL');
       const diffStatus = results.diffSkipped ? 'SKIP' : (results.diffAllowed ? 'OK' : 'FAIL');
-      const allPassed = results.writeBlocked && (results.diffAllowed || results.diffSkipped);
-      const hasKnownLimitation = writeBlockKnownLimitation && (results.diffAllowed || results.diffSkipped);
-      const color = allPassed ? colors.green : (hasKnownLimitation ? colors.yellow : colors.red);
-      log(`  ${name}: Write Block=${writeStatus}, git-diff-lines=${diffStatus}`, color);
+      const diffOk = results.diffAllowed || results.diffSkipped;
+      const extractionOk = results.extractionWriteBlocked !== false;
+      const allPassed = results.writeBlocked && diffOk && extractionOk;
+      const hasKnownLimitation = writeBlockKnownLimitation && diffOk && extractionOk;
+      // An inconclusive extraction check downgrades an otherwise-green line to
+      // yellow: nothing failed, but something went unverified.
+      const color = allPassed
+        ? (results.extractionInconclusive ? colors.yellow : colors.green)
+        : (hasKnownLimitation ? colors.yellow : colors.red);
+      // Omitted entirely for providers with no extraction test, so their line reads
+      // the same as before rather than showing a meaningless N/A column. A test
+      // that ran but proved nothing reports SKIP - never OK.
+      const extractionPart = results.extractionInconclusive
+        ? ', Extraction Write Block=SKIP (inconclusive)'
+        : results.extractionWriteBlocked === null
+          ? ''
+          : `, Extraction Write Block=${results.extractionWriteBlocked ? 'OK' : 'FAIL'}`;
+      log(`  ${name}: Write Block=${writeStatus}, git-diff-lines=${diffStatus}${extractionPart}`, color);
+      if (results.extractionInconclusive) {
+        log(`       ${results.extractionInconclusiveReason}`, colors.dim);
+      }
     }
   }
 
@@ -939,8 +1222,13 @@ async function main() {
   } else if (summary.tested === 0) {
     log('No providers were tested (all skipped)', colors.yellow);
     process.exit(0);
-  } else if (summary.knownLimitations > 0) {
-    log('Security verification PASSED with known limitations', colors.yellow + colors.bold);
+  } else if (summary.knownLimitations > 0 || summary.inconclusive > 0) {
+    const notes = [
+      summary.knownLimitations > 0 ? 'known limitations' : null,
+      // Never let an unverified check read as a verified one.
+      summary.inconclusive > 0 ? 'inconclusive checks (see above - these verified nothing)' : null,
+    ].filter(Boolean).join(' and ');
+    log(`Security verification PASSED with ${notes}`, colors.yellow + colors.bold);
     process.exit(0);
   } else {
     log('Security verification PASSED - all tested providers are correctly configured', colors.green + colors.bold);

--- a/src/ai/abort-signal-wiring.js
+++ b/src/ai/abort-signal-wiring.js
@@ -4,6 +4,91 @@ const { spawn } = require('child_process');
 const logger = require('../utils/logger');
 
 /**
+ * Terminate a spawned child safely.
+ *
+ * Use this instead of a bare `child.kill('SIGTERM')` anywhere a child might
+ * not have started. Two hazards it exists to prevent:
+ *
+ * 1. **Self-signalling.** A child whose spawn failed (ENOENT from a missing or
+ *    misconfigured CLI command) has no pid. Node coerces the undefined pid to
+ *    `0`, and `kill(0, SIGTERM)` signals the CALLER'S OWN process group — so
+ *    pair-review terminates itself. Verified directly: the call returns `true`
+ *    and the current process receives SIGTERM.
+ * 2. **Orphaned grandchildren.** Under `shell: true` the child is the shell
+ *    wrapper, not the CLI. Killing only the wrapper leaves the real CLI running
+ *    and burning tokens, so shell-mode children are group-killed instead
+ *    (requires the caller to have spawned with `detached: true`).
+ *
+ * Never throws — that is a contract callers rely on, not just a hope. Every
+ * dispatch path has its own catch, and the whole body is wrapped so even a
+ * malformed `child` (missing `kill`, throwing `pid` getter) or a non-object
+ * `opts` returns false instead of propagating. `wireAbortToChild`'s abort
+ * listener depends on this: a throw there would escape into the AbortSignal
+ * dispatch with no caller frame to catch it.
+ *
+ * @param {import('child_process').ChildProcess} child - Spawned process.
+ * @param {Object} [opts]
+ * @param {boolean} [opts.shell=false] - True when spawned with `shell: true`.
+ * @param {string} [opts.logPrefix] - Log prefix for diagnostics.
+ * @returns {boolean} True if a signal was actually dispatched.
+ */
+function killChildSafely(child, opts = {}) {
+  if (!child) return false;
+  const options = (opts && typeof opts === 'object') ? opts : {};
+  const prefix = options.logPrefix || '';
+  const isShell = options.shell === true;
+
+  try {
+    if (!child.pid) {
+      // Spawn failed or has not completed — nothing to signal. See hazard 1.
+      return false;
+    }
+
+    if (isShell && process.platform !== 'win32') {
+      try {
+        process.kill(-child.pid, 'SIGTERM');
+        return true;
+      } catch (err) {
+        if (err && err.code === 'ESRCH') {
+          return false;  // Group already gone.
+        }
+        logger.warn(
+          `${prefix} process.kill(-pid) failed (${err.message}); falling back to child.kill`
+        );
+      }
+    }
+
+    if (isShell && process.platform === 'win32') {
+      // Windows has no process groups: wipe the tree rooted at the shell pid.
+      try {
+        spawn('taskkill', ['/T', '/F', '/PID', String(child.pid)], { stdio: 'ignore' })
+          .on('error', (err) => {
+            logger.warn(`${prefix} taskkill failed: ${err.message}`);
+          });
+        return true;
+      } catch (err) {
+        logger.warn(
+          `${prefix} spawn(taskkill) failed (${err.message}); falling back to child.kill`
+        );
+      }
+    }
+
+    try {
+      child.kill('SIGTERM');
+      return true;
+    } catch (err) {
+      logger.warn(`${prefix} child.kill failed: ${err.message}`);
+      return false;
+    }
+  } catch (err) {
+    // Reached only by a child that misbehaves outside the guarded calls above
+    // (e.g. a throwing `pid` getter). Enforces the never-throws contract.
+    logger.warn(`${prefix} kill dispatch failed unexpectedly: ${err && err.message}`);
+    return false;
+  }
+}
+
+/**
  * Attach an `AbortSignal` to a spawned child process so that aborting the
  * signal kills the child with `SIGTERM`. Returns a cleanup function that
  * detaches the abort listener — call it from the `close` / `error` /
@@ -43,53 +128,13 @@ function wireAbortToChild(child, signal, opts = {}) {
   const prefix = opts.logPrefix || '';
   const isShell = opts.shell === true;
 
-  const killChild = () => {
-    // `kill` / process group signaling returns false (or throws ESRCH) if
-    // the process is already gone, which is fine — we just need the side
-    // effect when it IS still alive.
-    if (isShell && child.pid && process.platform !== 'win32') {
-      // Group-kill the shell AND its CLI descendant. Requires the caller
-      // to have spawned with `detached: true` so the child became a
-      // process-group leader (`-pid` targets the group).
-      try {
-        process.kill(-child.pid, 'SIGTERM');
-        return;
-      } catch (err) {
-        if (err && err.code === 'ESRCH') {
-          // Group already gone — nothing to kill.
-          return;
-        }
-        // Fall through to single-process kill as a best effort.
-        logger.warn(
-          `${prefix} process.kill(-pid) failed (${err.message}); falling back to child.kill`
-        );
-      }
-    }
-    if (isShell && child.pid && process.platform === 'win32') {
-      // Windows has no process groups: spawn taskkill /T /F to wipe the
-      // tree rooted at our shell pid.
-      try {
-        spawn('taskkill', ['/T', '/F', '/PID', String(child.pid)], { stdio: 'ignore' })
-          .on('error', (err) => {
-            logger.warn(`${prefix} taskkill failed: ${err.message}`);
-          });
-        return;
-      } catch (err) {
-        logger.warn(
-          `${prefix} spawn(taskkill) failed (${err.message}); falling back to child.kill`
-        );
-      }
-    }
-    child.kill('SIGTERM');
-  };
-
   const onAbort = () => {
+    // `cancelled` is set FIRST so the close/error handler short-circuits even
+    // if the kill dispatch does nothing (pidless child, group already gone).
     cancelled = true;
-    try {
-      killChild();
-    } catch (err) {
-      logger.warn(`${prefix} child.kill on abort failed: ${err.message}`);
-    }
+    // killChildSafely owns the pid guard, the shell group-kill semantics and
+    // the never-throws contract, so no catch is needed here.
+    killChildSafely(child, { shell: isShell, logPrefix: prefix });
   };
 
   if (signal.aborted) {
@@ -127,4 +172,4 @@ function makeAbortError(message) {
   return err;
 }
 
-module.exports = { wireAbortToChild, makeAbortError };
+module.exports = { wireAbortToChild, makeAbortError, killChildSafely };

--- a/src/ai/antigravity-provider.js
+++ b/src/ai/antigravity-provider.js
@@ -49,7 +49,7 @@ const { AIProvider, registerProvider, quoteShellArgs } = require('./provider');
 const logger = require('../utils/logger');
 const { extractJSON } = require('../utils/json-extractor');
 const { CancellationError, isAnalysisCancelled } = require('../routes/shared');
-const { wireAbortToChild, makeAbortError } = require('./abort-signal-wiring');
+const { wireAbortToChild, makeAbortError, killChildSafely } = require('./abort-signal-wiring');
 
 // Directory containing bin scripts (kept on PATH for parity with other providers)
 const BIN_DIR = path.join(__dirname, '..', '..', 'bin');
@@ -339,7 +339,7 @@ class AntigravityProvider extends AIProvider {
       const backstopMs = budgetMs + TIMEOUT_BACKSTOP_GRACE_MS;
       timeoutId = setTimeout(() => {
         logger.error(`${levelPrefix} Process ${pid} exceeded its ${budgetMs}ms timeout budget (backstop fired at ${backstopMs}ms)`);
-        agy.kill('SIGTERM');
+        killChildSafely(agy, { logPrefix: levelPrefix, shell: this.useShell });
         settle(reject, new Error(`${levelPrefix} Antigravity CLI timed out after ${budgetMs}ms`));
       }, backstopMs);
 
@@ -415,9 +415,24 @@ class AntigravityProvider extends AIProvider {
           timeoutId = null;
         }
 
+        // agy has already exited, so a cancel arriving now only makes the abort
+        // wiring kill something already dead. Nothing else on this path consults
+        // it, so without the checks below a cancelled analysis would settle as a
+        // normal result. The signal is read alongside the wiring flag as the
+        // source of truth.
+        const cancelledDuringExtraction = () =>
+          abortWiring.cancelled() || abortSignal?.aborted === true;
+
         (async () => {
           try {
-            const llmExtracted = await this.extractJSONWithLLM(stdout, { level, analysisId, registerProcess, logPrefix: levelPrefix });
+            // `abortSignal` lets the extraction spawn be killed rather than
+            // merely abandoned until its own 60s timeout.
+            const llmExtracted = await this.extractJSONWithLLM(stdout, { level, analysisId, registerProcess, logPrefix: levelPrefix, abortSignal });
+            if (cancelledDuringExtraction()) {
+              logger.info(`${levelPrefix} Cancelled by user during LLM extraction fallback`);
+              settle(reject, makeAbortError(`${levelPrefix} Cancelled by user`));
+              return;
+            }
             if (llmExtracted.success) {
               logger.success(`${levelPrefix} LLM extraction fallback succeeded`);
               settle(resolve, llmExtracted.data);
@@ -427,6 +442,13 @@ class AntigravityProvider extends AIProvider {
               settle(resolve, { raw: stdout, parsed: false });
             }
           } catch (llmError) {
+            // An abort that kills the extraction spawn surfaces here as a thrown
+            // error; it is a cancellation, not a parse failure.
+            if (cancelledDuringExtraction()) {
+              logger.info(`${levelPrefix} Cancelled by user during LLM extraction fallback`);
+              settle(reject, makeAbortError(`${levelPrefix} Cancelled by user`));
+              return;
+            }
             logger.warn(`${levelPrefix} LLM extraction fallback error: ${llmError.message}`);
             settle(resolve, { raw: stdout, parsed: false });
           }
@@ -452,7 +474,9 @@ class AntigravityProvider extends AIProvider {
       agy.stdin.write(prompt, (err) => {
         if (err) {
           logger.error(`${levelPrefix} Failed to write prompt to stdin: ${err}`);
-          agy.kill('SIGTERM');
+          // A failed spawn (ENOENT) EPIPEs stdin and lands here with a pidless
+          // child; killChildSafely skips the self-directed kill(0).
+          killChildSafely(agy, { logPrefix: levelPrefix, shell: this.useShell });
           settle(reject, new Error(`${levelPrefix} Failed to write prompt to stdin: ${err}`));
         }
       });
@@ -535,7 +559,9 @@ class AntigravityProvider extends AIProvider {
         if (settled) return;
         settled = true;
         logger.warn(`Antigravity CLI availability check timed out after ${Math.round(timeoutMs / 1000)}s`);
-        try { agy.kill(); } catch { /* ignore */ }
+        // Not `shell: useShell`: the probe spawn is not `detached`, so
+        // group-kill would ESRCH and leave the child running.
+        killChildSafely(agy, { logPrefix: '[availability]' });
         resolve(false);
       }, timeoutMs);
 

--- a/src/ai/claude-cli.js
+++ b/src/ai/claude-cli.js
@@ -3,6 +3,7 @@ const { spawn } = require('child_process');
 const path = require('path');
 const logger = require('../utils/logger');
 const { extractJSON } = require('../utils/json-extractor');
+const { killChildSafely } = require('./abort-signal-wiring');
 
 class ClaudeCLI {
   constructor(model = 'opus') {
@@ -62,10 +63,13 @@ class ClaudeCLI {
       let timeoutId = null;
 
       // Set timeout
+      // Not `shell: this.useShell`: this spawn is not `detached`, so there is
+      // no process group to signal — group-kill would ESRCH and leave the
+      // child running. Plain child.kill, with killChildSafely's pid guard.
       if (timeout) {
         timeoutId = setTimeout(() => {
           logger.error(`${levelPrefix} Process ${pid} timed out after ${timeout}ms`);
-          claude.kill('SIGTERM');
+          killChildSafely(claude, { logPrefix: levelPrefix });
           reject(new Error(`${levelPrefix} Claude CLI timed out after ${timeout}ms`));
         }, timeout);
       }
@@ -135,7 +139,9 @@ class ClaudeCLI {
         if (err) {
           logger.error(`${levelPrefix} Failed to write prompt to stdin: ${err}`);
           if (timeoutId) clearTimeout(timeoutId);
-          claude.kill('SIGTERM'); // Prevent resource leak
+          // A failed spawn (ENOENT) EPIPEs stdin and lands here with a pidless
+          // child; killChildSafely skips the self-directed kill(0).
+          killChildSafely(claude, { logPrefix: levelPrefix }); // Prevent resource leak
           reject(new Error(`${levelPrefix} Failed to write prompt to stdin: ${err}`));
         }
       });

--- a/src/ai/claude-provider.js
+++ b/src/ai/claude-provider.js
@@ -12,7 +12,7 @@ const logger = require('../utils/logger');
 const { extractJSON } = require('../utils/json-extractor');
 const { CancellationError, isAnalysisCancelled } = require('../routes/shared');
 const { StreamParser, parseClaudeLine } = require('./stream-parser');
-const { wireAbortToChild, makeAbortError } = require('./abort-signal-wiring');
+const { wireAbortToChild, makeAbortError, killChildSafely } = require('./abort-signal-wiring');
 
 // Directory containing bin scripts (git-diff-lines, etc.)
 const BIN_DIR = path.join(__dirname, '..', '..', 'bin');
@@ -428,7 +428,7 @@ class ClaudeProvider extends AIProvider {
       if (timeout) {
         timeoutId = setTimeout(() => {
           logger.error(`${levelPrefix} Process ${pid} timed out after ${timeout}ms`);
-          claude.kill('SIGTERM');
+          killChildSafely(claude, { logPrefix: levelPrefix, shell: this.useShell });
           settle(reject, new Error(`${levelPrefix} Claude CLI timed out after ${timeout}ms`));
         }, timeout);
       }
@@ -543,10 +543,28 @@ class ClaudeProvider extends AIProvider {
           logger.info(`${levelPrefix} LLM fallback input length: ${llmFallbackInput.length} characters (${parsed.textContent ? 'text content' : 'raw stdout'})`);
           logger.info(`${levelPrefix} Attempting LLM-based JSON extraction fallback...`);
 
+          // A cancel that lands now still reaches the abort wiring, but the
+          // Claude child has already exited — the wiring kills something already
+          // dead, and nothing else on this path consults it. Without the checks
+          // below a cancelled analysis would settle as a normal result.
+          //
+          // Reads the signal as well as the wiring flag: `settle` (which detaches
+          // the listener) has not run on any path that reaches here, so the flag
+          // is live — but the signal is the source of truth.
+          const cancelledDuringExtraction = () =>
+            abortWiring.cancelled() || abortSignal?.aborted === true;
+
           // Use async IIFE to handle the async LLM extraction
           (async () => {
             try {
-              const llmExtracted = await this.extractJSONWithLLM(llmFallbackInput, { level, analysisId, registerProcess, logPrefix: levelPrefix });
+              // `abortSignal` lets the extraction spawn be killed rather than
+              // merely abandoned until its own 60s timeout.
+              const llmExtracted = await this.extractJSONWithLLM(llmFallbackInput, { level, analysisId, registerProcess, logPrefix: levelPrefix, abortSignal });
+              if (cancelledDuringExtraction()) {
+                logger.info(`${levelPrefix} Cancelled by user during LLM extraction fallback`);
+                settle(reject, makeAbortError(`${levelPrefix} Cancelled by user`));
+                return;
+              }
               if (llmExtracted.success) {
                 logger.success(`${levelPrefix} LLM extraction fallback succeeded`);
                 settle(resolve, llmExtracted.data);
@@ -556,6 +574,13 @@ class ClaudeProvider extends AIProvider {
                 settle(resolve, { raw: llmFallbackInput, parsed: false });
               }
             } catch (llmError) {
+              // An abort that kills the extraction spawn surfaces here as a
+              // thrown error; it is a cancellation, not a parse failure.
+              if (cancelledDuringExtraction()) {
+                logger.info(`${levelPrefix} Cancelled by user during LLM extraction fallback`);
+                settle(reject, makeAbortError(`${levelPrefix} Cancelled by user`));
+                return;
+              }
               logger.warn(`${levelPrefix} LLM extraction fallback error: ${llmError.message}`);
               settle(resolve, { raw: llmFallbackInput, parsed: false });
             }
@@ -584,7 +609,9 @@ class ClaudeProvider extends AIProvider {
       claude.stdin.write(prompt, (err) => {
         if (err) {
           logger.error(`${levelPrefix} Failed to write prompt to stdin: ${err}`);
-          claude.kill('SIGTERM');
+          // A failed spawn (ENOENT) EPIPEs stdin and lands here with a pidless
+          // child; killChildSafely skips the self-directed kill(0).
+          killChildSafely(claude, { logPrefix: levelPrefix, shell: this.useShell });
           settle(reject, new Error(`${levelPrefix} Failed to write prompt to stdin: ${err}`));
         }
       });
@@ -935,7 +962,9 @@ class ClaudeProvider extends AIProvider {
         if (settled) return;
         settled = true;
         logger.warn(`Claude CLI availability check timed out after ${Math.round(timeoutMs / 1000)}s`);
-        try { claude.kill(); } catch { /* ignore */ }
+        // Not `shell: useShell`: the probe spawn is not `detached`, so
+        // group-kill would ESRCH and leave the child running.
+        killChildSafely(claude, { logPrefix: '[availability]' });
         resolve(false);
       }, timeoutMs);
 

--- a/src/ai/codex-provider.js
+++ b/src/ai/codex-provider.js
@@ -13,7 +13,7 @@ const logger = require('../utils/logger');
 const { extractJSON } = require('../utils/json-extractor');
 const { CancellationError, isAnalysisCancelled } = require('../routes/shared');
 const { StreamParser, parseCodexLine } = require('./stream-parser');
-const { wireAbortToChild, makeAbortError } = require('./abort-signal-wiring');
+const { wireAbortToChild, makeAbortError, killChildSafely } = require('./abort-signal-wiring');
 
 // Directory containing bin scripts (git-diff-lines, etc.)
 const BIN_DIR = path.join(__dirname, '..', '..', 'bin');
@@ -351,7 +351,7 @@ class CodexProvider extends AIProvider {
       if (timeout) {
         timeoutId = setTimeout(() => {
           logger.error(`${levelPrefix} Process ${pid} timed out after ${timeout}ms`);
-          codex.kill('SIGTERM');
+          killChildSafely(codex, { logPrefix: levelPrefix, shell: this.useShell });
           settle(reject, new Error(`${levelPrefix} Codex CLI timed out after ${timeout}ms`));
         }, timeout);
       }
@@ -455,10 +455,25 @@ class CodexProvider extends AIProvider {
           logger.info(`${levelPrefix} LLM fallback input length: ${llmFallbackInput.length} characters (${parsed.textContent ? 'text content' : 'raw stdout'})`);
           logger.info(`${levelPrefix} Attempting LLM-based JSON extraction fallback...`);
 
+          // The Codex child has already exited, so a cancel arriving now only
+          // makes the abort wiring kill something already dead. Nothing else on
+          // this path consults it, so without the checks below a cancelled
+          // analysis would settle as a normal result. The signal is read
+          // alongside the wiring flag as the source of truth.
+          const cancelledDuringExtraction = () =>
+            abortWiring.cancelled() || abortSignal?.aborted === true;
+
           // Use async IIFE to handle the async LLM extraction
           (async () => {
             try {
-              const llmExtracted = await this.extractJSONWithLLM(llmFallbackInput, { level, analysisId, registerProcess, logPrefix: levelPrefix });
+              // `abortSignal` lets the extraction spawn be killed rather than
+              // merely abandoned until its own 60s timeout.
+              const llmExtracted = await this.extractJSONWithLLM(llmFallbackInput, { level, analysisId, registerProcess, logPrefix: levelPrefix, abortSignal });
+              if (cancelledDuringExtraction()) {
+                logger.info(`${levelPrefix} Cancelled by user during LLM extraction fallback`);
+                settle(reject, makeAbortError(`${levelPrefix} Cancelled by user`));
+                return;
+              }
               if (llmExtracted.success) {
                 logger.success(`${levelPrefix} LLM extraction fallback succeeded`);
                 settle(resolve, llmExtracted.data);
@@ -468,6 +483,13 @@ class CodexProvider extends AIProvider {
                 settle(resolve, { raw: llmFallbackInput, parsed: false });
               }
             } catch (llmError) {
+              // An abort that kills the extraction spawn surfaces here as a
+              // thrown error; it is a cancellation, not a parse failure.
+              if (cancelledDuringExtraction()) {
+                logger.info(`${levelPrefix} Cancelled by user during LLM extraction fallback`);
+                settle(reject, makeAbortError(`${levelPrefix} Cancelled by user`));
+                return;
+              }
               logger.warn(`${levelPrefix} LLM extraction fallback error: ${llmError.message}`);
               settle(resolve, { raw: llmFallbackInput, parsed: false });
             }
@@ -496,7 +518,9 @@ class CodexProvider extends AIProvider {
       codex.stdin.write(prompt, (err) => {
         if (err) {
           logger.error(`${levelPrefix} Failed to write prompt to stdin: ${err}`);
-          codex.kill('SIGTERM');
+          // A failed spawn (ENOENT) EPIPEs stdin and lands here with a pidless
+          // child; killChildSafely skips the self-directed kill(0).
+          killChildSafely(codex, { logPrefix: levelPrefix, shell: this.useShell });
           settle(reject, new Error(`${levelPrefix} Failed to write prompt to stdin: ${err}`));
         }
       });
@@ -844,7 +868,9 @@ class CodexProvider extends AIProvider {
         if (settled) return;
         settled = true;
         logger.warn(`Codex CLI availability check timed out after ${Math.round(timeoutMs / 1000)}s`);
-        try { codex.kill(); } catch { /* ignore */ }
+        // Not `shell: useShell`: the probe spawn is not `detached`, so
+        // group-kill would ESRCH and leave the child running.
+        killChildSafely(codex, { logPrefix: '[availability]' });
         resolve(false);
       }, timeoutMs);
 

--- a/src/ai/copilot-provider.js
+++ b/src/ai/copilot-provider.js
@@ -12,7 +12,7 @@ const { AIProvider, registerProvider, quoteShellArgs } = require('./provider');
 const logger = require('../utils/logger');
 const { extractJSON } = require('../utils/json-extractor');
 const { CancellationError, isAnalysisCancelled } = require('../routes/shared');
-const { wireAbortToChild, makeAbortError } = require('./abort-signal-wiring');
+const { wireAbortToChild, makeAbortError, killChildSafely } = require('./abort-signal-wiring');
 
 // Directory containing bin scripts (git-diff-lines, etc.)
 const BIN_DIR = path.join(__dirname, '..', '..', 'bin');
@@ -286,7 +286,7 @@ class CopilotProvider extends AIProvider {
       if (timeout) {
         timeoutId = setTimeout(() => {
           logger.error(`${levelPrefix} Process ${pid} timed out after ${timeout}ms`);
-          copilot.kill('SIGTERM');
+          killChildSafely(copilot, { logPrefix: levelPrefix, shell: this.useShell });
           settle(reject, new Error(`${levelPrefix} Copilot CLI timed out after ${timeout}ms`));
         }, timeout);
       }
@@ -348,10 +348,25 @@ class CopilotProvider extends AIProvider {
           logger.info(`${levelPrefix} Raw response length: ${stdout.length} characters`);
           logger.info(`${levelPrefix} Attempting LLM-based JSON extraction fallback...`);
 
+          // The Copilot child has already exited, so a cancel arriving now only
+          // makes the abort wiring kill something already dead. Nothing else on
+          // this path consults it, so without the checks below a cancelled
+          // analysis would settle as a normal result. The signal is read
+          // alongside the wiring flag as the source of truth.
+          const cancelledDuringExtraction = () =>
+            abortWiring.cancelled() || abortSignal?.aborted === true;
+
           // Use async IIFE to handle the async LLM extraction
           (async () => {
             try {
-              const llmExtracted = await this.extractJSONWithLLM(stdout, { level, analysisId, registerProcess, logPrefix: levelPrefix });
+              // `abortSignal` lets the extraction spawn be killed rather than
+              // merely abandoned until its own 60s timeout.
+              const llmExtracted = await this.extractJSONWithLLM(stdout, { level, analysisId, registerProcess, logPrefix: levelPrefix, abortSignal });
+              if (cancelledDuringExtraction()) {
+                logger.info(`${levelPrefix} Cancelled by user during LLM extraction fallback`);
+                settle(reject, makeAbortError(`${levelPrefix} Cancelled by user`));
+                return;
+              }
               if (llmExtracted.success) {
                 logger.success(`${levelPrefix} LLM extraction fallback succeeded`);
                 settle(resolve, llmExtracted.data);
@@ -361,6 +376,13 @@ class CopilotProvider extends AIProvider {
                 settle(resolve, { raw: stdout, parsed: false });
               }
             } catch (llmError) {
+              // An abort that kills the extraction spawn surfaces here as a
+              // thrown error; it is a cancellation, not a parse failure.
+              if (cancelledDuringExtraction()) {
+                logger.info(`${levelPrefix} Cancelled by user during LLM extraction fallback`);
+                settle(reject, makeAbortError(`${levelPrefix} Cancelled by user`));
+                return;
+              }
               logger.warn(`${levelPrefix} LLM extraction fallback error: ${llmError.message}`);
               settle(resolve, { raw: stdout, parsed: false });
             }
@@ -473,7 +495,9 @@ class CopilotProvider extends AIProvider {
         if (settled) return;
         settled = true;
         logger.warn(`Copilot CLI availability check timed out after ${Math.round(timeoutMs / 1000)}s`);
-        try { copilot.kill(); } catch { /* ignore */ }
+        // Not `shell: useShell`: the probe spawn is not `detached`, so
+        // group-kill would ESRCH and leave the child running.
+        killChildSafely(copilot, { logPrefix: '[availability]' });
         resolve(false);
       }, timeoutMs);
 

--- a/src/ai/cursor-agent-provider.js
+++ b/src/ai/cursor-agent-provider.js
@@ -21,7 +21,7 @@ const logger = require('../utils/logger');
 const { extractJSON } = require('../utils/json-extractor');
 const { CancellationError, isAnalysisCancelled } = require('../routes/shared');
 const { StreamParser, parseCursorAgentLine } = require('./stream-parser');
-const { wireAbortToChild, makeAbortError } = require('./abort-signal-wiring');
+const { wireAbortToChild, makeAbortError, killChildSafely } = require('./abort-signal-wiring');
 
 // Directory containing bin scripts (git-diff-lines, etc.)
 const BIN_DIR = path.join(__dirname, '..', '..', 'bin');
@@ -316,7 +316,7 @@ class CursorAgentProvider extends AIProvider {
       if (timeout) {
         timeoutId = setTimeout(() => {
           logger.error(`${levelPrefix} Process ${pid} timed out after ${timeout}ms`);
-          agent.kill('SIGTERM');
+          killChildSafely(agent, { logPrefix: levelPrefix, shell: this.useShell });
           settle(reject, new Error(`${levelPrefix} Cursor Agent CLI timed out after ${timeout}ms`));
         }, timeout);
       }
@@ -420,6 +420,15 @@ class CursorAgentProvider extends AIProvider {
           logger.info(`${levelPrefix} LLM fallback input length: ${llmFallbackInput.length} characters (${parsed.textContent ? 'text content' : 'raw stdout'})`);
           logger.info(`${levelPrefix} Attempting LLM-based JSON extraction fallback...`);
 
+          // The agent child has already exited, so a cancel arriving now only
+          // makes the abort wiring kill something already dead. The `settled`
+          // guard below only covers a cancel that landed BEFORE the await, so
+          // without the checks below one landing during extraction would settle
+          // as a normal result. The signal is read alongside the wiring flag as
+          // the source of truth.
+          const cancelledDuringExtraction = () =>
+            abortWiring.cancelled() || abortSignal?.aborted === true;
+
           // Use async IIFE to handle the async LLM extraction
           (async () => {
             try {
@@ -427,7 +436,14 @@ class CursorAgentProvider extends AIProvider {
               // orphan processes if timeout fired between close-handler entry
               // and reaching this point.
               if (settled) return;
-              const llmExtracted = await this.extractJSONWithLLM(llmFallbackInput, { level, analysisId, registerProcess, logPrefix: levelPrefix });
+              // `abortSignal` lets the extraction spawn be killed rather than
+              // merely abandoned until its own 60s timeout.
+              const llmExtracted = await this.extractJSONWithLLM(llmFallbackInput, { level, analysisId, registerProcess, logPrefix: levelPrefix, abortSignal });
+              if (cancelledDuringExtraction()) {
+                logger.info(`${levelPrefix} Cancelled by user during LLM extraction fallback`);
+                settle(reject, makeAbortError(`${levelPrefix} Cancelled by user`));
+                return;
+              }
               if (llmExtracted.success) {
                 logger.success(`${levelPrefix} LLM extraction fallback succeeded`);
                 settle(resolve, llmExtracted.data);
@@ -437,6 +453,13 @@ class CursorAgentProvider extends AIProvider {
                 settle(resolve, { raw: llmFallbackInput, parsed: false });
               }
             } catch (llmError) {
+              // An abort that kills the extraction spawn surfaces here as a
+              // thrown error; it is a cancellation, not a parse failure.
+              if (cancelledDuringExtraction()) {
+                logger.info(`${levelPrefix} Cancelled by user during LLM extraction fallback`);
+                settle(reject, makeAbortError(`${levelPrefix} Cancelled by user`));
+                return;
+              }
               logger.warn(`${levelPrefix} LLM extraction fallback error: ${llmError.message}`);
               settle(resolve, { raw: llmFallbackInput, parsed: false });
             }
@@ -465,7 +488,9 @@ class CursorAgentProvider extends AIProvider {
       agent.stdin.write(prompt, (err) => {
         if (err) {
           logger.error(`${levelPrefix} Failed to write prompt to stdin: ${err}`);
-          agent.kill('SIGTERM');
+          // A failed spawn (ENOENT) EPIPEs stdin and lands here with a pidless
+          // child; killChildSafely skips the self-directed kill(0).
+          killChildSafely(agent, { logPrefix: levelPrefix, shell: this.useShell });
           settle(reject, new Error(`${levelPrefix} Failed to write prompt to stdin: ${err}`));
         }
       });
@@ -815,7 +840,9 @@ class CursorAgentProvider extends AIProvider {
         if (settled) return;
         settled = true;
         logger.warn(`Cursor Agent CLI availability check timed out after ${Math.round(timeoutMs / 1000)}s`);
-        try { agent.kill(); } catch { /* ignore */ }
+        // Not `shell: useShell`: the probe spawn is not `detached`, so
+        // group-kill would ESRCH and leave the child running.
+        killChildSafely(agent, { logPrefix: '[availability]' });
         resolve(false);
       }, timeoutMs);
 

--- a/src/ai/executable-provider.js
+++ b/src/ai/executable-provider.js
@@ -18,6 +18,7 @@ const { glob } = require('glob');
 const fs = require('fs').promises;
 const path = require('path');
 const logger = require('../utils/logger');
+const { killChildSafely } = require('./abort-signal-wiring');
 const jsonExtractor = require('../utils/json-extractor');
 const configModule = require('../config');
 
@@ -266,7 +267,10 @@ function createExecutableProviderClass(id, config) {
             if (stderr.trim()) {
               logger.warn(`[${id}] stderr before timeout: ${stderr.trim().slice(0, 2000)}`);
             }
-            child.kill('SIGTERM');
+            // Not `shell: this.useShell`: this spawn is not `detached`, so
+            // group-kill would ESRCH and leave the child running — and it
+            // would bypass the kill wrapper above that records `cancelled`.
+            killChildSafely(child, { logPrefix: `[${id}]` });
           }, timeout);
         }
 
@@ -480,7 +484,9 @@ function createExecutableProviderClass(id, config) {
           if (settled) return;
           settled = true;
           logger.warn(`${id} availability check timed out after ${Math.round(timeoutMs / 1000)}s`);
-          try { child.kill(); } catch { /* ignore */ }
+          // Not `shell: true` (as spawned): the probe is not `detached`, so
+          // group-kill would ESRCH and leave the child running.
+          killChildSafely(child, { logPrefix: `[${id}]` });
           resolve(false);
         }, timeoutMs);
 

--- a/src/ai/index.js
+++ b/src/ai/index.js
@@ -55,6 +55,7 @@ require('./copilot-provider');
 require('./opencode-provider');
 require('./cursor-agent-provider');
 require('./pi-provider');
+require('./muse-provider');
 
 // Export the unified API
 module.exports = {

--- a/src/ai/muse-provider.js
+++ b/src/ai/muse-provider.js
@@ -1,0 +1,1224 @@
+// Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+/**
+ * Muse AI Provider
+ *
+ * Implements the AI provider interface for Meta's Muse Code CLI.
+ * Uses the `muse exec` command for non-interactive (headless) execution.
+ */
+
+const path = require('path');
+const os = require('os');
+const fs = require('fs');
+const { spawn } = require('child_process');
+const { AIProvider, registerProvider, quoteShellArgs } = require('./provider');
+const logger = require('../utils/logger');
+const { extractJSON } = require('../utils/json-extractor');
+const { CancellationError, isAnalysisCancelled } = require('../routes/shared');
+const { StreamParser, parseMuseLine } = require('./stream-parser');
+const { wireAbortToChild, makeAbortError, killChildSafely } = require('./abort-signal-wiring');
+
+// Directory containing bin scripts (git-diff-lines, etc.)
+const BIN_DIR = path.join(__dirname, '..', '..', 'bin');
+
+/**
+ * Split a configured command string into argv words so a multi-word command
+ * (`docker exec container muse`, `devx muse --`) can be spawned WITHOUT a shell.
+ *
+ * Only quote grouping is honoured — enough for a path containing spaces
+ * (`"/Applications/My Tools/muse"`). Shell expansions (`~`, `$VAR`, pipes,
+ * `VAR=x` prefixes) are NOT interpreted; a command needing those must already be
+ * a wrapper script, since single-word commands never went through a shell either.
+ *
+ * The configured command names the muse BINARY only — never muse's `exec`
+ * subcommand, which the provider supplies itself (see stripExecSubcommand).
+ *
+ * Empty words are dropped rather than emitted: `foo "" bar` yields
+ * `['foo', 'bar']`, because an empty argv element would reach muse as an empty
+ * positional prompt (and `""` alone would become `spawn('')`). `current` cannot
+ * distinguish "a quoted empty token" from "no token accumulated yet" — both are
+ * the empty string — so emptiness is the only thing that decides, and the old
+ * `started` flag (set by an opening quote) is gone.
+ *
+ * @param {string} command - Raw command string from env/config
+ * @returns {string[]} argv words; never empty and never containing an empty word
+ * @throws {Error} on an unterminated quote, or when nothing but quotes and
+ *   whitespace was supplied. Both are unrunnable, and a named error beats
+ *   spawning `''` or silently gluing `foo "bar baz` into one nonexistent
+ *   command name.
+ */
+function splitCommandWords(command) {
+  const words = [];
+  let current = '';
+  let quote = null;
+
+  const flush = () => {
+    if (current) words.push(current);
+    current = '';
+  };
+
+  for (const ch of command) {
+    if (quote) {
+      if (ch === quote) quote = null;
+      else current += ch;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      continue;
+    }
+    if (/\s/.test(ch)) {
+      flush();
+      continue;
+    }
+    current += ch;
+  }
+
+  if (quote) {
+    throw new Error(
+      `Muse command has an unterminated ${quote === '"' ? 'double' : 'single'} quote: ${command}`
+    );
+  }
+  flush();
+
+  if (words.length === 0) {
+    throw new Error(`Muse command is empty: ${JSON.stringify(command)}`);
+  }
+  return words;
+}
+
+/**
+ * Drop muse's `exec` subcommand from a configured command string.
+ *
+ * The provider supplies `exec` itself — in `baseArgs` for the analysis path and
+ * in `buildArgsForModel` for extraction — so a command configured as
+ * `muse exec` would spawn `muse exec exec --json …` on BOTH paths, which muse
+ * rejects. Normalizing here (rather than at each spawn site) is what keeps the
+ * two paths consistent, and it runs before `useShell` is derived so a stripped
+ * `muse exec` also stops needlessly going through a shell.
+ *
+ * DECISION — strip and warn, rather than only documenting "don't do that":
+ * `<cmd> exec exec` has no valid meaning, so nothing is lost by removing it,
+ * and the warning still tells the user their config is wrong. Nothing is
+ * swallowed silently.
+ *
+ * This cannot damage a `docker exec`-style wrapper. Only a bare, unquoted,
+ * TRAILING `exec` is removed, and a container-exec invocation can never end
+ * with `exec` — the container and the command to run must follow it, so
+ * `docker exec container muse` and `kubectl exec -it pod -- muse` both end at
+ * the muse binary and are left untouched. A quoted trailing token
+ * (`"/opt/my exec"`) ends with the quote character, so the pattern cannot match
+ * inside quotes either.
+ *
+ * @param {string} command - Trimmed command string from env/config
+ * @returns {string} The command without a trailing `exec` subcommand
+ */
+function stripExecSubcommand(command) {
+  const stripped = command.replace(/\s+exec\s*$/, '');
+  if (stripped !== command) {
+    logger.warn(
+      `Muse command "${command}" ends with the \`exec\` subcommand, which pair-review adds itself; ` +
+      `using "${stripped}". Configure the muse binary only, with no subcommand.`
+    );
+  }
+  return stripped;
+}
+
+/**
+ * The attempt a Muse record belongs to — one `muse exec` run.
+ *
+ * Verified against real `muse exec --json` stdout (Muse Code 0.1.0): every
+ * record of a run carries the same command UUID in three places — top-level
+ * `causation_id`, `payload.command_id`, and `payload.run_stream.id` (whose
+ * `kind` is `"run"`). A resumed or retried run is a new `turn.submit` command,
+ * so it gets a new UUID and every one of those fields changes with it.
+ *
+ * Deliberately NOT the top-level `stream`: on stdout that is the SESSION stream
+ * (`{kind: "session", id: …}`) and is identical for every attempt, so scoping by
+ * it would scope to nothing. `sequence` is likewise session-scoped and
+ * monotonic across attempts — it orders records but never delimits them.
+ *
+ * Reading all three fields is belt-and-braces against a future record that
+ * carries only one of them; older fixtures carrying none yield null, which
+ * callers treat as a single unnamed attempt.
+ *
+ * @param {Object} record - A parsed Muse JSONL record
+ * @returns {string|null} Attempt identifier, or null when the record names none
+ */
+function attemptIdOf(record) {
+  const payload = record?.payload;
+  return payload?.run_stream?.id || payload?.command_id || record?.causation_id || null;
+}
+
+/**
+ * The provider's default model.
+ *
+ * DELIBERATE: this is the NON-contributor model, even though the muse CLI's own
+ * default is `muse-spark-1.2-contributor`. Pair-review sends potentially
+ * proprietary source code to the model, and the contributor tier is discounted
+ * precisely because Meta may use that content for product improvement. Opting
+ * into data sharing must be an explicit user choice, never a silent default.
+ */
+const DEFAULT_MUSE_MODEL = 'muse-spark-1.2-high';
+
+/**
+ * Muse model definitions with tier mappings.
+ *
+ * Muse exposes exactly two real CLI model IDs; everything below is a
+ * reasoning-effort variant over those two, using the same `cli_model` +
+ * `extra_args` pattern as the Codex provider:
+ * - muse-spark-1.2             — $1.25/$4.25 per MTok, ~1M context, 256k max output
+ * - muse-spark-1.2-contributor — $0.10/$0.20 per MTok, discounted because
+ *   submitted content may be used by Meta for product improvement
+ *
+ * `--reasoning-effort` accepts none|minimal|low|medium|high|xhigh|ultra
+ * (muse's own default is `high`).
+ *
+ * Ordering matters: each reasoning effort is listed as a non-contributor entry
+ * followed by its contributor twin, so that getFastTierModel() — which picks the
+ * FIRST `fast` model — selects the non-data-sharing model for auxiliary work
+ * like JSON extraction. Never put a contributor entry ahead of its twin.
+ */
+const MUSE_MODELS = [
+  {
+    id: 'muse-spark-1.2-ultra',
+    cli_model: 'muse-spark-1.2',
+    extra_args: ['--reasoning-effort', 'ultra'],
+    name: 'Muse Spark 1.2 Ultra',
+    tier: 'thorough',
+    tagline: 'Maximum Depth',
+    description: 'Muse Spark at the highest reasoning effort for the hardest reviews: architecture, concurrency, and security-sensitive changes.',
+    badge: 'Max Reasoning',
+    badgeClass: 'badge-power'
+  },
+  {
+    id: 'muse-spark-1.2-contributor-ultra',
+    cli_model: 'muse-spark-1.2-contributor',
+    extra_args: ['--reasoning-effort', 'ultra'],
+    name: 'Muse Spark 1.2 Contributor Ultra',
+    tier: 'thorough',
+    tagline: 'Discounted Depth',
+    description: 'Same model and highest reasoning effort at roughly a tenth of the cost. Content you send on this tier may be used by Meta for product improvement—do not select it for proprietary code.',
+    badge: 'Shares Data',
+    badgeClass: 'badge-power'
+  },
+  {
+    id: 'muse-spark-1.2-xhigh',
+    cli_model: 'muse-spark-1.2',
+    extra_args: ['--reasoning-effort', 'xhigh'],
+    name: 'Muse Spark 1.2 XHigh',
+    tier: 'thorough',
+    tagline: 'Frontier Depth',
+    description: 'Muse Spark with extra-high reasoning effort for difficult architectural reviews and subtle behavioral regressions.',
+    badge: 'Extra High',
+    badgeClass: 'badge-power'
+  },
+  {
+    id: 'muse-spark-1.2-contributor-xhigh',
+    cli_model: 'muse-spark-1.2-contributor',
+    extra_args: ['--reasoning-effort', 'xhigh'],
+    name: 'Muse Spark 1.2 Contributor XHigh',
+    tier: 'thorough',
+    tagline: 'Discounted Frontier',
+    description: 'Same model and extra-high reasoning effort at roughly a tenth of the cost. Content you send on this tier may be used by Meta for product improvement—do not select it for proprietary code.',
+    badge: 'Shares Data',
+    badgeClass: 'badge-power'
+  },
+  {
+    id: 'muse-spark-1.2-high',
+    // Aliases keep results/councils saved under a bare model ID resolving here.
+    aliases: ['muse-spark-1.2', 'muse-spark'],
+    cli_model: 'muse-spark-1.2',
+    extra_args: ['--reasoning-effort', 'high'],
+    name: 'Muse Spark 1.2 High',
+    tier: 'balanced',
+    tagline: 'Best Balance',
+    description: 'Meta\'s coding model with high reasoning effort and roughly 1M tokens of context—strong everyday PR review across large diffs.',
+    badge: 'Recommended',
+    badgeClass: 'badge-recommended',
+    default: true
+  },
+  {
+    id: 'muse-spark-1.2-contributor-high',
+    aliases: ['muse-spark-1.2-contributor'],
+    cli_model: 'muse-spark-1.2-contributor',
+    extra_args: ['--reasoning-effort', 'high'],
+    name: 'Muse Spark 1.2 Contributor High',
+    tier: 'balanced',
+    tagline: 'Discounted Tier',
+    description: 'Same model and high reasoning effort at roughly a tenth of the cost. Content you send on this tier may be used by Meta for product improvement—do not select it for proprietary code.',
+    badge: 'Shares Data',
+    badgeClass: 'badge-balanced'
+  },
+  {
+    id: 'muse-spark-1.2-low',
+    cli_model: 'muse-spark-1.2',
+    extra_args: ['--reasoning-effort', 'low'],
+    name: 'Muse Spark 1.2 Low',
+    tier: 'fast',
+    tagline: 'Quick Pass',
+    description: 'Muse Spark with low reasoning effort for fast surface scans of small, straightforward changes.',
+    badge: 'Fastest',
+    badgeClass: 'badge-speed'
+  },
+  {
+    id: 'muse-spark-1.2-contributor-low',
+    cli_model: 'muse-spark-1.2-contributor',
+    extra_args: ['--reasoning-effort', 'low'],
+    name: 'Muse Spark 1.2 Contributor Low',
+    tier: 'fast',
+    tagline: 'Lowest Cost',
+    description: 'The cheapest option: low reasoning effort on the discounted tier. Content you send on this tier may be used by Meta for product improvement—do not select it for proprietary code.',
+    badge: 'Shares Data',
+    badgeClass: 'badge-speed'
+  }
+];
+
+class MuseProvider extends AIProvider {
+  /**
+   * @param {string} model - Model identifier
+   * @param {Object} configOverrides - Config overrides from providers config
+   * @param {string} configOverrides.command - Custom CLI command
+   * @param {string[]} configOverrides.extra_args - Additional CLI arguments (appended)
+   * @param {Object} configOverrides.env - Additional environment variables
+   * @param {Object[]} configOverrides.models - Custom model definitions
+   * @param {boolean} configOverrides.yolo - Bypass approval and sandbox
+   */
+  constructor(model = DEFAULT_MUSE_MODEL, configOverrides = {}) {
+    super(model);
+
+    // Command precedence: ENV > config > default. A blank or whitespace-only
+    // override is treated as absent rather than passed on as an unspawnable
+    // command name.
+    const envCmd = process.env.PAIR_REVIEW_MUSE_CMD;
+    const configCmd = configOverrides.command;
+    const rawCmd = [envCmd, configCmd]
+      .map(c => (typeof c === 'string' ? c.trim() : ''))
+      .find(c => c) || 'muse';
+
+    // Normalize once, here, so the analysis path (baseArgs) and the extraction
+    // path (buildArgsForModel) can never disagree about whether `exec` is
+    // already present, and so `useShell` below is derived from the real command.
+    const museCmd = stripExecSubcommand(rawCmd);
+
+    // Store for use in execute, getExtractionConfig and testAvailability
+    this.museCmd = museCmd;
+    this.configOverrides = configOverrides;
+
+    // For multi-word commands, use shell mode (same pattern as Claude/Codex)
+    this.useShell = museCmd.includes(' ');
+
+    // SECURITY: Muse approval and sandbox flags
+    //
+    // `muse exec` is already headless, and with DEFAULT flags its tools are
+    // auto-approved by policy (side_effect_intent records report
+    // policy_decision: "allow:policy") — nothing blocks waiting for input.
+    // So the non-yolo path passes NO approval or sandbox flags at all.
+    //
+    // Do NOT add `--approval-mode never`: it DENIES every tool rather than
+    // auto-approving, so no tool runs and the process never emits a terminal
+    // record. `--yolo` is muse's documented "disable approval and sandbox and
+    // trust this workspace" switch and is the equivalent of Claude's
+    // --dangerously-skip-permissions.
+    //
+    // `--disable-write` blocks the write_file tool. It is defense in depth, not
+    // a guarantee: it only covers NON-shell writes, and review analysis needs
+    // shell so the model can run grep/find and the bundled git-diff-lines
+    // helper. A determined model can still write via bash. Blocking that would
+    // require `--disable-shell`, which also disables git-diff-lines and Level 3
+    // codebase exploration — the same tradeoff Codex documents for its
+    // workspace-write sandbox. Verified empirically: with `--disable-write`
+    // alone the model falls back to bash and the write succeeds; adding
+    // `--disable-shell` blocks it. See the writeBlockKnownLimitation note in
+    // scripts/verify-ai-permissions.js.
+    const safetyArgs = configOverrides.yolo ? ['--yolo'] : ['--disable-write'];
+
+    // Resolve cli_model + extra_args + env from built-in model, provider config,
+    // and per-model config. This is what lets reasoning variants like
+    // muse-spark-1.2-ultra pass `--model muse-spark-1.2` plus
+    // `--reasoning-effort ultra`.
+    const { cliModel, extraArgs, env } = this._resolveModelConfig(model);
+
+    // A cli_model of explicitly `null` omits --model entirely, letting muse pick
+    // its own default (Codex convention).
+    const modelArgs = cliModel === null ? [] : ['--model', cliModel];
+
+    this.extraEnv = env;
+
+    // Everything up to (but excluding) the `--prompt-file <path>` pair, which is
+    // appended in execute() once the temp file exists. Keeping the pair strictly
+    // last means no extra_args can displace the prompt.
+    //
+    // `extraArgs` is already the three-way merge (built-in model → provider
+    // config → per-model config) performed by _resolveModelConfig, so provider
+    // extra_args must NOT be spliced in again here.
+    this.baseArgs = ['exec', '--json', ...modelArgs, ...safetyArgs, ...extraArgs];
+  }
+
+  /**
+   * Resolve model configuration by looking up built-in and config override definitions.
+   * Produces the CLI model ID (for `--model`), merged extra_args, and merged env.
+   *
+   * Precedence for cli_model: config model > built-in model > modelId.
+   *
+   * @param {string} modelId
+   * @returns {{ builtIn: Object|undefined, configModel: Object|undefined, cliModel: string|null, extraArgs: string[], env: Object }}
+   * @private
+   */
+  _resolveModelConfig(modelId) {
+    const configOverrides = this.configOverrides || {};
+
+    const builtIn = MUSE_MODELS.find(m => m.id === modelId || (m.aliases && m.aliases.includes(modelId)));
+    const configModel = configOverrides.models?.find(m => m.id === modelId);
+
+    const cliModel = configModel?.cli_model !== undefined
+      ? configModel.cli_model
+      : (builtIn?.cli_model !== undefined ? builtIn.cli_model : modelId);
+
+    // Three-way merge for extra_args: built-in model → provider config → per-model config
+    const builtInArgs = builtIn?.extra_args || [];
+    const providerArgs = configOverrides.extra_args || [];
+    const configModelArgs = configModel?.extra_args || [];
+    const extraArgs = [...builtInArgs, ...providerArgs, ...configModelArgs];
+
+    // Three-way merge for env: built-in model → provider config → per-model config
+    const env = {
+      ...(builtIn?.env || {}),
+      ...(configOverrides.env || {}),
+      ...(configModel?.env || {})
+    };
+
+    return { builtIn, configModel, cliModel, extraArgs, env };
+  }
+
+  /**
+   * Build the command/args the ANALYSIS path spawns, wrapping for shell mode.
+   *
+   * `execute()` is the only other caller and routes through here, so an external
+   * inspector — notably scripts/verify-ai-permissions.js, which must exercise the
+   * real analysis invocation to make its findings meaningful — cannot drift from
+   * what actually runs. Do NOT reconstruct the invocation from
+   * getExtractionConfig(): that describes the JSON-extraction fallback, which is
+   * free to adopt a different tool/safety posture.
+   *
+   * @param {string[]} [trailingArgs=[]] - Args appended after baseArgs. execute()
+   *   passes `['--prompt-file', <tmp path>]`; callers without a per-run temp file
+   *   can pass the prompt as a single positional instead, since
+   *   `muse exec [OPTIONS] [PROMPT]` accepts one and never reads stdin.
+   * @returns {{command: string, args: string[], useShell: boolean}}
+   */
+  getAnalysisSpawnConfig(trailingArgs = []) {
+    const args = [...this.baseArgs, ...trailingArgs];
+
+    if (this.useShell) {
+      return {
+        command: `${this.museCmd} ${quoteShellArgs(args).join(' ')}`,
+        args: [],
+        useShell: true
+      };
+    }
+    return { command: this.museCmd, args, useShell: false };
+  }
+
+  /**
+   * Execute Muse CLI with a prompt
+   * @param {string} prompt - The prompt to send to Muse
+   * @param {Object} options - Optional configuration
+   * @returns {Promise<Object>} Parsed response or error
+   */
+  async execute(prompt, options = {}) {
+    return new Promise((resolve, reject) => {
+      const { cwd = process.cwd(), timeout = 300000, level = 'unknown', analysisId, registerProcess, onStreamEvent, logPrefix, abortSignal } = options;
+
+      const levelPrefix = logPrefix || `[Level ${level}]`;
+
+      // Already cancelled before we started: reject before creating a temp dir,
+      // writing a prompt that can run to megabytes, and spawning a process only
+      // to SIGTERM it. This runs ahead of the mkdtempSync below, so the early
+      // return cannot leak a temp dir — there is nothing yet to clean up.
+      // Semantics are unchanged; wireAbortToChild already handled a pre-aborted
+      // signal correctly, just after doing all that work.
+      if (abortSignal?.aborted) {
+        logger.info(`${levelPrefix} Skipping Muse CLI run: already cancelled`);
+        reject(makeAbortError(`${levelPrefix} Cancelled by user`));
+        return;
+      }
+
+      logger.info(`${levelPrefix} Executing Muse CLI...`);
+      logger.info(`${levelPrefix} Writing prompt: ${prompt.length} bytes`);
+
+      // `muse exec` takes the prompt either as a positional argument or via
+      // --prompt-file; it does NOT read stdin (it exits 2 with "missing prompt").
+      // Review prompts embed whole diffs, so a file is the only safe delivery —
+      // a positional arg would risk E2BIG. mkdtempSync (never a fixed /tmp path)
+      // keeps concurrent analyses from colliding.
+      let tmpDir;
+      let tmpFile;
+
+      // Idempotent: called from settle() (covers close/timeout/error/abort), and
+      // eagerly on close so the file is gone as soon as muse exits, even when the
+      // async LLM-extraction fallback delays settling. Declared BEFORE the write
+      // so the failure path below can use it: mkdtempSync creates the directory
+      // first, so a failing writeFileSync (ENOSPC/EACCES/EIO/EROFS/quota) would
+      // otherwise leak an empty directory with no child process to clean it up.
+      let tmpCleaned = false;
+      const cleanupTmpFile = () => {
+        if (tmpCleaned || !tmpDir) return;
+        tmpCleaned = true;
+        try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* ignore */ }
+      };
+
+      try {
+        tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pair-review-muse-'));
+        tmpFile = path.join(tmpDir, 'prompt.txt');
+        fs.writeFileSync(tmpFile, prompt);
+      } catch (err) {
+        cleanupTmpFile();
+        reject(new Error(`${levelPrefix} Failed to write Muse prompt file: ${err.message}`));
+        return;
+      }
+
+      const { command: fullCommand, args: fullArgs } = this.getAnalysisSpawnConfig(['--prompt-file', tmpFile]);
+
+      const muse = spawn(fullCommand, fullArgs, {
+        cwd,
+        env: {
+          ...process.env,
+          ...this.extraEnv,
+          PATH: `${BIN_DIR}:${process.env.PATH}`
+        },
+        shell: this.useShell,
+        // Detach in shell mode so wireAbortToChild can group-kill via
+        // process.kill(-pid). See claude-provider for the rationale.
+        detached: this.useShell
+      });
+
+      // Prompt is delivered via --prompt-file; close stdin so any wrapper script
+      // waiting on it doesn't keep the process alive.
+      muse.stdin.on('error', (err) => {
+        logger.debug(`${levelPrefix} stdin error (ignorable, prompt goes via file): ${err.message}`);
+      });
+      muse.stdin.end();
+
+      const pid = muse.pid;
+      logger.debug(`${levelPrefix} Muse CLI command: ${fullCommand} ${fullArgs.join(' ')}`);
+      logger.info(`${levelPrefix} Spawned Muse CLI process: PID ${pid}`);
+
+      // Register process for cancellation tracking if analysisId provided
+      if (analysisId && registerProcess) {
+        registerProcess(analysisId, muse);
+        logger.info(`${levelPrefix} Registered process ${pid} for analysis ${analysisId}`);
+      }
+
+      // Wire AbortSignal -> SIGTERM for tour/summary cancellation.
+      // shell flag triggers group-kill so the CLI grandchild dies with the shell.
+      const abortWiring = wireAbortToChild(muse, abortSignal, { logPrefix: levelPrefix, shell: this.useShell });
+
+      let stdout = '';
+      let stderr = '';
+      let timeoutId = null;
+      let settled = false;  // Guard against multiple resolve/reject calls
+      let lineBuffer = '';  // Buffer for incomplete JSONL lines
+      let lineCount = 0;    // Count of JSONL events for progress tracking
+
+      // Centralize detach and temp-file cleanup in `settle` so they happen
+      // regardless of which exit path (close/timeout/error/abort) wins. Avoids
+      // leaking a listener on the per-job AbortSignal that tour/summary
+      // generators reuse across many provider.execute() calls.
+      const settle = (fn, value) => {
+        if (settled) return;
+        settled = true;
+        if (timeoutId) clearTimeout(timeoutId);
+        abortWiring.detach();
+        cleanupTmpFile();
+        fn(value);
+      };
+
+      // Set up side-channel stream parser for live progress events
+      const streamParser = onStreamEvent
+        ? new StreamParser(parseMuseLine, onStreamEvent, { cwd })
+        : null;
+
+      // Set timeout
+      if (timeout) {
+        timeoutId = setTimeout(() => {
+          logger.error(`${levelPrefix} Process ${pid} timed out after ${timeout}ms`);
+          // Shell-aware: in shell mode `muse` is the shell wrapper (spawned
+          // detached above), so a bare kill would leave the real CLI running
+          // after this promise has already rejected.
+          killChildSafely(muse, { shell: this.useShell, logPrefix: levelPrefix });
+          settle(reject, new Error(`${levelPrefix} Muse CLI timed out after ${timeout}ms`));
+        }, timeout);
+      }
+
+      // Collect stdout with streaming JSONL parsing for debug visibility
+      muse.stdout.on('data', (data) => {
+        const chunk = data.toString();
+        stdout += chunk;
+
+        // Feed side-channel stream parser for live progress events
+        if (streamParser) {
+          streamParser.feed(chunk);
+        }
+
+        // Parse JSONL lines as they arrive for streaming debug output
+        lineBuffer += chunk;
+        const lines = lineBuffer.split('\n');
+        // Keep the last incomplete line in buffer
+        lineBuffer = lines.pop() || '';
+
+        for (const line of lines) {
+          if (line.trim()) {
+            lineCount++;
+            this.logStreamLine(line, lineCount, levelPrefix);
+          }
+        }
+      });
+
+      // Collect stderr
+      muse.stderr.on('data', (data) => {
+        stderr += data.toString();
+      });
+
+      // Handle completion
+      muse.on('close', (code) => {
+        cleanupTmpFile();
+        if (settled) return;  // Already settled by timeout or error
+
+        // Flush any remaining stream parser buffer
+        if (streamParser) {
+          streamParser.flush();
+        }
+
+        // BackgroundQueue-driven cancellation — mirror of claude-provider.
+        if (abortWiring.cancelled()) {
+          logger.info(`${levelPrefix} Muse CLI terminated by user cancel (exit code ${code})`);
+          settle(reject, makeAbortError(`${levelPrefix} Cancelled by user`));
+          return;
+        }
+
+        // Check for cancellation signals (SIGTERM=143, SIGKILL=137)
+        const isCancellationCode = code === 143 || code === 137;
+        if (isCancellationCode && analysisId && isAnalysisCancelled(analysisId)) {
+          logger.info(`${levelPrefix} Muse CLI terminated due to analysis cancellation (exit code ${code})`);
+          settle(reject, new CancellationError(`${levelPrefix} Analysis cancelled by user`));
+          return;
+        }
+
+        // Muse writes all human-facing noise (workspace root notice, skills
+        // warnings, untrusted-workspace notices) to stderr even on success, so
+        // stderr content alone is NOT an error signal — only the exit code is.
+        if (stderr.trim()) {
+          if (code !== 0) {
+            logger.error(`${levelPrefix} Muse CLI stderr (exit code ${code}): ${stderr}`);
+          } else {
+            logger.debug(`${levelPrefix} Muse CLI stderr (success): ${stderr}`);
+          }
+        }
+
+        // The terminal record carries the authoritative outcome. On failure its
+        // `reason` is far more useful than stderr, which only says
+        // "run ended with Failed".
+        const terminal = this.extractTerminalRecord(stdout);
+
+        if (code !== 0) {
+          logger.error(`${levelPrefix} Muse CLI exited with code ${code}`);
+          settle(reject, this.createExitError(code, stderr, levelPrefix, terminal?.reason));
+          return;
+        }
+
+        // Log completion with event count (only for successful completion)
+        logger.info(`${levelPrefix} Muse CLI completed: ${lineCount} JSONL events received`);
+
+        // Process any remaining buffered line
+        if (lineBuffer.trim()) {
+          lineCount++;
+          this.logStreamLine(lineBuffer, lineCount, levelPrefix);
+        }
+
+        // Parse the Muse JSONL response
+        const parsed = this.parseMuseResponse(stdout, level, levelPrefix);
+        if (parsed.success) {
+          logger.success(`${levelPrefix} Successfully parsed JSON response`);
+          // Dump the parsed data for debugging
+          const dataPreview = JSON.stringify(parsed.data, null, 2);
+          logger.debug(`${levelPrefix} [parsed_data] ${dataPreview.substring(0, 3000)}${dataPreview.length > 3000 ? '...' : ''}`);
+          // Log suggestion count if present
+          if (parsed.data?.suggestions) {
+            const count = Array.isArray(parsed.data.suggestions) ? parsed.data.suggestions.length : 0;
+            logger.info(`${levelPrefix} [response] ${count} suggestions in parsed response`);
+          }
+          settle(resolve, parsed.data);
+        } else if (!parsed.textContent) {
+          // No model-authored text to extract from — only muse's own transport
+          // envelopes. Feeding those to any extractor risks returning a
+          // lifecycle/terminal frame as though it were the review payload, so
+          // an empty run is reported as the failure it is.
+          logger.warn(`${levelPrefix} Regex extraction failed: ${parsed.error}`);
+          logger.warn(`${levelPrefix} No assistant text in Muse output; skipping LLM extraction fallback`);
+          settle(resolve, { raw: stdout, parsed: false });
+        } else {
+          // Regex extraction failed, try LLM-based extraction as fallback
+          logger.warn(`${levelPrefix} Regex extraction failed: ${parsed.error}`);
+          const llmFallbackInput = parsed.textContent;
+          logger.info(`${levelPrefix} LLM fallback input length: ${llmFallbackInput.length} characters`);
+          logger.info(`${levelPrefix} Attempting LLM-based JSON extraction fallback...`);
+
+          // A cancel that arrives while the extraction child is running reaches
+          // the abort wiring, but by then the muse child has already exited, so
+          // the wiring only kills something already dead. Nothing else here
+          // consults it — so without this check a cancelled analysis still
+          // settles with a normal result.
+          //
+          // Reads BOTH the wiring flag and the signal itself: `settle()` (which
+          // detaches the listener) has not run on any path that reaches here, so
+          // the flag is live — but the signal is the source of truth and stays
+          // correct no matter how the wiring evolves.
+          const cancelledDuringExtraction = () =>
+            abortWiring.cancelled() || abortSignal?.aborted === true;
+
+          // Use async IIFE to handle the async LLM extraction
+          (async () => {
+            try {
+              // `abortSignal` also lets the extraction spawn itself be killed
+              // rather than merely abandoned; providers that ignore the option
+              // simply run to completion and are caught by the check below.
+              const llmExtracted = await this.extractJSONWithLLM(llmFallbackInput, { level, analysisId, registerProcess, logPrefix: levelPrefix, abortSignal });
+              if (cancelledDuringExtraction()) {
+                logger.info(`${levelPrefix} Cancelled by user during LLM extraction fallback`);
+                settle(reject, makeAbortError(`${levelPrefix} Cancelled by user`));
+                return;
+              }
+              if (llmExtracted.success) {
+                logger.success(`${levelPrefix} LLM extraction fallback succeeded`);
+                settle(resolve, llmExtracted.data);
+              } else {
+                logger.warn(`${levelPrefix} LLM extraction fallback also failed: ${llmExtracted.error}`);
+                logger.info(`${levelPrefix} Raw response preview: ${llmFallbackInput.substring(0, 500)}...`);
+                settle(resolve, { raw: llmFallbackInput, parsed: false });
+              }
+            } catch (llmError) {
+              // An abort that kills the extraction spawn surfaces here as a
+              // thrown error; it is a cancellation, not a parse failure.
+              if (cancelledDuringExtraction()) {
+                logger.info(`${levelPrefix} Cancelled by user during LLM extraction fallback`);
+                settle(reject, makeAbortError(`${levelPrefix} Cancelled by user`));
+                return;
+              }
+              logger.warn(`${levelPrefix} LLM extraction fallback error: ${llmError.message}`);
+              settle(resolve, { raw: llmFallbackInput, parsed: false });
+            }
+          })();
+        }
+      });
+
+      // Handle errors
+      muse.on('error', (error) => {
+        cleanupTmpFile();
+        if (error.code === 'ENOENT') {
+          logger.error(`${levelPrefix} Muse CLI not found. Please ensure Muse Code is installed.`);
+          settle(reject, new Error(`${levelPrefix} Muse CLI not found. ${MuseProvider.getInstallInstructions()}`));
+        } else {
+          logger.error(`${levelPrefix} Muse process error: ${error}`);
+          settle(reject, error);
+        }
+      });
+    });
+  }
+
+  /**
+   * Find the run's terminal record in Muse JSONL output.
+   *
+   * Muse names the terminal record after its outcome — `run.terminal.completed`,
+   * `run.terminal.failed`, `run.terminal.cancelled` — but all of them share
+   * `payload.kind === 'run_terminal'` and carry `terminal`, `text` and `reason`.
+   * Matching on the `kind` discriminator therefore catches failures too, which
+   * matching only `run.terminal.completed` would miss.
+   *
+   * `attemptId` identifies which attempt this outcome belongs to, so the delta
+   * fallback in parseMuseResponse can be scoped to the SAME attempt instead of
+   * ranging over the whole transcript. See attemptIdOf.
+   *
+   * @param {string} stdout - Raw stdout from Muse CLI (JSONL format)
+   * @returns {{terminal: string, text: string, reason: string|null, attemptId: string|null}|null}
+   */
+  extractTerminalRecord(stdout) {
+    if (!stdout || !stdout.trim()) return null;
+
+    let found = null;
+    for (const line of stdout.split('\n')) {
+      if (!line.trim()) continue;
+      try {
+        const record = JSON.parse(line);
+        const payload = record.payload;
+        if (payload?.kind === 'run_terminal') {
+          // Keep the last one: a resumed/retried run can emit more than one.
+          found = {
+            terminal: payload.terminal || 'unknown',
+            text: payload.text || '',
+            reason: payload.reason || null,
+            attemptId: attemptIdOf(record)
+          };
+        }
+      } catch {
+        // Skip malformed lines — the caller degrades to delta accumulation.
+      }
+    }
+    return found;
+  }
+
+  /**
+   * Parse Muse CLI JSONL response.
+   *
+   * Every record is an envelope keyed by `payload_type`. The authoritative
+   * answer is the terminal record's `payload.text`; if that is missing we fall
+   * back to concatenating `run.output.delta` chunks in `sequence` order — but
+   * only those belonging to the SAME attempt the terminal record reports, so a
+   * multi-attempt transcript can never answer with a superseded attempt's text.
+   *
+   * Only model-authored text is ever handed to an extractor. Muse's envelopes
+   * are themselves valid JSON objects, so running the generic extractor over the
+   * raw JSONL could return a lifecycle/terminal frame as though it were the
+   * review payload — turning an empty or failed run into a false success. Raw
+   * stdout is therefore only parsed when it contains no envelopes at all (a
+   * wrapper that printed bare JSON, or output produced without `--json`).
+   *
+   * No outer try/catch: every JSON.parse below has its own, extractJSON returns
+   * a result object rather than throwing, and the remaining string operations
+   * are guarded by the type check at the top.
+   *
+   * @param {string} stdout - Raw stdout from Muse CLI (JSONL format)
+   * @param {string|number} level - Analysis level for logging
+   * @param {string} logPrefix - Logging prefix
+   * @returns {{success: boolean, data?: Object, error?: string, textContent?: string}}
+   *   `textContent` is set only when there is material safe to forward to the
+   *   LLM extraction fallback; its absence means "nothing but transport frames".
+   */
+  parseMuseResponse(stdout, level, logPrefix) {
+    const levelPrefix = logPrefix || `[Level ${level}]`;
+
+    if (typeof stdout !== 'string' || !stdout.trim()) {
+      return { success: false, error: 'Muse produced no output' };
+    }
+
+    const terminal = this.extractTerminalRecord(stdout);
+    let responseText = terminal?.text || '';
+    let source = 'terminal record';
+    // Whether stdout looks like muse's JSONL transport at all.
+    let sawEnvelope = terminal !== null;
+
+    if (!responseText) {
+      // Fall back to streamed deltas, ordered by the envelope's `sequence`
+      // so out-of-order chunks can't scramble the text.
+      const deltas = [];
+      for (const line of stdout.split('\n')) {
+        if (!line.trim()) continue;
+        try {
+          const record = JSON.parse(line);
+          if (record && (typeof record.payload_type === 'string' || typeof record.payload === 'object')) {
+            sawEnvelope = true;
+          }
+          if (record.payload_type === 'run.output.delta' && record.payload?.text) {
+            deltas.push({
+              sequence: record.sequence ?? 0,
+              attemptId: attemptIdOf(record),
+              text: record.payload.text
+            });
+          }
+        } catch {
+          logger.debug(`${levelPrefix} Skipping malformed JSONL line: ${line.substring(0, 100)}`);
+        }
+      }
+      deltas.sort((a, b) => a.sequence - b.sequence);
+
+      // Scope the deltas to ONE attempt, the same way extractTerminalRecord
+      // scopes the outcome to the last terminal record. Reading the two sources
+      // with different scoping rules is what let a multi-attempt transcript
+      // report a review the finishing attempt never produced: when the final
+      // attempt ended with no text, an unscoped concatenation resurrected an
+      // EARLIER attempt's deltas and presented them as that run's answer.
+      //
+      // The scope is the terminal record's attempt when there is one, otherwise
+      // the attempt of the last delta — which mirrors "keep the last" for a
+      // transcript that was cut off before any terminal record arrived.
+      // Transcripts naming no attempt at all (older shapes, hand-written
+      // fixtures) collapse to a single null scope, i.e. the previous behaviour.
+      const scopeId = terminal?.attemptId ?? (deltas.length ? deltas[deltas.length - 1].attemptId : null);
+      const scoped = deltas.filter(d => d.attemptId === scopeId);
+
+      if (scoped.length !== deltas.length) {
+        logger.info(
+          `${levelPrefix} Ignoring ${deltas.length - scoped.length} output delta(s) from earlier Muse attempts ` +
+          `(keeping attempt ${scopeId})`
+        );
+      }
+
+      // A terminal record whose attempt contributed no deltas leaves this
+      // empty on purpose: the run really did produce no answer, and the caller
+      // reports that instead of mining another attempt's text.
+      responseText = scoped.map(d => d.text).join('');
+      source = `${scoped.length} output deltas`;
+    }
+
+    if (responseText) {
+      logger.debug(`${levelPrefix} Extracted ${responseText.length} chars of assistant text from JSONL (${source})`);
+      const extracted = extractJSON(responseText, level, levelPrefix);
+      if (extracted.success) {
+        return extracted;
+      }
+
+      // Return textContent so the caller feeds the assistant text — never the
+      // raw JSONL — to the LLM extraction fallback.
+      logger.warn(`${levelPrefix} Assistant text is not JSON, treating as raw text`);
+      return { success: false, error: 'Assistant text is not valid JSON', textContent: responseText };
+    }
+
+    if (sawEnvelope) {
+      // Envelopes but no assistant text: the run produced no answer. Report that
+      // honestly rather than letting an extractor mine the transport frames.
+      logger.warn(`${levelPrefix} Muse emitted no assistant text (terminal: ${terminal?.terminal || 'none'})`);
+      return {
+        success: false,
+        error: `Muse produced no assistant text (terminal record: ${terminal?.terminal || 'none'}${terminal?.reason ? `, reason: ${terminal.reason}` : ''})`
+      };
+    }
+
+    // Not muse JSONL at all — safe to treat the whole output as model text.
+    const extracted = extractJSON(stdout, level, levelPrefix);
+    if (extracted.success) {
+      return extracted;
+    }
+    return { success: false, error: extracted.error || 'Output is not valid JSON', textContent: stdout };
+  }
+
+  /**
+   * Log a streaming JSONL line for debugging visibility.
+   *
+   * Muse records are envelopes discriminated by `payload_type`. Uses
+   * logger.streamDebug() which only logs when --debug-stream is enabled, except
+   * for the terminal record which is summarized at info level.
+   *
+   * Muse emits NO token usage in any record, so there is no token line to log.
+   *
+   * @param {string} line - A single JSONL line
+   * @param {number} lineNum - Line number for reference
+   * @param {string} levelPrefix - Logging prefix
+   */
+  logStreamLine(line, lineNum, levelPrefix) {
+    const streamEnabled = logger.isStreamDebugEnabled();
+
+    try {
+      const record = JSON.parse(line);
+      const payloadType = record.payload_type;
+      const payload = record.payload || {};
+
+      if (payload.kind === 'run_terminal') {
+        // Always summarize the terminal record at info level. Muse reports no
+        // token usage anywhere, so there are no counts to include.
+        const reasonPart = payload.reason ? ` reason=${payload.reason}` : '';
+        logger.info(`${levelPrefix} [run.terminal] ${payload.terminal || 'unknown'} (tokens not reported by Muse)${reasonPart}`);
+        return;
+      }
+
+      if (!streamEnabled) return;
+
+      if (payloadType === 'run.model.configured') {
+        const label = payload.display_label || payload.model_id || 'unknown';
+        logger.streamDebug(`${levelPrefix} [#${lineNum}] model: ${label}`);
+
+      } else if (payloadType === 'run.output.delta') {
+        const text = payload.text || '';
+        const preview = text.replace(/\n/g, '\\n').substring(0, 60);
+        logger.streamDebug(`${levelPrefix} [#${lineNum}] output.delta: ${preview}${text.length > 60 ? '...' : ''}`);
+
+      } else if (payloadType === 'task.lifecycle.side_effect_intent') {
+        const operation = payload.event?.operation || 'unknown';
+        const decision = payload.event?.policy_decision;
+        const decisionPart = decision ? ` [${decision}]` : '';
+        logger.streamDebug(`${levelPrefix} [#${lineNum}] side_effect_intent: ${operation}${decisionPart}`);
+
+      } else if (payloadType === 'tool.result') {
+        const callId = payload.call_id || '';
+        const toolName = payload.correlation_facts?.tool_name || '';
+        const outcome = payload.correlation_facts?.outcome || '';
+        const text = payload.text || '';
+        const preview = text.replace(/\n/g, '\\n').substring(0, 60);
+        const idPart = callId ? ` [${callId.substring(0, 12)}]` : '';
+        const namePart = toolName ? ` ${toolName}` : '';
+        const outcomePart = outcome ? ` ${outcome}` : '';
+        logger.streamDebug(`${levelPrefix} [#${lineNum}] tool.result${namePart}${idPart}${outcomePart} ${preview}${text.length > 60 ? '...' : ''}`);
+
+      } else if (payloadType === 'task.lifecycle.output') {
+        const chunk = payload.event?.chunk || '';
+        const preview = chunk.replace(/\n/g, '\\n').substring(0, 60);
+        logger.streamDebug(`${levelPrefix} [#${lineNum}] task.output: ${preview}${chunk.length > 60 ? '...' : ''}`);
+
+      } else if (payloadType === 'task.lifecycle.rejected') {
+        // `skip_if_running` is a benign internal reminder-task event — it is NOT
+        // an error and must never be surfaced as one. Every OTHER reason is a
+        // real tool/policy rejection, so it is logged visibly instead of being
+        // buried at stream-debug level under a "benign" label.
+        const reason = payload.event?.reason || 'unknown';
+        if (reason === 'skip_if_running') {
+          logger.streamDebug(`${levelPrefix} [#${lineNum}] task.rejected (benign): ${reason}`);
+        } else {
+          logger.warn(`${levelPrefix} [#${lineNum}] task.rejected: ${reason}`);
+        }
+
+      } else if (payloadType === 'task.lifecycle.failed') {
+        // A single background task (e.g. a reminder plugin) can fail while the
+        // run as a whole succeeds; the exit code and terminal record decide.
+        const reason = payload.event?.reason || 'unknown';
+        logger.streamDebug(`${levelPrefix} [#${lineNum}] task.failed: ${reason}`);
+
+      } else if (payloadType) {
+        logger.streamDebug(`${levelPrefix} [#${lineNum}] ${payloadType}`);
+      }
+      // Silently ignore records with no payload_type
+
+    } catch (parseError) {
+      if (streamEnabled) {
+        logger.streamDebug(`${levelPrefix} [#${lineNum}] (malformed: ${line.substring(0, 50)}${line.length > 50 ? '...' : ''})`);
+      }
+    }
+  }
+
+  /**
+   * Build args for Muse CLI extraction, applying provider and model extra_args.
+   *
+   * Note the deliberate absence of a trailing prompt marker: the shared
+   * extraction helper appends `--prompt-file <path>` itself, from the
+   * `promptFileArg` field getExtractionConfig sets.
+   *
+   * @param {string} model - The model identifier to use
+   * @param {Object} [resolved] - Pre-resolved output of `_resolveModelConfig(model)`.
+   *   Lets getExtractionConfig resolve once and reuse it for both args and env.
+   * @returns {string[]} Complete args array for the CLI
+   */
+  buildArgsForModel(model, resolved = null) {
+    const { cliModel, extraArgs } = resolved || this._resolveModelConfig(model);
+    const modelArgs = cliModel === null ? [] : ['--model', cliModel];
+
+    // Extraction only reformats already-captured text into JSON — it needs no
+    // filesystem or shell access at all. So unlike the analysis path (which
+    // keeps shell for grep/find and git-diff-lines), extraction is fully locked
+    // down. This mirrors Codex's `--sandbox read-only` extraction posture.
+    // Verified empirically: muse still returns bare JSON with both flags set.
+    const safetyArgs = this.configOverrides?.yolo
+      ? ['--yolo']
+      : ['--disable-write', '--disable-shell'];
+
+    return ['exec', '--json', ...modelArgs, ...safetyArgs, ...extraArgs];
+  }
+
+  /**
+   * Get CLI configuration for LLM extraction.
+   *
+   * Prompt delivery: `--prompt-file <path>`, the same mechanism the analysis
+   * path uses, and NEVER through a shell. Extraction input is an entire
+   * malformed model response, so keeping it off argv is what stops a large one
+   * from failing with E2BIG at the OS single-argument limit.
+   *
+   * The other two delivery modes the shared helper offers do not fit muse:
+   * - promptViaStdin fails outright: `muse exec` with no prompt argument exits 2
+   *   with "missing prompt"; it never reads stdin.
+   * - promptViaFile appends `@<path>` as a positional arg — Pi's @file syntax.
+   *   Muse would read the literal string "@/tmp/..." as the prompt.
+   *
+   * SECURITY — why `useShell` stays false here even now that the prompt is off
+   * argv: this spawn is not `detached`, so under `shell: true` a cancel or
+   * timeout would kill only the `/bin/sh` wrapper and orphan the real CLI (see
+   * the kill comment in extractJSONWithLLM). A multi-word command needs no
+   * shell anyway: `docker exec c muse` spawns `docker` with the rest as leading
+   * args. Anything needing genuine shell expansion must be a wrapper script —
+   * see splitCommandWords.
+   *
+   * @param {string} model - The model to use for extraction
+   * @returns {Object} Configuration for spawning extraction process
+   */
+  getExtractionConfig(model) {
+    // One resolve, reused for both the args and the merged env.
+    const resolved = this._resolveModelConfig(model);
+    const args = this.buildArgsForModel(model, resolved);
+
+    const [command, ...commandArgs] = splitCommandWords(this.museCmd);
+
+    return {
+      command,
+      args: [...commandArgs, ...args],
+      useShell: false,
+      promptViaStdin: false,
+      promptFileArg: '--prompt-file',
+      env: resolved.env
+    };
+  }
+
+  /**
+   * Build an actionable error for Muse CLI process failures.
+   *
+   * @param {number} code - Process exit code
+   * @param {string} stderr - Captured stderr
+   * @param {string} levelPrefix - Logging prefix
+   * @param {string} [terminalReason] - `reason` from the run's terminal record,
+   *   which carries the real failure detail when stderr only says
+   *   "run ended with Failed".
+   * @returns {Error}
+   */
+  createExitError(code, stderr, levelPrefix, terminalReason) {
+    const stderrText = stderr.trim();
+    // The terminal record's reason is the more specific diagnostic; check both
+    // it and stderr when classifying.
+    const diagnostic = [stderrText, terminalReason].filter(Boolean).join(' | ');
+
+    if (this.isAuthError(diagnostic)) {
+      return new Error(
+        `${levelPrefix} Muse CLI authentication failed. Run \`muse login\` (or set META_API_KEY) and try again. ` +
+        `Original error: ${diagnostic}`
+      );
+    }
+
+    if (this.isUnknownModelError(diagnostic)) {
+      return new Error(
+        `${levelPrefix} Muse CLI rejected the model "${this.model}" as unknown. ` +
+        `Check the model ID (and any cli_model override) against Muse's catalog. ` +
+        `Original error: ${diagnostic}`
+      );
+    }
+
+    const detail = diagnostic || '(no error output)';
+    return new Error(`${levelPrefix} Muse CLI exited with code ${code}: ${detail}`);
+  }
+
+  /**
+   * Detect authentication failures reported by the Muse CLI.
+   *
+   * Muse's own wording for an expired token is
+   * "still unauthorized after a token refresh; run `muse login` again".
+   *
+   * @param {string} text - Captured stderr and/or terminal reason
+   * @returns {boolean}
+   */
+  isAuthError(text) {
+    return /(?:still unauthorized after a token refresh|no login to refresh a key from|run `muse login`|starting logged out|401\s+Unauthorized|HTTP error:\s*401|\bUnauthorized\b)/i.test(text || '');
+  }
+
+  /**
+   * Detect an unknown/hidden model rejection. Muse fails fast with
+   * "model `X` is not in the catalog".
+   *
+   * @param {string} text - Captured stderr and/or terminal reason
+   * @returns {boolean}
+   */
+  isUnknownModelError(text) {
+    return /is (?:not in|hidden in) the catalog/i.test(text || '');
+  }
+
+  /**
+   * Test if Muse CLI is available.
+   * Uses a fast `--version` check instead of running a prompt.
+   * Uses the command configured in the instance (respects ENV > config > default).
+   * @param {number} [timeoutMs=10000] - Timeout in milliseconds for the probe
+   * @returns {Promise<boolean>}
+   */
+  async testAvailability(timeoutMs = 10000) {
+    return new Promise((resolve) => {
+      const useShell = this.useShell;
+      const command = useShell ? `${this.museCmd} --version` : this.museCmd;
+      const args = useShell ? [] : ['--version'];
+
+      // Log the actual command for debugging config/override issues
+      const fullCmd = useShell ? command : `${command} ${args.join(' ')}`;
+      logger.debug(`Muse availability check: ${fullCmd}`);
+
+      const muse = spawn(command, args, {
+        env: {
+          ...process.env,
+          // Same merged env execute() and getExtractionConfig() use. A setup
+          // whose muse only runs with `providers.muse.env` (or per-model env)
+          // set would otherwise be reported unavailable while the real
+          // invocation works fine.
+          ...this.extraEnv,
+          PATH: `${BIN_DIR}:${process.env.PATH}`
+        },
+        shell: useShell
+      });
+
+      let stdout = '';
+      let stderr = '';
+      let settled = false;
+
+      // Timeout guard: if the CLI hangs, resolve false
+      const availabilityTimeout = setTimeout(() => {
+        if (settled) return;
+        settled = true;
+        logger.warn(`Muse CLI availability check timed out after ${Math.round(timeoutMs / 1000)}s`);
+        // No `shell` flag even in shell mode: this probe does not spawn
+        // detached, so the child is not a process-group leader and a
+        // `process.kill(-pid)` would fail with ESRCH instead of terminating
+        // anything. The helper is still used for its pid guard, which stops a
+        // failed spawn (pid undefined -> 0) from signalling our own group.
+        killChildSafely(muse, { logPrefix: '[Muse availability]' });
+        resolve(false);
+      }, timeoutMs);
+
+      muse.stdout.on('data', (data) => {
+        stdout += data.toString();
+      });
+
+      muse.stderr.on('data', (data) => {
+        stderr += data.toString();
+      });
+
+      muse.on('close', (code) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(availabilityTimeout);
+        if (code === 0) {
+          logger.info(`Muse CLI available: ${stdout.trim()}`);
+          resolve(true);
+        } else {
+          const stderrMsg = stderr.trim() ? `: ${stderr.trim()}` : '';
+          logger.warn(`Muse CLI not available or returned unexpected output (exit code ${code})${stderrMsg}`);
+          resolve(false);
+        }
+      });
+
+      muse.on('error', (error) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(availabilityTimeout);
+        logger.warn(`Muse CLI not available: ${error.message}`);
+        resolve(false);
+      });
+    });
+  }
+
+  static getProviderName() {
+    return 'Muse';
+  }
+
+  static getProviderId() {
+    return 'muse';
+  }
+
+  static getModels() {
+    return MUSE_MODELS;
+  }
+
+  static getDefaultModel() {
+    return DEFAULT_MUSE_MODEL;
+  }
+
+  static getInstallInstructions() {
+    // `muse` on PATH is a self-updating launcher script that downloads the real
+    // binary alongside itself (macOS and Linux, arm64 and x86_64).
+    return 'Install Muse Code (macOS/Linux):\n' +
+           '  curl -fsSL https://api.meta.ai/muse-launcher.sh -o ~/.local/bin/muse && chmod +x ~/.local/bin/muse\n' +
+           'Then authenticate: muse login (or set META_API_KEY)\n' +
+           'Run `muse --help` for usage. Requires a directory on your PATH, e.g. ~/.local/bin.';
+  }
+}
+
+// Register this provider
+registerProvider('muse', MuseProvider);
+
+module.exports = MuseProvider;

--- a/src/ai/opencode-provider.js
+++ b/src/ai/opencode-provider.js
@@ -18,7 +18,7 @@ const logger = require('../utils/logger');
 const { extractJSON } = require('../utils/json-extractor');
 const { CancellationError, isAnalysisCancelled } = require('../routes/shared');
 const { StreamParser, parseOpenCodeLine } = require('./stream-parser');
-const { wireAbortToChild, makeAbortError } = require('./abort-signal-wiring');
+const { wireAbortToChild, makeAbortError, killChildSafely } = require('./abort-signal-wiring');
 
 // Directory containing bin scripts (git-diff-lines, etc.)
 const BIN_DIR = path.join(__dirname, '..', '..', 'bin');
@@ -169,7 +169,7 @@ class OpenCodeProvider extends AIProvider {
       if (timeout) {
         timeoutId = setTimeout(() => {
           logger.error(`${levelPrefix} Process ${pid} timed out after ${timeout}ms`);
-          opencode.kill('SIGTERM');
+          killChildSafely(opencode, { logPrefix: levelPrefix, shell: this.useShell });
           settle(reject, new Error(`${levelPrefix} OpenCode CLI timed out after ${timeout}ms`));
         }, timeout);
       }
@@ -274,10 +274,25 @@ class OpenCodeProvider extends AIProvider {
           logger.info(`${levelPrefix} LLM fallback input length: ${llmFallbackInput.length} characters (${parsed.textContent ? 'text content' : 'raw stdout'})`);
           logger.info(`${levelPrefix} Attempting LLM-based JSON extraction fallback...`);
 
+          // The opencode child has already exited, so a cancel arriving now only
+          // makes the abort wiring kill something already dead. Nothing else on
+          // this path consults it, so without the checks below a cancelled
+          // analysis would settle as a normal result. The signal is read
+          // alongside the wiring flag as the source of truth.
+          const cancelledDuringExtraction = () =>
+            abortWiring.cancelled() || abortSignal?.aborted === true;
+
           // Use async IIFE to handle the async LLM extraction
           (async () => {
             try {
-              const llmExtracted = await this.extractJSONWithLLM(llmFallbackInput, { level, analysisId, registerProcess, logPrefix: levelPrefix });
+              // `abortSignal` lets the extraction spawn be killed rather than
+              // merely abandoned until its own 60s timeout.
+              const llmExtracted = await this.extractJSONWithLLM(llmFallbackInput, { level, analysisId, registerProcess, logPrefix: levelPrefix, abortSignal });
+              if (cancelledDuringExtraction()) {
+                logger.info(`${levelPrefix} Cancelled by user during LLM extraction fallback`);
+                settle(reject, makeAbortError(`${levelPrefix} Cancelled by user`));
+                return;
+              }
               if (llmExtracted.success) {
                 logger.success(`${levelPrefix} LLM extraction fallback succeeded`);
                 settle(resolve, llmExtracted.data);
@@ -287,6 +302,13 @@ class OpenCodeProvider extends AIProvider {
                 settle(resolve, { raw: llmFallbackInput, parsed: false });
               }
             } catch (llmError) {
+              // An abort that kills the extraction spawn surfaces here as a
+              // thrown error; it is a cancellation, not a parse failure.
+              if (cancelledDuringExtraction()) {
+                logger.info(`${levelPrefix} Cancelled by user during LLM extraction fallback`);
+                settle(reject, makeAbortError(`${levelPrefix} Cancelled by user`));
+                return;
+              }
               logger.warn(`${levelPrefix} LLM extraction fallback error: ${llmError.message}`);
               settle(resolve, { raw: llmFallbackInput, parsed: false });
             }
@@ -319,7 +341,9 @@ class OpenCodeProvider extends AIProvider {
       opencode.stdin.write(prompt, (err) => {
         if (err) {
           logger.error(`${levelPrefix} Failed to write prompt to stdin: ${err}`);
-          opencode.kill('SIGTERM');
+          // A failed spawn (ENOENT) EPIPEs stdin and lands here with a pidless
+          // child; killChildSafely skips the self-directed kill(0).
+          killChildSafely(opencode, { logPrefix: levelPrefix, shell: this.useShell });
           settle(reject, new Error(`${levelPrefix} Failed to write prompt to stdin: ${err}`));
         }
       });
@@ -621,7 +645,9 @@ class OpenCodeProvider extends AIProvider {
         if (settled) return;
         settled = true;
         logger.warn(`OpenCode CLI availability check timed out after ${Math.round(timeoutMs / 1000)}s`);
-        try { opencode.kill(); } catch { /* ignore */ }
+        // Not `shell: useShell`: the probe spawn is not `detached`, so
+        // group-kill would ESRCH and leave the child running.
+        killChildSafely(opencode, { logPrefix: '[availability]' });
         resolve(false);
       }, timeoutMs);
 

--- a/src/ai/pi-provider.js
+++ b/src/ai/pi-provider.js
@@ -26,7 +26,7 @@ const logger = require('../utils/logger');
 const { extractJSON } = require('../utils/json-extractor');
 const { CancellationError, isAnalysisCancelled } = require('../routes/shared');
 const { createPiLineParser } = require('./stream-parser');
-const { wireAbortToChild, makeAbortError } = require('./abort-signal-wiring');
+const { wireAbortToChild, makeAbortError, killChildSafely } = require('./abort-signal-wiring');
 
 // Directory containing bin scripts (git-diff-lines, etc.)
 const BIN_DIR = path.join(__dirname, '..', '..', 'bin');
@@ -681,7 +681,7 @@ class PiProvider extends AIProvider {
       if (timeout) {
         timeoutId = setTimeout(() => {
           logger.error(`${levelPrefix} Process ${pid} timed out after ${timeout}ms`);
-          pi.kill('SIGTERM');
+          killChildSafely(pi, { logPrefix: levelPrefix, shell: this.useShell });
           settle(reject, new Error(`${levelPrefix} Pi CLI timed out after ${timeout}ms`));
         }, timeout);
       }
@@ -798,6 +798,15 @@ class PiProvider extends AIProvider {
           logger.info(`${levelPrefix} LLM fallback input length: ${llmFallbackInput.length} characters (${parsed.textContent ? 'text content' : 'raw fallback output'})`);
           logger.info(`${levelPrefix} Attempting LLM-based JSON extraction fallback...`);
 
+          // The pi child has already exited, so a cancel arriving now only makes
+          // the abort wiring kill something already dead. The `settled` guard
+          // below only covers a cancel that landed BEFORE the await, so without
+          // the checks below one landing during extraction would settle as a
+          // normal result. The signal is read alongside the wiring flag as the
+          // source of truth.
+          const cancelledDuringExtraction = () =>
+            abortWiring.cancelled() || abortSignal?.aborted === true;
+
           // Use async IIFE to handle the async LLM extraction
           (async () => {
             // Guard: if already settled (by timeout, process error, or cancellation),
@@ -805,7 +814,14 @@ class PiProvider extends AIProvider {
             if (settled) return;
 
             try {
-              const llmExtracted = await this.extractJSONWithLLM(llmFallbackInput, { level, analysisId, registerProcess, logPrefix: levelPrefix });
+              // `abortSignal` lets the extraction spawn be killed rather than
+              // merely abandoned until its own 60s timeout.
+              const llmExtracted = await this.extractJSONWithLLM(llmFallbackInput, { level, analysisId, registerProcess, logPrefix: levelPrefix, abortSignal });
+              if (cancelledDuringExtraction()) {
+                logger.info(`${levelPrefix} Cancelled by user during LLM extraction fallback`);
+                settle(reject, makeAbortError(`${levelPrefix} Cancelled by user`));
+                return;
+              }
               if (llmExtracted.success) {
                 logger.success(`${levelPrefix} LLM extraction fallback succeeded`);
                 settle(resolve, llmExtracted.data);
@@ -815,6 +831,13 @@ class PiProvider extends AIProvider {
                 settle(resolve, { raw: llmFallbackInput, parsed: false });
               }
             } catch (llmError) {
+              // An abort that kills the extraction spawn surfaces here as a
+              // thrown error; it is a cancellation, not a parse failure.
+              if (cancelledDuringExtraction()) {
+                logger.info(`${levelPrefix} Cancelled by user during LLM extraction fallback`);
+                settle(reject, makeAbortError(`${levelPrefix} Cancelled by user`));
+                return;
+              }
               logger.warn(`${levelPrefix} LLM extraction fallback error: ${llmError.message}`);
               settle(resolve, { raw: llmFallbackInput, parsed: false });
             }
@@ -1137,7 +1160,9 @@ class PiProvider extends AIProvider {
         if (settled) return;
         settled = true;
         logger.warn(`${name} CLI availability check timed out after ${Math.round(timeoutMs / 1000)}s`);
-        try { pi.kill(); } catch { /* ignore */ }
+        // Not `shell: useShell`: the probe spawn is not `detached`, so
+        // group-kill would ESRCH and leave the child running.
+        killChildSafely(pi, { logPrefix: '[availability]' });
         resolve(false);
       }, timeoutMs);
 

--- a/src/ai/provider.js
+++ b/src/ai/provider.js
@@ -13,6 +13,7 @@ const fs = require('fs');
 const { spawn } = require('child_process');
 const logger = require('../utils/logger');
 const { extractJSON } = require('../utils/json-extractor');
+const { killChildSafely, wireAbortToChild, makeAbortError } = require('./abort-signal-wiring');
 const { TIERS, TIER_ALIASES } = require('./prompts/config');
 
 // Directory containing bin scripts (git-diff-lines, etc.)
@@ -190,6 +191,10 @@ class AIProvider {
    * @property {boolean} useShell - Whether to use shell mode
    * @property {boolean} promptViaStdin - If true, send prompt to stdin; if false, append to args
    * @property {boolean} promptViaFile - If true, write prompt to a temp file and pass @filepath as a positional arg (Pi-specific @file syntax; currently only used by PiProvider)
+   * @property {string} promptFileArg - If set (e.g. `'--prompt-file'`), write prompt to a temp file
+   *   and append `[promptFileArg, filepath]` to args. For CLIs that take the prompt from a file via
+   *   a named flag (Muse). Takes precedence over promptViaFile; both keep the prompt off argv, so
+   *   neither can hit the OS single-argument limit.
    */
   getExtractionConfig(model) {
     // Default: extraction not supported
@@ -204,10 +209,15 @@ class AIProvider {
    * @param {string|number} options.level - Analysis level for logging
    * @param {string} options.analysisId - Analysis ID for process tracking (enables cancellation)
    * @param {Function} options.registerProcess - Function to register child process for cancellation
+   * @param {AbortSignal} [options.abortSignal] - Optional cancellation signal. When
+   *   supplied and aborted, the extraction child is killed and the returned promise
+   *   REJECTS with an AbortError (`isCancellation: true`) instead of resolving.
+   *   Callers that omit it keep the original resolve-only contract: every failure
+   *   still comes back as `{ success: false, error }`.
    * @returns {Promise<{success: boolean, data?: Object, error?: string}>}
    */
   async extractJSONWithLLM(rawResponse, options = {}) {
-    const { level = 'extraction', analysisId, registerProcess, logPrefix } = options;
+    const { level = 'extraction', analysisId, registerProcess, logPrefix, abortSignal } = options;
     const levelPrefix = logPrefix || `[Level ${level}]`;
 
     // Get the fast-tier model, with fallback to analysis model
@@ -222,27 +232,38 @@ class AIProvider {
       };
     }
 
-    const { command, args, useShell, promptViaStdin, promptViaFile, env: configEnv } = config;
+    const { command, args, useShell, promptViaStdin, promptViaFile, promptFileArg, env: configEnv } = config;
     const prompt = `Extract the JSON object from the following text. Return ONLY the valid JSON, nothing else. Do not include any explanation, markdown formatting, or code blocks - just the raw JSON.
 
 === BEGIN INPUT TEXT ===
 ${rawResponse}
 === END INPUT TEXT ===`;
 
-    return new Promise((resolve) => {
+    return new Promise((resolve, reject) => {
+      // Already cancelled before we got here: don't spawn at all. Nothing has
+      // been written to disk yet, so there is nothing to clean up.
+      if (abortSignal && abortSignal.aborted) {
+        logger.info(`${levelPrefix} LLM extraction skipped: already cancelled`);
+        reject(makeAbortError(`${levelPrefix} Cancelled by user`));
+        return;
+      }
+
       // Build final command and args based on prompt delivery method
-      // promptViaFile: write to temp file, pass @filepath as positional arg (Pi @file syntax)
+      // promptFileArg:  write to temp file, pass `<flag> <path>` (Muse --prompt-file)
+      // promptViaFile:  write to temp file, pass `@filepath` as positional arg (Pi @file syntax)
       // promptViaStdin: write to process stdin after spawn
       // default: pass prompt as positional CLI arg
+      // The two file modes share one write/cleanup path and differ only in how
+      // the path reaches argv, so there is a single place that can leak a file.
       let tmpFile = null;
       let cleanupTmpFile = () => {};
       let finalArgs;
 
-      if (promptViaFile) {
+      if (promptFileArg || promptViaFile) {
         tmpFile = path.join(os.tmpdir(), `pair-review-extract-${Date.now()}-${process.pid}-${crypto.randomUUID()}.txt`);
         fs.writeFileSync(tmpFile, prompt);
         cleanupTmpFile = () => { try { fs.unlinkSync(tmpFile); } catch { /* ignore */ } };
-        finalArgs = [...args, `@${tmpFile}`];
+        finalArgs = promptFileArg ? [...args, promptFileArg, tmpFile] : [...args, `@${tmpFile}`];
       } else {
         finalArgs = promptViaStdin ? args : [...args, prompt];
       }
@@ -265,21 +286,47 @@ ${rawResponse}
         logger.info(`${levelPrefix} Registered extraction process ${proc.pid} for analysis ${analysisId}`);
       }
 
+      // Wire the optional AbortSignal -> SIGTERM. With no signal this is inert
+      // (`cancelled()` is always false, `detach()` a no-op), so callers that
+      // omit `abortSignal` behave exactly as before.
+      //
+      // Not `shell: useShell`: this spawn is not `detached`, so there is no
+      // process group to signal — group-kill would ESRCH and leave the child
+      // running. Plain child.kill, with the pid guard from killChildSafely.
+      // Same reasoning applies to the timeout path below.
+      const abortWiring = wireAbortToChild(proc, abortSignal, { logPrefix: levelPrefix });
+
       let stdout = '';
       let stderr = '';
       let settled = false;
       const timeout = 60000; // 60 second timeout for extraction
 
-      const settle = (result) => {
+      // Detaching is centralized here so it ALWAYS runs when this call returns,
+      // including via the timeout path that settles before the child exits.
+      // Analysis jobs reuse a single per-job signal across many provider calls,
+      // so a listener that outlives one call accumulates for the whole job.
+      const finish = (fn, value) => {
         if (settled) return;
         settled = true;
         if (timeoutId) clearTimeout(timeoutId);
-        resolve(result);
+        abortWiring.detach();
+        fn(value);
       };
+      const settle = (result) => finish(resolve, result);
+      const cancel = () => finish(reject, makeAbortError(`${levelPrefix} Cancelled by user`));
 
       const timeoutId = setTimeout(() => {
-        logger.warn(`${levelPrefix} LLM extraction timed out after ${timeout}ms`);
-        proc.kill('SIGTERM');
+        const cancelled = abortWiring.cancelled();
+        logger.warn(cancelled
+          ? `${levelPrefix} LLM extraction did not exit after cancellation`
+          : `${levelPrefix} LLM extraction timed out after ${timeout}ms`);
+        killChildSafely(proc, { logPrefix: levelPrefix });
+        if (cancelled) {
+          // Killed on cancel but the child never exited. Report the cancel, not
+          // the timeout, so the caller still sees an AbortError.
+          cancel();
+          return;
+        }
         settle({ success: false, error: 'LLM extraction timed out' });
       }, timeout);
 
@@ -294,6 +341,15 @@ ${rawResponse}
       proc.on('close', (code) => {
         cleanupTmpFile();
         if (settled) return;
+
+        // We SIGTERMed the child because the caller's signal aborted. Surface
+        // it as an AbortError so upstream can tell a user cancel from a real
+        // failure, rather than reporting a bogus non-zero exit.
+        if (abortWiring.cancelled()) {
+          logger.info(`${levelPrefix} LLM extraction cancelled by user (exit code ${code})`);
+          cancel();
+          return;
+        }
 
         if (code !== 0) {
           logger.warn(`${levelPrefix} LLM extraction process exited with code ${code}`);
@@ -320,28 +376,55 @@ ${rawResponse}
 
       proc.on('error', (error) => {
         cleanupTmpFile();
+        if (abortWiring.cancelled()) {
+          // A pidless child (spawn failure) is never signalled, so a cancel can
+          // land here instead of on `close`.
+          logger.info(`${levelPrefix} LLM extraction cancelled by user`);
+          cancel();
+          return;
+        }
         logger.warn(`${levelPrefix} LLM extraction process error: ${error.message}`);
         settle({ success: false, error: error.message });
       });
 
-      // Deliver prompt based on config method
-      if (promptViaStdin) {
-        // Handle stdin errors (e.g., EPIPE if process exits before write completes)
-        proc.stdin.on('error', (err) => {
-          logger.warn(`${levelPrefix} extraction stdin error: ${err.message}`);
-        });
+      // Deliver the prompt, then close stdin on EVERY delivery path — including
+      // plain-argv delivery, which used to leave it open. The target CLI may
+      // ignore stdin, but a wrapper command (`devx muse --`, `docker exec ...`)
+      // can block on an open stdin and hang until the extraction timeout above.
+      // The analysis paths in every provider end stdin for exactly this reason.
+      const stdin = proc.stdin;
+      if (stdin) {
+        // EPIPE arrives asynchronously when the CLI exits before the write
+        // drains; with no listener it becomes an unhandled 'error' event.
+        // Guarded because a stdin that is not a writable stream must not throw
+        // inside this executor and reject a promise callers expect to resolve.
+        if (typeof stdin.on === 'function') {
+          stdin.on('error', (err) => {
+            logger.warn(`${levelPrefix} extraction stdin error: ${err.message}`);
+          });
+        }
 
-        proc.stdin.write(prompt, (err) => {
-          if (err) {
-            logger.warn(`${levelPrefix} Failed to write extraction prompt: ${err}`);
-            proc.kill('SIGTERM');
-            settle({ success: false, error: `Failed to write prompt: ${err}` });
-          }
-        });
-        proc.stdin.end();
-      } else if (promptViaFile) {
-        // Prompt delivered via @file arg — close stdin so wrappers (e.g., devx) don't hang
-        proc.stdin.end();
+        if (promptViaStdin) {
+          stdin.write(prompt, (err) => {
+            if (err) {
+              // A cancel kills the child, which EPIPEs this write. That lands
+              // here before `close` fires, so without this check the cancelled
+              // call would settle as an ordinary write failure.
+              if (abortWiring.cancelled()) {
+                logger.info(`${levelPrefix} LLM extraction cancelled by user before the prompt was written`);
+                cancel();
+                return;
+              }
+              logger.warn(`${levelPrefix} Failed to write extraction prompt: ${err}`);
+              killChildSafely(proc, { logPrefix: levelPrefix });
+              settle({ success: false, error: `Failed to write prompt: ${err}` });
+            }
+          });
+        }
+
+        if (typeof stdin.end === 'function') {
+          stdin.end();
+        }
       }
     });
   }

--- a/src/ai/stream-parser.js
+++ b/src/ai/stream-parser.js
@@ -268,6 +268,76 @@ function parseOpenCodeLine(line, options = {}) {
 }
 
 /**
+ * Parse a single Muse JSONL line into a normalized event.
+ * Returns null if the line should not be emitted.
+ *
+ * Muse wraps every record in an envelope; the discriminator is `payload_type`
+ * and the interesting fields live under `payload`:
+ * - run.output.delta (payload.text) → assistant_text
+ * - task.lifecycle.side_effect_intent with payload.event.operation === 'tool:<name>' → tool_use
+ * - everything else (run.lifecycle.*, task.lifecycle.{proposed,accepted,started,
+ *   scheduled,status,completed,failed,rejected,output}, tool.result,
+ *   run.model.configured, run.terminal.*) → filtered out
+ *
+ * Note: side_effect_intent also fires for `model.meta.response` (the model call
+ * itself, not a tool); only `tool:`-prefixed operations become tool_use events.
+ *
+ * @param {string} line - A single JSONL line from Muse stdout
+ * @param {Object} [options] - Parse options
+ * @param {string} [options.cwd] - Working directory to strip from file paths
+ * @returns {{ type: string, text: string, timestamp: number } | null}
+ */
+function parseMuseLine(line, options = {}) {
+  if (!line || !line.trim()) return null;
+
+  const { cwd } = options;
+
+  try {
+    const event = JSON.parse(line);
+    const payloadType = event.payload_type;
+    const payload = event.payload || {};
+
+    if (payloadType === 'run.output.delta') {
+      const text = payload.text;
+      if (text && text.trim()) {
+        return {
+          type: 'assistant_text',
+          text: truncateSnippet(text),
+          timestamp: Date.now()
+        };
+      }
+      return null;
+    }
+
+    if (payloadType === 'task.lifecycle.side_effect_intent') {
+      const operation = payload.event?.operation || '';
+      if (!operation.startsWith('tool:')) return null;
+
+      const toolName = operation.slice('tool:'.length) || 'unknown';
+      // Muse's side_effect_intent record carries no tool arguments, so this
+      // resolves to '' today and the event shows the bare tool name. The lookup
+      // stays so a future muse release that adds arguments needs no code change.
+      const detail = extractToolDetail(
+        payload.event?.input || payload.event?.args || payload.event?.arguments,
+        cwd
+      );
+      const text = detail ? `${toolName}: ${detail}` : toolName;
+      return {
+        type: 'tool_use',
+        text: truncateSnippet(text),
+        timestamp: Date.now()
+      };
+    }
+
+    return null;
+  } catch {
+    // Best-effort side channel — silently ignore non-JSON or malformed lines.
+    // The main stdout buffer handles authoritative response parsing.
+    return null;
+  }
+}
+
+/**
  * Line-buffered stream parser that handles partial lines across chunks.
  * Feeds data incrementally and calls onEvent for each parsed event.
  */
@@ -586,6 +656,7 @@ module.exports = {
   extractToolDetail,
   parseClaudeLine,
   parseCodexLine,
+  parseMuseLine,
   parseOpenCodeLine,
   parseCursorAgentLine,
   parsePiLine,

--- a/src/config.js
+++ b/src/config.js
@@ -66,7 +66,7 @@ const DEFAULT_CONFIG = {
   port: 7247,
   single_port: true,  // When true, reuse a single server on the configured port; new invocations delegate to the running server
   theme: "light",
-  default_provider: "claude",  // AI provider: 'claude', 'antigravity', 'codex', 'copilot', 'opencode', 'cursor-agent', 'pi'
+  default_provider: "claude",  // AI provider: 'claude', 'antigravity', 'codex', 'copilot', 'opencode', 'cursor-agent', 'pi', 'muse'
   default_model: "opus",       // Model within the provider (e.g., 'opus' for Claude, 'gemini-3.1-pro-low' for Antigravity)
   tours: {
     enabled: false,            // When true, the guided-tour feature is available (toolbar button visible, etc.)

--- a/src/main.js
+++ b/src/main.js
@@ -240,7 +240,7 @@ OPTIONS:
                             --model when the model belongs to a non-default
                             provider (e.g. --provider codex --model gpt-5.5).
                             Available: claude, antigravity, codex, copilot,
-                            opencode, cursor-agent, pi
+                            opencode, cursor-agent, pi, muse
     --council <handle>      Run analysis with a saved council (multi-voice). Handle is a
                             council name, name-slug, or id (prefix). See --list-councils.
     --list-councils         List saved councils (handles to use with --council) and exit
@@ -275,6 +275,7 @@ ENVIRONMENT VARIABLES:
     PAIR_REVIEW_CLAUDE_CMD  Custom command to invoke Claude CLI (default: claude)
     PAIR_REVIEW_ANTIGRAVITY_CMD  Custom command to invoke Antigravity CLI (default: agy)
     PAIR_REVIEW_CODEX_CMD   Custom command to invoke Codex CLI (default: codex)
+    PAIR_REVIEW_MUSE_CMD    Custom command to invoke Muse Code CLI (default: muse)
 
 CONFIGURATION:
     Config file: ~/.pair-review/config.json
@@ -664,6 +665,7 @@ ENVIRONMENT VARIABLES:
     PAIR_REVIEW_CLAUDE_CMD  Custom Claude CLI command (default: claude)
     PAIR_REVIEW_ANTIGRAVITY_CMD  Custom Antigravity CLI command (default: agy)
     PAIR_REVIEW_CODEX_CMD   Custom Codex CLI command (default: codex)
+    PAIR_REVIEW_MUSE_CMD    Custom Muse Code CLI command (default: muse)
     PAIR_REVIEW_DB_NAME     Custom database filename (overrides config)
 
 LOCAL CONFIG:
@@ -674,6 +676,7 @@ AI PROVIDERS:
     Claude (default): Requires 'claude' CLI installed
     Antigravity: Requires 'agy' CLI installed
     Codex: Requires 'codex' CLI installed
+    Muse: Requires 'muse' CLI installed
 
     Select provider per-repository in the web UI settings.
 `);

--- a/tests/unit/abort-signal-wiring.test.js
+++ b/tests/unit/abort-signal-wiring.test.js
@@ -1,7 +1,17 @@
 // Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-const { wireAbortToChild, makeAbortError } = require('../../src/ai/abort-signal-wiring.js');
+const { EventEmitter } = require('events');
+
+// Spy on child_process.spawn BEFORE requiring the module under test: it
+// destructures `spawn` at require time, so a spy installed later would be
+// invisible. The stub implementation also guarantees the Windows `taskkill`
+// branch never spawns a real process.
+const mockSpawn = vi
+  .spyOn(require('child_process'), 'spawn')
+  .mockImplementation(() => new EventEmitter());
+
+const { wireAbortToChild, makeAbortError, killChildSafely } = require('../../src/ai/abort-signal-wiring.js');
 
 /**
  * Build a fake ChildProcess just expressive enough for wireAbortToChild:
@@ -94,6 +104,39 @@ describe('wireAbortToChild', () => {
     expect(lateChild.kill).toHaveBeenCalledTimes(1);
   });
 
+  // The abort listener has no catch of its own — it relies on killChildSafely
+  // being total. A malformed child must therefore not take the listener down.
+  // The pre-aborted signal is the load-bearing case: onAbort runs synchronously
+  // inside wireAbortToChild, so a throw propagates straight to this caller
+  // (a post-wiring abort would be swallowed by EventTarget dispatch and prove
+  // nothing).
+  it('a malformed child whose kill is not a function cannot take down the abort listener', () => {
+    const child = { pid: 4242 };  // no kill method at all
+    const controller = new AbortController();
+    controller.abort();
+
+    let wiring;
+    expect(() => { wiring = wireAbortToChild(child, controller.signal, { logPrefix: '[test]' }); })
+      .not.toThrow();
+    // The cancel is still recorded so the close/error handler short-circuits.
+    expect(wiring.cancelled()).toBe(true);
+  });
+
+  it('a child with a throwing pid getter cannot take down the abort listener', () => {
+    const child = {
+      get pid() { throw new Error('pid getter exploded'); },
+      kill: vi.fn(),
+    };
+    const controller = new AbortController();
+    controller.abort();
+
+    let wiring;
+    expect(() => { wiring = wireAbortToChild(child, controller.signal, { logPrefix: '[test]' }); })
+      .not.toThrow();
+    expect(wiring.cancelled()).toBe(true);
+    expect(child.kill).not.toHaveBeenCalled();
+  });
+
   it('logs and swallows when child.kill throws (abort listener does not throw)', () => {
     const child = {
       pid: 99,
@@ -105,6 +148,38 @@ describe('wireAbortToChild', () => {
     wireAbortToChild(child, controller.signal, { logPrefix: '[test]' });
     expect(() => controller.abort()).not.toThrow();
     expect(child.kill).toHaveBeenCalledTimes(1);
+  });
+
+  // Regression: a child whose spawn failed (ENOENT) has `pid === undefined`.
+  // Calling child.kill() on it does NOT no-op — Node coerces the undefined pid
+  // to 0, and kill(0, SIGTERM) signals the CALLER'S OWN process group, so
+  // pair-review terminated itself. Reproduced with a real failed spawn: the
+  // call returned true and the current process received SIGTERM.
+  it('does not call child.kill when the spawn failed (pid is undefined)', () => {
+    // NOT makeFakeChild(undefined): a default parameter would substitute a real
+    // pid. A failed spawn genuinely has no pid.
+    const child = { pid: undefined, kill: vi.fn(() => true) };
+    const controller = new AbortController();
+    const wiring = wireAbortToChild(child, controller.signal);
+
+    controller.abort();
+
+    expect(child.kill).not.toHaveBeenCalled();
+    // The abort is still recorded so the close/error handler short-circuits.
+    expect(wiring.cancelled()).toBe(true);
+  });
+
+  it('does not call child.kill for a pre-aborted signal when the spawn failed', () => {
+    // NOT makeFakeChild(undefined): a default parameter would substitute a real
+    // pid. A failed spawn genuinely has no pid.
+    const child = { pid: undefined, kill: vi.fn(() => true) };
+    const controller = new AbortController();
+    controller.abort();
+
+    const wiring = wireAbortToChild(child, controller.signal);
+
+    expect(child.kill).not.toHaveBeenCalled();
+    expect(wiring.cancelled()).toBe(true);
   });
 
   describe('shell-mode option', () => {
@@ -183,6 +258,197 @@ describe('wireAbortToChild', () => {
       expect(groupKill).not.toHaveBeenCalled();
       expect(child.kill).toHaveBeenCalledWith('SIGTERM');
     });
+
+    // Same self-signal hazard as the non-shell case: with no pid the group-kill
+    // branch is skipped, and the child.kill fallback must not fire either —
+    // process.kill(-undefined) and child.kill() are both self-directed.
+    it('shell: true signals nothing when the spawn failed (pid is undefined)', () => {
+      Object.defineProperty(process, 'platform', { value: 'darwin' });
+      const groupKill = vi.fn();
+      process.kill = groupKill;
+      // NOT makeFakeChild(undefined): a default parameter would substitute a real
+    // pid. A failed spawn genuinely has no pid.
+    const child = { pid: undefined, kill: vi.fn(() => true) };
+      const controller = new AbortController();
+
+      const wiring = wireAbortToChild(child, controller.signal, { shell: true });
+      controller.abort();
+
+      expect(groupKill).not.toHaveBeenCalled();
+      expect(child.kill).not.toHaveBeenCalled();
+      expect(wiring.cancelled()).toBe(true);
+    });
+  });
+});
+
+// killChildSafely is the shared primitive behind every provider's timeout,
+// stdin-write-error and availability-probe kill. wireAbortToChild delegates to
+// it too, so these tests pin the contract directly rather than through wiring.
+describe('killChildSafely', () => {
+  let origPlatform;
+  let origKill;
+
+  beforeEach(() => {
+    origPlatform = process.platform;
+    origKill = process.kill;
+    mockSpawn.mockClear();
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: origPlatform });
+    process.kill = origKill;
+  });
+
+  it('returns false for a null/undefined child', () => {
+    expect(killChildSafely(null)).toBe(false);
+    expect(killChildSafely(undefined)).toBe(false);
+  });
+
+  // The production bug this helper exists for: a child whose spawn failed
+  // (ENOENT) has no pid, Node coerces it to 0, and kill(0, SIGTERM) signals
+  // the CALLER'S own process group — pair-review terminates itself.
+  it('dispatches nothing for a pidless child, in both shell and non-shell mode', () => {
+    // NOT makeFakeChild(undefined): the default parameter would substitute a
+    // real pid. A failed spawn genuinely has no pid.
+    const child = { pid: undefined, kill: vi.fn(() => true) };
+    const groupKill = vi.fn();
+    process.kill = groupKill;
+
+    expect(killChildSafely(child)).toBe(false);
+    expect(killChildSafely(child, { shell: true })).toBe(false);
+
+    expect(child.kill).not.toHaveBeenCalled();
+    expect(groupKill).not.toHaveBeenCalled();
+  });
+
+  // pid 0 is the literal self-signal value, so the guard must treat it as
+  // "no child" rather than as a valid target.
+  it('treats pid 0 as pidless', () => {
+    const child = { pid: 0, kill: vi.fn(() => true) };
+    expect(killChildSafely(child)).toBe(false);
+    expect(child.kill).not.toHaveBeenCalled();
+  });
+
+  it('non-shell mode terminates via child.kill(SIGTERM)', () => {
+    const groupKill = vi.fn();
+    process.kill = groupKill;
+
+    const child = makeFakeChild(4242);
+    expect(killChildSafely(child)).toBe(true);
+    expect(child.kill).toHaveBeenCalledWith('SIGTERM');
+    expect(groupKill).not.toHaveBeenCalled();
+  });
+
+  it('shell mode on POSIX group-kills via process.kill(-pid) so the CLI grandchild dies too', () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin' });
+    const groupKill = vi.fn();
+    process.kill = groupKill;
+
+    const child = makeFakeChild(7777);
+    expect(killChildSafely(child, { shell: true })).toBe(true);
+    expect(groupKill).toHaveBeenCalledWith(-7777, 'SIGTERM');
+    expect(child.kill).not.toHaveBeenCalled();
+  });
+
+  it('shell mode reports false on ESRCH (group already gone) without falling back', () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin' });
+    const groupKill = vi.fn(() => {
+      const err = new Error('no such process');
+      err.code = 'ESRCH';
+      throw err;
+    });
+    process.kill = groupKill;
+
+    const child = makeFakeChild(8888);
+    let result;
+    expect(() => { result = killChildSafely(child, { shell: true }); }).not.toThrow();
+    expect(result).toBe(false);
+    expect(child.kill).not.toHaveBeenCalled();
+  });
+
+  it('shell mode falls back to child.kill when group-kill fails with a non-ESRCH error', () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin' });
+    process.kill = vi.fn(() => {
+      throw new Error('EPERM');
+    });
+
+    const child = makeFakeChild(9999);
+    expect(killChildSafely(child, { shell: true, logPrefix: '[test]' })).toBe(true);
+    expect(child.kill).toHaveBeenCalledWith('SIGTERM');
+  });
+
+  it('shell mode on Windows wipes the tree with taskkill /T /F', () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+    const groupKill = vi.fn();
+    process.kill = groupKill;
+
+    const child = makeFakeChild(555);
+    expect(killChildSafely(child, { shell: true })).toBe(true);
+    expect(mockSpawn).toHaveBeenCalledWith(
+      'taskkill',
+      ['/T', '/F', '/PID', '555'],
+      { stdio: 'ignore' }
+    );
+    // Windows has no process groups, so the POSIX branch must be skipped.
+    expect(groupKill).not.toHaveBeenCalled();
+    expect(child.kill).not.toHaveBeenCalled();
+  });
+
+  it('falls back to child.kill when spawning taskkill throws', () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+    mockSpawn.mockImplementationOnce(() => {
+      throw new Error('spawn EPERM');
+    });
+
+    const child = makeFakeChild(556);
+    expect(killChildSafely(child, { shell: true, logPrefix: '[test]' })).toBe(true);
+    expect(child.kill).toHaveBeenCalledWith('SIGTERM');
+  });
+
+  // Totality of this helper is what lets wireAbortToChild's abort listener run
+  // without a catch of its own. These pin the three ways a caller can hand it
+  // something malformed.
+  it('reports false instead of throwing when the child has no kill method', () => {
+    const child = { pid: 4242 };
+
+    let result;
+    expect(() => { result = killChildSafely(child, { logPrefix: '[test]' }); }).not.toThrow();
+    expect(result).toBe(false);
+  });
+
+  it('reports false instead of throwing when reading child.pid throws', () => {
+    const child = {
+      get pid() { throw new Error('pid getter exploded'); },
+      kill: vi.fn(),
+    };
+
+    let result;
+    expect(() => { result = killChildSafely(child, { logPrefix: '[test]' }); }).not.toThrow();
+    expect(result).toBe(false);
+    expect(child.kill).not.toHaveBeenCalled();
+  });
+
+  it('tolerates a null/non-object opts argument', () => {
+    const child = makeFakeChild(1234);
+
+    let result;
+    expect(() => { result = killChildSafely(child, null); }).not.toThrow();
+    expect(result).toBe(true);
+    expect(child.kill).toHaveBeenCalledWith('SIGTERM');
+  });
+
+  it('never throws and reports false when child.kill itself throws', () => {
+    const child = {
+      pid: 99,
+      kill: vi.fn(() => {
+        throw new Error('kill exploded');
+      }),
+    };
+
+    let result;
+    expect(() => { result = killChildSafely(child, { logPrefix: '[test]' }); }).not.toThrow();
+    expect(result).toBe(false);
+    expect(child.kill).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/tests/unit/antigravity-provider.test.js
+++ b/tests/unit/antigravity-provider.test.js
@@ -557,6 +557,72 @@ describe('AntigravityProvider', () => {
           vi.useRealTimers();
         }
       });
+
+      it('forwards the abort signal so the extraction spawn can be killed, not merely abandoned', async () => {
+        const child = createMockChild();
+        mockSpawn.mockReturnValue(child);
+
+        const provider = new AntigravityProvider('gemini-3.1-pro-low');
+        const spy = vi.spyOn(provider, 'extractJSONWithLLM')
+          .mockResolvedValue({ success: true, data: { suggestions: [] } });
+        const controller = new AbortController();
+
+        const promise = provider.execute('prompt', { abortSignal: controller.signal });
+        child.stdout.emit('data', Buffer.from(PLAIN));
+        child.emit('close', 0);
+
+        expect(await promise).toEqual({ suggestions: [] });
+        // Without the signal the extraction child outlives a cancel until its
+        // own 60s timeout.
+        expect(spy).toHaveBeenCalledWith(PLAIN, expect.objectContaining({ abortSignal: controller.signal }));
+      });
+
+      it('reports a cancel that lands while the fallback is still running', async () => {
+        // agy has already exited by this point, so the abort wiring only kills
+        // something already dead. Without the post-await re-check a cancelled
+        // analysis would settle with a normal result.
+        const child = createMockChild();
+        mockSpawn.mockReturnValue(child);
+
+        const provider = new AntigravityProvider('gemini-3.1-pro-low');
+        const controller = new AbortController();
+        vi.spyOn(provider, 'extractJSONWithLLM').mockImplementation(async () => {
+          controller.abort();
+          return { success: true, data: { suggestions: [{ id: 1 }] } };
+        });
+
+        const promise = provider.execute('prompt', { abortSignal: controller.signal });
+        const failure = promise.then(() => null, (err) => err);
+        child.stdout.emit('data', Buffer.from(PLAIN));
+        child.emit('close', 0);
+
+        const error = await failure;
+        expect(error).toBeInstanceOf(Error);
+        expect(error.name).toBe('AbortError');
+        expect(error.isCancellation).toBe(true);
+        expect(error.message).toMatch(/Cancelled by user/);
+      });
+
+      it('treats an abort that kills the extraction spawn as a cancel, not a parse failure', async () => {
+        const child = createMockChild();
+        mockSpawn.mockReturnValue(child);
+
+        const provider = new AntigravityProvider('gemini-3.1-pro-low');
+        const controller = new AbortController();
+        vi.spyOn(provider, 'extractJSONWithLLM').mockImplementation(async () => {
+          controller.abort();
+          throw new Error('spawn terminated by SIGTERM');
+        });
+
+        const promise = provider.execute('prompt', { abortSignal: controller.signal });
+        const failure = promise.then(() => null, (err) => err);
+        child.stdout.emit('data', Buffer.from(PLAIN));
+        child.emit('close', 0);
+
+        const error = await failure;
+        expect(error.name).toBe('AbortError');
+        expect(error.isCancellation).toBe(true);
+      });
     });
 
     // The two cancellation paths intentionally reject with DIFFERENT error

--- a/tests/unit/claude-provider.test.js
+++ b/tests/unit/claude-provider.test.js
@@ -27,6 +27,16 @@ vi.mock('../../src/utils/logger', () => {
   };
 });
 
+// Spy on child_process.spawn BEFORE the provider is required, so the provider's
+// destructured `spawn` reference resolves to the spy. vi.mock does not intercept
+// CJS requires of Node built-in modules in vitest (see executable-provider.test.js).
+// Default behaviour delegates to the real spawn, so only tests that arm it with
+// mockReturnValue get a fake child.
+const childProcess = require('child_process');
+const realSpawn = childProcess.spawn;
+const mockSpawn = vi.fn((...args) => realSpawn(...args));
+childProcess.spawn = mockSpawn;
+
 // Import after mocks are set up
 const ClaudeProvider = require('../../src/ai/claude-provider');
 const { quoteShellArgs } = require('../../src/ai/provider');
@@ -1367,6 +1377,134 @@ describe('ClaudeProvider', () => {
         }
       });
       expect(() => provider.logStreamLine(line, '[Level 1]')).not.toThrow();
+    });
+  });
+
+  // When the model answers in prose the LLM-extraction fallback runs. A cancel
+  // arriving while it is in flight must reject, not be laundered into a normal
+  // "unparsed response" result that makes the job look like it completed.
+  describe('LLM-extraction fallback cancellation', () => {
+    const { EventEmitter } = require('events');
+    const PROSE = 'I could not analyse this diff.';
+
+    afterEach(() => {
+      // Leave the spy delegating to the real spawn so an armed fake child
+      // cannot leak into a later test.
+      mockSpawn.mockImplementation((...args) => realSpawn(...args));
+    });
+
+    /**
+     * Minimal child mirroring the surface execute() touches: stdout/stderr
+     * emitters, a writable stdin, kill, pid.
+     *
+     * @returns {EventEmitter} Fake child process
+     */
+    function createMockChild() {
+      const child = new EventEmitter();
+      child.stdout = new EventEmitter();
+      child.stderr = new EventEmitter();
+      child.pid = 4242;
+      child.kill = vi.fn();
+
+      const stdin = new EventEmitter();
+      stdin.write = vi.fn((data, cb) => {
+        if (typeof cb === 'function') cb();
+        return true;
+      });
+      stdin.end = vi.fn();
+      child.stdin = stdin;
+
+      return child;
+    }
+
+    /**
+     * Drive execute() to the extraction fallback: claude exits 0 having emitted
+     * assistant text that is not JSON.
+     *
+     * @param {EventEmitter} child - Fake child returned by the spawn spy
+     */
+    function reachExtractionFallback(child) {
+      child.stdout.emit('data', JSON.stringify({
+        type: 'result',
+        result: { content: [{ type: 'text', text: PROSE }] }
+      }) + '\n');
+      child.emit('close', 0);
+    }
+
+    it('forwards the abort signal so the extraction spawn can be killed, not merely abandoned', async () => {
+      const child = createMockChild();
+      mockSpawn.mockReturnValue(child);
+
+      const provider = new ClaudeProvider('sonnet');
+      const spy = vi.spyOn(provider, 'extractJSONWithLLM')
+        .mockResolvedValue({ success: true, data: { suggestions: [] } });
+      const controller = new AbortController();
+
+      const promise = provider.execute('prompt', { abortSignal: controller.signal });
+      reachExtractionFallback(child);
+
+      expect(await promise).toEqual({ suggestions: [] });
+      // Without the signal the extraction child survives a cancel until its own
+      // 60s timeout.
+      expect(spy).toHaveBeenCalledWith(PROSE, expect.objectContaining({ abortSignal: controller.signal }));
+    });
+
+    it('reports a cancel that lands while the fallback is still running', async () => {
+      // Claude has already exited by this point, so the abort wiring only kills
+      // something already dead. Without the post-await re-check a cancelled
+      // analysis would settle with a normal result.
+      const child = createMockChild();
+      mockSpawn.mockReturnValue(child);
+
+      const provider = new ClaudeProvider('sonnet');
+      const controller = new AbortController();
+      vi.spyOn(provider, 'extractJSONWithLLM').mockImplementation(async () => {
+        controller.abort();
+        return { success: true, data: { suggestions: [{ id: 1 }] } };
+      });
+
+      const promise = provider.execute('prompt', { abortSignal: controller.signal });
+      const failure = promise.then(() => null, (err) => err);
+      reachExtractionFallback(child);
+
+      const error = await failure;
+      expect(error).toBeInstanceOf(Error);
+      expect(error.name).toBe('AbortError');
+      expect(error.isCancellation).toBe(true);
+      expect(error.message).toMatch(/Cancelled by user/);
+    });
+
+    it('treats an abort that kills the extraction spawn as a cancel, not a parse failure', async () => {
+      const child = createMockChild();
+      mockSpawn.mockReturnValue(child);
+
+      const provider = new ClaudeProvider('sonnet');
+      const controller = new AbortController();
+      vi.spyOn(provider, 'extractJSONWithLLM').mockImplementation(async () => {
+        controller.abort();
+        throw new Error('spawn terminated by SIGTERM');
+      });
+
+      const promise = provider.execute('prompt', { abortSignal: controller.signal });
+      const failure = promise.then(() => null, (err) => err);
+      reachExtractionFallback(child);
+
+      const error = await failure;
+      expect(error.name).toBe('AbortError');
+      expect(error.isCancellation).toBe(true);
+    });
+
+    it('degrades to raw text when the extraction fallback throws without a cancel', async () => {
+      const child = createMockChild();
+      mockSpawn.mockReturnValue(child);
+
+      const provider = new ClaudeProvider('sonnet');
+      vi.spyOn(provider, 'extractJSONWithLLM').mockRejectedValue(new Error('extractor blew up'));
+
+      const promise = provider.execute('prompt', {});
+      reachExtractionFallback(child);
+
+      expect(await promise).toEqual({ raw: PROSE, parsed: false });
     });
   });
 

--- a/tests/unit/codex-provider.test.js
+++ b/tests/unit/codex-provider.test.js
@@ -27,6 +27,16 @@ vi.mock('../../src/utils/logger', () => {
   };
 });
 
+// Spy on child_process.spawn BEFORE the provider is required, so the provider's
+// destructured `spawn` reference resolves to the spy. vi.mock does not intercept
+// CJS requires of Node built-in modules in vitest (see executable-provider.test.js).
+// Default behaviour delegates to the real spawn, so only tests that arm it with
+// mockReturnValue get a fake child.
+const childProcess = require('child_process');
+const realSpawn = childProcess.spawn;
+const mockSpawn = vi.fn((...args) => realSpawn(...args));
+childProcess.spawn = mockSpawn;
+
 // Import after mocks are set up
 const CodexProvider = require('../../src/ai/codex-provider');
 
@@ -577,6 +587,134 @@ describe('CodexProvider', () => {
         expect(result.success).toBe(true);
         expect(result.data).toEqual({ found: true });
       });
+    });
+  });
+
+  // When the model answers in prose the LLM-extraction fallback runs. A cancel
+  // arriving while it is in flight must reject, not be laundered into a normal
+  // "unparsed response" result that makes the job look like it completed.
+  describe('LLM-extraction fallback cancellation', () => {
+    const { EventEmitter } = require('events');
+    const PROSE = 'I could not analyse this diff.';
+
+    afterEach(() => {
+      // Leave the spy delegating to the real spawn so an armed fake child
+      // cannot leak into a later test.
+      mockSpawn.mockImplementation((...args) => realSpawn(...args));
+    });
+
+    /**
+     * Minimal child mirroring the surface execute() touches: stdout/stderr
+     * emitters, a writable stdin, kill, pid.
+     *
+     * @returns {EventEmitter} Fake child process
+     */
+    function createMockChild() {
+      const child = new EventEmitter();
+      child.stdout = new EventEmitter();
+      child.stderr = new EventEmitter();
+      child.pid = 4242;
+      child.kill = vi.fn();
+
+      const stdin = new EventEmitter();
+      stdin.write = vi.fn((data, cb) => {
+        if (typeof cb === 'function') cb();
+        return true;
+      });
+      stdin.end = vi.fn();
+      child.stdin = stdin;
+
+      return child;
+    }
+
+    /**
+     * Drive execute() to the extraction fallback: codex exits 0 having emitted
+     * an agent_message whose text is not JSON.
+     *
+     * @param {EventEmitter} child - Fake child returned by the spawn spy
+     */
+    function reachExtractionFallback(child) {
+      child.stdout.emit('data', JSON.stringify({
+        type: 'item.completed',
+        item: { type: 'agent_message', text: PROSE }
+      }) + '\n');
+      child.emit('close', 0);
+    }
+
+    it('forwards the abort signal so the extraction spawn can be killed, not merely abandoned', async () => {
+      const child = createMockChild();
+      mockSpawn.mockReturnValue(child);
+
+      const provider = new CodexProvider('gpt-5.4-mini');
+      const spy = vi.spyOn(provider, 'extractJSONWithLLM')
+        .mockResolvedValue({ success: true, data: { suggestions: [] } });
+      const controller = new AbortController();
+
+      const promise = provider.execute('prompt', { abortSignal: controller.signal });
+      reachExtractionFallback(child);
+
+      expect(await promise).toEqual({ suggestions: [] });
+      // Without the signal the extraction child survives a cancel until its own
+      // 60s timeout.
+      expect(spy).toHaveBeenCalledWith(PROSE, expect.objectContaining({ abortSignal: controller.signal }));
+    });
+
+    it('reports a cancel that lands while the fallback is still running', async () => {
+      // Codex has already exited by this point, so the abort wiring only kills
+      // something already dead. Without the post-await re-check a cancelled
+      // analysis would settle with a normal result.
+      const child = createMockChild();
+      mockSpawn.mockReturnValue(child);
+
+      const provider = new CodexProvider('gpt-5.4-mini');
+      const controller = new AbortController();
+      vi.spyOn(provider, 'extractJSONWithLLM').mockImplementation(async () => {
+        controller.abort();
+        return { success: true, data: { suggestions: [{ id: 1 }] } };
+      });
+
+      const promise = provider.execute('prompt', { abortSignal: controller.signal });
+      const failure = promise.then(() => null, (err) => err);
+      reachExtractionFallback(child);
+
+      const error = await failure;
+      expect(error).toBeInstanceOf(Error);
+      expect(error.name).toBe('AbortError');
+      expect(error.isCancellation).toBe(true);
+      expect(error.message).toMatch(/Cancelled by user/);
+    });
+
+    it('treats an abort that kills the extraction spawn as a cancel, not a parse failure', async () => {
+      const child = createMockChild();
+      mockSpawn.mockReturnValue(child);
+
+      const provider = new CodexProvider('gpt-5.4-mini');
+      const controller = new AbortController();
+      vi.spyOn(provider, 'extractJSONWithLLM').mockImplementation(async () => {
+        controller.abort();
+        throw new Error('spawn terminated by SIGTERM');
+      });
+
+      const promise = provider.execute('prompt', { abortSignal: controller.signal });
+      const failure = promise.then(() => null, (err) => err);
+      reachExtractionFallback(child);
+
+      const error = await failure;
+      expect(error.name).toBe('AbortError');
+      expect(error.isCancellation).toBe(true);
+    });
+
+    it('degrades to raw text when the extraction fallback throws without a cancel', async () => {
+      const child = createMockChild();
+      mockSpawn.mockReturnValue(child);
+
+      const provider = new CodexProvider('gpt-5.4-mini');
+      vi.spyOn(provider, 'extractJSONWithLLM').mockRejectedValue(new Error('extractor blew up'));
+
+      const promise = provider.execute('prompt', {});
+      reachExtractionFallback(child);
+
+      expect(await promise).toEqual({ raw: PROSE, parsed: false });
     });
   });
 

--- a/tests/unit/copilot-provider.test.js
+++ b/tests/unit/copilot-provider.test.js
@@ -50,6 +50,8 @@ describe('CopilotProvider', () => {
       try {
         const child = new EventEmitter();
         child.stdout = new EventEmitter();
+        // A hung CLI has a real pid; killChildSafely skips pidless children.
+        child.pid = 4242;
         child.kill = vi.fn();
         mockSpawn.mockReturnValue(child);
 
@@ -80,6 +82,9 @@ describe('CopilotProvider', () => {
       try {
         const child = new EventEmitter();
         child.stdout = new EventEmitter();
+        // pid set so "kill not called" proves the timer was cleared rather
+        // than passing vacuously via killChildSafely's pidless guard.
+        child.pid = 4242;
         child.kill = vi.fn();
         mockSpawn.mockReturnValue(child);
 
@@ -315,6 +320,115 @@ describe('CopilotProvider', () => {
         expect(args).toContain('shell(rm)');
         expect(args).toContain('write');
       });
+    });
+  });
+
+  // Copilot emits PLAIN TEXT, so extractJSON often fails and the LLM-extraction
+  // fallback is a routine production path. A cancel arriving while it runs must
+  // not be laundered into a normal "unparsed response" result.
+  describe('LLM-extraction fallback cancellation', () => {
+    const { EventEmitter } = require('events');
+    const PLAIN = 'copilot says: nothing to report. No JSON anywhere in here.';
+
+    /**
+     * Minimal child mirroring the surface execute() touches.
+     *
+     * @returns {EventEmitter} Fake child process
+     */
+    function createMockChild() {
+      const child = new EventEmitter();
+      child.stdout = new EventEmitter();
+      child.stderr = new EventEmitter();
+      child.pid = 4242;
+      child.kill = vi.fn();
+      return child;
+    }
+
+    /**
+     * Drive execute() to the extraction fallback: copilot exits 0 having
+     * emitted text that is not JSON.
+     *
+     * @param {EventEmitter} child - Fake child returned by the spawn spy
+     */
+    function reachExtractionFallback(child) {
+      child.stdout.emit('data', Buffer.from(PLAIN));
+      child.emit('close', 0);
+    }
+
+    it('forwards the abort signal so the extraction spawn can be killed, not merely abandoned', async () => {
+      const child = createMockChild();
+      mockSpawn.mockReturnValue(child);
+
+      const provider = new CopilotProvider();
+      const spy = vi.spyOn(provider, 'extractJSONWithLLM')
+        .mockResolvedValue({ success: true, data: { suggestions: [] } });
+      const controller = new AbortController();
+
+      const promise = provider.execute('prompt', { abortSignal: controller.signal });
+      reachExtractionFallback(child);
+
+      expect(await promise).toEqual({ suggestions: [] });
+      // Without the signal the extraction child survives a cancel until its own
+      // 60s timeout.
+      expect(spy).toHaveBeenCalledWith(PLAIN, expect.objectContaining({ abortSignal: controller.signal }));
+    });
+
+    it('reports a cancel that lands while the fallback is still running', async () => {
+      // Copilot has already exited by this point, so the abort wiring only kills
+      // something already dead. Without the post-await re-check a cancelled
+      // analysis would settle with a normal result.
+      const child = createMockChild();
+      mockSpawn.mockReturnValue(child);
+
+      const provider = new CopilotProvider();
+      const controller = new AbortController();
+      vi.spyOn(provider, 'extractJSONWithLLM').mockImplementation(async () => {
+        controller.abort();
+        return { success: true, data: { suggestions: [{ id: 1 }] } };
+      });
+
+      const promise = provider.execute('prompt', { abortSignal: controller.signal });
+      const failure = promise.then(() => null, (err) => err);
+      reachExtractionFallback(child);
+
+      const error = await failure;
+      expect(error).toBeInstanceOf(Error);
+      expect(error.name).toBe('AbortError');
+      expect(error.isCancellation).toBe(true);
+      expect(error.message).toMatch(/Cancelled by user/);
+    });
+
+    it('treats an abort that kills the extraction spawn as a cancel, not a parse failure', async () => {
+      const child = createMockChild();
+      mockSpawn.mockReturnValue(child);
+
+      const provider = new CopilotProvider();
+      const controller = new AbortController();
+      vi.spyOn(provider, 'extractJSONWithLLM').mockImplementation(async () => {
+        controller.abort();
+        throw new Error('spawn terminated by SIGTERM');
+      });
+
+      const promise = provider.execute('prompt', { abortSignal: controller.signal });
+      const failure = promise.then(() => null, (err) => err);
+      reachExtractionFallback(child);
+
+      const error = await failure;
+      expect(error.name).toBe('AbortError');
+      expect(error.isCancellation).toBe(true);
+    });
+
+    it('degrades to raw text when the extraction fallback throws without a cancel', async () => {
+      const child = createMockChild();
+      mockSpawn.mockReturnValue(child);
+
+      const provider = new CopilotProvider();
+      vi.spyOn(provider, 'extractJSONWithLLM').mockRejectedValue(new Error('extractor blew up'));
+
+      const promise = provider.execute('prompt', {});
+      reachExtractionFallback(child);
+
+      expect(await promise).toEqual({ raw: PLAIN, parsed: false });
     });
   });
 

--- a/tests/unit/cursor-agent-provider.test.js
+++ b/tests/unit/cursor-agent-provider.test.js
@@ -5,10 +5,8 @@ import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
  * Unit tests for CursorAgentProvider
  *
  * These tests focus on static methods, constructor behavior, response parsing,
- * and stream logging without requiring actual CLI processes.
- *
- * Note: execute() tests that require child_process.spawn mocking are not yet
- * implemented (would need a separate file for module isolation).
+ * and stream logging without requiring actual CLI processes. The spawn spy
+ * below additionally covers execute()'s LLM-extraction fallback.
  */
 
 // Mock logger to suppress output during tests
@@ -29,6 +27,16 @@ vi.mock('../../src/utils/logger', () => {
     setStreamDebugEnabled: (enabled) => { streamDebugEnabled = enabled; }
   };
 });
+
+// Spy on child_process.spawn BEFORE the provider is required, so the provider's
+// destructured `spawn` reference resolves to the spy. vi.mock does not intercept
+// CJS requires of Node built-in modules in vitest (see executable-provider.test.js).
+// Default behaviour delegates to the real spawn, so only tests that arm it with
+// mockReturnValue get a fake child.
+const childProcess = require('child_process');
+const realSpawn = childProcess.spawn;
+const mockSpawn = vi.fn((...args) => realSpawn(...args));
+childProcess.spawn = mockSpawn;
 
 // Import after mocks are set up
 const CursorAgentProvider = require('../../src/ai/cursor-agent-provider');
@@ -471,6 +479,136 @@ describe('CursorAgentProvider', () => {
         expect(result.success).toBe(true);
         expect(result.data).toEqual({ source: 'assistant' });
       });
+    });
+  });
+
+  // When the model answers in prose the LLM-extraction fallback runs. A cancel
+  // arriving while it is in flight must reject, not be laundered into a normal
+  // "unparsed response" result that makes the job look like it completed. The
+  // pre-existing `settled` guard only covers a cancel that landed BEFORE the
+  // await, so these tests abort from inside the extraction call.
+  describe('LLM-extraction fallback cancellation', () => {
+    const { EventEmitter } = require('events');
+    const PROSE = 'I could not analyse this diff.';
+
+    afterEach(() => {
+      // Leave the spy delegating to the real spawn so an armed fake child
+      // cannot leak into a later test.
+      mockSpawn.mockImplementation((...args) => realSpawn(...args));
+    });
+
+    /**
+     * Minimal child mirroring the surface execute() touches: stdout/stderr
+     * emitters, a writable stdin, kill, pid.
+     *
+     * @returns {EventEmitter} Fake child process
+     */
+    function createMockChild() {
+      const child = new EventEmitter();
+      child.stdout = new EventEmitter();
+      child.stderr = new EventEmitter();
+      child.pid = 4242;
+      child.kill = vi.fn();
+
+      const stdin = new EventEmitter();
+      stdin.write = vi.fn((data, cb) => {
+        if (typeof cb === 'function') cb();
+        return true;
+      });
+      stdin.end = vi.fn();
+      child.stdin = stdin;
+
+      return child;
+    }
+
+    /**
+     * Drive execute() to the extraction fallback: the agent exits 0 having
+     * emitted assistant text that is not JSON.
+     *
+     * @param {EventEmitter} child - Fake child returned by the spawn spy
+     */
+    function reachExtractionFallback(child) {
+      child.stdout.emit('data', JSON.stringify({
+        type: 'assistant',
+        message: { role: 'assistant', content: [{ type: 'text', text: PROSE }] }
+      }) + '\n');
+      child.emit('close', 0);
+    }
+
+    it('forwards the abort signal so the extraction spawn can be killed, not merely abandoned', async () => {
+      const child = createMockChild();
+      mockSpawn.mockReturnValue(child);
+
+      const provider = new CursorAgentProvider('sonnet-4.5');
+      const spy = vi.spyOn(provider, 'extractJSONWithLLM')
+        .mockResolvedValue({ success: true, data: { suggestions: [] } });
+      const controller = new AbortController();
+
+      const promise = provider.execute('prompt', { abortSignal: controller.signal });
+      reachExtractionFallback(child);
+
+      expect(await promise).toEqual({ suggestions: [] });
+      // Without the signal the extraction child survives a cancel until its own
+      // 60s timeout.
+      expect(spy).toHaveBeenCalledWith(PROSE, expect.objectContaining({ abortSignal: controller.signal }));
+    });
+
+    it('reports a cancel that lands while the fallback is still running', async () => {
+      // The agent has already exited by this point, so the abort wiring only
+      // kills something already dead. Without the post-await re-check a
+      // cancelled analysis would settle with a normal result.
+      const child = createMockChild();
+      mockSpawn.mockReturnValue(child);
+
+      const provider = new CursorAgentProvider('sonnet-4.5');
+      const controller = new AbortController();
+      vi.spyOn(provider, 'extractJSONWithLLM').mockImplementation(async () => {
+        controller.abort();
+        return { success: true, data: { suggestions: [{ id: 1 }] } };
+      });
+
+      const promise = provider.execute('prompt', { abortSignal: controller.signal });
+      const failure = promise.then(() => null, (err) => err);
+      reachExtractionFallback(child);
+
+      const error = await failure;
+      expect(error).toBeInstanceOf(Error);
+      expect(error.name).toBe('AbortError');
+      expect(error.isCancellation).toBe(true);
+      expect(error.message).toMatch(/Cancelled by user/);
+    });
+
+    it('treats an abort that kills the extraction spawn as a cancel, not a parse failure', async () => {
+      const child = createMockChild();
+      mockSpawn.mockReturnValue(child);
+
+      const provider = new CursorAgentProvider('sonnet-4.5');
+      const controller = new AbortController();
+      vi.spyOn(provider, 'extractJSONWithLLM').mockImplementation(async () => {
+        controller.abort();
+        throw new Error('spawn terminated by SIGTERM');
+      });
+
+      const promise = provider.execute('prompt', { abortSignal: controller.signal });
+      const failure = promise.then(() => null, (err) => err);
+      reachExtractionFallback(child);
+
+      const error = await failure;
+      expect(error.name).toBe('AbortError');
+      expect(error.isCancellation).toBe(true);
+    });
+
+    it('degrades to raw text when the extraction fallback throws without a cancel', async () => {
+      const child = createMockChild();
+      mockSpawn.mockReturnValue(child);
+
+      const provider = new CursorAgentProvider('sonnet-4.5');
+      vi.spyOn(provider, 'extractJSONWithLLM').mockRejectedValue(new Error('extractor blew up'));
+
+      const promise = provider.execute('prompt', {});
+      reachExtractionFallback(child);
+
+      expect(await promise).toEqual({ raw: PROSE, parsed: false });
     });
   });
 

--- a/tests/unit/llm-extraction.test.js
+++ b/tests/unit/llm-extraction.test.js
@@ -1,22 +1,39 @@
 // Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
-import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi, afterEach, afterAll } from 'vitest';
 
 /**
  * Unit tests for LLM-based JSON extraction fallback
  *
- * Tests the refactored extraction logic in AIProvider base class,
- * including tier-based model selection and extraction configuration.
- *
- * Note: Tests requiring spawn mocking are skipped due to vitest/CommonJS
- * module isolation limitations. The extraction functionality is verified
- * through integration tests and manual testing.
+ * Tests the extraction logic in the AIProvider base class: tier-based model
+ * selection, per-provider extraction configuration, and the spawn lifecycle
+ * of `extractJSONWithLLM` itself (stdin closing, cancellation).
  */
 
-// Import providers directly for synchronous tests
-import ClaudeProvider from '../../src/ai/claude-provider.js';
-import AntigravityProvider from '../../src/ai/antigravity-provider.js';
-import CodexProvider from '../../src/ai/codex-provider.js';
-import CopilotProvider from '../../src/ai/copilot-provider.js';
+const { EventEmitter } = require('events');
+const fs = require('fs');
+
+// Patch child_process.spawn with a mock that delegates to the real
+// implementation by default. This MUST happen before provider.js is loaded
+// (via the requires below), because it destructures spawn at import time:
+//   const { spawn } = require('child_process');
+// vitest's vi.mock does not intercept CJS require of Node built-ins, so the
+// module object is patched directly instead. Same pattern as pi-provider.test.js.
+const childProcess = require('child_process');
+const realSpawn = childProcess.spawn;
+const mockSpawn = vi.fn((...args) => realSpawn(...args));
+childProcess.spawn = mockSpawn;
+
+// Required (not imported) so the spawn patch above lands first.
+const ClaudeProvider = require('../../src/ai/claude-provider.js');
+const AntigravityProvider = require('../../src/ai/antigravity-provider.js');
+const CodexProvider = require('../../src/ai/codex-provider.js');
+const CopilotProvider = require('../../src/ai/copilot-provider.js');
+const { AIProvider } = require('../../src/ai/provider.js');
+const logger = require('../../src/utils/logger');
+
+afterAll(() => {
+  childProcess.spawn = realSpawn;
+});
 
 describe('LLM-based JSON extraction fallback', () => {
   const originalEnv = { ...process.env };
@@ -236,6 +253,424 @@ describe('LLM-based JSON extraction fallback', () => {
         const config = provider.getExtractionConfig('test-model');
         expect(config.promptViaStdin).toBe(true);
       }
+    });
+  });
+});
+
+/**
+ * Spawn-lifecycle tests for the shared `extractJSONWithLLM` implementation.
+ *
+ * A minimal AIProvider subclass stands in for a real provider so each prompt
+ * delivery mode can be exercised directly. The method under test is the real
+ * one inherited from AIProvider — nothing is reimplemented here.
+ */
+class TestExtractionProvider extends AIProvider {
+  constructor(extractionConfig) {
+    super('fast-model');
+    this._extractionConfig = extractionConfig;
+  }
+
+  static getProviderId() { return 'test-extraction'; }
+  static getModels() { return [{ id: 'fast-model', tier: 'fast' }]; }
+
+  getExtractionConfig() { return this._extractionConfig; }
+}
+
+/**
+ * Fake ChildProcess with just enough surface for extractJSONWithLLM:
+ * stdout/stderr streams, a kill spy, and a stdin double that records writes.
+ */
+function makeFakeChild({ pid = 4321, stdin = true } = {}) {
+  const child = new EventEmitter();
+  child.pid = pid;
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.kill = vi.fn(() => true);
+  child.stdin = stdin
+    ? {
+      on: vi.fn(),
+      write: vi.fn((_data, cb) => { if (cb) cb(null); }),
+      end: vi.fn(),
+    }
+    : null;
+  return child;
+}
+
+const ARGV_CONFIG = { command: 'muse', args: ['exec'], useShell: false, promptViaStdin: false };
+const STDIN_CONFIG = { command: 'claude', args: ['-p'], useShell: false, promptViaStdin: true };
+// Pi's @file syntax: the path rides argv as a single `@<path>` positional.
+const AT_FILE_CONFIG = { command: 'pi', args: ['-p'], useShell: false, promptViaStdin: false, promptViaFile: true };
+// Muse's named flag: the helper appends `--prompt-file <path>` itself.
+const FILE_ARG_CONFIG = {
+  command: 'muse', args: ['exec'], useShell: false, promptViaStdin: false, promptFileArg: '--prompt-file'
+};
+
+describe('extractJSONWithLLM spawn lifecycle', () => {
+  let loggerSpies;
+
+  beforeEach(() => {
+    mockSpawn.mockClear();
+    // Keep extraction chatter out of the test output without hiding failures.
+    loggerSpies = ['info', 'warn', 'error', 'success', 'debug'].map(
+      m => vi.spyOn(logger, m).mockImplementation(() => {})
+    );
+  });
+
+  afterEach(() => {
+    loggerSpies.forEach(s => s.mockRestore());
+    vi.useRealTimers();
+  });
+
+  describe('stdin closing', () => {
+    // Regression: the plain-argv branch used to leave stdin open. A wrapper
+    // command (`devx muse --`, `docker exec ... muse`) can block on an open
+    // stdin and hang until the 60s extraction timeout.
+    it('ends stdin on the plain-argv branch and never writes the prompt there', async () => {
+      const child = makeFakeChild();
+      mockSpawn.mockReturnValueOnce(child);
+
+      const provider = new TestExtractionProvider(ARGV_CONFIG);
+      const promise = provider.extractJSONWithLLM('noise {"findings": []} noise');
+
+      // The prompt rides along as the trailing positional arg, not on stdin.
+      const [, spawnArgs] = mockSpawn.mock.calls[0];
+      expect(spawnArgs[0]).toBe('exec');
+      expect(spawnArgs[spawnArgs.length - 1]).toContain('Extract the JSON object');
+      expect(child.stdin.write).not.toHaveBeenCalled();
+      expect(child.stdin.end).toHaveBeenCalledTimes(1);
+
+      child.stdout.emit('data', Buffer.from('{"findings": []}'));
+      child.emit('close', 0);
+      await expect(promise).resolves.toEqual({ success: true, data: { findings: [] } });
+    });
+
+    it('attaches a stdin error handler on the plain-argv branch so EPIPE cannot go unhandled', async () => {
+      const child = makeFakeChild();
+      mockSpawn.mockReturnValueOnce(child);
+
+      const provider = new TestExtractionProvider(ARGV_CONFIG);
+      const promise = provider.extractJSONWithLLM('raw');
+
+      const errorHandler = child.stdin.on.mock.calls.find(([evt]) => evt === 'error');
+      expect(errorHandler).toBeDefined();
+      expect(() => errorHandler[1](new Error('EPIPE'))).not.toThrow();
+
+      child.emit('close', 0);
+      await promise;
+    });
+
+    it('still writes the prompt and ends stdin on the stdin branch', async () => {
+      const child = makeFakeChild();
+      mockSpawn.mockReturnValueOnce(child);
+
+      const provider = new TestExtractionProvider(STDIN_CONFIG);
+      const promise = provider.extractJSONWithLLM('raw {"ok": true}');
+
+      const [, spawnArgs] = mockSpawn.mock.calls[0];
+      expect(spawnArgs).toEqual(['-p']);  // prompt is NOT appended to argv
+      expect(child.stdin.write).toHaveBeenCalledTimes(1);
+      expect(child.stdin.write.mock.calls[0][0]).toContain('Extract the JSON object');
+      expect(child.stdin.end).toHaveBeenCalledTimes(1);
+
+      child.stdout.emit('data', Buffer.from('{"ok": true}'));
+      child.emit('close', 0);
+      await expect(promise).resolves.toEqual({ success: true, data: { ok: true } });
+    });
+
+    it('tolerates a child with no stdin stream at all', async () => {
+      const child = makeFakeChild({ stdin: false });
+      mockSpawn.mockReturnValueOnce(child);
+
+      const provider = new TestExtractionProvider(ARGV_CONFIG);
+      const promise = provider.extractJSONWithLLM('raw {"ok": true}');
+
+      child.stdout.emit('data', Buffer.from('{"ok": true}'));
+      child.emit('close', 0);
+      await expect(promise).resolves.toEqual({ success: true, data: { ok: true } });
+    });
+  });
+
+  // Extraction input is a whole malformed model response, so the two file modes
+  // exist to keep it off argv — a large one on argv fails the spawn with E2BIG.
+  describe('prompt file delivery', () => {
+    /** The path the helper passed to spawn, for whichever file mode is in play. */
+    function tmpPathFromSpawn() {
+      const [, spawnArgs] = mockSpawn.mock.calls[0];
+      const last = spawnArgs[spawnArgs.length - 1];
+      return last.startsWith('@') ? last.slice(1) : last;
+    }
+
+    it('writes the prompt to a temp file and appends [flag, path] for promptFileArg', async () => {
+      const child = makeFakeChild();
+      mockSpawn.mockReturnValueOnce(child);
+
+      const provider = new TestExtractionProvider(FILE_ARG_CONFIG);
+      const promise = provider.extractJSONWithLLM('noise {"findings": []} noise');
+
+      const [, spawnArgs] = mockSpawn.mock.calls[0];
+      expect(spawnArgs.slice(0, 2)).toEqual(['exec', '--prompt-file']);
+      expect(spawnArgs).toHaveLength(3);
+
+      const tmpPath = tmpPathFromSpawn();
+      expect(fs.readFileSync(tmpPath, 'utf8')).toContain('Extract the JSON object');
+      // The prompt itself must never reach argv, and nothing goes to stdin.
+      expect(spawnArgs.some(a => a.includes('Extract the JSON object'))).toBe(false);
+      expect(child.stdin.write).not.toHaveBeenCalled();
+      expect(child.stdin.end).toHaveBeenCalledTimes(1);
+
+      child.stdout.emit('data', Buffer.from('{"findings": []}'));
+      child.emit('close', 0);
+      await expect(promise).resolves.toEqual({ success: true, data: { findings: [] } });
+
+      expect(fs.existsSync(tmpPath)).toBe(false);
+    });
+
+    it('removes the promptFileArg temp file when the spawn fails outright', async () => {
+      const child = makeFakeChild();
+      mockSpawn.mockReturnValueOnce(child);
+
+      const provider = new TestExtractionProvider(FILE_ARG_CONFIG);
+      const promise = provider.extractJSONWithLLM('raw');
+      const tmpPath = tmpPathFromSpawn();
+      expect(fs.existsSync(tmpPath)).toBe(true);
+
+      // No `close` follows a spawn error, so the error path owns the cleanup.
+      child.emit('error', new Error('spawn ENOENT'));
+      await expect(promise).resolves.toEqual({ success: false, error: 'spawn ENOENT' });
+
+      expect(fs.existsSync(tmpPath)).toBe(false);
+    });
+
+    it('still appends @path for promptViaFile (Pi) rather than a named flag', async () => {
+      const child = makeFakeChild();
+      mockSpawn.mockReturnValueOnce(child);
+
+      const provider = new TestExtractionProvider(AT_FILE_CONFIG);
+      const promise = provider.extractJSONWithLLM('raw {"ok": true}');
+
+      const [, spawnArgs] = mockSpawn.mock.calls[0];
+      expect(spawnArgs).toHaveLength(2);
+      expect(spawnArgs[0]).toBe('-p');
+      expect(spawnArgs[1]).toMatch(/^@.+/);
+      expect(spawnArgs).not.toContain('--prompt-file');
+
+      const tmpPath = tmpPathFromSpawn();
+      expect(fs.readFileSync(tmpPath, 'utf8')).toContain('Extract the JSON object');
+      expect(child.stdin.write).not.toHaveBeenCalled();
+
+      child.stdout.emit('data', Buffer.from('{"ok": true}'));
+      child.emit('close', 0);
+      await expect(promise).resolves.toEqual({ success: true, data: { ok: true } });
+
+      expect(fs.existsSync(tmpPath)).toBe(false);
+    });
+
+    it('removes the promptViaFile temp file when the spawn fails outright', async () => {
+      const child = makeFakeChild();
+      mockSpawn.mockReturnValueOnce(child);
+
+      const provider = new TestExtractionProvider(AT_FILE_CONFIG);
+      const promise = provider.extractJSONWithLLM('raw');
+      const tmpPath = tmpPathFromSpawn();
+      expect(fs.existsSync(tmpPath)).toBe(true);
+
+      child.emit('error', new Error('spawn ENOENT'));
+      await promise;
+
+      expect(fs.existsSync(tmpPath)).toBe(false);
+    });
+
+    it('lets promptFileArg win when a config sets both file modes', async () => {
+      const child = makeFakeChild();
+      mockSpawn.mockReturnValueOnce(child);
+
+      const provider = new TestExtractionProvider({ ...AT_FILE_CONFIG, promptFileArg: '--prompt-file' });
+      const promise = provider.extractJSONWithLLM('raw');
+
+      const [, spawnArgs] = mockSpawn.mock.calls[0];
+      expect(spawnArgs.slice(0, 2)).toEqual(['-p', '--prompt-file']);
+      expect(spawnArgs[2]).not.toMatch(/^@/);
+
+      child.emit('close', 0);
+      await promise;
+      expect(fs.existsSync(tmpPathFromSpawn())).toBe(false);
+    });
+
+    it('leaves no temp file behind for the argv and stdin modes', async () => {
+      for (const config of [ARGV_CONFIG, STDIN_CONFIG]) {
+        mockSpawn.mockClear();
+        const child = makeFakeChild();
+        mockSpawn.mockReturnValueOnce(child);
+
+        const promise = new TestExtractionProvider(config).extractJSONWithLLM('raw {"ok": true}');
+        const [, spawnArgs] = mockSpawn.mock.calls[0];
+        expect(spawnArgs).not.toContain('--prompt-file');
+        expect(spawnArgs.some(a => a.startsWith('@'))).toBe(false);
+
+        child.stdout.emit('data', Buffer.from('{"ok": true}'));
+        child.emit('close', 0);
+        await expect(promise).resolves.toEqual({ success: true, data: { ok: true } });
+      }
+    });
+  });
+
+  describe('abortSignal support', () => {
+    it('resolves normally when no abortSignal is supplied (unchanged contract)', async () => {
+      const child = makeFakeChild();
+      mockSpawn.mockReturnValueOnce(child);
+
+      const provider = new TestExtractionProvider(ARGV_CONFIG);
+      const promise = provider.extractJSONWithLLM('raw');
+
+      child.emit('close', 1);
+      // Failures still come back as a resolved {success:false}, never a rejection.
+      await expect(promise).resolves.toEqual({
+        success: false,
+        error: 'Process exited with code 1',
+      });
+      expect(child.kill).not.toHaveBeenCalled();
+    });
+
+    it('does not spawn at all when the signal is already aborted', async () => {
+      const controller = new AbortController();
+      controller.abort();
+
+      const provider = new TestExtractionProvider(ARGV_CONFIG);
+      await expect(
+        provider.extractJSONWithLLM('raw', { abortSignal: controller.signal })
+      ).rejects.toMatchObject({ name: 'AbortError', isCancellation: true });
+
+      expect(mockSpawn).not.toHaveBeenCalled();
+    });
+
+    it('kills the child and rejects with an AbortError when the signal aborts mid-flight', async () => {
+      const child = makeFakeChild();
+      mockSpawn.mockReturnValueOnce(child);
+
+      const controller = new AbortController();
+      const provider = new TestExtractionProvider(ARGV_CONFIG);
+      const promise = provider.extractJSONWithLLM('raw', { abortSignal: controller.signal });
+
+      controller.abort();
+      expect(child.kill).toHaveBeenCalledWith('SIGTERM');
+
+      child.emit('close', 143);
+      await expect(promise).rejects.toMatchObject({ name: 'AbortError', isCancellation: true });
+    });
+
+    // The cancel must win even if the child happened to finish cleanly in the
+    // race — otherwise a cancelled job reports a successful extraction.
+    it('rejects on cancel even when the child closes with a parseable result', async () => {
+      const child = makeFakeChild();
+      mockSpawn.mockReturnValueOnce(child);
+
+      const controller = new AbortController();
+      const provider = new TestExtractionProvider(ARGV_CONFIG);
+      const promise = provider.extractJSONWithLLM('raw', { abortSignal: controller.signal });
+
+      controller.abort();
+      child.stdout.emit('data', Buffer.from('{"findings": []}'));
+      child.emit('close', 0);
+
+      await expect(promise).rejects.toMatchObject({ name: 'AbortError' });
+    });
+
+    // A spawn failure leaves the child pidless, so killChildSafely signals
+    // nothing and `close` may never arrive — the cancel has to be recognized
+    // on the error path too.
+    it('surfaces a cancel that lands on the error path as an AbortError', async () => {
+      // Not `makeFakeChild({ pid: undefined })`: the default parameter would
+      // substitute a real pid. A failed spawn genuinely has no pid.
+      const child = makeFakeChild();
+      child.pid = undefined;
+      mockSpawn.mockReturnValueOnce(child);
+
+      const controller = new AbortController();
+      const provider = new TestExtractionProvider(ARGV_CONFIG);
+      const promise = provider.extractJSONWithLLM('raw', { abortSignal: controller.signal });
+
+      controller.abort();
+      child.emit('error', new Error('spawn ENOENT'));
+
+      await expect(promise).rejects.toMatchObject({ name: 'AbortError' });
+      expect(child.kill).not.toHaveBeenCalled();
+    });
+
+    // The kill EPIPEs a pending stdin write, and that callback fires before
+    // `close` does — so the write-error path has to recognize the cancel too,
+    // or a cancelled call settles as an ordinary write failure.
+    it('treats a cancel-induced stdin write failure as a cancel, not a write error', async () => {
+      const child = makeFakeChild();
+      let writeCallback;
+      child.stdin.write = vi.fn((_data, cb) => { writeCallback = cb; });
+      mockSpawn.mockReturnValueOnce(child);
+
+      const controller = new AbortController();
+      const provider = new TestExtractionProvider(STDIN_CONFIG);
+      const promise = provider.extractJSONWithLLM('raw', { abortSignal: controller.signal });
+
+      controller.abort();
+      writeCallback(Object.assign(new Error('write EPIPE'), { code: 'EPIPE' }));
+
+      await expect(promise).rejects.toMatchObject({ name: 'AbortError', isCancellation: true });
+    });
+
+    // Analysis jobs reuse one per-job signal across many calls; a listener left
+    // attached after each call accumulates for the life of the job.
+    it('detaches the abort listener once extraction settles', async () => {
+      const child = makeFakeChild();
+      mockSpawn.mockReturnValueOnce(child);
+
+      const controller = new AbortController();
+      const provider = new TestExtractionProvider(ARGV_CONFIG);
+      const promise = provider.extractJSONWithLLM('raw', { abortSignal: controller.signal });
+
+      child.stdout.emit('data', Buffer.from('{"ok": true}'));
+      child.emit('close', 0);
+      await expect(promise).resolves.toEqual({ success: true, data: { ok: true } });
+
+      // Aborting after the fact must not reach the already-finished child.
+      controller.abort();
+      expect(child.kill).not.toHaveBeenCalled();
+    });
+
+    it('reports a timeout (not a cancel) when no signal fired', async () => {
+      vi.useFakeTimers();
+      const child = makeFakeChild();
+      mockSpawn.mockReturnValueOnce(child);
+
+      const provider = new TestExtractionProvider(ARGV_CONFIG);
+      const promise = provider.extractJSONWithLLM('raw');
+
+      await vi.advanceTimersByTimeAsync(60000);
+
+      await expect(promise).resolves.toEqual({
+        success: false,
+        error: 'LLM extraction timed out',
+      });
+      expect(child.kill).toHaveBeenCalledWith('SIGTERM');
+    });
+
+    it('reports a cancel when the child ignores SIGTERM until the timeout', async () => {
+      vi.useFakeTimers();
+      const child = makeFakeChild();
+      mockSpawn.mockReturnValueOnce(child);
+
+      const controller = new AbortController();
+      const provider = new TestExtractionProvider(ARGV_CONFIG);
+      // Capture the outcome up front: the rejection fires while the timers are
+      // being advanced, and an unobserved rejection at that moment is reported
+      // as an unhandled error even though the test later awaits it.
+      const settled = provider
+        .extractJSONWithLLM('raw', { abortSignal: controller.signal })
+        .then(result => ({ result }), error => ({ error }));
+
+      controller.abort();
+      // Child never emits close; the extraction timeout is the only way out.
+      await vi.advanceTimersByTimeAsync(60000);
+
+      const { error } = await settled;
+      expect(error).toMatchObject({ name: 'AbortError', isCancellation: true });
     });
   });
 });

--- a/tests/unit/muse-provider.test.js
+++ b/tests/unit/muse-provider.test.js
@@ -1,0 +1,1727 @@
+// Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+/**
+ * Unit tests for MuseProvider
+ *
+ * These tests focus on static methods, constructor behavior, arg construction,
+ * and response parsing without requiring an actual Muse CLI process.
+ *
+ * All JSONL fixtures below mirror real `muse exec --json` output
+ * (Muse Code 0.1.0): every record is an envelope whose discriminator is
+ * `payload_type`, with the interesting fields under `payload`.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { EventEmitter } = require('events');
+const logger = require('../../src/utils/logger');
+
+// Spy on child_process.spawn BEFORE the provider is required, so the provider's
+// destructured `spawn` reference resolves to the spy. vi.mock does not intercept
+// CJS requires of Node built-in modules in vitest (see copilot-provider.test.js).
+//
+// The provider captures that reference once, at require time, so this spy can
+// never be replaced — and `vi.restoreAllMocks()` only restores the property on
+// `child_process`, leaving the captured spy holding the previous test's
+// implementation and call history. beforeEach therefore re-arms it explicitly:
+// call history cleared, implementation back to the real spawn (the ENOENT test
+// wants a genuine spawn failure).
+const childProcess = require('child_process');
+const realSpawn = childProcess.spawn;
+const mockSpawn = vi.spyOn(childProcess, 'spawn');
+
+const MuseProvider = require('../../src/ai/muse-provider');
+
+/**
+ * Silence the logger and make its output methods assertable.
+ *
+ * Deliberately NOT `vi.mock('../../src/utils/logger')`: both this file and the
+ * provider reach the logger through CommonJS `require`, which resolves via
+ * Node's loader and never enters vitest's module graph, so a `vi.mock` factory
+ * is silently ignored — the real singleton is what both sides get. Spying on
+ * that singleton is the only thing that actually intercepts the calls.
+ *
+ * `isStreamDebugEnabled`/`setStreamDebugEnabled` stay real so logStreamLine
+ * reads the same flag the tests set.
+ */
+const SPIED_LOG_METHODS = ['info', 'warn', 'error', 'success', 'debug', 'streamDebug', 'section', 'log'];
+function spyOnLogger() {
+  for (const method of SPIED_LOG_METHODS) {
+    vi.spyOn(logger, method).mockImplementation(() => {});
+  }
+}
+
+/** Build one line of muse JSONL. */
+function record(payloadType, payload, extra = {}) {
+  return JSON.stringify({ payload_type: payloadType, payload, ...extra });
+}
+
+/**
+ * The run's terminal record, named after its outcome.
+ *
+ * `attemptId` is the command UUID of the `muse exec` attempt the outcome
+ * belongs to. Real records carry it in all three places attemptIdOf reads;
+ * omitting it yields the older shape that names no attempt at all.
+ */
+function terminalRecord(terminal, text, reason = null, attemptId = null) {
+  const payload = { kind: 'run_terminal', terminal, text, reason };
+  const extra = {};
+  if (attemptId) {
+    payload.command_id = attemptId;
+    payload.run_stream = { kind: 'run', id: attemptId };
+    extra.causation_id = attemptId;
+    extra.stream = { kind: 'session', id: 'session-1' };
+  }
+  return record(`run.terminal.${terminal}`, payload, extra);
+}
+
+/**
+ * An output delta scoped to one `muse exec` attempt.
+ *
+ * The top-level `stream` is deliberately the SAME for every attempt: on stdout
+ * it is the SESSION stream, so scoping by it would scope to nothing. Only the
+ * command UUID distinguishes attempts.
+ */
+function deltaRecord(text, sequence, attemptId) {
+  return record(
+    'run.output.delta',
+    { text, command_id: attemptId, run_stream: { kind: 'run', id: attemptId } },
+    { sequence, causation_id: attemptId, stream: { kind: 'session', id: 'session-1' } }
+  );
+}
+
+/**
+ * Record every prompt directory execute() creates, so a test can assert on the
+ * exact path instead of diffing os.tmpdir() (which other forks also write to).
+ *
+ * The provider calls `fs.mkdtempSync(...)` as a property of the same `fs`
+ * module object this file requires, so spying on it intercepts the real call.
+ *
+ * @returns {string[]} live array of created directories
+ */
+function trackPromptDirs() {
+  const created = [];
+  const realMkdtemp = fs.mkdtempSync;
+  vi.spyOn(fs, 'mkdtempSync').mockImplementation((prefix, ...rest) => {
+    const dir = realMkdtemp.call(fs, prefix, ...rest);
+    created.push(dir);
+    return dir;
+  });
+  return created;
+}
+
+/**
+ * Minimal stand-in for a spawned muse process: the exact surface execute() and
+ * testAvailability() touch.
+ *
+ * `pid` is only defaulted when the caller omits the key entirely — passing
+ * `{ pid: undefined }` really does produce a pidless child, which is what the
+ * killChildSafely guard needs. A `pid = 4242` default parameter would silently
+ * hand back a live pid instead.
+ */
+function makeFakeChild(overrides = {}) {
+  const child = new EventEmitter();
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+
+  const stdin = new EventEmitter();
+  stdin.end = vi.fn();
+  child.stdin = stdin;
+
+  child.pid = 'pid' in overrides ? overrides.pid : 4242;
+  child.kill = vi.fn(() => true);
+  return child;
+}
+
+/**
+ * Assert execute() created exactly one prompt directory and removed it.
+ *
+ * The length check is not decoration: `fs.existsSync(undefined)` swallows the
+ * error and returns false, so an empty tracking array would satisfy the removal
+ * assertion on its own.
+ */
+function expectPromptDirRemoved(promptDirs) {
+  expect(promptDirs).toHaveLength(1);
+  expect(fs.existsSync(promptDirs[0])).toBe(false);
+}
+
+/** Settle a promise without letting a rejection escape as unhandled. */
+function settledError(promise) {
+  return promise.then(() => null, (err) => err);
+}
+
+describe('MuseProvider', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    spyOnLogger();
+    mockSpawn.mockReset();
+    mockSpawn.mockImplementation((...args) => realSpawn.apply(childProcess, args));
+    delete process.env.PAIR_REVIEW_MUSE_CMD;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    process.env = { ...originalEnv };
+  });
+
+  describe('static methods', () => {
+    it('returns the correct provider name', () => {
+      expect(MuseProvider.getProviderName()).toBe('Muse');
+    });
+
+    it('returns the correct provider ID', () => {
+      expect(MuseProvider.getProviderId()).toBe('muse');
+    });
+
+    it('returns muse-spark-1.2-high as the default model', () => {
+      expect(MuseProvider.getDefaultModel()).toBe('muse-spark-1.2-high');
+    });
+
+    it('returns models with the expected structure', () => {
+      const models = MuseProvider.getModels();
+      expect(Array.isArray(models)).toBe(true);
+      expect(models.length).toBeGreaterThan(0);
+      for (const model of models) {
+        expect(model).toHaveProperty('id');
+        expect(model).toHaveProperty('tier');
+        expect(model).toHaveProperty('name');
+        expect(model).toHaveProperty('description');
+        expect(['fast', 'balanced', 'thorough']).toContain(model.tier);
+      }
+    });
+
+    it('gives every model a real cli_model and reasoning effort', () => {
+      for (const model of MuseProvider.getModels()) {
+        expect(['muse-spark-1.2', 'muse-spark-1.2-contributor']).toContain(model.cli_model);
+        expect(model.extra_args[0]).toBe('--reasoning-effort');
+        expect(['none', 'minimal', 'low', 'medium', 'high', 'xhigh', 'ultra'])
+          .toContain(model.extra_args[1]);
+      }
+    });
+
+    it('marks exactly one model as the default and it is not a contributor model', () => {
+      const defaults = MuseProvider.getModels().filter(m => m.default === true);
+      expect(defaults).toHaveLength(1);
+      expect(defaults[0].id).toBe(MuseProvider.getDefaultModel());
+      // Reviews carry potentially proprietary source, so the data-sharing tier
+      // must never be the silent default even though muse's own CLI default is
+      // the contributor model.
+      expect(defaults[0].cli_model).toBe('muse-spark-1.2');
+    });
+
+    it('warns in the description of every contributor model that Meta may use the content', () => {
+      const contributors = MuseProvider.getModels()
+        .filter(m => m.cli_model === 'muse-spark-1.2-contributor');
+      expect(contributors.length).toBeGreaterThan(0);
+      for (const model of contributors) {
+        expect(model.description).toMatch(/used by Meta for product improvement/i);
+      }
+    });
+
+    it('orders the fast tier so the non-contributor model is picked for extraction', () => {
+      // getFastTierModel() takes the FIRST fast-tier model; it must not resolve
+      // to the data-sharing tier. Adding models must never disturb this order.
+      const firstFast = MuseProvider.getModels().find(m => m.tier === 'fast');
+      expect(firstFast.cli_model).toBe('muse-spark-1.2');
+      expect(new MuseProvider().getFastTierModel()).toBe('muse-spark-1.2-low');
+    });
+
+    it('offers a contributor counterpart at every reasoning effort it exposes', () => {
+      const models = MuseProvider.getModels();
+      const effortOf = (m) => m.extra_args[1];
+      const efforts = new Set(models.filter(m => m.cli_model === 'muse-spark-1.2').map(effortOf));
+      const contributorEfforts = new Set(
+        models.filter(m => m.cli_model === 'muse-spark-1.2-contributor').map(effortOf)
+      );
+
+      expect([...efforts].sort()).toEqual(['high', 'low', 'ultra', 'xhigh']);
+      expect([...contributorEfforts].sort()).toEqual(['high', 'low', 'ultra', 'xhigh']);
+      expect(models).toHaveLength(8);
+    });
+
+    it('pairs each contributor variant right after its non-contributor twin', () => {
+      // Display order, and the invariant getFastTierModel() depends on: the
+      // non-data-sharing model always comes first within a pairing.
+      expect(MuseProvider.getModels().map(m => m.id)).toEqual([
+        'muse-spark-1.2-ultra',
+        'muse-spark-1.2-contributor-ultra',
+        'muse-spark-1.2-xhigh',
+        'muse-spark-1.2-contributor-xhigh',
+        'muse-spark-1.2-high',
+        'muse-spark-1.2-contributor-high',
+        'muse-spark-1.2-low',
+        'muse-spark-1.2-contributor-low'
+      ]);
+    });
+
+    it('gives the new thorough contributor variants the thorough tier and shares-data badge', () => {
+      const byId = Object.fromEntries(MuseProvider.getModels().map(m => [m.id, m]));
+
+      for (const id of ['muse-spark-1.2-contributor-ultra', 'muse-spark-1.2-contributor-xhigh']) {
+        expect(byId[id].tier).toBe('thorough');
+        expect(byId[id].badge).toBe('Shares Data');
+        expect(byId[id].badgeClass).toBe('badge-power');
+      }
+      expect(byId['muse-spark-1.2-contributor-ultra'].extra_args).toEqual(['--reasoning-effort', 'ultra']);
+      expect(byId['muse-spark-1.2-contributor-xhigh'].extra_args).toEqual(['--reasoning-effort', 'xhigh']);
+    });
+
+    it('provides real install instructions naming the launcher and muse login', () => {
+      const instructions = MuseProvider.getInstallInstructions();
+      expect(instructions).toContain('api.meta.ai/muse-launcher.sh');
+      expect(instructions).toContain('muse login');
+      // Muse is not distributed on npm; never suggest a package name.
+      expect(instructions).not.toMatch(/npm install/i);
+    });
+  });
+
+  describe('constructor', () => {
+    it('defaults to the muse command', () => {
+      expect(new MuseProvider().museCmd).toBe('muse');
+    });
+
+    it('prefers the config command over the default', () => {
+      expect(new MuseProvider('muse-spark-1.2-high', { command: '/opt/muse' }).museCmd)
+        .toBe('/opt/muse');
+    });
+
+    it('prefers PAIR_REVIEW_MUSE_CMD over the config command', () => {
+      process.env.PAIR_REVIEW_MUSE_CMD = '/env/muse';
+      expect(new MuseProvider('muse-spark-1.2-high', { command: '/opt/muse' }).museCmd)
+        .toBe('/env/muse');
+    });
+
+    it('does not use shell mode for a single-word command', () => {
+      expect(new MuseProvider().useShell).toBe(false);
+    });
+
+    it('strips a trailing exec subcommand so neither spawn path builds `exec exec`', () => {
+      // The provider supplies `exec` itself on BOTH paths, so a command
+      // configured as `muse exec` would spawn `muse exec exec --json …`, which
+      // muse rejects. Normalizing in the constructor is what keeps the analysis
+      // and extraction paths from disagreeing about whether it is already there.
+      const provider = new MuseProvider('muse-spark-1.2-high', { command: 'muse exec' });
+
+      expect(provider.museCmd).toBe('muse');
+      expect(provider.baseArgs.filter(a => a === 'exec')).toHaveLength(1);
+      expect(provider.buildArgsForModel('muse-spark-1.2-low').filter(a => a === 'exec')).toHaveLength(1);
+
+      const extraction = provider.getExtractionConfig('muse-spark-1.2-low');
+      expect(extraction.command).toBe('muse');
+      expect(extraction.args.filter(a => a === 'exec')).toHaveLength(1);
+
+      // Nothing is swallowed silently: the user still learns their config is wrong.
+      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('`exec` subcommand'));
+    });
+
+    it('stops a stripped command from needlessly going through a shell', () => {
+      // `useShell` is derived AFTER stripping, so `muse exec` is single-word
+      // again by the time the flag is computed.
+      expect(new MuseProvider('muse-spark-1.2-high', { command: 'muse exec' }).useShell).toBe(false);
+    });
+
+    it('strips a trailing exec from the environment override too', () => {
+      process.env.PAIR_REVIEW_MUSE_CMD = '/opt/muse exec';
+      expect(new MuseProvider().museCmd).toBe('/opt/muse');
+    });
+
+    it.each([
+      ['docker exec container muse'],
+      ['kubectl exec -it pod -- muse']
+    ])('leaves the container-exec wrapper %s untouched', (command) => {
+      // Only a bare TRAILING `exec` is removed. A container-exec invocation can
+      // never end with `exec` — the container and the command to run follow it.
+      const provider = new MuseProvider('muse-spark-1.2-high', { command });
+      expect(provider.museCmd).toBe(command);
+      expect(provider.useShell).toBe(true);
+    });
+
+    it('does not strip an exec that sits inside a quoted path', () => {
+      // A quoted trailing token ends with the quote character, so the pattern
+      // cannot reach inside it.
+      const provider = new MuseProvider('muse-spark-1.2-high', { command: '"/opt/my exec"' });
+      expect(provider.museCmd).toBe('"/opt/my exec"');
+      expect(provider.getExtractionConfig('muse-spark-1.2-low').command).toBe('/opt/my exec');
+    });
+
+    it('uses shell mode for a multi-word command', () => {
+      expect(new MuseProvider('muse-spark-1.2-high', { command: 'devx muse --' }).useShell)
+        .toBe(true);
+    });
+
+    it('builds baseArgs with exec, --json, --model, the safety flag and the reasoning effort', () => {
+      expect(new MuseProvider('muse-spark-1.2-high').baseArgs).toEqual([
+        'exec', '--json', '--model', 'muse-spark-1.2', '--disable-write', '--reasoning-effort', 'high'
+      ]);
+    });
+
+    it('maps each effort variant onto the right cli model', () => {
+      expect(new MuseProvider('muse-spark-1.2-ultra').baseArgs)
+        .toEqual(['exec', '--json', '--model', 'muse-spark-1.2', '--disable-write', '--reasoning-effort', 'ultra']);
+      expect(new MuseProvider('muse-spark-1.2-contributor-low').baseArgs)
+        .toEqual(['exec', '--json', '--model', 'muse-spark-1.2-contributor', '--disable-write', '--reasoning-effort', 'low']);
+    });
+
+    it('never bakes a --prompt-file pair into baseArgs', () => {
+      // The temp path only exists during a run; execute() appends the pair.
+      expect(new MuseProvider().baseArgs).not.toContain('--prompt-file');
+    });
+
+    it('does not set command or args (the prompt path is per-run)', () => {
+      const provider = new MuseProvider();
+      expect(provider.command).toBeUndefined();
+      expect(provider.args).toBeUndefined();
+    });
+
+    it.each([
+      ['muse-spark-1.2'],
+      ['muse-spark']
+    ])('resolves the alias %s to the high-effort variant', (alias) => {
+      expect(new MuseProvider(alias).baseArgs).toEqual([
+        'exec', '--json', '--model', 'muse-spark-1.2', '--disable-write', '--reasoning-effort', 'high'
+      ]);
+    });
+
+    it('passes --disable-write but no approval or sandbox flags outside yolo mode', () => {
+      // `muse exec` already auto-approves tools by policy when run headlessly, so
+      // no approval flag is needed. `--approval-mode never` would DENY every tool
+      // (no tool runs, no terminal record emitted), so it must never appear.
+      // `--disable-write` blocks the write_file tool; shell stays enabled because
+      // analysis needs grep/find and the bundled git-diff-lines helper.
+      const args = new MuseProvider('muse-spark-1.2-high').baseArgs;
+      expect(args).toContain('--disable-write');
+      expect(args).not.toContain('--yolo');
+      expect(args).not.toContain('--approval-mode');
+      expect(args).not.toContain('--sandbox');
+      // Disabling shell would break git-diff-lines and Level 3 exploration.
+      expect(args).not.toContain('--disable-shell');
+    });
+
+    it('passes --yolo instead of --disable-write in yolo mode', () => {
+      const args = new MuseProvider('muse-spark-1.2-high', { yolo: true }).baseArgs;
+      expect(args).toEqual([
+        'exec', '--json', '--model', 'muse-spark-1.2', '--yolo', '--reasoning-effort', 'high'
+      ]);
+      expect(args).not.toContain('--disable-write');
+    });
+
+    it('fully locks down the extraction path, which needs no tools', () => {
+      // Unlike analysis, extraction only reformats captured text into JSON, so it
+      // gets no filesystem and no shell — mirroring Codex's read-only extraction.
+      const args = new MuseProvider('muse-spark-1.2-high').buildArgsForModel('muse-spark-1.2-low');
+      expect(args).toContain('--disable-write');
+      expect(args).toContain('--disable-shell');
+    });
+
+    it('omits --model entirely when cli_model is explicitly null', () => {
+      const provider = new MuseProvider('custom', {
+        models: [{ id: 'custom', tier: 'fast', cli_model: null, extra_args: ['--reasoning-effort', 'minimal'] }]
+      });
+      // Dropping --model must not drop the safety flag with it.
+      expect(provider.baseArgs).toEqual(['exec', '--json', '--disable-write', '--reasoning-effort', 'minimal']);
+      expect(provider.baseArgs).not.toContain('--model');
+    });
+
+    it('falls back to the model id as cli_model for an unknown model', () => {
+      expect(new MuseProvider('some-future-model').baseArgs)
+        .toEqual(['exec', '--json', '--model', 'some-future-model', '--disable-write']);
+    });
+
+    it('appends provider-level extra_args exactly once', () => {
+      // Regression: _resolveModelConfig already merges provider extra_args, so
+      // splicing configOverrides.extra_args separately duplicated every flag.
+      const provider = new MuseProvider('muse-spark-1.2-high', {
+        extra_args: ['--disable-web-tools']
+      });
+      const occurrences = provider.baseArgs.filter(a => a === '--disable-web-tools');
+      expect(occurrences).toHaveLength(1);
+      expect(provider.baseArgs).toEqual([
+        'exec', '--json', '--model', 'muse-spark-1.2', '--disable-write',
+        '--reasoning-effort', 'high', '--disable-web-tools'
+      ]);
+    });
+
+    it('merges extra_args from built-in, provider config, and per-model config in order', () => {
+      const provider = new MuseProvider('muse-spark-1.2-high', {
+        extra_args: ['--provider-flag'],
+        models: [{ id: 'muse-spark-1.2-high', tier: 'balanced', extra_args: ['--model-flag'] }]
+      });
+      expect(provider.baseArgs).toEqual([
+        'exec', '--json', '--model', 'muse-spark-1.2', '--disable-write',
+        '--reasoning-effort', 'high', '--provider-flag', '--model-flag'
+      ]);
+    });
+
+    it('lets a per-model cli_model override the built-in one', () => {
+      const provider = new MuseProvider('muse-spark-1.2-high', {
+        models: [{ id: 'muse-spark-1.2-high', tier: 'balanced', cli_model: 'muse-spark-1.2-contributor' }]
+      });
+      expect(provider.baseArgs).toContain('muse-spark-1.2-contributor');
+    });
+
+    it('merges env with per-model config winning over provider config', () => {
+      const provider = new MuseProvider('muse-spark-1.2-high', {
+        env: { SHARED: 'provider', ONLY_PROVIDER: 'yes' },
+        models: [{ id: 'muse-spark-1.2-high', tier: 'balanced', env: { SHARED: 'model' } }]
+      });
+      expect(provider.extraEnv).toEqual({ SHARED: 'model', ONLY_PROVIDER: 'yes' });
+    });
+
+    it('defaults extraEnv to an empty object', () => {
+      expect(new MuseProvider().extraEnv).toEqual({});
+    });
+  });
+
+  describe('getAnalysisSpawnConfig', () => {
+    it('returns the bare command and args in non-shell mode', () => {
+      expect(new MuseProvider('muse-spark-1.2-high').getAnalysisSpawnConfig()).toEqual({
+        command: 'muse',
+        args: ['exec', '--json', '--model', 'muse-spark-1.2', '--disable-write', '--reasoning-effort', 'high'],
+        useShell: false
+      });
+    });
+
+    it('appends trailing args last so no configured extra_args can displace the prompt', () => {
+      // Both extra_args tiers must be populated: with none configured,
+      // `[...baseArgs, ...trailingArgs]` trivially satisfies the invariant even
+      // if merged args could land after the pair. These are the args that could
+      // realistically be appended too late.
+      const provider = new MuseProvider('muse-spark-1.2-high', {
+        extra_args: ['--provider-flag', 'pv'],
+        models: [{
+          id: 'muse-spark-1.2-high',
+          tier: 'balanced',
+          extra_args: ['--model-flag', 'mv']
+        }]
+      });
+      const { args } = provider.getAnalysisSpawnConfig(['--prompt-file', '/tmp/x/prompt.txt']);
+
+      expect(args.slice(-2)).toEqual(['--prompt-file', '/tmp/x/prompt.txt']);
+      // The flags really are present, so the invariant above was under load.
+      expect(args).toContain('--provider-flag');
+      expect(args).toContain('--model-flag');
+      expect(args.indexOf('--provider-flag')).toBeLessThan(args.indexOf('--prompt-file'));
+      expect(args.indexOf('--model-flag')).toBeLessThan(args.indexOf('--prompt-file'));
+      // ...and only the trailing pair carries the prompt path.
+      expect(args.filter(a => a === '--prompt-file')).toHaveLength(1);
+    });
+
+    it('accepts a positional prompt as the trailing arg', () => {
+      // `muse exec [OPTIONS] [PROMPT]` — used by the permissions verify script,
+      // which has no per-run temp file.
+      const { args } = new MuseProvider().getAnalysisSpawnConfig(['review this']);
+      expect(args[args.length - 1]).toBe('review this');
+    });
+
+    it('folds args into the command string in shell mode', () => {
+      const result = new MuseProvider('muse-spark-1.2-high', { command: 'devx muse --' })
+        .getAnalysisSpawnConfig(['--prompt-file', '/tmp/x/prompt.txt']);
+      expect(result.useShell).toBe(true);
+      expect(result.args).toEqual([]);
+      // quoteShellArgs only quotes args carrying shell-special characters, so a
+      // plain path stays bare; the space-bearing case is covered below.
+      expect(result.command).toBe(
+        'devx muse -- exec --json --model muse-spark-1.2 --disable-write --reasoning-effort high --prompt-file /tmp/x/prompt.txt'
+      );
+    });
+
+    it('shell-quotes paths containing spaces', () => {
+      const { command } = new MuseProvider('muse-spark-1.2-high', { command: 'devx muse --' })
+        .getAnalysisSpawnConfig(['--prompt-file', '/tmp/a b/prompt.txt']);
+      expect(command).toContain("'/tmp/a b/prompt.txt'");
+    });
+
+    it('shell-quotes a positional prompt containing an apostrophe', () => {
+      const { command } = new MuseProvider('muse-spark-1.2-high', { command: 'devx muse --' })
+        .getAnalysisSpawnConfig(["it's a prompt"]);
+      expect(command).toContain("'it'\\''s a prompt'");
+    });
+
+    it('does not mutate baseArgs', () => {
+      const provider = new MuseProvider();
+      const before = [...provider.baseArgs];
+      provider.getAnalysisSpawnConfig(['--prompt-file', '/tmp/x']);
+      expect(provider.baseArgs).toEqual(before);
+    });
+  });
+
+  describe('buildArgsForModel', () => {
+    it('locks the same model down harder than the analysis path does', () => {
+      // Identical model, deliberately different safety posture: analysis keeps
+      // shell so the model can run grep/find and git-diff-lines, while
+      // extraction only reformats captured text and so gets no tools at all.
+      const provider = new MuseProvider('muse-spark-1.2-high');
+      expect(provider.baseArgs).toEqual([
+        'exec', '--json', '--model', 'muse-spark-1.2', '--disable-write', '--reasoning-effort', 'high'
+      ]);
+      expect(provider.buildArgsForModel('muse-spark-1.2-high')).toEqual([
+        'exec', '--json', '--model', 'muse-spark-1.2', '--disable-write', '--disable-shell', '--reasoning-effort', 'high'
+      ]);
+    });
+
+    it('resolves a different extraction model', () => {
+      expect(new MuseProvider('muse-spark-1.2-ultra').buildArgsForModel('muse-spark-1.2-low'))
+        .toEqual(['exec', '--json', '--model', 'muse-spark-1.2', '--disable-write', '--disable-shell', '--reasoning-effort', 'low']);
+    });
+
+    it('carries yolo through to extraction', () => {
+      expect(new MuseProvider('muse-spark-1.2-high', { yolo: true }).buildArgsForModel('muse-spark-1.2-low'))
+        .toContain('--yolo');
+    });
+
+    it('never appends a prompt marker', () => {
+      const args = new MuseProvider().buildArgsForModel('muse-spark-1.2-low');
+      expect(args).not.toContain('--prompt-file');
+      expect(args).not.toContain('-');
+    });
+  });
+
+  describe('getExtractionConfig', () => {
+    it('delivers the prompt through --prompt-file, not argv, stdin, or @file', () => {
+      // Extraction input is a whole malformed model response: on argv a large
+      // one fails the spawn with E2BIG. `muse exec` never reads stdin (exits 2
+      // with "missing prompt"), and the helper's promptViaFile mode appends
+      // Pi's `@<path>` syntax, which muse would read as literal prompt text.
+      const config = new MuseProvider().getExtractionConfig('muse-spark-1.2-low');
+      expect(config.promptFileArg).toBe('--prompt-file');
+      expect(config.promptViaStdin).toBe(false);
+      expect(config.promptViaFile).toBeUndefined();
+    });
+
+    it('returns the command and args for non-shell mode', () => {
+      const config = new MuseProvider().getExtractionConfig('muse-spark-1.2-low');
+      expect(config.command).toBe('muse');
+      expect(config.useShell).toBe(false);
+      expect(config.args).toEqual([
+        'exec', '--json', '--model', 'muse-spark-1.2', '--disable-write', '--disable-shell', '--reasoning-effort', 'low'
+      ]);
+    });
+
+    it('splits a multi-word command into argv instead of folding it into a shell string', () => {
+      // SECURITY REGRESSION: this used to return a prebuilt command string with
+      // useShell: true, back when the prompt was a trailing argv element — Node
+      // joined everything UNQUOTED into `/bin/sh -c`, so the multi-KB prompt was
+      // re-parsed as shell syntax. The prompt now goes via --prompt-file, but
+      // shell mode must STAY off: this spawn is not detached, so a cancel would
+      // kill only the shell wrapper and orphan the CLI.
+      const config = new MuseProvider('muse-spark-1.2-high', { command: 'devx muse --' })
+        .getExtractionConfig('muse-spark-1.2-low');
+
+      expect(config.useShell).toBe(false);
+      expect(config.command).toBe('devx');
+      expect(config.args).toEqual([
+        'muse', '--',
+        'exec', '--json', '--model', 'muse-spark-1.2', '--disable-write', '--disable-shell',
+        '--reasoning-effort', 'low'
+      ]);
+      expect(config.promptViaStdin).toBe(false);
+      // No element may be a space-joined command line: that is the shape a shell
+      // would have to re-parse.
+      for (const arg of config.args) {
+        expect(arg).not.toContain(' ');
+      }
+    });
+
+    it('splits a plain multi-word command into a leading command plus argv words', () => {
+      const config = new MuseProvider('muse-spark-1.2-high', { command: 'docker exec container muse' })
+        .getExtractionConfig('muse-spark-1.2-low');
+      expect(config.useShell).toBe(false);
+      expect(config.command).toBe('docker');
+      expect(config.args.slice(0, 3)).toEqual(['exec', 'container', 'muse']);
+      expect(config.args.slice(3, 5)).toEqual(['exec', '--json']);
+    });
+
+    it('keeps a quoted path containing spaces as a single argv word', () => {
+      // Quote grouping is the one shell nicety splitCommandWords honours, so an
+      // installed-app path survives as one word rather than three. The trailing
+      // word is deliberately NOT `exec`: the constructor strips that, which
+      // would leave `args[0] === 'exec'` true no matter how the split behaved.
+      const config = new MuseProvider('muse-spark-1.2-high', {
+        command: '"/Applications/My Tools/muse" --workspace-trust'
+      }).getExtractionConfig('muse-spark-1.2-low');
+      expect(config.command).toBe('/Applications/My Tools/muse');
+      expect(config.args[0]).toBe('--workspace-trust');
+      expect(config.args[1]).toBe('exec');
+      expect(config.args).not.toContain('"/Applications/My');
+    });
+
+    it('drops empty quoted words instead of emitting them as argv elements', () => {
+      // An empty argv element reaches muse as an empty positional prompt, and a
+      // leading one would become spawn('').
+      const config = new MuseProvider('muse-spark-1.2-high', { command: 'devx "" muse' })
+        .getExtractionConfig('muse-spark-1.2-low');
+      expect(config.command).toBe('devx');
+      expect(config.args.slice(0, 2)).toEqual(['muse', 'exec']);
+      expect(config.args).not.toContain('');
+    });
+
+    it.each([
+      ['devx "muse --', 'double'],
+      ["devx 'muse --", 'single']
+    ])('throws a named error for the unterminated %s quote rather than gluing the words together', (command, kind) => {
+      const provider = new MuseProvider('muse-spark-1.2-high', { command });
+      expect(() => provider.getExtractionConfig('muse-spark-1.2-low'))
+        .toThrow(new RegExp(`unterminated ${kind} quote`));
+    });
+
+    it('throws rather than spawning an empty command name when only quotes were configured', () => {
+      const provider = new MuseProvider('muse-spark-1.2-high', { command: '""' });
+      expect(() => provider.getExtractionConfig('muse-spark-1.2-low'))
+        .toThrow(/Muse command is empty/);
+    });
+
+    it('still spawns a single-word command directly, with no argv prefix', () => {
+      const config = new MuseProvider('muse-spark-1.2-high', { command: '/opt/muse' })
+        .getExtractionConfig('muse-spark-1.2-low');
+      expect(config.command).toBe('/opt/muse');
+      expect(config.args[0]).toBe('exec');
+    });
+
+    it('surfaces the merged env for the extraction model', () => {
+      const config = new MuseProvider('muse-spark-1.2-high', { env: { TOKEN: 'x' } })
+        .getExtractionConfig('muse-spark-1.2-low');
+      expect(config.env).toEqual({ TOKEN: 'x' });
+    });
+
+    it('honours a custom command from the environment', () => {
+      process.env.PAIR_REVIEW_MUSE_CMD = '/env/muse';
+      expect(new MuseProvider().getExtractionConfig('muse-spark-1.2-low').command).toBe('/env/muse');
+    });
+
+    // End to end through the shared helper: config fields alone can't prove the
+    // prompt actually leaves argv.
+    it('spawns extraction with the prompt in a file and cleans it up afterwards', async () => {
+      const child = makeFakeChild();
+      mockSpawn.mockReturnValueOnce(child);
+
+      const promise = new MuseProvider().extractJSONWithLLM('garbage {"findings": []} garbage');
+
+      const [command, args] = mockSpawn.mock.calls[0];
+      expect(command).toBe('muse');
+      const flagIndex = args.indexOf('--prompt-file');
+      expect(flagIndex).toBeGreaterThan(-1);
+
+      const promptPath = args[flagIndex + 1];
+      expect(fs.readFileSync(promptPath, 'utf8')).toContain('Extract the JSON object');
+      // The prompt text itself never becomes an argv word — that is the E2BIG fix.
+      expect(args.some(a => a.includes('Extract the JSON object'))).toBe(false);
+      // Extraction runs on the fast, non-data-sharing model.
+      expect(args[args.indexOf('--model') + 1]).toBe('muse-spark-1.2');
+
+      child.stdout.emit('data', Buffer.from('{"findings": []}'));
+      child.emit('close', 0);
+      await expect(promise).resolves.toEqual({ success: true, data: { findings: [] } });
+
+      expect(fs.existsSync(promptPath)).toBe(false);
+    });
+  });
+
+  describe('extractTerminalRecord', () => {
+    it('returns null for empty output', () => {
+      expect(new MuseProvider().extractTerminalRecord('')).toBeNull();
+      expect(new MuseProvider().extractTerminalRecord('   ')).toBeNull();
+    });
+
+    it('returns null when no terminal record is present', () => {
+      const stdout = [record('run.lifecycle.started', {}), record('run.output.delta', { text: 'hi' })].join('\n');
+      expect(new MuseProvider().extractTerminalRecord(stdout)).toBeNull();
+    });
+
+    it('finds a completed terminal record', () => {
+      const stdout = [record('run.output.delta', { text: 'hi' }), terminalRecord('completed', '{"a":1}')].join('\n');
+      expect(new MuseProvider().extractTerminalRecord(stdout))
+        .toEqual({ terminal: 'completed', text: '{"a":1}', reason: null, attemptId: null });
+    });
+
+    it('finds a failed terminal record via the payload kind, not the payload_type', () => {
+      // Muse names the record after its outcome (run.terminal.failed), so
+      // matching only run.terminal.completed would silently miss failures.
+      const stdout = terminalRecord('failed', '', 'server_error: The model failed to generate a response.');
+      expect(new MuseProvider().extractTerminalRecord(stdout)).toEqual({
+        terminal: 'failed',
+        text: '',
+        reason: 'server_error: The model failed to generate a response.',
+        attemptId: null
+      });
+    });
+
+    it('finds a cancelled terminal record', () => {
+      expect(new MuseProvider().extractTerminalRecord(terminalRecord('cancelled', '')).terminal)
+        .toBe('cancelled');
+    });
+
+    it('skips malformed lines', () => {
+      const stdout = ['{not json', '', terminalRecord('completed', 'ok')].join('\n');
+      expect(new MuseProvider().extractTerminalRecord(stdout).text).toBe('ok');
+    });
+
+    it('keeps the last terminal record when more than one is present', () => {
+      const stdout = [terminalRecord('failed', '', 'first'), terminalRecord('completed', 'second')].join('\n');
+      expect(new MuseProvider().extractTerminalRecord(stdout).text).toBe('second');
+    });
+
+    it('reports the attempt the outcome belongs to', () => {
+      const record = terminalRecord('completed', 'done', null, 'cmd-uuid-2');
+      expect(new MuseProvider().extractTerminalRecord(record).attemptId).toBe('cmd-uuid-2');
+    });
+
+    it.each([
+      ['run_stream.id', { run_stream: { kind: 'run', id: 'from-run-stream' }, command_id: 'from-command-id' }, { causation_id: 'from-causation' }, 'from-run-stream'],
+      ['command_id', { command_id: 'from-command-id' }, { causation_id: 'from-causation' }, 'from-command-id'],
+      ['causation_id', {}, { causation_id: 'from-causation' }, 'from-causation']
+    ])('falls back to %s when the richer fields are absent', (_label, idFields, extra, expected) => {
+      // Belt and braces against a future record that carries only one of the
+      // three, so the delta scoping never silently degrades to "no attempt".
+      const line = record(
+        'run.terminal.completed',
+        { kind: 'run_terminal', terminal: 'completed', text: 'done', ...idFields },
+        extra
+      );
+      expect(new MuseProvider().extractTerminalRecord(line).attemptId).toBe(expected);
+    });
+
+    it('never reads the session stream as the attempt', () => {
+      // On stdout the top-level `stream` is the SESSION stream and is identical
+      // for every attempt, so scoping by it would scope to nothing.
+      const line = record(
+        'run.terminal.completed',
+        { kind: 'run_terminal', terminal: 'completed', text: 'done' },
+        { stream: { kind: 'session', id: 'session-1' }, sequence: 42 }
+      );
+      expect(new MuseProvider().extractTerminalRecord(line).attemptId).toBeNull();
+    });
+  });
+
+  describe('parseMuseResponse', () => {
+    it('parses JSON from the terminal record text', () => {
+      const stdout = terminalRecord('completed', '{"suggestions":[{"line":1}]}');
+      const result = new MuseProvider().parseMuseResponse(stdout, 1, '[Level 1]');
+      expect(result.success).toBe(true);
+      expect(result.data.suggestions).toHaveLength(1);
+    });
+
+    it('falls back to concatenating output deltas when the terminal text is empty', () => {
+      const stdout = [
+        record('run.output.delta', { text: '{"suggestions":' }, { sequence: 10 }),
+        record('run.output.delta', { text: '[]}' }, { sequence: 11 }),
+        terminalRecord('completed', '')
+      ].join('\n');
+      const result = new MuseProvider().parseMuseResponse(stdout, 1, '[Level 1]');
+      expect(result.success).toBe(true);
+      expect(result.data).toEqual({ suggestions: [] });
+    });
+
+    it('orders delta fallback text by sequence, not arrival order', () => {
+      const stdout = [
+        record('run.output.delta', { text: '[]}' }, { sequence: 11 }),
+        record('run.output.delta', { text: '{"suggestions":' }, { sequence: 10 })
+      ].join('\n');
+      const result = new MuseProvider().parseMuseResponse(stdout, 1, '[Level 1]');
+      expect(result.success).toBe(true);
+      expect(result.data).toEqual({ suggestions: [] });
+    });
+
+    it('never resurrects a superseded attempt when the finishing attempt produced no text', () => {
+      // A resumed/retried run is a new `turn.submit` command, so its records
+      // carry a new UUID. Reading the terminal record and the deltas with
+      // different scoping rules is what let an unscoped concatenation present an
+      // EARLIER attempt's review as the answer of the attempt that finished.
+      const stdout = [
+        deltaRecord('{"suggestions":[{"line":1,"body":"stale"}]}', 10, 'attempt-a'),
+        terminalRecord('completed', '', null, 'attempt-b')
+      ].join('\n');
+
+      const result = new MuseProvider().parseMuseResponse(stdout, 1, '[Level 1]');
+      expect(result.success).toBe(false);
+      expect(result.data).toBeUndefined();
+      // Nothing safe to forward: the run really did produce no answer.
+      expect(result.textContent).toBeUndefined();
+      expect(result.error).toContain('no assistant text');
+      expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('earlier Muse attempts'));
+    });
+
+    it('concatenates only the finishing attempt deltas in a multi-attempt transcript', () => {
+      const stdout = [
+        deltaRecord('{"suggestions":[{"line":1,"body":"stale"}]}', 10, 'attempt-a'),
+        deltaRecord('{"suggestions":', 11, 'attempt-b'),
+        deltaRecord('[]}', 12, 'attempt-b'),
+        terminalRecord('completed', '', null, 'attempt-b')
+      ].join('\n');
+
+      const result = new MuseProvider().parseMuseResponse(stdout, 1, '[Level 1]');
+      expect(result.success).toBe(true);
+      expect(result.data).toEqual({ suggestions: [] });
+    });
+
+    it('scopes to the last delta attempt when the transcript ends before any terminal record', () => {
+      // Mirrors "keep the last terminal record" for a run that was cut off.
+      const stdout = [
+        deltaRecord('{"suggestions":[{"line":1,"body":"stale"}]}', 10, 'attempt-a'),
+        deltaRecord('{"suggestions":[]}', 11, 'attempt-b')
+      ].join('\n');
+
+      const result = new MuseProvider().parseMuseResponse(stdout, 1, '[Level 1]');
+      expect(result.success).toBe(true);
+      expect(result.data).toEqual({ suggestions: [] });
+    });
+
+    it('treats a transcript that names no attempt at all as one attempt', () => {
+      // Older record shapes and hand-written fixtures collapse to a single null
+      // scope, i.e. the pre-scoping behaviour, rather than being filtered away.
+      const stdout = [
+        record('run.output.delta', { text: '{"suggestions":' }, { sequence: 10 }),
+        record('run.output.delta', { text: '[]}' }, { sequence: 11 }),
+        terminalRecord('completed', '')
+      ].join('\n');
+
+      const result = new MuseProvider().parseMuseResponse(stdout, 1, '[Level 1]');
+      expect(result.success).toBe(true);
+      expect(result.data).toEqual({ suggestions: [] });
+      expect(logger.info).not.toHaveBeenCalledWith(expect.stringContaining('earlier Muse attempts'));
+    });
+
+    it('prefers the terminal record text over the deltas', () => {
+      const stdout = [
+        record('run.output.delta', { text: '{"from":"delta"}' }, { sequence: 1 }),
+        terminalRecord('completed', '{"from":"terminal"}')
+      ].join('\n');
+      const result = new MuseProvider().parseMuseResponse(stdout, 1, '[Level 1]');
+      expect(result.data).toEqual({ from: 'terminal' });
+    });
+
+    it('returns the assistant text as textContent when it is not JSON', () => {
+      const stdout = terminalRecord('completed', 'I could not analyse this diff.');
+      const result = new MuseProvider().parseMuseResponse(stdout, 1, '[Level 1]');
+      expect(result.success).toBe(false);
+      // The LLM fallback must receive the assistant text, never the raw JSONL.
+      expect(result.textContent).toBe('I could not analyse this diff.');
+      expect(result.textContent).not.toContain('payload_type');
+    });
+
+    it('extracts JSON wrapped in markdown fences', () => {
+      const stdout = terminalRecord('completed', '```json\n{"suggestions":[]}\n```');
+      const result = new MuseProvider().parseMuseResponse(stdout, 1, '[Level 1]');
+      expect(result.success).toBe(true);
+      expect(result.data).toEqual({ suggestions: [] });
+    });
+
+    it('skips malformed JSONL lines while collecting deltas', () => {
+      const stdout = [
+        '{not json',
+        record('run.output.delta', { text: '{"ok":true}' }, { sequence: 1 })
+      ].join('\n');
+      const result = new MuseProvider().parseMuseResponse(stdout, 1, '[Level 1]');
+      expect(result.success).toBe(true);
+      expect(result.data).toEqual({ ok: true });
+    });
+
+    it('falls back to extracting JSON from raw stdout when there is no assistant text', () => {
+      const result = new MuseProvider().parseMuseResponse('{"suggestions":[]}', 1, '[Level 1]');
+      expect(result.success).toBe(true);
+    });
+
+    it('reports failure for empty stdout', () => {
+      expect(new MuseProvider().parseMuseResponse('', 1, '[Level 1]').success).toBe(false);
+    });
+
+    it('never mines muse transport envelopes for a payload when there is no assistant text', () => {
+      // Every muse record is itself valid JSON, so handing raw JSONL to the
+      // generic extractor would return a lifecycle/terminal frame as though it
+      // were the review — turning a failed run into a false success.
+      const stdout = [
+        record('run.lifecycle.started', { kind: 'run_started', run_id: 'r1' }),
+        record('run.model.configured', { model_id: 'muse-spark-1.2' }),
+        terminalRecord('failed', '', 'server_error: The model failed to generate a response.')
+      ].join('\n');
+
+      const result = new MuseProvider().parseMuseResponse(stdout, 1, '[Level 1]');
+      expect(result.success).toBe(false);
+      expect(result.data).toBeUndefined();
+      // A missing textContent is what stops the LLM extraction fallback from
+      // being fed the transport frames.
+      expect(result.textContent).toBeUndefined();
+      expect(result.error).toContain('no assistant text');
+      expect(result.error).toContain('failed');
+      expect(result.error).toContain('server_error');
+    });
+
+    it('reports an empty but successful run as a failure rather than a false success', () => {
+      const stdout = [
+        record('run.lifecycle.started', { kind: 'run_started' }),
+        terminalRecord('completed', '')
+      ].join('\n');
+      const result = new MuseProvider().parseMuseResponse(stdout, 1, '[Level 1]');
+      expect(result.success).toBe(false);
+      expect(result.textContent).toBeUndefined();
+      expect(result.error).toContain('no assistant text');
+    });
+
+    it('still forwards genuinely non-JSONL output to the extraction fallback', () => {
+      // The envelope guard must not swallow output from a wrapper that printed
+      // plain text: with no envelopes at all, the whole output is model text.
+      const result = new MuseProvider().parseMuseResponse('I could not analyse this.', 1, '[Level 1]');
+      expect(result.success).toBe(false);
+      expect(result.textContent).toBe('I could not analyse this.');
+    });
+  });
+
+  describe('isAuthError', () => {
+    it.each([
+      'still unauthorized after a token refresh; run `muse login` again',
+      'no login to refresh a key from; run `muse login` or set META_API_KEY',
+      'starting logged out (run `muse login`)',
+      'HTTP error: 401',
+      '401 Unauthorized'
+    ])('detects %s', (stderr) => {
+      expect(new MuseProvider().isAuthError(stderr)).toBe(true);
+    });
+
+    it('does not treat an unrelated failure as an auth error', () => {
+      const provider = new MuseProvider();
+      expect(provider.isAuthError('server_error: The model failed to generate a response.')).toBe(false);
+      expect(provider.isAuthError('')).toBe(false);
+      expect(provider.isAuthError(undefined)).toBe(false);
+    });
+  });
+
+  describe('isUnknownModelError', () => {
+    it('detects a model missing from the catalog', () => {
+      expect(new MuseProvider().isUnknownModelError('model `nope` is not in the catalog')).toBe(true);
+    });
+
+    it('detects a hidden model', () => {
+      expect(new MuseProvider().isUnknownModelError('model is hidden in the catalog')).toBe(true);
+    });
+
+    it('ignores unrelated errors', () => {
+      expect(new MuseProvider().isUnknownModelError('some other failure')).toBe(false);
+      expect(new MuseProvider().isUnknownModelError(undefined)).toBe(false);
+    });
+  });
+
+  describe('createExitError', () => {
+    it('produces an actionable message for an auth failure', () => {
+      const error = new MuseProvider().createExitError(
+        1, 'still unauthorized after a token refresh; run `muse login` again', '[Level 1]'
+      );
+      expect(error.message).toContain('authentication failed');
+      expect(error.message).toContain('muse login');
+    });
+
+    it('produces an actionable message for an unknown model', () => {
+      const error = new MuseProvider('muse-spark-1.2-high').createExitError(
+        1, 'model `totally-not-a-model` is not in the catalog', '[Level 1]'
+      );
+      expect(error.message).toContain('unknown');
+      expect(error.message).toContain('muse-spark-1.2-high');
+    });
+
+    it('surfaces the terminal reason when stderr is unhelpful', () => {
+      // On failure muse's stderr says only "run ended with Failed"; the real
+      // reason exists nowhere but the JSONL terminal record.
+      const error = new MuseProvider().createExitError(
+        1, 'run ended with Failed', '[Level 1]', 'server_error: The model failed to generate a response.'
+      );
+      expect(error.message).toContain('server_error: The model failed to generate a response.');
+    });
+
+    it('classifies an auth failure reported only in the terminal reason', () => {
+      const error = new MuseProvider().createExitError(
+        1, 'run ended with Failed', '[Level 1]', 'still unauthorized after a token refresh; run `muse login` again'
+      );
+      expect(error.message).toContain('authentication failed');
+    });
+
+    it('includes the exit code for a generic failure', () => {
+      const error = new MuseProvider().createExitError(3, 'something broke', '[Level 1]');
+      expect(error.message).toContain('exited with code 3');
+      expect(error.message).toContain('something broke');
+    });
+
+    it('handles empty stderr without producing a dangling message', () => {
+      expect(new MuseProvider().createExitError(1, '', '[Level 1]').message)
+        .toContain('(no error output)');
+    });
+  });
+
+  describe('logStreamLine', () => {
+    afterEach(() => {
+      logger.setStreamDebugEnabled(false);
+    });
+
+    it('logs the terminal record at info level even without stream debug', () => {
+      logger.setStreamDebugEnabled(false);
+      new MuseProvider().logStreamLine(terminalRecord('completed', 'done'), 1, '[Level 1]');
+      expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('run.terminal'));
+    });
+
+    it('states that Muse reports no token usage', () => {
+      // Muse emits no usage anywhere; counts must never be fabricated.
+      new MuseProvider().logStreamLine(terminalRecord('completed', 'done'), 1, '[Level 1]');
+      expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('tokens not reported'));
+    });
+
+    it('includes the failure reason in the terminal log line', () => {
+      new MuseProvider().logStreamLine(terminalRecord('failed', '', 'server_error'), 1, '[Level 1]');
+      expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('server_error'));
+    });
+
+    it('stays silent for non-terminal records when stream debug is off', () => {
+      logger.setStreamDebugEnabled(false);
+      new MuseProvider().logStreamLine(record('run.output.delta', { text: 'hi' }), 1, '[Level 1]');
+      expect(logger.streamDebug).not.toHaveBeenCalled();
+      expect(logger.info).not.toHaveBeenCalled();
+    });
+
+    it('logs output deltas when stream debug is on', () => {
+      logger.setStreamDebugEnabled(true);
+      new MuseProvider().logStreamLine(record('run.output.delta', { text: 'thinking' }), 2, '[Level 1]');
+      expect(logger.streamDebug).toHaveBeenCalledWith(expect.stringContaining('output.delta'));
+    });
+
+    it('logs a side_effect_intent with its policy decision', () => {
+      logger.setStreamDebugEnabled(true);
+      new MuseProvider().logStreamLine(
+        record('task.lifecycle.side_effect_intent', {
+          event: { operation: 'tool:read_file', policy_decision: 'allow:policy' }
+        }), 3, '[Level 1]'
+      );
+      expect(logger.streamDebug).toHaveBeenCalledWith(
+        expect.stringContaining('tool:read_file')
+      );
+      expect(logger.streamDebug).toHaveBeenCalledWith(
+        expect.stringContaining('allow:policy')
+      );
+    });
+
+    it('marks a skip_if_running rejection as benign and never as an error', () => {
+      logger.setStreamDebugEnabled(true);
+      new MuseProvider().logStreamLine(
+        record('task.lifecycle.rejected', { event: { reason: 'skip_if_running' } }), 4, '[Level 1]'
+      );
+      expect(logger.streamDebug).toHaveBeenCalledWith(expect.stringContaining('benign'));
+      expect(logger.error).not.toHaveBeenCalled();
+      expect(logger.warn).not.toHaveBeenCalled();
+    });
+
+    it('warns on a rejection whose reason is not the benign skip_if_running', () => {
+      // Only `skip_if_running` (an internal reminder-task reminder) is benign.
+      // Every other reason is a real tool/policy rejection and must be visible
+      // rather than buried under the "benign" label.
+      logger.setStreamDebugEnabled(true);
+      new MuseProvider().logStreamLine(
+        record('task.lifecycle.rejected', { event: { reason: 'policy_denied' } }), 4, '[Level 1]'
+      );
+      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('task.rejected'));
+      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('policy_denied'));
+      expect(logger.streamDebug).not.toHaveBeenCalledWith(expect.stringContaining('benign'));
+    });
+
+    it('reports an unknown rejection reason rather than silently dropping it', () => {
+      logger.setStreamDebugEnabled(true);
+      new MuseProvider().logStreamLine(
+        record('task.lifecycle.rejected', { event: {} }), 5, '[Level 1]'
+      );
+      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('unknown'));
+    });
+
+    it('does not escalate a background task failure', () => {
+      // A reminder-plugin task can fail while the run as a whole succeeds; only
+      // the exit code and terminal record are authoritative.
+      logger.setStreamDebugEnabled(true);
+      new MuseProvider().logStreamLine(
+        record('task.lifecycle.failed', { event: { reason: 'provider does not support base instructions' } }),
+        5, '[Level 1]'
+      );
+      expect(logger.error).not.toHaveBeenCalled();
+      expect(logger.warn).not.toHaveBeenCalled();
+    });
+
+    it('logs the configured model', () => {
+      logger.setStreamDebugEnabled(true);
+      new MuseProvider().logStreamLine(
+        record('run.model.configured', { model_id: 'muse-spark-1.2', display_label: 'muse-spark-1.2' }),
+        6, '[Level 1]'
+      );
+      expect(logger.streamDebug).toHaveBeenCalledWith(expect.stringContaining('muse-spark-1.2'));
+    });
+
+    it('logs a tool result with its outcome', () => {
+      logger.setStreamDebugEnabled(true);
+      new MuseProvider().logStreamLine(
+        record('tool.result', {
+          call_id: 'call_0123456789abcdef',
+          text: 'Read text file `sample.js`.',
+          correlation_facts: { tool_name: 'read_file', outcome: 'success' }
+        }), 7, '[Level 1]'
+      );
+      expect(logger.streamDebug).toHaveBeenCalledWith(expect.stringContaining('read_file'));
+      expect(logger.streamDebug).toHaveBeenCalledWith(expect.stringContaining('success'));
+    });
+
+    it('does not throw on malformed JSON', () => {
+      logger.setStreamDebugEnabled(true);
+      expect(() => new MuseProvider().logStreamLine('{not json', 8, '[Level 1]')).not.toThrow();
+      expect(logger.streamDebug).toHaveBeenCalledWith(expect.stringContaining('malformed'));
+    });
+
+    it('does not throw on a record with no payload_type', () => {
+      logger.setStreamDebugEnabled(true);
+      expect(() => new MuseProvider().logStreamLine('{"payload":{}}', 9, '[Level 1]')).not.toThrow();
+    });
+  });
+
+  describe('testAvailability', () => {
+    // Load-bearing contract: this probe gates provider selection, so it must
+    // RESOLVE on every failure mode. A rejection here would surface as an
+    // unhandled failure in the availability sweep rather than "not installed".
+
+    it('resolves true when the version probe exits 0', async () => {
+      const child = makeFakeChild();
+      mockSpawn.mockReturnValue(child);
+
+      const promise = new MuseProvider().testAvailability(10000);
+
+      const [command, args, options] = mockSpawn.mock.lastCall;
+      expect(command).toBe('muse');
+      expect(args).toEqual(['--version']);
+      expect(options.shell).toBe(false);
+
+      child.stdout.emit('data', 'muse 0.1.0\n');
+      child.emit('close', 0);
+      await expect(promise).resolves.toBe(true);
+    });
+
+    it('probes a multi-word command through a shell', async () => {
+      const child = makeFakeChild();
+      mockSpawn.mockReturnValue(child);
+
+      const promise = new MuseProvider('muse-spark-1.2-high', { command: 'devx muse --' })
+        .testAvailability(10000);
+
+      const [command, args, options] = mockSpawn.mock.lastCall;
+      expect(command).toBe('devx muse -- --version');
+      expect(args).toEqual([]);
+      expect(options.shell).toBe(true);
+
+      child.emit('close', 0);
+      await expect(promise).resolves.toBe(true);
+    });
+
+    it('applies the merged provider env to the probe', async () => {
+      // A setup whose muse only runs with `providers.muse.env` (or per-model
+      // env) set would otherwise be reported unavailable while the real
+      // invocation works fine.
+      const child = makeFakeChild();
+      mockSpawn.mockReturnValue(child);
+
+      const promise = new MuseProvider('muse-spark-1.2-high', {
+        env: { META_API_KEY: 'provider-key' },
+        models: [{ id: 'muse-spark-1.2-high', tier: 'balanced', env: { MUSE_ENDPOINT: 'internal' } }]
+      }).testAvailability(10000);
+
+      const [, , options] = mockSpawn.mock.lastCall;
+      expect(options.env.META_API_KEY).toBe('provider-key');
+      expect(options.env.MUSE_ENDPOINT).toBe('internal');
+      // The bin dir still has to lead PATH for the bundled helpers.
+      expect(options.env.PATH.startsWith(path.join(__dirname, '..', '..', 'bin'))).toBe(true);
+
+      child.emit('close', 0);
+      await expect(promise).resolves.toBe(true);
+    });
+
+    it('resolves false, rather than rejecting, on a non-zero exit', async () => {
+      const child = makeFakeChild();
+      mockSpawn.mockReturnValue(child);
+
+      const promise = new MuseProvider().testAvailability(10000);
+      child.stderr.emit('data', 'unrecognized option --version\n');
+      child.emit('close', 2);
+
+      await expect(promise).resolves.toBe(false);
+      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('exit code 2'));
+    });
+
+    it('resolves false, rather than rejecting, when the spawn itself fails', async () => {
+      const child = makeFakeChild({ pid: undefined });
+      mockSpawn.mockReturnValue(child);
+
+      const promise = new MuseProvider().testAvailability(10000);
+      const spawnError = new Error('spawn muse ENOENT');
+      spawnError.code = 'ENOENT';
+      child.emit('error', spawnError);
+
+      await expect(promise).resolves.toBe(false);
+      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('spawn muse ENOENT'));
+    });
+
+    it('kills the child and resolves false when the probe exceeds timeoutMs', async () => {
+      const child = makeFakeChild();
+      mockSpawn.mockReturnValue(child);
+
+      // Fake timers must be released in `finally`: a failing assertion would
+      // otherwise leak them into every later test in this file.
+      vi.useFakeTimers();
+      try {
+        const promise = new MuseProvider().testAvailability(5000);
+        await vi.advanceTimersByTimeAsync(5000);
+        await expect(promise).resolves.toBe(false);
+      } finally {
+        vi.useRealTimers();
+      }
+
+      expect(child.kill).toHaveBeenCalledWith('SIGTERM');
+    });
+
+    it('signals nothing on timeout when a failed spawn left the child pidless', async () => {
+      // Node coerces an undefined pid to 0, and kill(0, SIGTERM) signals OUR own
+      // process group — pair-review would terminate itself. Uses the default
+      // 10s timeout, so that parameter is exercised too.
+      const child = makeFakeChild({ pid: undefined });
+      mockSpawn.mockReturnValue(child);
+
+      vi.useFakeTimers();
+      try {
+        const promise = new MuseProvider().testAvailability();
+        await vi.advanceTimersByTimeAsync(10000);
+        await expect(promise).resolves.toBe(false);
+      } finally {
+        vi.useRealTimers();
+      }
+
+      expect(child.kill).not.toHaveBeenCalled();
+    });
+
+    it('ignores a close that arrives after the timeout already resolved', async () => {
+      const child = makeFakeChild();
+      mockSpawn.mockReturnValue(child);
+
+      vi.useFakeTimers();
+      try {
+        const promise = new MuseProvider().testAvailability(5000);
+        await vi.advanceTimersByTimeAsync(5000);
+        // The killed child reports its exit afterwards; the settled guard must
+        // absorb it rather than settling twice.
+        child.emit('close', 0);
+        await expect(promise).resolves.toBe(false);
+      } finally {
+        vi.useRealTimers();
+      }
+
+      // The promise itself cannot catch a missing guard (a second resolve is a
+      // no-op), but the log can: without it, a timed-out probe would announce
+      // the CLI as available.
+      expect(logger.info).not.toHaveBeenCalledWith(expect.stringContaining('Muse CLI available'));
+    });
+  });
+
+  describe('execute', () => {
+    it('resolves the parsed payload, passes --prompt-file last, and removes the prompt dir', async () => {
+      const promptDirs = trackPromptDirs();
+      const child = makeFakeChild();
+      mockSpawn.mockReturnValue(child);
+
+      const promise = new MuseProvider('muse-spark-1.2-high')
+        .execute('analyse this diff', { level: 1, timeout: 300000 });
+
+      expect(promptDirs).toHaveLength(1);
+      const promptFile = path.join(promptDirs[0], 'prompt.txt');
+      expect(fs.readFileSync(promptFile, 'utf8')).toBe('analyse this diff');
+
+      const [, spawnArgs] = mockSpawn.mock.lastCall;
+      expect(spawnArgs.slice(-2)).toEqual(['--prompt-file', promptFile]);
+
+      child.stdout.emit('data', terminalRecord('completed', '{"suggestions":[{"line":1}]}') + '\n');
+      child.emit('close', 0);
+
+      await expect(promise).resolves.toEqual({ suggestions: [{ line: 1 }] });
+      expectPromptDirRemoved(promptDirs);
+    });
+
+    it('rejects with the terminal reason and removes the prompt dir on a non-zero exit', async () => {
+      const promptDirs = trackPromptDirs();
+      const child = makeFakeChild();
+      mockSpawn.mockReturnValue(child);
+
+      const promise = new MuseProvider('muse-spark-1.2-high').execute('prompt', { level: 1, timeout: 300000 });
+
+      // muse's stderr only says the run failed; the reason lives in the JSONL.
+      child.stderr.emit('data', 'run ended with Failed\n');
+      child.stdout.emit('data',
+        terminalRecord('failed', '', 'server_error: The model failed to generate a response.') + '\n');
+      child.emit('close', 1);
+
+      const error = await settledError(promise);
+      expect(error).toBeInstanceOf(Error);
+      expect(error.message).toContain('exited with code 1');
+      expect(error.message).toContain('server_error: The model failed to generate a response.');
+      expectPromptDirRemoved(promptDirs);
+    });
+
+    it('kills the child, rejects, and removes the prompt dir when the run times out', async () => {
+      const promptDirs = trackPromptDirs();
+      const child = makeFakeChild();
+      mockSpawn.mockReturnValue(child);
+
+      vi.useFakeTimers();
+      try {
+        const promise = new MuseProvider('muse-spark-1.2-high').execute('prompt', { level: 1, timeout: 1000 });
+        // Attach the rejection handler BEFORE advancing, so the rejection is
+        // never momentarily unhandled.
+        const failure = settledError(promise);
+        await vi.advanceTimersByTimeAsync(1000);
+
+        const error = await failure;
+        expect(error).toBeInstanceOf(Error);
+        expect(error.message).toMatch(/Muse CLI timed out after 1000ms/);
+      } finally {
+        vi.useRealTimers();
+      }
+
+      expect(child.kill).toHaveBeenCalledWith('SIGTERM');
+      expectPromptDirRemoved(promptDirs);
+    });
+
+    it('reports install instructions and cleans up the temp file when the CLI is missing', async () => {
+      const promptDirs = trackPromptDirs();
+      // Deliberately a real spawn: this exercises Node's own ENOENT path.
+      const provider = new MuseProvider('muse-spark-1.2-high', {
+        command: '/nonexistent/definitely-not-muse'
+      });
+
+      const error = await settledError(provider.execute('prompt', { level: 1, timeout: 10000 }));
+      expect(error.message).toMatch(/Muse CLI not found/);
+      // A plain failure, NOT a cancellation — the abort test below relies on
+      // these two being distinguishable.
+      expect(error.name).toBe('Error');
+      expect(error.isCancellation).toBeUndefined();
+
+      // The prompt file must be removed on every exit path, including spawn errors.
+      expectPromptDirRemoved(promptDirs);
+    });
+
+    it('rejects a pre-aborted run before writing a prompt or spawning anything', async () => {
+      // The early return sits ahead of mkdtempSync, so it cannot leak a temp dir
+      // — there is nothing yet to clean up. Asserting that NO directory was
+      // created is what pins that ordering: moved below the write, this would
+      // leak a directory with no child process around to remove it.
+      //
+      // The error identity matters too. This test used to spawn
+      // '/nonexistent/definitely-not-muse', so ENOENT rejected it before abort
+      // semantics settled anything and a bare `.rejects.toThrow()` passed either
+      // way — deleting the pre-aborted branch entirely would have kept it green.
+      const promptDirs = trackPromptDirs();
+      const child = makeFakeChild();
+      mockSpawn.mockReturnValue(child);
+
+      const error = await settledError(
+        new MuseProvider('muse-spark-1.2-high').execute('prompt', {
+          level: 1,
+          timeout: 300000,
+          abortSignal: AbortSignal.abort()
+        })
+      );
+
+      expect(error).toBeInstanceOf(Error);
+      expect(error.name).toBe('AbortError');
+      expect(error.isCancellation).toBe(true);
+      expect(error.message).toMatch(/Cancelled by user/);
+      expect(error.message).not.toMatch(/not found/);
+      // No prompt written, no process spawned, nothing to SIGTERM.
+      expect(promptDirs).toEqual([]);
+      expect(mockSpawn).not.toHaveBeenCalled();
+      expect(child.kill).not.toHaveBeenCalled();
+    });
+
+    it('removes the temp directory when the prompt write fails after mkdtemp succeeded', async () => {
+      // mkdtempSync creates the directory first, so a failing writeFileSync
+      // (ENOSPC/EACCES/EIO/quota) used to leak an empty directory with no child
+      // process around to clean it up.
+      const promptDirs = trackPromptDirs();
+      vi.spyOn(fs, 'writeFileSync').mockImplementation(() => {
+        const err = new Error('ENOSPC: no space left on device');
+        err.code = 'ENOSPC';
+        throw err;
+      });
+
+      const error = await settledError(
+        new MuseProvider('muse-spark-1.2-high').execute('prompt', { level: 1, timeout: 300000 })
+      );
+
+      expect(error.message).toMatch(/Failed to write Muse prompt file/);
+      expect(error.message).toContain('no space left on device');
+      expect(mockSpawn).not.toHaveBeenCalled();
+      expectPromptDirRemoved(promptDirs);
+    });
+
+    it('reports failure instead of returning transport envelopes when muse emits no assistant text', async () => {
+      const promptDirs = trackPromptDirs();
+      const child = makeFakeChild();
+      mockSpawn.mockReturnValue(child);
+      const provider = new MuseProvider('muse-spark-1.2-high');
+      const llmFallback = vi.spyOn(provider, 'extractJSONWithLLM');
+
+      const promise = provider.execute('prompt', { level: 1, timeout: 300000 });
+      const stdout = [
+        record('run.lifecycle.started', { kind: 'run_started', run_id: 'r1' }),
+        record('run.model.configured', { model_id: 'muse-spark-1.2' }),
+        terminalRecord('completed', '')
+      ].join('\n') + '\n';
+      child.stdout.emit('data', stdout);
+      child.emit('close', 0);
+
+      const result = await promise;
+      expect(result.parsed).toBe(false);
+      expect(result.raw).toBe(stdout);
+      // None of muse's own envelope fields may masquerade as review findings.
+      expect(result.suggestions).toBeUndefined();
+      expect(result.payload).toBeUndefined();
+      expect(result.payload_type).toBeUndefined();
+      expect(result.kind).toBeUndefined();
+      // The envelopes must not reach the extraction fallback either.
+      expect(llmFallback).not.toHaveBeenCalled();
+      expectPromptDirRemoved(promptDirs);
+    });
+
+    /**
+     * Drive execute() to the LLM-extraction fallback: muse exits 0 having
+     * emitted assistant text that is not JSON.
+     *
+     * @param {Object} child - Fake child returned by the spawn spy
+     * @param {string} [text='I could not analyse this diff.'] - Assistant text
+     */
+    function reachExtractionFallback(child, text = 'I could not analyse this diff.') {
+      child.stdout.emit('data', terminalRecord('completed', text) + '\n');
+      child.emit('close', 0);
+    }
+
+    it('forwards the abort signal so the extraction spawn can be killed, not merely abandoned', async () => {
+      const promptDirs = trackPromptDirs();
+      const child = makeFakeChild();
+      mockSpawn.mockReturnValue(child);
+      const provider = new MuseProvider('muse-spark-1.2-high');
+      const llmFallback = vi.spyOn(provider, 'extractJSONWithLLM')
+        .mockResolvedValue({ success: true, data: { suggestions: [] } });
+      const controller = new AbortController();
+
+      const promise = provider.execute('prompt', {
+        level: 1,
+        timeout: 300000,
+        analysisId: 'analysis-1',
+        abortSignal: controller.signal
+      });
+      reachExtractionFallback(child);
+
+      await expect(promise).resolves.toEqual({ suggestions: [] });
+      expect(llmFallback).toHaveBeenCalledWith(
+        'I could not analyse this diff.',
+        expect.objectContaining({ abortSignal: controller.signal })
+      );
+      expectPromptDirRemoved(promptDirs);
+    });
+
+    it('reports a cancel that lands while the extraction fallback is still running', async () => {
+      // By this point the muse child has already exited, so the abort wiring
+      // only kills something already dead. Without the post-await re-check a
+      // cancelled analysis would settle with a normal result.
+      const promptDirs = trackPromptDirs();
+      const child = makeFakeChild();
+      mockSpawn.mockReturnValue(child);
+      const provider = new MuseProvider('muse-spark-1.2-high');
+      const controller = new AbortController();
+      vi.spyOn(provider, 'extractJSONWithLLM').mockImplementation(async () => {
+        controller.abort();
+        return { success: true, data: { suggestions: [{ line: 1 }] } };
+      });
+
+      const promise = provider.execute('prompt', {
+        level: 1,
+        timeout: 300000,
+        abortSignal: controller.signal
+      });
+      const failure = settledError(promise);
+      reachExtractionFallback(child);
+
+      const error = await failure;
+      expect(error).toBeInstanceOf(Error);
+      expect(error.name).toBe('AbortError');
+      expect(error.isCancellation).toBe(true);
+      expect(error.message).toMatch(/Cancelled by user/);
+      expectPromptDirRemoved(promptDirs);
+    });
+
+    it('treats an abort that kills the extraction spawn as a cancel, not a parse failure', async () => {
+      const promptDirs = trackPromptDirs();
+      const child = makeFakeChild();
+      mockSpawn.mockReturnValue(child);
+      const provider = new MuseProvider('muse-spark-1.2-high');
+      const controller = new AbortController();
+      vi.spyOn(provider, 'extractJSONWithLLM').mockImplementation(async () => {
+        controller.abort();
+        throw new Error('spawn terminated by SIGTERM');
+      });
+
+      const promise = provider.execute('prompt', {
+        level: 1,
+        timeout: 300000,
+        abortSignal: controller.signal
+      });
+      const failure = settledError(promise);
+      reachExtractionFallback(child);
+
+      const error = await failure;
+      expect(error.name).toBe('AbortError');
+      expect(error.isCancellation).toBe(true);
+      expectPromptDirRemoved(promptDirs);
+    });
+
+    it('degrades to raw text when the extraction fallback throws without a cancel', async () => {
+      const promptDirs = trackPromptDirs();
+      const child = makeFakeChild();
+      mockSpawn.mockReturnValue(child);
+      const provider = new MuseProvider('muse-spark-1.2-high');
+      vi.spyOn(provider, 'extractJSONWithLLM').mockRejectedValue(new Error('extraction CLI blew up'));
+
+      const promise = provider.execute('prompt', { level: 1, timeout: 300000 });
+      reachExtractionFallback(child);
+
+      // Never the raw JSONL: only the assistant text the model actually wrote.
+      await expect(promise).resolves.toEqual({
+        raw: 'I could not analyse this diff.',
+        parsed: false
+      });
+      expectPromptDirRemoved(promptDirs);
+    });
+  });
+
+  // execute() passes `shell: this.useShell` to both wireAbortToChild and the
+  // timeout killChildSafely. Every other execute() test builds the provider with
+  // the default single-word `muse`, so useShell is false and
+  // `expect(child.kill).toHaveBeenCalledWith('SIGTERM')` would pass VACUOUSLY in
+  // shell mode — where the real CLI is the shell's grandchild and child.kill is
+  // never reached. These pin the group-kill path so a dropped or inverted flag
+  // cannot silently leak the CLI behind its wrapper.
+  describe('execute in shell mode', () => {
+    let origPlatform;
+    let origKill;
+
+    beforeEach(() => {
+      origPlatform = process.platform;
+      origKill = process.kill;
+      // The POSIX branch is the one under test; Windows taskkill is covered in
+      // tests/unit/abort-signal-wiring.test.js.
+      Object.defineProperty(process, 'platform', { value: 'darwin' });
+    });
+
+    afterEach(() => {
+      Object.defineProperty(process, 'platform', { value: origPlatform });
+      process.kill = origKill;
+    });
+
+    it('group-kills the whole shell process group when the run times out', async () => {
+      const groupKill = vi.fn();
+      process.kill = groupKill;
+      const promptDirs = trackPromptDirs();
+      const child = makeFakeChild();
+      mockSpawn.mockReturnValue(child);
+
+      const provider = new MuseProvider('muse-spark-1.2-high', { command: 'devx muse --' });
+      expect(provider.useShell).toBe(true);
+
+      vi.useFakeTimers();
+      try {
+        const promise = provider.execute('prompt', { level: 1, timeout: 1000 });
+        const failure = settledError(promise);
+
+        // Detached at spawn time, or there is no process group to signal and
+        // process.kill(-pid) would fail with ESRCH.
+        const [, , options] = mockSpawn.mock.lastCall;
+        expect(options.shell).toBe(true);
+        expect(options.detached).toBe(true);
+
+        await vi.advanceTimersByTimeAsync(1000);
+        const error = await failure;
+        expect(error).toBeInstanceOf(Error);
+        expect(error.message).toMatch(/Muse CLI timed out after 1000ms/);
+      } finally {
+        vi.useRealTimers();
+      }
+
+      expect(groupKill).toHaveBeenCalledWith(-child.pid, 'SIGTERM');
+      // Killing only the wrapper would leave the real CLI running and burning
+      // tokens after this promise has already rejected.
+      expect(child.kill).not.toHaveBeenCalled();
+      expectPromptDirRemoved(promptDirs);
+    });
+
+    it('group-kills the whole shell process group when an abort arrives mid-run', async () => {
+      const groupKill = vi.fn();
+      process.kill = groupKill;
+      const promptDirs = trackPromptDirs();
+      const child = makeFakeChild();
+      mockSpawn.mockReturnValue(child);
+
+      // Deliberately NOT a pre-aborted signal: execute() returns before spawning
+      // for that, so no kill of any kind would be dispatched.
+      const controller = new AbortController();
+      const promise = new MuseProvider('muse-spark-1.2-high', { command: 'devx muse --' })
+        .execute('prompt', { level: 1, timeout: 300000, abortSignal: controller.signal });
+      const failure = settledError(promise);
+
+      controller.abort();
+
+      expect(groupKill).toHaveBeenCalledWith(-child.pid, 'SIGTERM');
+      expect(child.kill).not.toHaveBeenCalled();
+
+      child.emit('close', 143);
+      const error = await failure;
+      expect(error.name).toBe('AbortError');
+      expect(error.isCancellation).toBe(true);
+      expectPromptDirRemoved(promptDirs);
+    });
+
+    it('signals only the child, never a process group, for a single-word command', async () => {
+      // The counterpart that makes the two assertions above non-vacuous: an
+      // inverted flag would show up here as a group-kill of a child that was
+      // never detached.
+      const groupKill = vi.fn();
+      process.kill = groupKill;
+      const promptDirs = trackPromptDirs();
+      const child = makeFakeChild();
+      mockSpawn.mockReturnValue(child);
+
+      const controller = new AbortController();
+      const promise = new MuseProvider('muse-spark-1.2-high')
+        .execute('prompt', { level: 1, timeout: 300000, abortSignal: controller.signal });
+      const failure = settledError(promise);
+
+      const [, , options] = mockSpawn.mock.lastCall;
+      expect(options.shell).toBe(false);
+      expect(options.detached).toBe(false);
+
+      controller.abort();
+
+      expect(child.kill).toHaveBeenCalledWith('SIGTERM');
+      expect(groupKill).not.toHaveBeenCalled();
+
+      child.emit('close', 143);
+      expect((await failure).name).toBe('AbortError');
+      expectPromptDirRemoved(promptDirs);
+    });
+  });
+
+  describe('provider registration', () => {
+    it('registers itself under the muse id on import', () => {
+      const { getProviderClass, getRegisteredProviderIds } = require('../../src/ai/provider');
+      expect(getRegisteredProviderIds()).toContain('muse');
+      expect(getProviderClass('muse')).toBe(MuseProvider);
+    });
+
+    it('exports the class directly rather than under a named key', () => {
+      expect(typeof MuseProvider).toBe('function');
+      expect(MuseProvider.name).toBe('MuseProvider');
+    });
+  });
+});

--- a/tests/unit/opencode-provider.test.js
+++ b/tests/unit/opencode-provider.test.js
@@ -56,6 +56,8 @@ describe('OpenCodeProvider', () => {
       try {
         const child = new EventEmitter();
         child.stdout = new EventEmitter();
+        // A hung CLI has a real pid; killChildSafely skips pidless children.
+        child.pid = 4242;
         child.kill = vi.fn();
         mockSpawn.mockReturnValue(child);
 
@@ -86,6 +88,9 @@ describe('OpenCodeProvider', () => {
       try {
         const child = new EventEmitter();
         child.stdout = new EventEmitter();
+        // pid set so "kill not called" proves the timer was cleared rather
+        // than passing vacuously via killChildSafely's pidless guard.
+        child.pid = 4242;
         child.kill = vi.fn();
         mockSpawn.mockReturnValue(child);
 
@@ -555,6 +560,128 @@ describe('OpenCodeProvider', () => {
       logger.setStreamDebugEnabled(true);
       const line = JSON.stringify({ type: 'text' });
       expect(() => provider.logStreamLine(line, 1, '[Level 1]')).not.toThrow();
+    });
+  });
+
+  // When the model answers in prose the LLM-extraction fallback runs. A cancel
+  // arriving while it is in flight must reject, not be laundered into a normal
+  // "unparsed response" result.
+  describe('LLM-extraction fallback cancellation', () => {
+    const { EventEmitter } = require('events');
+    const PROSE = 'I could not analyse this diff.';
+
+    /**
+     * Minimal child mirroring the surface execute() touches: stdout/stderr
+     * emitters, a writable stdin, kill, pid.
+     *
+     * @returns {EventEmitter} Fake child process
+     */
+    function createMockChild() {
+      const child = new EventEmitter();
+      child.stdout = new EventEmitter();
+      child.stderr = new EventEmitter();
+      child.pid = 4242;
+      child.kill = vi.fn();
+
+      const stdin = new EventEmitter();
+      stdin.write = vi.fn((data, cb) => {
+        if (typeof cb === 'function') cb();
+        return true;
+      });
+      stdin.end = vi.fn();
+      child.stdin = stdin;
+
+      return child;
+    }
+
+    /**
+     * Drive execute() to the extraction fallback: opencode exits 0 having
+     * emitted assistant text that is not JSON.
+     *
+     * @param {EventEmitter} child - Fake child returned by the spawn spy
+     */
+    function reachExtractionFallback(child) {
+      child.stdout.emit('data', JSON.stringify({
+        type: 'text',
+        part: { type: 'text', text: PROSE }
+      }) + '\n');
+      child.emit('close', 0);
+    }
+
+    it('forwards the abort signal so the extraction spawn can be killed, not merely abandoned', async () => {
+      const child = createMockChild();
+      mockSpawn.mockReturnValue(child);
+
+      const provider = new OpenCodeProvider('test-model');
+      const spy = vi.spyOn(provider, 'extractJSONWithLLM')
+        .mockResolvedValue({ success: true, data: { suggestions: [] } });
+      const controller = new AbortController();
+
+      const promise = provider.execute('prompt', { abortSignal: controller.signal });
+      reachExtractionFallback(child);
+
+      expect(await promise).toEqual({ suggestions: [] });
+      // Without the signal the extraction child survives a cancel until its own
+      // 60s timeout.
+      expect(spy).toHaveBeenCalledWith(PROSE, expect.objectContaining({ abortSignal: controller.signal }));
+    });
+
+    it('reports a cancel that lands while the fallback is still running', async () => {
+      // opencode has already exited by this point, so the abort wiring only
+      // kills something already dead. Without the post-await re-check a
+      // cancelled analysis would settle with a normal result.
+      const child = createMockChild();
+      mockSpawn.mockReturnValue(child);
+
+      const provider = new OpenCodeProvider('test-model');
+      const controller = new AbortController();
+      vi.spyOn(provider, 'extractJSONWithLLM').mockImplementation(async () => {
+        controller.abort();
+        return { success: true, data: { suggestions: [{ id: 1 }] } };
+      });
+
+      const promise = provider.execute('prompt', { abortSignal: controller.signal });
+      const failure = promise.then(() => null, (err) => err);
+      reachExtractionFallback(child);
+
+      const error = await failure;
+      expect(error).toBeInstanceOf(Error);
+      expect(error.name).toBe('AbortError');
+      expect(error.isCancellation).toBe(true);
+      expect(error.message).toMatch(/Cancelled by user/);
+    });
+
+    it('treats an abort that kills the extraction spawn as a cancel, not a parse failure', async () => {
+      const child = createMockChild();
+      mockSpawn.mockReturnValue(child);
+
+      const provider = new OpenCodeProvider('test-model');
+      const controller = new AbortController();
+      vi.spyOn(provider, 'extractJSONWithLLM').mockImplementation(async () => {
+        controller.abort();
+        throw new Error('spawn terminated by SIGTERM');
+      });
+
+      const promise = provider.execute('prompt', { abortSignal: controller.signal });
+      const failure = promise.then(() => null, (err) => err);
+      reachExtractionFallback(child);
+
+      const error = await failure;
+      expect(error.name).toBe('AbortError');
+      expect(error.isCancellation).toBe(true);
+    });
+
+    it('degrades to raw text when the extraction fallback throws without a cancel', async () => {
+      const child = createMockChild();
+      mockSpawn.mockReturnValue(child);
+
+      const provider = new OpenCodeProvider('test-model');
+      vi.spyOn(provider, 'extractJSONWithLLM').mockRejectedValue(new Error('extractor blew up'));
+
+      const promise = provider.execute('prompt', {});
+      reachExtractionFallback(child);
+
+      expect(await promise).toEqual({ raw: PROSE, parsed: false });
     });
   });
 

--- a/tests/unit/pi-provider.test.js
+++ b/tests/unit/pi-provider.test.js
@@ -1270,6 +1270,8 @@ describe('PiProvider', () => {
       // Create a fake child process that never emits 'close'
       const fakeChild = new EventEmitter();
       fakeChild.stdout = new EventEmitter();
+      // A hung CLI has a real pid; killChildSafely skips pidless children.
+      fakeChild.pid = 12345;
       fakeChild.kill = vi.fn();
 
       mockSpawn.mockReturnValueOnce(fakeChild);
@@ -1292,6 +1294,8 @@ describe('PiProvider', () => {
 
       const fakeChild = new EventEmitter();
       fakeChild.stdout = new EventEmitter();
+      // A hung CLI has a real pid; killChildSafely skips pidless children.
+      fakeChild.pid = 12345;
       fakeChild.kill = vi.fn();
 
       mockSpawn.mockReturnValueOnce(fakeChild);
@@ -1321,6 +1325,9 @@ describe('PiProvider', () => {
       // Create a fake child process that exits quickly
       const fakeChild = new EventEmitter();
       fakeChild.stdout = new EventEmitter();
+      // pid set so "kill not called" proves the timer was cleared rather
+      // than passing vacuously via killChildSafely's pidless guard.
+      fakeChild.pid = 12345;
       fakeChild.kill = vi.fn();
 
       mockSpawn.mockReturnValueOnce(fakeChild);
@@ -1602,6 +1609,136 @@ describe('PiProvider', () => {
       } finally {
         warnSpy.mockRestore();
       }
+    });
+  });
+
+  // When the model answers in prose the LLM-extraction fallback runs. A cancel
+  // arriving while it is in flight must reject, not be laundered into a normal
+  // "unparsed response" result that makes the job look like it completed. The
+  // pre-existing `settled` guard only covers a cancel that landed BEFORE the
+  // await, so these tests abort from inside the extraction call.
+  describe('LLM-extraction fallback cancellation', () => {
+    const { EventEmitter } = require('events');
+    const fs = require('fs');
+    const PROSE = 'I could not analyse this diff.';
+
+    let writeFileSpy;
+    let unlinkSpy;
+
+    beforeEach(() => {
+      writeFileSpy = vi.spyOn(fs, 'writeFileSync').mockImplementation(() => {});
+      unlinkSpy = vi.spyOn(fs, 'unlinkSync').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      writeFileSpy.mockRestore();
+      unlinkSpy.mockRestore();
+    });
+
+    /**
+     * Minimal child mirroring the surface execute() touches. Pi delivers the
+     * prompt via @file, so stdin only needs end().
+     *
+     * @returns {EventEmitter} Fake child process
+     */
+    function createMockChild() {
+      const child = new EventEmitter();
+      child.stdin = { end: vi.fn() };
+      child.stdout = new EventEmitter();
+      child.stderr = new EventEmitter();
+      child.pid = 12345;
+      child.kill = vi.fn();
+      mockSpawn.mockReturnValueOnce(child);
+      return child;
+    }
+
+    /**
+     * Drive execute() to the extraction fallback: pi exits 0 having emitted
+     * assistant text that is not JSON.
+     *
+     * @param {EventEmitter} child - Fake child returned by the spawn spy
+     */
+    function reachExtractionFallback(child) {
+      child.stdout.emit('data', Buffer.from(JSON.stringify({
+        type: 'message_end',
+        message: { role: 'assistant', content: [{ type: 'text', text: PROSE }] }
+      }) + '\n'));
+      child.emit('close', 0);
+    }
+
+    it('forwards the abort signal so the extraction spawn can be killed, not merely abandoned', async () => {
+      const child = createMockChild();
+
+      const provider = new PiProvider('test-model');
+      const spy = vi.spyOn(provider, 'extractJSONWithLLM')
+        .mockResolvedValue({ success: true, data: { suggestions: [] } });
+      const controller = new AbortController();
+
+      const promise = provider.execute('prompt', { level: 1, abortSignal: controller.signal });
+      reachExtractionFallback(child);
+
+      expect(await promise).toEqual({ suggestions: [] });
+      // Without the signal the extraction child survives a cancel until its own
+      // 60s timeout.
+      expect(spy).toHaveBeenCalledWith(PROSE, expect.objectContaining({ abortSignal: controller.signal }));
+      // The prompt file must still be removed.
+      expect(unlinkSpy).toHaveBeenCalledWith(writeFileSpy.mock.calls[0][0]);
+    });
+
+    it('reports a cancel that lands while the fallback is still running', async () => {
+      // Pi has already exited by this point, so the abort wiring only kills
+      // something already dead. Without the post-await re-check a cancelled
+      // analysis would settle with a normal result.
+      const child = createMockChild();
+
+      const provider = new PiProvider('test-model');
+      const controller = new AbortController();
+      vi.spyOn(provider, 'extractJSONWithLLM').mockImplementation(async () => {
+        controller.abort();
+        return { success: true, data: { suggestions: [{ id: 1 }] } };
+      });
+
+      const promise = provider.execute('prompt', { level: 1, abortSignal: controller.signal });
+      const failure = promise.then(() => null, (err) => err);
+      reachExtractionFallback(child);
+
+      const error = await failure;
+      expect(error).toBeInstanceOf(Error);
+      expect(error.name).toBe('AbortError');
+      expect(error.isCancellation).toBe(true);
+      expect(error.message).toMatch(/Cancelled by user/);
+      expect(unlinkSpy).toHaveBeenCalledWith(writeFileSpy.mock.calls[0][0]);
+    });
+
+    it('treats an abort that kills the extraction spawn as a cancel, not a parse failure', async () => {
+      const child = createMockChild();
+
+      const provider = new PiProvider('test-model');
+      const controller = new AbortController();
+      vi.spyOn(provider, 'extractJSONWithLLM').mockImplementation(async () => {
+        controller.abort();
+        throw new Error('spawn terminated by SIGTERM');
+      });
+
+      const promise = provider.execute('prompt', { level: 1, abortSignal: controller.signal });
+      const failure = promise.then(() => null, (err) => err);
+      reachExtractionFallback(child);
+
+      const error = await failure;
+      expect(error.name).toBe('AbortError');
+      expect(error.isCancellation).toBe(true);
+    });
+
+    it('degrades to raw text when the extraction fallback throws without a cancel', async () => {
+      const child = createMockChild();
+
+      const provider = new PiProvider('test-model');
+      vi.spyOn(provider, 'extractJSONWithLLM').mockRejectedValue(new Error('extractor blew up'));
+
+      const promise = provider.execute('prompt', { level: 1 });
+      reachExtractionFallback(child);
+
+      expect(await promise).toEqual({ raw: PROSE, parsed: false });
     });
   });
 

--- a/tests/unit/stream-parser.test.js
+++ b/tests/unit/stream-parser.test.js
@@ -21,7 +21,7 @@ vi.mock('../../src/utils/logger', () => {
   };
 });
 
-const { StreamParser, truncateSnippet, stripPathPrefix, extractToolDetail, parseClaudeLine, parseCodexLine, parseOpenCodeLine, parseCursorAgentLine, parsePiLine, createPiLineParser } = require('../../src/ai/stream-parser');
+const { StreamParser, truncateSnippet, stripPathPrefix, extractToolDetail, parseClaudeLine, parseCodexLine, parseMuseLine, parseOpenCodeLine, parseCursorAgentLine, parsePiLine, createPiLineParser } = require('../../src/ai/stream-parser');
 
 // ---------------------------------------------------------------------------
 // truncateSnippet
@@ -560,6 +560,222 @@ describe('parseCodexLine', () => {
     expect(result.type).toBe('tool_use');
     expect(result.text).toContain('editor');
     expect(result.text).toContain('open file.txt');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseMuseLine
+//
+// Record shapes below are copied from real `muse exec --json` output
+// (Muse Code 0.1.0). Muse wraps everything in an envelope: the discriminator is
+// `payload_type` and the interesting fields live under `payload`.
+// ---------------------------------------------------------------------------
+describe('parseMuseLine', () => {
+  it('returns null for empty input', () => {
+    expect(parseMuseLine('')).toBeNull();
+  });
+
+  it('returns null for null input', () => {
+    expect(parseMuseLine(null)).toBeNull();
+  });
+
+  it('returns null for undefined input', () => {
+    expect(parseMuseLine(undefined)).toBeNull();
+  });
+
+  it('returns null for whitespace-only input', () => {
+    expect(parseMuseLine('   \t  ')).toBeNull();
+  });
+
+  it('returns null for malformed JSON without throwing', () => {
+    expect(() => parseMuseLine('{not json')).not.toThrow();
+    expect(parseMuseLine('{not json')).toBeNull();
+  });
+
+  it('returns null for a record with no payload_type', () => {
+    expect(parseMuseLine(JSON.stringify({ payload: { text: 'hi' } }))).toBeNull();
+  });
+
+  it('returns null for a record with no payload', () => {
+    expect(parseMuseLine(JSON.stringify({ payload_type: 'run.output.delta' }))).toBeNull();
+  });
+
+  it('parses run.output.delta as an assistant_text event', () => {
+    const line = JSON.stringify({
+      payload_type: 'run.output.delta',
+      sequence: 15,
+      payload: { kind: 'run_output_delta', text: 'Analyzing the diff now.' }
+    });
+    const result = parseMuseLine(line);
+    expect(result).not.toBeNull();
+    expect(result.type).toBe('assistant_text');
+    expect(result.text).toBe('Analyzing the diff now.');
+    expect(typeof result.timestamp).toBe('number');
+  });
+
+  it('returns null for run.output.delta with empty text', () => {
+    const line = JSON.stringify({
+      payload_type: 'run.output.delta',
+      payload: { kind: 'run_output_delta', text: '' }
+    });
+    expect(parseMuseLine(line)).toBeNull();
+  });
+
+  it('returns null for run.output.delta with whitespace-only text', () => {
+    const line = JSON.stringify({
+      payload_type: 'run.output.delta',
+      payload: { kind: 'run_output_delta', text: '   \n  ' }
+    });
+    expect(parseMuseLine(line)).toBeNull();
+  });
+
+  it('truncates long assistant text', () => {
+    const line = JSON.stringify({
+      payload_type: 'run.output.delta',
+      payload: { kind: 'run_output_delta', text: 'x'.repeat(500) }
+    });
+    const result = parseMuseLine(line);
+    expect(result.text.length).toBeLessThanOrEqual(201);
+    expect(result.text.endsWith('…')).toBe(true);
+  });
+
+  it('parses a tool: side_effect_intent as a tool_use event', () => {
+    const line = JSON.stringify({
+      payload_type: 'task.lifecycle.side_effect_intent',
+      payload: {
+        kind: 'task_lifecycle',
+        event: {
+          kind: 'side_effect_intent',
+          operation: 'tool:read_file',
+          policy_decision: 'allow:policy'
+        }
+      }
+    });
+    const result = parseMuseLine(line);
+    expect(result).not.toBeNull();
+    expect(result.type).toBe('tool_use');
+    // Muse's side_effect_intent record carries no tool arguments, so the event
+    // shows the bare tool name.
+    expect(result.text).toBe('read_file');
+    expect(typeof result.timestamp).toBe('number');
+  });
+
+  it('parses a tool:bash side_effect_intent', () => {
+    const line = JSON.stringify({
+      payload_type: 'task.lifecycle.side_effect_intent',
+      payload: { event: { operation: 'tool:bash', policy_decision: 'allow:policy' } }
+    });
+    expect(parseMuseLine(line).text).toBe('bash');
+  });
+
+  it('returns null for the model.meta.response side_effect_intent (not a tool)', () => {
+    const line = JSON.stringify({
+      payload_type: 'task.lifecycle.side_effect_intent',
+      payload: {
+        event: {
+          kind: 'side_effect_intent',
+          operation: 'model.meta.response',
+          policy_decision: 'not_applicable'
+        }
+      }
+    });
+    expect(parseMuseLine(line)).toBeNull();
+  });
+
+  it('returns null for a side_effect_intent with no operation', () => {
+    const line = JSON.stringify({
+      payload_type: 'task.lifecycle.side_effect_intent',
+      payload: { event: {} }
+    });
+    expect(parseMuseLine(line)).toBeNull();
+  });
+
+  it('falls back to "unknown" for a bare "tool:" operation', () => {
+    const line = JSON.stringify({
+      payload_type: 'task.lifecycle.side_effect_intent',
+      payload: { event: { operation: 'tool:' } }
+    });
+    expect(parseMuseLine(line).text).toBe('unknown');
+  });
+
+  it.each([
+    'runtime.command.accepted',
+    'session.run.linked',
+    'run.model.configured',
+    'turn.input.user',
+    'run.lifecycle.started',
+    'task.stream.linked',
+    'task.lifecycle.proposed',
+    'task.lifecycle.accepted',
+    'task.lifecycle.started',
+    'task.lifecycle.scheduled',
+    'task.lifecycle.status',
+    'task.lifecycle.completed',
+    'task.lifecycle.output',
+    'task.lifecycle.failed',
+    'task.lifecycle.rejected',
+    'tool.result',
+    'run.terminal.completed',
+    'run.terminal.failed'
+  ])('filters out %s records', (payloadType) => {
+    const line = JSON.stringify({
+      payload_type: payloadType,
+      payload: { kind: 'whatever', text: 'should not surface', event: { chunk: 'nope' } }
+    });
+    expect(parseMuseLine(line)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseMuseLine with cwd option
+// ---------------------------------------------------------------------------
+describe('parseMuseLine with cwd option', () => {
+  const cwd = '/Users/dev/worktree';
+
+  it('strips the cwd prefix when a future muse release supplies tool args', () => {
+    // Muse does not emit tool arguments today. The parser still routes them
+    // through extractToolDetail so that if a later release adds them, paths are
+    // reported relative to the worktree with no code change required.
+    const line = JSON.stringify({
+      payload_type: 'task.lifecycle.side_effect_intent',
+      payload: {
+        event: {
+          operation: 'tool:read_file',
+          input: { file_path: '/Users/dev/worktree/src/app.js' }
+        }
+      }
+    });
+    const result = parseMuseLine(line, { cwd });
+    expect(result.type).toBe('tool_use');
+    expect(result.text).toBe('read_file: src/app.js');
+  });
+
+  it('surfaces a command detail when present', () => {
+    const line = JSON.stringify({
+      payload_type: 'task.lifecycle.side_effect_intent',
+      payload: {
+        event: { operation: 'tool:bash', args: { command: 'git status' } }
+      }
+    });
+    expect(parseMuseLine(line, { cwd }).text).toBe('bash: git status');
+  });
+
+  it('leaves paths outside the cwd untouched', () => {
+    const line = JSON.stringify({
+      payload_type: 'task.lifecycle.side_effect_intent',
+      payload: {
+        event: { operation: 'tool:read_file', arguments: { path: '/etc/hosts' } }
+      }
+    });
+    expect(parseMuseLine(line, { cwd }).text).toBe('read_file: /etc/hosts');
+  });
+
+  it('works without a cwd option', () => {
+    const line = JSON.stringify({
+      payload_type: 'task.lifecycle.side_effect_intent',
+      payload: { event: { operation: 'tool:read_file', input: { file_path: '/a/b.js' } } }
+    });
+    expect(parseMuseLine(line).text).toBe('read_file: /a/b.js');
   });
 });
 


### PR DESCRIPTION
Adds Meta's Muse Code CLI (`muse`) as an analysis provider, plus the cross-provider spawn/cancellation fixes that building it surfaced.

## Muse provider

Driven headlessly via `muse exec --json`, prompt delivered with `--prompt-file` (the CLI does not read stdin — it exits 2 with "missing prompt"). Override the command with `PAIR_REVIEW_MUSE_CMD`. Analysis-only: the CLI exposes no ACP server mode, so there is no Muse chat provider.

Eight built-in models map two real CLI models across four reasoning-effort levels:

| tier | non-contributor | contributor |
|---|---|---|
| thorough | `muse-spark-1.2-ultra`, `muse-spark-1.2-xhigh` | `muse-spark-1.2-contributor-ultra`, `muse-spark-1.2-contributor-xhigh` |
| balanced | `muse-spark-1.2-high` (**default**) | `muse-spark-1.2-contributor-high` |
| fast | `muse-spark-1.2-low` | `muse-spark-1.2-contributor-low` |

The `-contributor` models are ~10x cheaper because Meta may use their content for product improvement. Since a review sends your diff and surrounding source to the model, the default deliberately stays on the non-contributor model — opting in is always an explicit choice. That constraint is load-bearing in one non-obvious place: `getFastTierModel()` picks the *first* `fast` entry for JSON extraction, so the model array order is pinned by a test to keep extraction off the data-sharing tier.

## Cross-provider fixes

Three defects in shared spawn paths, each with regression coverage:

- **Self-termination on cancel.** A child whose spawn failed (missing/misconfigured CLI) has no pid; Node coerces it to `0`, and `kill(0, SIGTERM)` signals pair-review's *own* process group. Cancelling an analysis killed pair-review. Now centralized in `killChildSafely`, which also owns shell-mode group-kill and a never-throws contract the abort listener depends on.
- **Extraction hang on wrapper commands.** `extractJSONWithLLM` closed the child's stdin only for stdin and `@file` delivery. Plain-argv delivery left it open, and a wrapper (`docker exec ... muse`) can block on it until the 60-second timeout. Stdin now ends on every path, with an `error` listener so a late EPIPE cannot become an unhandled exception.
- **Cancellation ignored during extraction.** The fallback could neither stop its spawn nor change its outcome, so a cancelled job came back as ordinary unparseable output. It now takes an `abortSignal`, kills the child, and rejects with an `AbortError`; Claude, Codex, Copilot, Antigravity, Cursor Agent, OpenCode and Pi all forward it and re-check cancellation in both the resolve and error paths.

Extraction keeps `useShell: false` throughout. That spawn is not `detached`, so under `shell: true` a cancel would kill only the `/bin/sh` wrapper and orphan the real CLI — the exact token burn the change is meant to stop.

## Testing

`pnpm vitest run tests/unit tests/integration` → **281 files, 9369 tests passed**.

New coverage: the Muse provider end to end (JSONL parsing, terminal records, auth/unknown-model errors, extraction config, model resolution), the `promptFileArg` delivery mode in the shared extraction helper, `killChildSafely`'s pid guard and group-kill semantics, and per-provider assertions that `abortSignal` is forwarded and that a mid-extraction cancel rejects with an `AbortError` rather than resolving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)