### PR TITLE
fix: restore consolidation on headless PR analysis (#557)

### DIFF
--- a/.changeset/fix-headless-pr-metadata-shape.md
+++ b/.changeset/fix-headless-pr-metadata-shape.md
@@ -1,0 +1,13 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Fix headless PR analysis silently skipping every consolidation stage.
+
+On the headless PR paths — `--headless`, `--ai-draft`, and `--ai-review` — the analyzer was handed the raw stored `pr_data` blob as its PR metadata instead of the normalized `pr_metadata` row the web routes pass. In that blob `repository` is an object (`{ full_name, clone_url, … }`) rather than the `"owner/repo"` string, so `buildDedupContext` threw `TypeError: prMetadata.repository?.split is not a function`. Because every consolidation and orchestration stage builds its dedup context first, that single throw was swallowed by the store-everything fallback: the run still reported `status: completed` / `ok: true`, but the final suggestion set became the unmerged union of all three analysis levels — and, for a council, of every voice. A 3-voice council on a ~30-file PR returned 45 suggestions (13 + 13 + 19) with the same issue repeated in up to seven wordings. Every headless PR analysis reaching consolidation had been affected since the exclude-previous-findings feature introduced `buildDedupContext`, including the reviews posted by `--ai-draft`/`--ai-review` workflows.
+
+Both headless call sites now read PR metadata through `PRMetadataRepository.getByPR`, the same accessor the web routes use, so the analyzer receives one shape from every entry point. Two lower-severity defects on the same path are fixed as a consequence: prompts had been rendering `**Repository:** [object Object]`, omitting the `**PR #:**` line (the number lives under `number` in the blob), and dropping the PR description entirely (it lives under `body`).
+
+As defense in depth, the analyzer's metadata readers now accept either shape rather than assuming the normalized one, so a future caller passing the raw blob degrades nothing.
+
+Headless output also surfaces the outcome. `--headless --json` gains a top-level `consolidation` field — `"success"`, `"failed"`, `"skipped"` (nothing to merge: a council that resolved to a single voice or level, which is healthy), or `null` — and the human-readable output prints a warning when consolidation failed. Previously the only evidence was a stderr line and `level_outcomes` on the run row, leaving a machine consumer unable to tell a consolidated review from a duplicate-laden concatenation. Only `"failed"` indicates degraded output, so branch on that value rather than on `!= "success"`.

--- a/README.md
+++ b/README.md
@@ -373,6 +373,7 @@ consolidated suggestion layer the app shows by default):
 {
   "ok": true,                 // false on failure (see below)
   "mode": "local",            // "pr" or "local"
+  "consolidation": "success", // "success", "failed", "skipped", or null (see below)
   "run": {
     "id": "…",                 // analysis run id
     "review_id": 1,
@@ -416,6 +417,25 @@ consolidated suggestion layer the app shows by default):
   ],
   "count": 1                   // suggestions.length
 }
+```
+
+**`consolidation`** reports the outcome of the final cross-level (and, for a
+council, cross-voice) consolidation step:
+
+| Value | Meaning |
+| --- | --- |
+| `"success"` | Consolidation ran and merged the inputs. |
+| `"failed"` | It threw. The run still completes and `ok` stays `true`, but `suggestions` is the raw union of every analysis level and every council voice rather than a merged review — expect duplicates and a much larger `count`. |
+| `"skipped"` | There was nothing to merge — a council that resolved to a single voice or a single level, or an executable provider that returns its own final set. The suggestion set is the intended one; this is a healthy outcome, not a degraded one. |
+| `null` | The run recorded no consolidation stage. |
+
+Only `"failed"` indicates degraded output, so branch on that value rather than on
+`!= "success"` — a single-voice council legitimately reports `"skipped"`. The
+human-readable (non-`--json`) output prints a warning for `"failed"` only.
+
+```bash
+# Treat a degraded run as a failure
+[ "$(echo "$result" | jq -r '.consolidation')" = "failed" ] && echo "unconsolidated!" >&2
 ```
 
 **On failure** (invalid flags, an unreadable `--instructions-file`, or an

--- a/src/ai/analyzer.js
+++ b/src/ai/analyzer.js
@@ -131,7 +131,7 @@ async function runExecutableVoice(voiceProvider, reviewId, worktreePath, prMetad
   try {
     const executableContext = {
       title: prMetadata.title || null,
-      description: prMetadata.description || null,
+      description: resolveReviewDescription(prMetadata) || null,
       cwd: worktreePath,
       outputDir: tmpDir,
       model: voiceProvider.resolvedModel !== undefined ? voiceProvider.resolvedModel : (voiceProvider.model || null),
@@ -202,17 +202,63 @@ async function runExecutableVoice(voiceProvider, reviewId, worktreePath, prMetad
 }
 
 /**
+ * Resolve the `owner/repo` identifier from review metadata.
+ *
+ * Review metadata reaches the analyzer in more than one shape:
+ *   - the normalized `pr_metadata` row (server routes, headless PR path), where
+ *     `repository` is the `"owner/repo"` string;
+ *   - the raw stored `pr_data` blob, where `repository` is the GitHub API object
+ *     `{ full_name, clone_url, ssh_url, default_branch }`;
+ *   - local reviews, where `repository` is a bare directory name (no slash).
+ *
+ * Accept all three instead of assuming a string. Callers used to do
+ * `prMetadata.repository?.split('/')`, which threw `TypeError` on the object
+ * shape — and because every consolidation stage builds its dedup context first,
+ * that single throw silently disabled consolidation for the whole run (#557).
+ *
+ * @param {Object} prMetadata - PR/review metadata
+ * @returns {string|null} The repository identifier, or null when unavailable
+ */
+function resolveRepositorySlug(prMetadata) {
+  const repository = prMetadata?.repository;
+  if (typeof repository === 'string') return repository || null;
+  if (repository && typeof repository.full_name === 'string') return repository.full_name || null;
+  return null;
+}
+
+/**
+ * Resolve the review description from review metadata.
+ *
+ * The normalized `pr_metadata` row and local metadata both use `description`;
+ * the raw `pr_data` blob carries the same text under the GitHub API's `body`.
+ * Accepting both keeps the PR description in the prompt regardless of which
+ * shape a caller passes — the same shape divergence behind #557.
+ *
+ * @param {Object} prMetadata - PR/review metadata
+ * @returns {string|null|undefined} The description, or null/undefined when unset
+ */
+function resolveReviewDescription(prMetadata) {
+  return prMetadata?.description ?? prMetadata?.body;
+}
+
+/**
  * Build the dedup context object from PR metadata and run identifiers.
  *
- * @param {Object} prMetadata - PR metadata with repository and pr_number
+ * Tolerates both metadata shapes described on {@link resolveRepositorySlug}: the
+ * pull request number is read from `pr_number` (normalized row) and falls back
+ * to `number` (raw `pr_data` blob). Local reviews carry neither and yield
+ * `undefined`, which the dedup consumers already treat as "not a PR".
+ *
+ * @param {Object} prMetadata - PR metadata with repository and pr_number/number
  * @param {Object} ids - { reviewId, serverPort, runId, excludeRunIds }
  * @param {string} [ids.runId] - Single run ID to exclude (backward compat)
  * @param {string[]} [ids.excludeRunIds] - Array of run IDs to exclude (takes precedence over runId)
  * @returns {Object} { owner, repo, pullNumber, reviewId, serverPort, runId, excludeRunIds }
  */
 function buildDedupContext(prMetadata, { reviewId, serverPort, runId, excludeRunIds }) {
-  const [owner, repo] = prMetadata.repository?.split('/') || [];
-  return { owner, repo, pullNumber: prMetadata.pr_number, reviewId, serverPort, runId, excludeRunIds };
+  const [owner, repo] = resolveRepositorySlug(prMetadata)?.split('/') || [];
+  const pullNumber = prMetadata?.pr_number ?? prMetadata?.number;
+  return { owner, repo, pullNumber, reviewId, serverPort, runId, excludeRunIds };
 }
 
 /**
@@ -1219,20 +1265,25 @@ Or simply ignore any changes to files matching these patterns in your analysis.
    * @returns {string} Context section or empty string
    */
   buildPRContextSection(prMetadata, criticalNote) {
+    const description = resolveReviewDescription(prMetadata);
     // Check for null/undefined explicitly to include section even if fields are empty strings
-    if (prMetadata.title != null || prMetadata.description != null) {
+    if (prMetadata.title != null || description != null) {
       const isLocal = prMetadata.reviewType === 'local';
       const sectionTitle = isLocal ? 'Review Context' : 'Pull Request Context';
       const descriptionLabel = isLocal ? 'Description:' : "Author's Description:";
 
-      // Build metadata lines (repository for both modes, PR-specific fields only for PR mode)
+      // Build metadata lines (repository for both modes, PR-specific fields only for PR mode).
+      // Both fields go through the shape-tolerant resolvers so a raw `pr_data`
+      // blob renders "owner/repo" rather than "[object Object]" (#557).
       const lines = [];
-      if (prMetadata.repository) {
-        lines.push(`**Repository:** ${prMetadata.repository}`);
+      const repositorySlug = resolveRepositorySlug(prMetadata);
+      if (repositorySlug) {
+        lines.push(`**Repository:** ${repositorySlug}`);
       }
       if (!isLocal) {
-        if (prMetadata.pr_number) {
-          lines.push(`**PR #:** ${prMetadata.pr_number}`);
+        const pullNumber = prMetadata.pr_number ?? prMetadata.number;
+        if (pullNumber) {
+          lines.push(`**PR #:** ${pullNumber}`);
         }
         if (prMetadata.author) {
           lines.push(`**Author:** @${prMetadata.author}`);
@@ -1245,7 +1296,7 @@ Or simply ignore any changes to files matching these patterns in your analysis.
 ${metadataLines}**Title:** ${prMetadata.title || '(No title provided)'}
 
 **${descriptionLabel}**
-${prMetadata.description || '(No description provided)'}
+${description || '(No description provided)'}
 
 ⚠️ **Critical Note:** ${criticalNote}
 
@@ -4158,5 +4209,7 @@ File-level suggestions should NOT have a line number. They apply to the entire f
 
 module.exports = Analyzer;
 module.exports.buildDedupContext = buildDedupContext;
+module.exports.resolveRepositorySlug = resolveRepositorySlug;
+module.exports.resolveReviewDescription = resolveReviewDescription;
 module.exports.buildDedupInstructions = buildDedupInstructions;
 module.exports.fetchExistingReviewComments = fetchExistingReviewComments;

--- a/src/main.js
+++ b/src/main.js
@@ -2,7 +2,7 @@
 const fs = require('fs');
 const { v4: uuidv4 } = require('uuid');
 const { loadConfig, getConfigDir, showWelcomeMessage, resolveDbName, resolveRepoOptions, resolvePoolConfig, getRepoResetScript, resolveLoadSkills, buildCouncilProviderOverrides } = require('./config');
-const { initializeDatabase, run, queryOne, query, migrateExistingWorktrees, WorktreeRepository, ReviewRepository, RepoSettingsRepository, GitHubReviewRepository, WorktreePoolRepository, CouncilRepository, CommentRepository, AnalysisRunRepository } = require('./database');
+const { initializeDatabase, run, queryOne, query, migrateExistingWorktrees, WorktreeRepository, ReviewRepository, RepoSettingsRepository, GitHubReviewRepository, WorktreePoolRepository, CouncilRepository, CommentRepository, AnalysisRunRepository, PRMetadataRepository } = require('./database');
 const { PRArgumentParser } = require('./github/parser');
 const { GitHubClient } = require('./github/client');
 const { GitWorktreeManager } = require('./git/worktree');
@@ -1544,17 +1544,25 @@ async function performHeadlessReview(args, config, db, flags, options, externalP
       }).catch(err => { logger.warn(`Review hook failed: ${err.message}`); });
     }
 
-    // Get PR metadata ID for AI analysis
-    const prMetadata = await queryOne(db, `
-      SELECT id, pr_data FROM pr_metadata
-      WHERE pr_number = ? AND repository = ? COLLATE NOCASE
-    `, [prInfo.number, repository]);
+    // Get PR metadata for AI analysis.
+    //
+    // Read it through PRMetadataRepository.getByPR — the SAME accessor the web
+    // routes use (src/routes/pr.js) — so the analyzer receives the normalized
+    // row shape it expects: `repository` as the "owner/repo" string, `pr_number`
+    // as the number, plus `description`/`author` from their columns. Passing the
+    // raw `pr_data` blob here (the previous behavior) handed the analyzer the
+    // GitHub API shape, where `repository` is an object and the number lives
+    // under `number`, which made buildDedupContext throw and silently drop every
+    // consolidation stage into its store-everything fallback (#557).
+    const prMetadataRepo = new PRMetadataRepository(db);
+    const prMetadata = await prMetadataRepo.getByPR(prInfo.number, repository);
 
     if (!prMetadata) {
       throw new Error('Failed to retrieve stored PR metadata');
     }
 
-    const storedPRData = JSON.parse(prMetadata.pr_data);
+    // The raw blob is still needed for fields that live only in pr_data (node_id).
+    const storedPRData = prMetadata.pr_data_parsed;
 
     // Get or create a review record for this PR
     // The review.id is passed to the analyzer so comments use review.id, not prMetadata.id
@@ -1603,7 +1611,7 @@ async function performHeadlessReview(args, config, db, flags, options, externalP
       const { result: analysisResult } = await runHeadlessAnalysis(db, config, {
         reviewId: review.id,
         worktreePath,
-        prMetadata: storedPRData,
+        prMetadata,
         changedFiles: null,
         repository,
         repoSettings,
@@ -1871,7 +1879,11 @@ Found ${validSuggestions.length} suggestion${validSuggestions.length === 1 ? '' 
  * @param {Object} params
  * @param {number} params.reviewId - Review id comments are stored under
  * @param {string} params.worktreePath - Checked-out worktree / local repo path
- * @param {Object} params.prMetadata - PR/local metadata (head_sha, base_sha, etc.)
+ * @param {Object} params.prMetadata - PR/local metadata (head_sha, base_sha, etc.).
+ *   PR mode MUST pass the normalized `pr_metadata` row (`repository` as the
+ *   "owner/repo" string, `pr_number` as the number) — the raw `pr_data` blob has
+ *   `repository` as an object and the number under `number`, which breaks dedup
+ *   context construction and, with it, consolidation (#557).
  * @param {Array|null} params.changedFiles - Changed-file list (local mode) or null (PR mode computes it)
  * @param {string} params.repository - owner/repo
  * @param {Object|null} params.repoSettings - Repo settings row
@@ -1956,9 +1968,11 @@ async function runHeadlessAnalysis(db, config, {
  *   convention) so the in-memory usage tracker populated by
  *   `resetAndRehydrate()` is the one acquisitions go through. Falls back to a
  *   fresh instance only when not supplied.
- * @returns {Promise<Object>} { githubClient, worktreePath, storedPRData, review,
+ * @returns {Promise<Object>} { githubClient, worktreePath, prMetadata, review,
  *   repository, repoSettings, poolWorktreeId, poolLifecycle, reviewConfig,
- *   providerOverrides }
+ *   providerOverrides }. `prMetadata` is the normalized `pr_metadata` row from
+ *   `PRMetadataRepository.getByPR` — the shape the analyzer expects — NOT the
+ *   raw `pr_data` blob (#557).
  */
 async function preparePrHeadless(db, config, flags, prArgs, externalPoolLifecycle = null) {
   const parser = new PRArgumentParser(config);
@@ -2163,16 +2177,15 @@ async function preparePrHeadless(db, config, flags, prArgs, externalPoolLifecycl
     }).catch(err => { logger.warn(`Review hook failed: ${err.message}`); });
   }
 
-  const prMetadata = await queryOne(db, `
-    SELECT id, pr_data FROM pr_metadata
-    WHERE pr_number = ? AND repository = ? COLLATE NOCASE
-  `, [prInfo.number, repository]);
+  // Read through PRMetadataRepository.getByPR so the analyzer gets the same
+  // normalized row the web routes pass (see the matching comment in
+  // performHeadlessReview and issue #557).
+  const prMetadataRepo = new PRMetadataRepository(db);
+  const prMetadata = await prMetadataRepo.getByPR(prInfo.number, repository);
 
   if (!prMetadata) {
     throw new Error('Failed to retrieve stored PR metadata');
   }
-
-  const storedPRData = JSON.parse(prMetadata.pr_data);
 
   const reviewRepo = new ReviewRepository(db);
   const { review } = await reviewRepo.getOrCreate({ prNumber: prInfo.number, repository });
@@ -2202,7 +2215,7 @@ async function preparePrHeadless(db, config, flags, prArgs, externalPoolLifecycl
   return {
     githubClient,
     worktreePath,
-    storedPRData,
+    prMetadata,
     review,
     repository,
     repoSettings,
@@ -2470,7 +2483,7 @@ async function handleHeadlessAnalysis(prArgs, config, db, flags, poolLifecycle) 
       ({ runId } = await runHeadlessAnalysis(db, config, {
         reviewId: prep.review.id,
         worktreePath: prep.worktreePath,
-        prMetadata: prep.storedPRData,
+        prMetadata: prep.prMetadata,
         changedFiles: null,
         repository: prep.repository,
         repoSettings: prep.repoSettings,
@@ -2506,7 +2519,9 @@ async function handleHeadlessAnalysis(prArgs, config, db, flags, poolLifecycle) 
  * @param {Object} db - Database instance
  * @param {string} runId - Analysis run id
  * @param {'pr'|'local'} mode - Review mode (passthrough)
- * @returns {Promise<Object>} { ok, mode, run, suggestions, count }
+ * @returns {Promise<Object>} { ok, mode, consolidation, run, suggestions, count }
+ *   where `consolidation` is 'success' | 'failed' | 'skipped' | null — see the
+ *   inline comment on the field for what each value means for `suggestions`.
  */
 async function buildHeadlessJson(db, runId, mode) {
   const run = await new AnalysisRunRepository(db).getById(runId, { includeDiff: false });
@@ -2526,6 +2541,26 @@ async function buildHeadlessJson(db, runId, mode) {
     // see buildHeadlessErrorJson for the failure shape.
     ok: true,
     mode,
+    // Hoisted out of `run.level_outcomes` because it materially changes what
+    // `suggestions` contains. When consolidation throws, every analyzer path
+    // falls back to storing the raw union of all levels (and, for a council, all
+    // voices) and STILL records status 'completed' — so a consumer branching only
+    // on `ok`/`status` cannot tell a consolidated review from a duplicate-laden
+    // concatenation.
+    //
+    // A straight passthrough of whatever the analyzer recorded, so the domain is
+    // the analyzer's, not ours:
+    //   'success' — consolidation ran and merged the inputs.
+    //   'failed'  — it threw; `suggestions` is the unmerged union. DEGRADED.
+    //   'skipped' — nothing to merge (single voice / single level / an executable
+    //               tool that returns its own final set). HEALTHY: the suggestion
+    //               set is already the intended one, which is why
+    //               emitHeadlessResult warns on 'failed' only.
+    //   null      — the run recorded no consolidation stage at all.
+    // Deliberately NOT collapsed to a boolean or folded into null: the web UI
+    // renders the same tri-state (public/js/modules/analysis-history.js), and
+    // 'skipped' carries information null does not.
+    consolidation: run?.level_outcomes?.consolidation ?? null,
     run,
     suggestions,
     count: suggestions.length
@@ -2563,6 +2598,11 @@ function buildHeadlessErrorJson({ mode, error }) {
  * Otherwise prints a human-readable summary to stdout. A successful run with zero
  * suggestions is still success — operational errors propagate to main()'s catch.
  *
+ * Both output modes flag a failed consolidation, which completes the run but
+ * replaces the consolidated review with the raw union of every level/voice.
+ *
+ * Exported for unit testing.
+ *
  * @param {Object} db - Database instance
  * @param {Object} params
  * @param {string} params.runId - Analysis run id
@@ -2591,6 +2631,13 @@ async function emitHeadlessResult(db, { runId, mode, flags }) {
   }
   lines.push(`  Config type: ${run.config_type || 'standard'}`);
   lines.push(`  Status:      ${run.status || '(unknown)'}`);
+  // A failed consolidation still completes the run, so the status line alone
+  // understates it — call out that the listing below is unconsolidated.
+  if (doc.consolidation === 'failed') {
+    lines.push('');
+    lines.push('  WARNING: consolidation failed. The suggestions below are the raw union of');
+    lines.push('           every analysis level (and every council voice) — expect duplicates.');
+  }
   if (run.summary) {
     lines.push('');
     lines.push('Summary:');
@@ -2792,4 +2839,4 @@ if (require.main === module) {
   main();
 }
 
-module.exports = { main, parseArgs, detectPRFromGitHubEnvironment, printCouncilList, handleHeadlessAnalysis, handleHeadlessDelegated, runHeadlessAnalysis, buildHeadlessJson, buildHeadlessErrorJson, resolveCliInstructions };
+module.exports = { main, parseArgs, detectPRFromGitHubEnvironment, printCouncilList, handleHeadlessAnalysis, handleHeadlessDelegated, runHeadlessAnalysis, buildHeadlessJson, buildHeadlessErrorJson, emitHeadlessResult, resolveCliInstructions };

--- a/tests/unit/analyzer-metadata-shape.test.js
+++ b/tests/unit/analyzer-metadata-shape.test.js
@@ -1,0 +1,297 @@
+// Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+/**
+ * Regression tests for the PR-metadata shape contract (issue #557).
+ *
+ * `prMetadata` reaches the analyzer in two shapes:
+ *
+ *   1. the NORMALIZED `pr_metadata` row (`PRMetadataRepository.getByPR`) — what
+ *      the web routes and, since #557, the headless CLI paths pass. `repository`
+ *      is the "owner/repo" string, the number is `pr_number`, the body is
+ *      `description`.
+ *   2. the RAW stored `pr_data` blob (the GitHub API shape) — what the headless
+ *      paths used to pass. `repository` is an OBJECT
+ *      (`{ full_name, clone_url, ... }`), the number is `number`, the body is
+ *      `body`.
+ *
+ * The bug: `buildDedupContext` did `prMetadata.repository?.split('/')`, which
+ * threw `TypeError: prMetadata.repository?.split is not a function` on shape 2.
+ * Because every consolidation/orchestration stage builds its dedup context
+ * FIRST, that one throw was caught by the store-everything fallback, so runs
+ * completed "successfully" while emitting the unmerged union of all levels (and
+ * all council voices).
+ *
+ * These tests pin BOTH halves of the fix: the shape-tolerant resolvers, and the
+ * producer/consumer contract between `getByPR` and `buildDedupContext`.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { createTestDatabase, closeTestDatabase } from '../utils/schema.js';
+
+const {
+  buildDedupContext,
+  resolveRepositorySlug,
+  resolveReviewDescription
+} = require('../../src/ai/analyzer');
+const Analyzer = require('../../src/ai/analyzer');
+const { PRMetadataRepository } = require('../../src/database.js');
+
+const IDS = { reviewId: 42, serverPort: 7247, runId: 'run-1' };
+
+/** The normalized `pr_metadata` row shape (what getByPR returns). */
+const NORMALIZED_METADATA = {
+  id: 7,
+  pr_number: 123,
+  repository: 'in-the-loop-labs/pair-review',
+  title: 'Add a thing',
+  description: 'This PR adds a thing.',
+  author: 'tjwp',
+  base_branch: 'main',
+  head_branch: 'feature',
+  base_sha: 'base123',
+  head_sha: 'head456'
+};
+
+/** The raw stored `pr_data` blob shape (GitHub API shape). */
+const RAW_BLOB_METADATA = {
+  number: 123,
+  node_id: 'PR_kwDO123',
+  title: 'Add a thing',
+  body: 'This PR adds a thing.',
+  author: 'tjwp',
+  base_branch: 'main',
+  head_branch: 'feature',
+  base_sha: 'base123',
+  head_sha: 'head456',
+  repository: {
+    full_name: 'in-the-loop-labs/pair-review',
+    clone_url: 'https://github.com/in-the-loop-labs/pair-review.git',
+    ssh_url: 'git@github.com:in-the-loop-labs/pair-review.git',
+    default_branch: 'main'
+  }
+};
+
+describe('resolveRepositorySlug', () => {
+  it('returns the string form unchanged', () => {
+    expect(resolveRepositorySlug({ repository: 'owner/repo' })).toBe('owner/repo');
+  });
+
+  it('returns a bare local directory name unchanged (local reviews have no slash)', () => {
+    expect(resolveRepositorySlug({ repository: 'pair-review' })).toBe('pair-review');
+  });
+
+  it('unwraps full_name from the GitHub API object shape', () => {
+    expect(resolveRepositorySlug({ repository: { full_name: 'owner/repo', clone_url: 'x' } }))
+      .toBe('owner/repo');
+  });
+
+  it('returns null for an object with no usable full_name', () => {
+    expect(resolveRepositorySlug({ repository: { clone_url: 'x' } })).toBeNull();
+  });
+
+  it('returns null for missing, empty, and nullish metadata', () => {
+    expect(resolveRepositorySlug({})).toBeNull();
+    expect(resolveRepositorySlug({ repository: '' })).toBeNull();
+    expect(resolveRepositorySlug({ repository: null })).toBeNull();
+    expect(resolveRepositorySlug(null)).toBeNull();
+    expect(resolveRepositorySlug(undefined)).toBeNull();
+  });
+});
+
+describe('resolveReviewDescription', () => {
+  it('prefers the normalized `description` field', () => {
+    expect(resolveReviewDescription({ description: 'normalized', body: 'raw' })).toBe('normalized');
+  });
+
+  it('falls back to the raw blob `body` field', () => {
+    expect(resolveReviewDescription({ body: 'raw' })).toBe('raw');
+  });
+
+  it('treats a null description as unset and falls through to body', () => {
+    expect(resolveReviewDescription({ description: null, body: 'raw' })).toBe('raw');
+  });
+
+  it('preserves an empty-string description rather than falling through to body', () => {
+    // `??` (not `||`) — an empty description is a deliberate value, not "unset".
+    expect(resolveReviewDescription({ description: '', body: 'raw' })).toBe('');
+  });
+
+  it('is nullish when neither field is present', () => {
+    // Local reviews pass `description: null` with no `body`; the prompt builder
+    // treats nullish the same as it always has (section omitted / placeholder).
+    expect(resolveReviewDescription({ description: null })).toBeUndefined();
+    expect(resolveReviewDescription({})).toBeUndefined();
+    expect(resolveReviewDescription(null)).toBeUndefined();
+  });
+});
+
+describe('buildDedupContext', () => {
+  it('extracts owner/repo/pullNumber from the normalized row shape', () => {
+    expect(buildDedupContext(NORMALIZED_METADATA, IDS)).toEqual({
+      owner: 'in-the-loop-labs',
+      repo: 'pair-review',
+      pullNumber: 123,
+      reviewId: 42,
+      serverPort: 7247,
+      runId: 'run-1',
+      excludeRunIds: undefined
+    });
+  });
+
+  it('does not throw on the raw pr_data blob shape (#557 regression)', () => {
+    // The exact failure: `prMetadata.repository?.split is not a function`.
+    // Optional chaining did NOT help — the value is present, just not a string.
+    expect(() => buildDedupContext(RAW_BLOB_METADATA, IDS)).not.toThrow();
+  });
+
+  it('resolves owner/repo/pullNumber from the raw pr_data blob shape', () => {
+    expect(buildDedupContext(RAW_BLOB_METADATA, IDS)).toEqual({
+      owner: 'in-the-loop-labs',
+      repo: 'pair-review',
+      pullNumber: 123,
+      reviewId: 42,
+      serverPort: 7247,
+      runId: 'run-1',
+      excludeRunIds: undefined
+    });
+  });
+
+  it('produces an identical dedup context from either metadata shape', () => {
+    expect(buildDedupContext(RAW_BLOB_METADATA, IDS))
+      .toEqual(buildDedupContext(NORMALIZED_METADATA, IDS));
+  });
+
+  it('prefers pr_number over number when both are present', () => {
+    const ctx = buildDedupContext({ repository: 'o/r', pr_number: 1, number: 999 }, IDS);
+    expect(ctx.pullNumber).toBe(1);
+  });
+
+  it('passes excludeRunIds through', () => {
+    const ctx = buildDedupContext(NORMALIZED_METADATA, { ...IDS, excludeRunIds: ['a', 'b'] });
+    expect(ctx.excludeRunIds).toEqual(['a', 'b']);
+  });
+
+  it('yields undefined owner/repo/pullNumber for local metadata (no repo slug, no PR number)', () => {
+    const localMetadata = {
+      repository: 'pair-review',
+      reviewType: 'local',
+      title: 'Local changes in pair-review',
+      description: 'Reviewing uncommitted changes',
+      head_sha: 'abc'
+    };
+    const ctx = buildDedupContext(localMetadata, IDS);
+    expect(ctx.owner).toBe('pair-review');
+    expect(ctx.repo).toBeUndefined();
+    expect(ctx.pullNumber).toBeUndefined();
+  });
+
+  it('does not throw when repository is missing entirely', () => {
+    const ctx = buildDedupContext({ head_sha: 'abc' }, IDS);
+    expect(ctx.owner).toBeUndefined();
+    expect(ctx.repo).toBeUndefined();
+    expect(ctx.pullNumber).toBeUndefined();
+  });
+});
+
+describe('buildPRContextSection metadata rendering', () => {
+  /** buildPRContextSection is an instance method but reads no instance state. */
+  const analyzer = Object.create(Analyzer.prototype);
+
+  it('renders owner/repo, PR number, and description from the normalized shape', () => {
+    const out = analyzer.buildPRContextSection(NORMALIZED_METADATA, 'note');
+    expect(out).toContain('**Repository:** in-the-loop-labs/pair-review');
+    expect(out).toContain('**PR #:** 123');
+    expect(out).toContain('This PR adds a thing.');
+  });
+
+  it('renders the same fields from the raw pr_data blob shape', () => {
+    const out = analyzer.buildPRContextSection(RAW_BLOB_METADATA, 'note');
+    // Previously rendered "**Repository:** [object Object]", omitted the PR
+    // number (stored under `number`), and lost the body (stored under `body`).
+    expect(out).not.toContain('[object Object]');
+    expect(out).toContain('**Repository:** in-the-loop-labs/pair-review');
+    expect(out).toContain('**PR #:** 123');
+    expect(out).toContain('This PR adds a thing.');
+    expect(out).not.toContain('(No description provided)');
+  });
+
+  it('omits PR-only fields for local reviews', () => {
+    const out = analyzer.buildPRContextSection({
+      reviewType: 'local',
+      repository: 'pair-review',
+      title: 'Local changes',
+      description: 'Uncommitted work'
+    }, 'note');
+    expect(out).toContain('## Review Context');
+    expect(out).toContain('**Repository:** pair-review');
+    expect(out).not.toContain('**PR #:**');
+  });
+});
+
+describe('getByPR → buildDedupContext contract', () => {
+  let db;
+
+  beforeEach(() => {
+    db = createTestDatabase();
+  });
+
+  afterEach(() => {
+    closeTestDatabase(db);
+  });
+
+  /**
+   * The cross-boundary contract that broke in #557: the headless paths read PR
+   * metadata from the DB and hand it straight to the analyzer. Assert the
+   * PRODUCER (`getByPR`) emits a shape the CONSUMER (`buildDedupContext`)
+   * resolves to a real owner/repo/pullNumber — so dedup and, with it,
+   * consolidation actually run.
+   */
+  it('getByPR output yields a fully-populated dedup context', async () => {
+    db.prepare(`
+      INSERT INTO pr_metadata
+        (pr_number, repository, title, description, author, base_branch, head_branch, pr_data)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      123,
+      'in-the-loop-labs/pair-review',
+      'Add a thing',
+      'This PR adds a thing.',
+      'tjwp',
+      'main',
+      'feature',
+      JSON.stringify(RAW_BLOB_METADATA)
+    );
+
+    const row = await new PRMetadataRepository(db).getByPR(123, 'in-the-loop-labs/pair-review');
+    const ctx = buildDedupContext(row, IDS);
+
+    expect(ctx.owner).toBe('in-the-loop-labs');
+    expect(ctx.repo).toBe('pair-review');
+    expect(ctx.pullNumber).toBe(123);
+  });
+
+  it('getByPR output carries the analyzer prompt fields (description, author, SHAs)', async () => {
+    db.prepare(`
+      INSERT INTO pr_metadata
+        (pr_number, repository, title, description, author, base_branch, head_branch, pr_data)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      123,
+      'in-the-loop-labs/pair-review',
+      'Add a thing',
+      'This PR adds a thing.',
+      'tjwp',
+      'main',
+      'feature',
+      JSON.stringify(RAW_BLOB_METADATA)
+    );
+
+    const row = await new PRMetadataRepository(db).getByPR(123, 'in-the-loop-labs/pair-review');
+
+    expect(row.description).toBe('This PR adds a thing.');
+    expect(row.author).toBe('tjwp');
+    expect(row.base_sha).toBe('base123');
+    expect(row.head_sha).toBe('head456');
+    // The raw blob stays reachable for pr_data-only fields (e.g. node_id).
+    expect(row.pr_data_parsed.node_id).toBe('PR_kwDO123');
+  });
+});

--- a/tests/unit/headless-json.test.js
+++ b/tests/unit/headless-json.test.js
@@ -11,6 +11,7 @@
  *   - per-level rows, raw rows, dismissed finals, and other runs' rows are excluded
  *   - `count` matches `suggestions.length`
  *   - `run.level_outcomes` / `run.levels_config` are JSON-parsed objects
+ *   - the consolidation outcome is hoisted to a top-level `consolidation` field
  *   - per-suggestion `reasoning` is JSON-parsed
  *   - `mode` passes through unchanged ('pr' and 'local')
  *   - the (potentially large) `diff` column is NOT included
@@ -19,7 +20,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { createTestDatabase, closeTestDatabase, seedTestReview } from '../utils/schema.js';
 
-const { buildHeadlessJson, buildHeadlessErrorJson } = require('../../src/main.js');
+const { buildHeadlessJson, buildHeadlessErrorJson, emitHeadlessResult } = require('../../src/main.js');
 
 const RUN_ID = 'run-under-test';
 const OTHER_RUN_ID = 'some-other-run';
@@ -238,6 +239,183 @@ describe('buildHeadlessJson', () => {
     expect(doc.suggestions).toEqual([]);
     expect(doc.count).toBe(0);
     expect(doc.mode).toBe('pr');
+  });
+
+  /**
+   * A failed consolidation still records status 'completed' and returns
+   * `ok: true` — the analyzer falls back to storing the raw union of every level
+   * (and every council voice). Without a top-level signal a machine consumer
+   * cannot distinguish that from a real consolidated review (issue #557).
+   */
+  describe('consolidation outcome hoisting', () => {
+    it('surfaces consolidation: "failed" at the top level while keeping ok: true', async () => {
+      const failedRunId = 'consolidation-failed-run';
+      seedRun(db, {
+        id: failedRunId,
+        reviewId,
+        overrides: {
+          level_outcomes: JSON.stringify({
+            level1: 'success', level2: 'success', level3: 'success', consolidation: 'failed'
+          })
+        }
+      });
+
+      const doc = await buildHeadlessJson(db, failedRunId, 'pr');
+      expect(doc.consolidation).toBe('failed');
+      // The run still completed; `ok` stays true so existing consumers do not break.
+      expect(doc.ok).toBe(true);
+      expect(doc.run.status).toBe('completed');
+    });
+
+    it('surfaces consolidation: "success" for a healthy run', async () => {
+      const okRunId = 'consolidation-ok-run';
+      seedRun(db, {
+        id: okRunId,
+        reviewId,
+        overrides: { level_outcomes: JSON.stringify({ consolidation: 'success' }) }
+      });
+
+      const doc = await buildHeadlessJson(db, okRunId, 'pr');
+      expect(doc.consolidation).toBe('success');
+    });
+
+    /**
+     * 'skipped' is a THIRD, healthy value — the council paths record it when a
+     * run resolves to a single voice or a single level and there is nothing to
+     * merge (src/ai/analyzer.js). It must survive as itself rather than being
+     * folded into 'success' or null: the web UI renders the same tri-state, and
+     * a consumer treating `!= 'success'` as degraded would misclassify a
+     * perfectly good single-voice council run.
+     */
+    it('surfaces consolidation: "skipped" distinctly from success and null', async () => {
+      const skippedRunId = 'consolidation-skipped-run';
+      seedRun(db, {
+        id: skippedRunId,
+        reviewId,
+        overrides: { level_outcomes: JSON.stringify({ consolidation: 'skipped' }) }
+      });
+
+      const doc = await buildHeadlessJson(db, skippedRunId, 'pr');
+      expect(doc.consolidation).toBe('skipped');
+      expect(doc.ok).toBe(true);
+    });
+
+    it('is null when level_outcomes records no consolidation stage', async () => {
+      // RUN_ID's seeded level_outcomes has per-level entries but no consolidation key.
+      const doc = await buildHeadlessJson(db, RUN_ID, 'pr');
+      expect(doc.consolidation).toBeNull();
+    });
+
+    it('is null when the run has no level_outcomes at all', async () => {
+      const bareRunId = 'bare-run';
+      seedRun(db, { id: bareRunId, reviewId, overrides: { level_outcomes: null } });
+
+      const doc = await buildHeadlessJson(db, bareRunId, 'pr');
+      expect(doc.consolidation).toBeNull();
+    });
+
+    it('is null for an unknown run id (no throw)', async () => {
+      const doc = await buildHeadlessJson(db, 'no-such-run', 'pr');
+      expect(doc.consolidation).toBeNull();
+    });
+  });
+});
+
+/**
+ * emitHeadlessResult writes the run outcome to stdout — JSON in --json mode, a
+ * human-readable block otherwise. These tests capture stdout rather than
+ * spawning the CLI, and focus on the consolidation-failure signal (#557), which
+ * is invisible in the status line alone.
+ */
+describe('emitHeadlessResult', () => {
+  let db;
+  let reviewId;
+  let written;
+  let restoreStdout;
+
+  beforeEach(() => {
+    db = createTestDatabase();
+    reviewId = seedTestReview(db, { prNumber: 1, repository: 'owner/repo' });
+
+    written = [];
+    const original = process.stdout.write.bind(process.stdout);
+    process.stdout.write = (chunk, ...rest) => {
+      written.push(String(chunk));
+      return true;
+    };
+    restoreStdout = () => { process.stdout.write = original; };
+  });
+
+  afterEach(() => {
+    // Restore FIRST — a failing assertion must not leave stdout patched for
+    // every later test in this file.
+    restoreStdout();
+    closeTestDatabase(db);
+  });
+
+  /** All stdout written during the call, joined. */
+  const output = () => written.join('');
+
+  it('warns in the human-readable output when consolidation failed', async () => {
+    const failedRunId = 'emit-failed-run';
+    seedRun(db, {
+      id: failedRunId,
+      reviewId,
+      overrides: { level_outcomes: JSON.stringify({ consolidation: 'failed' }) }
+    });
+
+    await emitHeadlessResult(db, { runId: failedRunId, mode: 'pr', flags: {} });
+
+    expect(output()).toContain('WARNING: consolidation failed');
+    expect(output()).toContain('raw union of');
+  });
+
+  it('does not warn when consolidation succeeded', async () => {
+    const okRunId = 'emit-ok-run';
+    seedRun(db, {
+      id: okRunId,
+      reviewId,
+      overrides: { level_outcomes: JSON.stringify({ consolidation: 'success' }) }
+    });
+
+    await emitHeadlessResult(db, { runId: okRunId, mode: 'pr', flags: {} });
+
+    expect(output()).not.toContain('WARNING');
+    expect(output()).toContain('Headless analysis complete');
+  });
+
+  it('does not warn when consolidation was skipped (a healthy outcome)', async () => {
+    // 'skipped' means there was nothing to merge (single voice / single level),
+    // NOT that the result is degraded — warning here would cry wolf on every
+    // single-voice council run.
+    const skippedRunId = 'emit-skipped-run';
+    seedRun(db, {
+      id: skippedRunId,
+      reviewId,
+      overrides: { level_outcomes: JSON.stringify({ consolidation: 'skipped' }) }
+    });
+
+    await emitHeadlessResult(db, { runId: skippedRunId, mode: 'pr', flags: {} });
+
+    expect(output()).not.toContain('WARNING');
+    expect(output()).toContain('Headless analysis complete');
+  });
+
+  it('emits the consolidation field in --json mode', async () => {
+    const failedRunId = 'emit-json-run';
+    seedRun(db, {
+      id: failedRunId,
+      reviewId,
+      overrides: { level_outcomes: JSON.stringify({ consolidation: 'failed' }) }
+    });
+
+    await emitHeadlessResult(db, { runId: failedRunId, mode: 'pr', flags: { json: true } });
+
+    const doc = JSON.parse(output());
+    expect(doc.consolidation).toBe('failed');
+    expect(doc.ok).toBe(true);
+    // JSON mode emits ONLY the document — no human-readable warning text.
+    expect(output()).not.toContain('WARNING');
   });
 });
 


### PR DESCRIPTION
Fixes #557.

## The bug

The headless PR paths (`--headless`, `--ai-draft`, `--ai-review`) passed the raw stored `pr_data` blob to the analyzer, where the web routes pass the normalized `pr_metadata` row. In that blob `repository` is a GitHub API object (`{ full_name, clone_url, … }`) rather than the `"owner/repo"` string, so `buildDedupContext` threw:

```
TypeError: prMetadata.repository?.split is not a function
```

Reproduced against the exact shape `src/github/client.js` stores:

```
OLD threw: rawBlob.repository?.split is not a function
NEW: {"owner":"in-the-loop-labs","repo":"pair-review","pullNumber":557,...}
```

Every consolidation and orchestration stage builds its dedup context first, so that single throw was swallowed by the store-everything fallback. Runs reported `status: completed` / `ok: true` while emitting the **unmerged union of all three levels** and, for a council, of every voice — 45 suggestions from a 3-voice council on a ~30-file PR (13 + 13 + 19), the same issue repeated up to seven times. Every headless PR analysis reaching consolidation had been affected since `buildDedupContext` was introduced, including reviews posted by `--ai-draft`/`--ai-review` workflows.

## The fix

Both headless call sites now read through `PRMetadataRepository.getByPR` — the same accessor `src/routes/pr.js:2192` uses — so every entry point hands the analyzer one shape. Parity is structural rather than a parallel hand-mapping, which matters given how easily these two paths drift.

**Two adjacent bugs the same mismatch caused**, not mentioned in the issue: headless prompts were rendering `**Repository:** [object Object]`, omitting the `**PR #:**` line (the blob keys it `number`), and dropping the PR description entirely (keyed `body`). So `--ai-draft`/`--ai-review` have been reviewing PRs without their descriptions, not just without consolidation.

**Defense in depth** — the analyzer's metadata readers (`resolveRepositorySlug`, `resolveReviewDescription`) now accept either shape, so a future caller passing the raw blob degrades nothing.

## Observability

`--headless --json` gains a top-level `consolidation` field, and the human-readable output warns when it failed. Previously the only evidence was a stderr line and `level_outcomes` on the run row.

| Value | Meaning |
| --- | --- |
| `"success"` | Consolidation ran and merged the inputs. |
| `"failed"` | It threw; `suggestions` is the unmerged union. **Degraded.** |
| `"skipped"` | Nothing to merge (single voice / single level / executable provider). **Healthy.** |
| `null` | No consolidation stage recorded. |

Only `"failed"` means degraded output, so consumers should branch on `== "failed"` rather than `!= "success"` — a single-voice council legitimately reports `"skipped"`. The value is a straight passthrough of what the analyzer records and is deliberately not collapsed: the web UI already renders the same tri-state.

## Testing

- New `tests/unit/analyzer-metadata-shape.test.js` (23 tests), including a producer/consumer contract test binding `getByPR` output to `buildDedupContext` — the exact boundary that broke.
- 8 new tests in `headless-json.test.js` covering the tri-state and the warn-on-`failed`-only rule.
- Full suite: **9399 passed**. The 3 failures in `tests/integration/first-run.test.js` are pre-existing — verified identical on a clean tree from the same working directory (known local CLI-spawn hang, not a regression).
- No frontend code touched, so no E2E run.

Changeset included (`patch`). README's documented JSON shape updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)