### PR TITLE
fix: stop consolidation from silently dropping all suggestions on parse failure

### DIFF
--- a/.changeset/fix-silent-consolidation-loss.md
+++ b/.changeset/fix-silent-consolidation-loss.md
@@ -1,0 +1,9 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Fix consolidation silently dropping all suggestions on JSON parse failure (#560)
+
+- JSON extraction now repairs unescaped control characters (raw newlines, tabs, etc.) inside string literals before giving up, recovering large consolidation responses that embed code snippets.
+- If a consolidation response still cannot be parsed while the per-level or per-voice input was non-empty, the run now falls back to the unconsolidated suggestions and reports `consolidation: 'failed'` instead of returning success with zero suggestions. This applies to all consolidation paths: cross-level orchestration, cross-voice council consolidation, and intra-level council consolidation.
+- The live progress indicator no longer overwrites a failed consolidation step with "completed" when the run finishes (PR mode, local mode, and council runs).

--- a/src/ai/analyzer.js
+++ b/src/ai/analyzer.js
@@ -385,6 +385,20 @@ A suggestion is a duplicate if it targets the same file and overlapping lines an
   return sections.join('\n\n');
 }
 
+/**
+ * A response object is "ours" if it carries any key from our response schema.
+ * A string `summary` alone is a valid zero-finding result (e.g. "all findings
+ * duplicated existing comments"), so it counts. Shared by both acceptance
+ * branches in parseResponseWithMeta so they cannot drift (issue #560).
+ * @param {Object} obj - Candidate response object
+ * @returns {boolean} True if the object carries any schema key
+ */
+function hasSchemaKeys(obj) {
+  return Array.isArray(obj.suggestions) ||
+    Array.isArray(obj.fileLevelSuggestions) ||
+    typeof obj.summary === 'string';
+}
+
 class Analyzer {
   /**
    * @param {Object} database - Database instance
@@ -643,9 +657,15 @@ class Analyzer {
 
         const orchestrationResult = await this.orchestrateWithAI(allSuggestions, prMetadata, mergedInstructions, worktreePath, { analysisId, tier, progressCallback, timeout: executionTimeout, logPrefix, reviewerNum, excludePrevious, dedupContext, githubClient });
 
-        // Report orchestration step as completed
+        // orchestrateWithAI degrades to the raw union of level suggestions when
+        // consolidation fails internally — report that honestly instead of 'success'
+        const consolidationOutcome = orchestrationResult.consolidationFailed ? 'failed' : 'success';
+
+        // Report orchestration step outcome
         if (progressCallback) {
-          progressCallback({ level: 'orchestration', status: 'completed', progress: 'Cross-level consolidation complete' });
+          progressCallback(orchestrationResult.consolidationFailed
+            ? { level: 'orchestration', status: 'failed', progress: 'Cross-level consolidation failed' }
+            : { level: 'orchestration', status: 'completed', progress: 'Cross-level consolidation complete' });
         }
 
         // Validate and finalize suggestions
@@ -670,7 +690,7 @@ class Analyzer {
           level1: levelResults.level1.status,
           level2: levelResults.level2.status,
           level3: levelResults.level3.status,
-          consolidation: 'success'
+          consolidation: consolidationOutcome
         };
 
         // Update analysis_run record with completion data
@@ -694,7 +714,8 @@ class Analyzer {
           suggestions: finalSuggestions,
           levelResults,
           levelOutcomes,
-          summary: orchestrationResult.summary
+          summary: orchestrationResult.summary,
+          ...(orchestrationResult.consolidationFailed ? { orchestrationFailed: true } : {})
         };
 
       } catch (orchestrationError) {
@@ -1192,6 +1213,8 @@ Or simply ignore any changes to files matching these patterns in your analysis.
       });
 
       // Parse and validate the response
+      // A parse failure here still reports Level 1 success with zero suggestions;
+      // honest per-level parse-failure reporting is a known follow-up to issue #560.
       updateProgress('Processing AI results');
       const parsedSuggestions = this.parseResponse(response, 1);
       logger.success(`${lp}Parsed ${parsedSuggestions.length} valid Level 1 suggestions`);
@@ -1623,30 +1646,64 @@ If you are unsure, use "NEW" - it is correct for the vast majority of suggestion
    * @param {Array} previousSuggestions - Previous suggestions to check for duplicates
    */
   parseResponse(response, level, previousSuggestions = []) {
+    return this.parseResponseWithMeta(response, level, previousSuggestions).suggestions;
+  }
+
+  /**
+   * Parse a response into suggestions, also reporting whether the response was
+   * recognizable as our response schema. `parseFailed: true` means no parseable
+   * suggestions were found — nothing in the response carried any of our schema
+   * keys (suggestions / fileLevelSuggestions / summary). That is distinct from
+   * a legitimately empty `suggestions: []` or a summary-only zero-finding
+   * response — consolidation callers use the distinction to fall back instead
+   * of silently reporting success with zero suggestions (issue #560).
+   *
+   * @param {Object} response - Provider response
+   * @param {number|string} level - Analysis level (for logging)
+   * @param {Array} previousSuggestions - Previous suggestions to check for duplicates
+   * @returns {{ suggestions: Array, parseFailed: boolean }}
+   */
+  parseResponseWithMeta(response, level, previousSuggestions = []) {
     const levelPrefix = `[Level ${level}]`;
 
     // Separate previous suggestions into line-level and file-level for deduplication
     const previousLineSuggestions = previousSuggestions.filter(s => !s.is_file_level);
     const previousFileLevelSuggestions = previousSuggestions.filter(s => s.is_file_level);
 
-    // If response is already parsed JSON
-    if (response.suggestions && Array.isArray(response.suggestions)) {
-      const lineSuggestions = this.validateSuggestions(response.suggestions, previousLineSuggestions);
-      const fileLevelSuggestions = response.fileLevelSuggestions
-        ? this.validateFileLevelSuggestions(response.fileLevelSuggestions, previousFileLevelSuggestions)
-        : [];
-      return [...lineSuggestions, ...fileLevelSuggestions];
+    // Already-parsed branch — the common path: providers resolve parsed schema
+    // objects directly and only fall back to `{ raw, parsed: false }` (which
+    // never carries a string summary) when their own parsing fails. Suggestion
+    // arrays are authoritative regardless of any `raw` payload; a summary alone
+    // is accepted here only when there is no `raw` payload to try first, so a
+    // hypothetical `{ summary, raw }` shape with extractable suggestions in
+    // `raw` does not lose them (final summary-only acceptance is below).
+    // validateSuggestions requires real arrays, so default the missing ones —
+    // a summary-only object has neither.
+    if (Array.isArray(response.suggestions) || Array.isArray(response.fileLevelSuggestions) ||
+        (hasSchemaKeys(response) && !response.raw)) {
+      const lineSuggestions = this.validateSuggestions(response.suggestions || [], previousLineSuggestions);
+      const fileLevelSuggestions = this.validateFileLevelSuggestions(
+        response.fileLevelSuggestions || [], previousFileLevelSuggestions
+      );
+      return { suggestions: [...lineSuggestions, ...fileLevelSuggestions], parseFailed: false };
     }
 
-    // If response is raw text, try multiple extraction strategies
+    // If response is raw text, try multiple extraction strategies. Extraction can
+    // latch onto unrelated JSON fragments in prose, so only JSON carrying one of
+    // our schema keys counts as parsed — a summary-only object is a legitimate
+    // zero-finding response (e.g. "all findings duplicated existing comments").
     if (response.raw) {
       const extracted = extractJSON(response.raw, level);
-      if (extracted.success && extracted.data.suggestions && Array.isArray(extracted.data.suggestions)) {
-        const lineSuggestions = this.validateSuggestions(extracted.data.suggestions, previousLineSuggestions);
+      if (extracted.success && hasSchemaKeys(extracted.data)) {
+        const lineSuggestions = this.validateSuggestions(extracted.data.suggestions || [], previousLineSuggestions);
         const fileLevelSuggestions = extracted.data.fileLevelSuggestions
           ? this.validateFileLevelSuggestions(extracted.data.fileLevelSuggestions, previousFileLevelSuggestions)
           : [];
-        return [...lineSuggestions, ...fileLevelSuggestions];
+        return { suggestions: [...lineSuggestions, ...fileLevelSuggestions], parseFailed: false };
+      } else if (extracted.success) {
+        logger.warn(`${levelPrefix} Extracted JSON carried none of the expected schema keys (suggestions/fileLevelSuggestions/summary)`);
+        logger.info(`${levelPrefix} Raw response length: ${response.raw.length} characters`);
+        logger.info(`${levelPrefix} Raw response preview: ${response.raw.substring(0, 500)}...`);
       } else {
         logger.warn(`${levelPrefix} JSON extraction failed: ${extracted.error}`);
         logger.info(`${levelPrefix} Raw response length: ${response.raw.length} characters`);
@@ -1654,9 +1711,17 @@ If you are unsure, use "NEW" - it is correct for the vast majority of suggestion
       }
     }
 
+    // A string `summary` alone is a valid zero-finding result — reached only
+    // for a `{ summary, raw }` response whose raw extraction yielded nothing
+    // better (arrays would have been accepted above).
+    if (hasSchemaKeys(response)) {
+      logger.info(`${levelPrefix} Accepting summary-only response as a zero-finding result`);
+      return { suggestions: [], parseFailed: false };
+    }
+
     // Fallback to empty array
     logger.warn(`${levelPrefix} No valid suggestions found in response`);
-    return [];
+    return { suggestions: [], parseFailed: true };
   }
 
   /**
@@ -2161,6 +2226,8 @@ If you are unsure, use "NEW" - it is correct for the vast majority of suggestion
       });
 
       // Parse and validate the response
+      // A parse failure here still reports Level 2 success with zero suggestions;
+      // honest per-level parse-failure reporting is a known follow-up to issue #560.
       updateProgress('Processing AI results');
       let suggestions = this.parseResponse(response, 2);
       logger.success(`${lp}Parsed ${suggestions.length} valid Level 2 suggestions`);
@@ -2275,6 +2342,8 @@ If you are unsure, use "NEW" - it is correct for the vast majority of suggestion
       });
 
       // Parse and validate the response
+      // A parse failure here still reports Level 3 success with zero suggestions;
+      // honest per-level parse-failure reporting is a known follow-up to issue #560.
       updateProgress('Processing codebase context results');
       let suggestions = this.parseResponse(response, 3);
       logger.success(`${lp}Parsed ${suggestions.length} valid Level 3 suggestions`);
@@ -2782,7 +2851,9 @@ File-level suggestions should NOT have a line number. They apply to the entire f
    * @param {Object} [options.excludePrevious] - { github: bool, feedback: bool } for dedup
    * @param {Object} [options.dedupContext] - { owner, repo, pullNumber, reviewId, serverPort }
    * @param {Object} [options.githubClient] - GitHubClient used to pre-fetch existing PR review comments for dedup
-   * @returns {Promise<Array>} Curated suggestions array
+   * @returns {Promise<{suggestions: Array, summary: string, consolidationFailed?: boolean}>}
+   *   Consolidation result. `consolidationFailed: true` means the suggestions
+   *   array is the raw union of all levels rather than a curated set.
    */
   async orchestrateWithAI(allSuggestions, prMetadata, customInstructions = null, worktreePath = null, options = {}) {
     const { analysisId, tier = 'balanced', progressCallback, providerOverride, modelOverride, timeout = 600000, logPrefix: lp = '', reviewerNum, excludePrevious, dedupContext, githubClient } = options;
@@ -2842,7 +2913,7 @@ File-level suggestions should NOT have a line number. They apply to the entire f
       });
 
       // Parse the orchestrated response
-      const orchestratedSuggestions = this.parseResponse(response, 'orchestration');
+      const { suggestions: orchestratedSuggestions, parseFailed } = this.parseResponseWithMeta(response, 'orchestration');
 
       // Debug: If consolidation returned 0 suggestions but there was input, log for investigation
       const inputLevel1Count = allSuggestions.level1?.length || 0;
@@ -2866,6 +2937,17 @@ File-level suggestions should NOT have a line number. They apply to the entire f
         }
       }
 
+      // A response with no parseable suggestions (nothing recognizable as our
+      // response schema), when the levels produced suggestions, means every
+      // input suggestion would be silently dropped. Route that through the
+      // fallback below instead of reporting success with zero suggestions
+      // (issue #560). A parseable-but-empty `suggestions: []` is left alone —
+      // the consolidator may legitimately curate everything away (e.g. dedup
+      // against previously posted comments).
+      if (parseFailed && hadInputSuggestions) {
+        throw new Error('Consolidation response could not be parsed; falling back to unconsolidated suggestions');
+      }
+
       // Extract summary from the orchestration response
       let summary = `Analyzed PR with ${orchestratedSuggestions.length} curated suggestions`;
       if (response.summary) {
@@ -2883,8 +2965,11 @@ File-level suggestions should NOT have a line number. They apply to the entire f
         suggestions: orchestratedSuggestions,
         summary: summary
       };
-      
+
     } catch (error) {
+      // Cancellation is not a consolidation failure — propagate so the run is
+      // recorded as cancelled instead of consolidation 'failed'
+      if (error.isCancellation) throw error;
       logger.warn(`${lp}[Consolidation] Cross-level consolidation failed: ${error.message}`);
       logger.warn(`${lp}[Consolidation] Falling back to storing all original suggestions`);
 
@@ -2911,7 +2996,8 @@ File-level suggestions should NOT have a line number. They apply to the entire f
 
       return {
         suggestions: fallbackSuggestions,
-        summary: `Analysis complete (consolidation failed): ${fallbackSuggestions.length} suggestions from all analysis levels`
+        summary: `Analysis complete (consolidation failed): ${fallbackSuggestions.length} suggestions from all analysis levels`,
+        consolidationFailed: true
       };
     }
   }
@@ -3372,6 +3458,10 @@ File-level suggestions should NOT have a line number. They apply to the entire f
       logger.info('[ReviewerCouncil] Single reviewer result — skipping consolidation');
       const singleResult = successfulVoices[0].result;
 
+      // Preserve the surviving reviewer's own outcomes (e.g. a failed intra-run
+      // consolidation) — only cross-voice consolidation was skipped here
+      const singleLevelOutcomes = singleResult.levelOutcomes || { consolidation: 'skipped' };
+
       const finalSuggestions = this.validateAndFinalizeSuggestions(
         singleResult.suggestions, fileLineCountMap, validFiles
       );
@@ -3383,7 +3473,7 @@ File-level suggestions should NOT have a line number. They apply to the entire f
           summary: singleResult.summary,
           totalSuggestions: finalSuggestions.length,
           filesAnalyzed: validFiles.length,
-          levelOutcomes: { consolidation: 'skipped' }
+          levelOutcomes: singleLevelOutcomes
         });
       } catch (err) {
         logger.warn(`[ReviewerCouncil] Failed to update parent run: ${err.message}`);
@@ -3393,7 +3483,7 @@ File-level suggestions should NOT have a line number. They apply to the entire f
         runId: parentRunId,
         suggestions: finalSuggestions,
         summary: singleResult.summary || `Review council complete: ${finalSuggestions.length} suggestions`,
-        levelOutcomes: { consolidation: 'skipped' }
+        levelOutcomes: singleLevelOutcomes
       };
     }
 
@@ -3471,6 +3561,17 @@ File-level suggestions should NOT have a line number. They apply to the entire f
 
       logger.success(`[ReviewerCouncil] Analysis complete: ${finalSuggestions.length} consolidated suggestions`);
 
+      // Terminal orchestration event must be voiceId-less: events with a
+      // voiceId only update levels[4].voices, never the aggregate status
+      if (progressCallback) {
+        progressCallback({
+          status: 'completed',
+          progress: 'Cross-reviewer consolidation complete',
+          level: 'orchestration',
+          voiceCentric: true
+        });
+      }
+
       return {
         runId: parentRunId,
         suggestions: finalSuggestions,
@@ -3478,7 +3579,22 @@ File-level suggestions should NOT have a line number. They apply to the entire f
         levelOutcomes: { consolidation: 'success' }
       };
     } catch (error) {
+      // Cancellation is not a consolidation failure — propagate so the run is
+      // recorded as cancelled instead of consolidation 'failed'
+      if (error.isCancellation) throw error;
       logger.error(`[ReviewerCouncil] Cross-reviewer consolidation failed: ${error.message}`);
+
+      // Surface the failure live — without a terminal voiceId-less event,
+      // levels[4] stays 'running' and the completion handler would show
+      // consolidation as completed while the run records it as failed
+      if (progressCallback) {
+        progressCallback({
+          status: 'failed',
+          progress: 'Consolidation failed — showing unconsolidated results',
+          level: 'orchestration',
+          voiceCentric: true
+        });
+      }
 
       // Fallback: use all voice suggestions combined
       const fallbackSuggestions = this.validateAndFinalizeSuggestions(
@@ -3728,6 +3844,10 @@ File-level suggestions should NOT have a line number. They apply to the entire f
     }
 
     // Pass 1: Intra-level consolidation (for levels with >1 reviewer)
+    // Track Pass 1 fallbacks so the final outcome reports them as a failed
+    // consolidation even when Pass 2 succeeds (the final set then contains
+    // raw, unconsolidated suggestions for the affected level)
+    let intraLevelConsolidationFailed = false;
     const consolidatedPerLevel = {};
     for (const [levelStr, suggestions] of Object.entries(levelSuggestions)) {
       const level = parseInt(levelStr);
@@ -3764,7 +3884,11 @@ File-level suggestions should NOT have a line number. They apply to the entire f
             progressCallback({ level: `consolidation-L${level}`, status: 'completed', progress: `Level ${level} consolidation complete` });
           }
         } catch (error) {
+          // Cancellation is not a consolidation failure — propagate so the run
+          // is recorded as cancelled instead of consolidation 'failed'
+          if (error.isCancellation) throw error;
           logger.warn(`[Council] Intra-level consolidation failed for Level ${level}: ${error.message}`);
+          intraLevelConsolidationFailed = true;
           consolidatedPerLevel[level] = suggestions; // Fallback to raw
           // Report intra-level consolidation step as failed
           if (progressCallback) {
@@ -3791,9 +3915,18 @@ File-level suggestions should NOT have a line number. They apply to the entire f
         { analysisId, tier: orchTier, progressCallback, providerOverride: orchProvider, modelOverride: orchModel, timeout: orchConfig.timeout || 600000, excludePrevious, dedupContext, githubClient }
       );
 
-      // Report cross-level orchestration step as completed
+      // orchestrateWithAI degrades to the raw union of level suggestions when
+      // consolidation fails internally, and a Pass 1 fallback means raw
+      // suggestions leaked into the final set — report either honestly
+      // instead of 'success'
+      const consolidationOutcome = (intraLevelConsolidationFailed || orchestrationResult.consolidationFailed)
+        ? 'failed' : 'success';
+
+      // Report cross-level orchestration step outcome
       if (progressCallback) {
-        progressCallback({ level: 'orchestration', status: 'completed', progress: 'Cross-level consolidation complete' });
+        progressCallback(orchestrationResult.consolidationFailed
+          ? { level: 'orchestration', status: 'failed', progress: 'Cross-level consolidation failed' }
+          : { level: 'orchestration', status: 'completed', progress: 'Cross-level consolidation complete' });
       }
 
       const finalSuggestions = this.validateAndFinalizeSuggestions(
@@ -3809,9 +3942,13 @@ File-level suggestions should NOT have a line number. They apply to the entire f
         runId,
         suggestions: finalSuggestions,
         summary: orchestrationResult.summary,
-        levelOutcomes: { consolidation: 'success' }
+        ...(consolidationOutcome === 'failed' ? { orchestrationFailed: true } : {}),
+        levelOutcomes: { consolidation: consolidationOutcome }
       };
     } catch (error) {
+      // Cancellation is not a consolidation failure — propagate so the run is
+      // recorded as cancelled instead of consolidation 'failed'
+      if (error.isCancellation) throw error;
       logger.error(`[Council] Cross-level consolidation failed: ${error.message}`);
 
       // Report cross-level orchestration step as failed
@@ -3883,6 +4020,8 @@ File-level suggestions should NOT have a line number. They apply to the entire f
       });
 
       // Parse response
+      // A parse failure here still reports the voice as completed with zero
+      // suggestions; honest per-voice reporting is a known follow-up to issue #560.
       const suggestions = this.parseResponse(response, level);
       logger.success(`[Council] ${displayLabel}: parsed ${suggestions.length} suggestions`);
 
@@ -3974,7 +4113,19 @@ File-level suggestions should NOT have a line number. They apply to the entire f
       } : undefined
     });
 
-    return this.parseResponse(response, level);
+    // Use the disambiguated identifier so parse logs don't read as the
+    // Level N reviewer itself (matches the provider call's level above)
+    const { suggestions: consolidated, parseFailed } = this.parseResponseWithMeta(response, `consolidation-L${level}`);
+
+    // A consolidation response with no parseable suggestions (nothing
+    // recognizable as our response schema) would silently drop every reviewer
+    // suggestion for this level (issue #560). Throw so the caller falls back
+    // to the raw per-reviewer suggestions instead.
+    if (parseFailed && suggestionCount > 0) {
+      throw new Error(`Level ${level} consolidation response could not be parsed (${suggestionCount} reviewer suggestions at risk); falling back to raw suggestions`);
+    }
+
+    return consolidated;
   }
 
   /**
@@ -4161,7 +4312,20 @@ File-level suggestions should NOT have a line number. They apply to the entire f
       } : undefined
     });
 
-    const suggestions = this.parseResponse(response, 'consolidation');
+    const { suggestions, parseFailed } = this.parseResponseWithMeta(response, 'consolidation');
+
+    // If the consolidation response carried no parseable suggestions (nothing
+    // recognizable as our response schema) while the voices produced
+    // suggestions, every voice suggestion would be silently dropped and the
+    // run would still report success (issue #560). Throw so
+    // the caller's fallback path stores the raw voice suggestions and records
+    // the consolidation outcome as 'failed'. A parseable-but-empty
+    // `suggestions: []` is a legitimate outcome (e.g. dedup curated everything
+    // away) and is not treated as a failure.
+    const inputSuggestionCount = voiceReviews.reduce((sum, v) => sum + (v.suggestionCount || 0), 0);
+    if (parseFailed && inputSuggestionCount > 0) {
+      throw new Error(`Cross-voice consolidation response could not be parsed (${inputSuggestionCount} voice suggestions at risk); falling back to unconsolidated suggestions`);
+    }
 
     // Extract summary from response, falling back to raw JSON extraction (same pattern as orchestrateWithAI)
     let summary;

--- a/src/routes/analyses.js
+++ b/src/routes/analyses.js
@@ -31,7 +31,8 @@ const {
   localReviewDiffs,
   broadcastProgress,
   killProcesses,
-  createProgressCallback
+  createProgressCallback,
+  finalizeConsolidationLevel
 } = require('./shared');
 const { generateScopedDiff, computeScopedDigest, getCurrentBranch } = require('../local-review');
 const { reviewScope } = require('../local-scope');
@@ -675,7 +676,10 @@ async function launchCouncilAnalysis(db, modeContext, councilConfig, councilId, 
         suggestionsCount: result.suggestions.length,
         levels: {
           ...currentStatus.levels,
-          4: { status: 'completed', progress: 'Results finalized' }
+          // Derive the terminal consolidation state from the authoritative
+          // result — the run finishing does not mean consolidation succeeded,
+          // and some council paths never emit a terminal orchestration event
+          4: finalizeConsolidationLevel(result, currentStatus.levels?.[4])
         }
       };
       for (const levelKey of ['1', '2', '3', 'exec']) {

--- a/src/routes/local.js
+++ b/src/routes/local.js
@@ -54,6 +54,7 @@ const {
   broadcastProgress,
   CancellationError,
   createProgressCallback,
+  finalizeConsolidationLevel,
   parseEnabledLevels,
   registerProcess: registerProcessForCancellation
 } = require('./shared');
@@ -1657,11 +1658,11 @@ router.post('/api/local/:reviewId/analyses', async (req, res) => {
           };
         }
 
-        // Mark orchestration (level 4) as completed
-        currentStatus.levels[4] = {
-          status: 'completed',
-          progress: 'Results finalized'
-        };
+        // Derive the terminal consolidation (level 4) state from the
+        // authoritative result — the run finishing does not mean the
+        // consolidation step succeeded, and some council paths never emit a
+        // terminal orchestration progress event
+        currentStatus.levels[4] = finalizeConsolidationLevel(result, currentStatus.levels?.[4]);
 
         const completedStatus = {
           ...currentStatus,

--- a/src/routes/mcp.js
+++ b/src/routes/mcp.js
@@ -22,7 +22,8 @@ const {
   localReviewDiffs,
   determineCompletionInfo,
   broadcastProgress,
-  createProgressCallback
+  createProgressCallback,
+  finalizeConsolidationLevel
 } = require('./shared');
 const { safeParseJson } = require('../utils/safe-parse-json');
 const { resolveLoadSkills, resolveHostBinding } = require('../config');
@@ -56,7 +57,9 @@ async function handleAnalysisCompletion(analysisId, runId, result, savePersisten
       currentStatus.levels[i] = { status: 'completed', progress: `Level ${i} complete` };
     }
   }
-  currentStatus.levels[4] = { status: 'completed', progress: 'Results finalized' };
+  // Derive the terminal consolidation state from the authoritative result —
+  // the run finishing does not mean the consolidation step succeeded
+  currentStatus.levels[4] = finalizeConsolidationLevel(result, currentStatus.levels?.[4]);
 
   const completedStatus = {
     ...currentStatus,

--- a/src/routes/pr.js
+++ b/src/routes/pr.js
@@ -47,6 +47,7 @@ const {
   determineCompletionInfo,
   broadcastProgress,
   createProgressCallback,
+  finalizeConsolidationLevel,
   parseEnabledLevels,
   registerProcess: registerProcessForCancellation
 } = require('./shared');
@@ -2481,10 +2482,11 @@ router.post('/api/pr/:owner/:repo/:number/analyses', async (req, res) => {
           };
         }
 
-        currentStatus.levels[4] = {
-          status: 'completed',
-          progress: 'Results finalized'
-        };
+        // Derive the terminal consolidation (level 4) state from the
+        // authoritative result — the run finishing does not mean the
+        // consolidation step succeeded, and some council paths never emit a
+        // terminal orchestration progress event
+        currentStatus.levels[4] = finalizeConsolidationLevel(result, currentStatus.levels?.[4]);
 
         const completedStatus = {
           ...currentStatus,

--- a/src/routes/shared.js
+++ b/src/routes/shared.js
@@ -522,6 +522,32 @@ function createProgressCallback(analysisId) {
 }
 
 /**
+ * Build the terminal level-4 (consolidation) progress state for a completed
+ * analysis. The outcome is driven by the authoritative analyzer result rather
+ * than the transient progress state alone — some council paths never emit a
+ * terminal voiceId-less orchestration event, so levels[4] can still read
+ * 'running' even when consolidation failed (issue #560).
+ *
+ * @param {Object} result - Analyzer result (may carry levelOutcomes / orchestrationFailed)
+ * @param {Object} [level4] - Current levels[4] progress state, if any
+ * @returns {Object} Terminal level-4 state (preserves existing steps/voices maps)
+ */
+function finalizeConsolidationLevel(result, level4) {
+  const consolidationFailed =
+    result?.levelOutcomes?.consolidation === 'failed' ||
+    result?.orchestrationFailed === true ||
+    level4?.status === 'failed';
+  return {
+    // Spread keeps the `steps` / `voices` maps a plain
+    // `{ status, progress }` replacement would silently drop
+    ...level4,
+    ...(consolidationFailed
+      ? { status: 'failed', progress: 'Consolidation failed — showing unconsolidated results' }
+      : { status: 'completed', progress: 'Results finalized' })
+  };
+}
+
+/**
  * Parse enabledLevels from a request body into a normalized { 1: bool, 2: bool, 3: bool } object.
  *
  * Accepts three formats:
@@ -570,5 +596,6 @@ module.exports = {
   killProcesses,
   isAnalysisCancelled,
   createProgressCallback,
+  finalizeConsolidationLevel,
   parseEnabledLevels
 };

--- a/src/routes/stack-analysis.js
+++ b/src/routes/stack-analysis.js
@@ -43,6 +43,7 @@ const {
   determineCompletionInfo,
   broadcastProgress,
   createProgressCallback,
+  finalizeConsolidationLevel,
   parseEnabledLevels,
   registerProcess: registerProcessForCancellation,
   killProcesses
@@ -586,7 +587,9 @@ async function launchStackSingleAnalysis(deps, db, config, {
       for (let lvl = 1; lvl <= completionInfo.completedLevel; lvl++) {
         currentStatus.levels[lvl] = { status: 'completed', progress: `Level ${lvl} complete` };
       }
-      currentStatus.levels[4] = { status: 'completed', progress: 'Results finalized' };
+      // Derive the terminal consolidation state from the authoritative result —
+      // the run finishing does not mean the consolidation step succeeded
+      currentStatus.levels[4] = finalizeConsolidationLevel(result, currentStatus.levels?.[4]);
       const completedStatus = {
         ...currentStatus,
         status: 'completed',

--- a/src/utils/json-extractor.js
+++ b/src/utils/json-extractor.js
@@ -2,40 +2,114 @@
 const logger = require('./logger');
 
 /**
- * Extract JSON from text responses using multiple strategies.
- * This is a shared utility to ensure consistent JSON extraction across the application.
+ * Escape a single control character (U+0000 - U+001F) to its JSON string form.
+ * @param {string} ch - Single control character
+ * @returns {string} Escaped form (e.g. '\\n', '\\u0001')
+ */
+function escapeControlCharacter(ch) {
+  switch (ch) {
+    case '\n': return '\\n';
+    case '\r': return '\\r';
+    case '\t': return '\\t';
+    case '\b': return '\\b';
+    case '\f': return '\\f';
+    default: return '\\u' + ch.charCodeAt(0).toString(16).padStart(4, '0');
+  }
+}
+
+/**
+ * Escape raw (unescaped) control characters found inside JSON string literals.
+ *
+ * LLM responses that embed code snippets in string values sometimes contain
+ * literal newlines/tabs instead of the \n / \t escapes JSON requires. A single
+ * such character makes JSON.parse reject the entire response ("Bad control
+ * character in string literal"), which can silently discard every suggestion
+ * in a large consolidation response (issue #560).
+ *
+ * Walks the text tracking string/escape state (the same state machine used by
+ * the bracket-matching strategy) and rewrites control characters (U+0000 -
+ * U+001F) that appear inside string literals to their escaped forms. Text
+ * outside string literals is left untouched — control characters there are
+ * legal JSON whitespace or would be a structural error sanitization cannot fix.
+ *
+ * @param {string} text - Candidate JSON text
+ * @returns {string} Text with in-string control characters escaped
+ */
+function sanitizeControlCharactersInStrings(text) {
+  let result = '';
+  let inString = false;
+  let escaped = false;
+
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i];
+
+    if (!inString) {
+      if (ch === '"') inString = true;
+      result += ch;
+      continue;
+    }
+
+    if (escaped) {
+      escaped = false;
+      if (ch.charCodeAt(0) < 0x20) {
+        // A raw control character cannot follow a backslash in valid JSON.
+        // Double the dangling backslash into a literal '\\' and escape the
+        // control character itself.
+        result += '\\' + escapeControlCharacter(ch);
+      } else {
+        result += ch;
+      }
+      continue;
+    }
+
+    if (ch === '\\') {
+      escaped = true;
+      result += ch;
+      continue;
+    }
+
+    if (ch === '"') {
+      inString = false;
+      result += ch;
+      continue;
+    }
+
+    if (ch.charCodeAt(0) < 0x20) {
+      result += escapeControlCharacter(ch);
+      continue;
+    }
+
+    result += ch;
+  }
+
+  return result;
+}
+
+/**
+ * Run all extraction strategies against a candidate text.
  *
  * Strategies are tried in order:
  *   1. Markdown code blocks (```json ... ```)
- *   2. Direct JSON.parse of the trimmed response
+ *   2. Direct JSON.parse of the trimmed text
  *   3. First { to last } substring
  *   4. Known JSON key anchors (e.g. {"level", {"suggestions")
  *   5. Forward scan: try JSON.parse from every top-level { in the text
  *   6. Bracket-matched substring from the first {
  *
- * @param {string} response - Raw response text (may include preamble/postamble prose)
- * @param {string|number} level - Level identifier for logging (e.g., 1, 2, 3, 'orchestration', 'unknown')
- * @param {string} [logPrefix] - Custom log prefix to use instead of `[Level <level>]`.
- *   Used by callers (e.g., summary generation, council mode) that have a more
- *   meaningful identifier than a numeric analysis level.
- * @returns {Object} Extraction result with success flag and data/error
+ * @param {string} text - Candidate text (may include preamble/postamble prose)
+ * @returns {{data: (Object|null), strategy: number|undefined, strategyErrors: Array<string>}}
+ *   data is null when every strategy failed; strategyErrors collects per-strategy failures
  */
-function extractJSON(response, level = 'unknown', logPrefix) {
-  const levelPrefix = logPrefix || `[Level ${level}]`;
-
-  if (!response || !response.trim()) {
-    return { success: false, error: 'Empty response' };
-  }
-
+function runExtractionStrategies(text) {
   const strategies = [
     // Strategy 1: Look for markdown code blocks with 'json' label
     () => {
       // First, try to find ```json specifically (more precise)
-      let codeBlockMatch = response.match(/```json\s*\n([\s\S]*?)\n```/);
+      let codeBlockMatch = text.match(/```json\s*\n([\s\S]*?)\n```/);
 
       // If not found, try generic ``` blocks
       if (!codeBlockMatch) {
-        codeBlockMatch = response.match(/```\s*\n([\s\S]*?)\n```/);
+        codeBlockMatch = text.match(/```\s*\n([\s\S]*?)\n```/);
       }
 
       if (codeBlockMatch && codeBlockMatch[1]) {
@@ -48,18 +122,18 @@ function extractJSON(response, level = 'unknown', logPrefix) {
       throw new Error('No JSON code block found');
     },
 
-    // Strategy 2: Try the entire response as JSON (fast path for clean responses)
+    // Strategy 2: Try the entire text as JSON (fast path for clean responses)
     () => {
-      return JSON.parse(response.trim());
+      return JSON.parse(text.trim());
     },
 
     // Strategy 3: Look for JSON between first { and last }
-    // Works when the response is just JSON or has minimal wrapping
+    // Works when the text is just JSON or has minimal wrapping
     () => {
-      const firstBrace = response.indexOf('{');
-      const lastBrace = response.lastIndexOf('}');
+      const firstBrace = text.indexOf('{');
+      const lastBrace = text.lastIndexOf('}');
       if (firstBrace !== -1 && lastBrace !== -1 && lastBrace > firstBrace) {
-        return JSON.parse(response.substring(firstBrace, lastBrace + 1));
+        return JSON.parse(text.substring(firstBrace, lastBrace + 1));
       }
       throw new Error('No valid JSON braces found');
     },
@@ -80,13 +154,13 @@ function extractJSON(response, level = 'unknown', logPrefix) {
       ];
 
       for (const anchor of anchors) {
-        const match = response.match(anchor);
+        const match = text.match(anchor);
         if (match) {
           const startIdx = match.index;
           // Find the matching closing brace from the end
-          const lastBrace = response.lastIndexOf('}');
+          const lastBrace = text.lastIndexOf('}');
           if (lastBrace > startIdx) {
-            const candidate = response.substring(startIdx, lastBrace + 1);
+            const candidate = text.substring(startIdx, lastBrace + 1);
             return JSON.parse(candidate);
           }
         }
@@ -102,19 +176,19 @@ function extractJSON(response, level = 'unknown', logPrefix) {
       // Limit attempts to avoid excessive parsing on very large non-JSON text
       const maxAttempts = 20;
       let attempts = 0;
-      const lastBrace = response.lastIndexOf('}');
+      const lastBrace = text.lastIndexOf('}');
 
-      while (searchFrom < response.length && attempts < maxAttempts) {
-        const braceIdx = response.indexOf('{', searchFrom);
+      while (searchFrom < text.length && attempts < maxAttempts) {
+        const braceIdx = text.indexOf('{', searchFrom);
         if (braceIdx === -1) break;
 
         attempts++;
         try {
-          // Try parsing from this brace to the end of the response.
+          // Try parsing from this brace to the end of the text.
           // JSON.parse is lenient about trailing content only if we trim to the
           // right boundary, so use lastIndexOf('}') from the end.
           if (lastBrace > braceIdx) {
-            const candidate = response.substring(braceIdx, lastBrace + 1);
+            const candidate = text.substring(braceIdx, lastBrace + 1);
             const parsed = JSON.parse(candidate);
             if (parsed && typeof parsed === 'object') {
               return parsed;
@@ -133,15 +207,15 @@ function extractJSON(response, level = 'unknown', logPrefix) {
     // the end of the first top-level object. No iteration cap — the loop
     // runs for the full length of the matched region.
     () => {
-      const firstBrace = response.indexOf('{');
+      const firstBrace = text.indexOf('{');
       if (firstBrace === -1) throw new Error('No opening brace found');
 
       let braceCount = 0;
       let inString = false;
       let escaped = false;
 
-      for (let i = firstBrace; i < response.length; i++) {
-        const ch = response[i];
+      for (let i = firstBrace; i < text.length; i++) {
+        const ch = text[i];
 
         if (escaped) {
           escaped = false;
@@ -164,7 +238,7 @@ function extractJSON(response, level = 'unknown', logPrefix) {
         else if (ch === '}') {
           braceCount--;
           if (braceCount === 0) {
-            return JSON.parse(response.substring(firstBrace, i + 1));
+            return JSON.parse(text.substring(firstBrace, i + 1));
           }
         }
       }
@@ -177,17 +251,64 @@ function extractJSON(response, level = 'unknown', logPrefix) {
     try {
       const data = strategies[i]();
       if (data && typeof data === 'object') {
-        logger.info(`${levelPrefix} JSON extraction successful using strategy ${i + 1}`);
-        return { success: true, data };
+        return { data, strategy: i + 1, strategyErrors };
       }
     } catch (error) {
       strategyErrors.push(`S${i + 1}: ${error.message}`);
     }
   }
+  return { data: null, strategy: undefined, strategyErrors };
+}
 
-  // All strategies failed — log details for debugging
+/**
+ * Extract JSON from text responses using multiple strategies.
+ * This is a shared utility to ensure consistent JSON extraction across the application.
+ *
+ * The strategies (see runExtractionStrategies) run against the original
+ * response first. If all fail, a repair pass escapes raw control characters
+ * inside string literals (issue #560) and the strategies run once more against
+ * the sanitized text.
+ *
+ * @param {string} response - Raw response text (may include preamble/postamble prose)
+ * @param {string|number} level - Level identifier for logging (e.g., 1, 2, 3, 'orchestration', 'unknown')
+ * @param {string} [logPrefix] - Custom log prefix to use instead of `[Level <level>]`.
+ *   Used by callers (e.g., summary generation, council mode) that have a more
+ *   meaningful identifier than a numeric analysis level.
+ * @returns {Object} Extraction result with success flag and data/error
+ */
+function extractJSON(response, level = 'unknown', logPrefix) {
+  const levelPrefix = logPrefix || `[Level ${level}]`;
+
+  if (!response || !response.trim()) {
+    return { success: false, error: 'Empty response' };
+  }
+
+  const firstPass = runExtractionStrategies(response);
+  if (firstPass.data) {
+    logger.info(`${levelPrefix} JSON extraction successful using strategy ${firstPass.strategy}`);
+    return { success: true, data: firstPass.data };
+  }
+
+  // Repair pass: escape raw control characters inside string literals and
+  // retry. Sanitize only from the first { onward so quotes in surrounding
+  // prose don't desync the in-string state machine.
+  const braceIdx = response.indexOf('{');
+  const sanitized = braceIdx === -1
+    ? response
+    : response.slice(0, braceIdx) + sanitizeControlCharactersInStrings(response.slice(braceIdx));
+  const repairAttempted = sanitized !== response;
+  if (repairAttempted) {
+    const repairPass = runExtractionStrategies(sanitized);
+    if (repairPass.data) {
+      logger.info(`${levelPrefix} JSON extraction successful using strategy ${repairPass.strategy} after control-character repair`);
+      return { success: true, data: repairPass.data };
+    }
+  }
+
+  // All strategies failed — log the first pass's errors so `position N`
+  // offsets line up with the original-response preview below
   logger.warn(`${levelPrefix} All JSON extraction strategies failed`);
-  logger.warn(`${levelPrefix} Strategy errors: ${strategyErrors.join('; ')}`);
+  logger.warn(`${levelPrefix} Strategy errors: ${firstPass.strategyErrors.join('; ')}${repairAttempted ? ' (a control-character repair pass was also attempted and failed)' : ''}`);
   logger.warn(`${levelPrefix} Response length: ${response.length} chars, preview: ${response.substring(0, 200)}...`);
 
   return {
@@ -197,4 +318,4 @@ function extractJSON(response, level = 'unknown', logPrefix) {
   };
 }
 
-module.exports = { extractJSON };
+module.exports = { extractJSON, sanitizeControlCharactersInStrings };

--- a/tests/unit/analyzer-consolidation-loss.test.js
+++ b/tests/unit/analyzer-consolidation-loss.test.js
@@ -1,0 +1,441 @@
+// Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// analyzer.js destructures createProvider from src/ai/index at load time
+// (line 2), so the binding is captured the first time the module is required.
+// Install the spy on the module object BEFORE requiring the Analyzer so the
+// destructured binding picks up the spy. (vi.mock would also work — see
+// analyzer-consolidation.test.js — but a spy lets us swap the return value
+// per test.)
+const aiIndex = require('../../src/ai/index');
+const createProvider = vi.spyOn(aiIndex, 'createProvider');
+
+const Analyzer = require('../../src/ai/analyzer');
+
+/**
+ * Regression tests for issue #560: consolidation could silently drop every
+ * suggestion when the model response failed JSON extraction, yet still report
+ * `consolidation: 'success'`. These tests verify that a parse failure with
+ * non-empty input takes the fallback path (raw suggestions preserved) and is
+ * reported as a failure, while a legitimately empty, parseable response
+ * (`suggestions: []`) still counts as success.
+ */
+
+const prMetadata = { pr_number: 42, reviewType: 'pr', title: 'Test PR' };
+
+function mockProviderResponse(response) {
+  createProvider.mockReturnValue({
+    execute: vi.fn().mockResolvedValue(response)
+  });
+}
+
+const inputSuggestions = {
+  level1: [
+    { file: 'src/a.js', line_start: 1, line_end: 1, type: 'bug', title: 'Bug A', description: 'desc A', confidence: 0.9 }
+  ],
+  level2: [
+    { file: 'src/b.js', line_start: 2, line_end: 2, type: 'improvement', title: 'Imp B', description: 'desc B', confidence: 0.8 }
+  ],
+  level3: []
+};
+
+describe('parseResponseWithMeta', () => {
+  let analyzer;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    analyzer = new Analyzer({}, 'sonnet', 'claude');
+  });
+
+  it('reports parseFailed: false for a response with a suggestions array', () => {
+    const result = analyzer.parseResponseWithMeta({ suggestions: [] }, 'consolidation');
+    expect(result.parseFailed).toBe(false);
+    expect(result.suggestions).toEqual([]);
+  });
+
+  it('reports parseFailed: false for raw text containing extractable JSON', () => {
+    const result = analyzer.parseResponseWithMeta(
+      { raw: '{"suggestions": [], "summary": "clean"}' },
+      'consolidation'
+    );
+    expect(result.parseFailed).toBe(false);
+  });
+
+  it('reports parseFailed: false for a response with only a fileLevelSuggestions array', () => {
+    const result = analyzer.parseResponseWithMeta(
+      {
+        fileLevelSuggestions: [{ file: 'src/a.js', type: 'design', title: 'Split module', description: 'd', confidence: 0.9 }],
+        summary: 'file-level only'
+      },
+      'consolidation'
+    );
+    expect(result.parseFailed).toBe(false);
+    expect(result.suggestions).toHaveLength(1);
+    expect(result.suggestions[0].is_file_level).toBe(true);
+  });
+
+  it('reports parseFailed: false for a raw summary-only zero-finding response', () => {
+    const result = analyzer.parseResponseWithMeta(
+      { raw: '{"summary": "All findings duplicated existing comments"}' },
+      'consolidation'
+    );
+    expect(result.parseFailed).toBe(false);
+    expect(result.suggestions).toEqual([]);
+  });
+
+  it('reports parseFailed: false for an already-parsed summary-only zero-finding response', () => {
+    const result = analyzer.parseResponseWithMeta(
+      { summary: 'All findings duplicated existing comments' },
+      'consolidation'
+    );
+    expect(result.parseFailed).toBe(false);
+    expect(result.suggestions).toEqual([]);
+  });
+
+  it('prefers extractable suggestions in raw over a summary-only acceptance for a { summary, raw } response', () => {
+    const result = analyzer.parseResponseWithMeta(
+      {
+        summary: 'top-level summary',
+        raw: '{"suggestions": [{"file": "src/a.js", "line_start": 1, "line_end": 1, "type": "bug", "title": "From raw", "description": "d", "confidence": 0.9}]}'
+      },
+      'consolidation'
+    );
+    expect(result.parseFailed).toBe(false);
+    expect(result.suggestions).toHaveLength(1);
+    expect(result.suggestions[0].title).toBe('From raw');
+  });
+
+  it('accepts summary-only for a { summary, raw } response when raw extraction fails', () => {
+    const result = analyzer.parseResponseWithMeta(
+      { summary: 'All findings duplicated existing comments', raw: 'not json at all' },
+      'consolidation'
+    );
+    expect(result.parseFailed).toBe(false);
+    expect(result.suggestions).toEqual([]);
+  });
+
+  it('reports parseFailed: true for extractable JSON with none of the schema keys', () => {
+    const result = analyzer.parseResponseWithMeta({ raw: '{"foo": 1}' }, 'consolidation');
+    expect(result.parseFailed).toBe(true);
+    expect(result.suggestions).toEqual([]);
+  });
+
+  it('reports parseFailed: true for raw text with no extractable JSON', () => {
+    const result = analyzer.parseResponseWithMeta({ raw: 'not json at all' }, 'consolidation');
+    expect(result.parseFailed).toBe(true);
+    expect(result.suggestions).toEqual([]);
+  });
+
+  it('reports parseFailed: true for a response with neither suggestions nor raw', () => {
+    const result = analyzer.parseResponseWithMeta({}, 'consolidation');
+    expect(result.parseFailed).toBe(true);
+  });
+
+  it('parseResponse still returns a bare suggestions array', () => {
+    const suggestions = analyzer.parseResponse({ suggestions: [] }, 'consolidation');
+    expect(suggestions).toEqual([]);
+  });
+});
+
+describe('orchestrateWithAI parse-failure fallback (issue #560)', () => {
+  let analyzer;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    analyzer = new Analyzer({}, 'sonnet', 'claude');
+  });
+
+  it('falls back to the raw union and flags consolidationFailed when the response is unparseable and input was non-empty', async () => {
+    mockProviderResponse({ raw: 'The review looked at several files but the output is not JSON.' });
+
+    const result = await analyzer.orchestrateWithAI(inputSuggestions, prMetadata, null, null, { timeout: 1000 });
+
+    expect(result.consolidationFailed).toBe(true);
+    // Both input suggestions must be preserved, not silently dropped
+    expect(result.suggestions).toHaveLength(2);
+    expect(result.suggestions.map(s => s.title).sort()).toEqual(['Bug A', 'Imp B']);
+    expect(result.summary).toContain('consolidation failed');
+  });
+
+  it('reports success for a parseable response that legitimately returns zero suggestions', async () => {
+    mockProviderResponse({ suggestions: [], summary: 'All findings were duplicates of existing comments' });
+
+    const result = await analyzer.orchestrateWithAI(inputSuggestions, prMetadata, null, null, { timeout: 1000 });
+
+    expect(result.consolidationFailed).toBeUndefined();
+    expect(result.suggestions).toEqual([]);
+    expect(result.summary).toBe('All findings were duplicates of existing comments');
+  });
+
+  it('reports success for an already-parsed summary-only response with non-empty input', async () => {
+    // Providers resolve parsed objects directly, so a zero-finding
+    // consolidation legitimately arrives as `{ summary }` with no arrays
+    mockProviderResponse({ summary: 'All findings duplicated existing comments' });
+
+    const result = await analyzer.orchestrateWithAI(inputSuggestions, prMetadata, null, null, { timeout: 1000 });
+
+    expect(result.consolidationFailed).toBeUndefined();
+    expect(result.suggestions).toEqual([]);
+    expect(result.summary).toBe('All findings duplicated existing comments');
+  });
+
+  it('does not flag failure for an unparseable response when there were no input suggestions', async () => {
+    mockProviderResponse({ raw: 'nothing to consolidate' });
+
+    const result = await analyzer.orchestrateWithAI(
+      { level1: [], level2: [], level3: [] }, prMetadata, null, null, { timeout: 1000 }
+    );
+
+    expect(result.consolidationFailed).toBeUndefined();
+    expect(result.suggestions).toEqual([]);
+  });
+});
+
+describe('_crossVoiceConsolidate parse-failure handling (issue #560)', () => {
+  let analyzer;
+
+  const voiceReviews = [
+    {
+      voiceKey: 'voice-1',
+      provider: 'claude',
+      model: 'opus',
+      suggestionCount: 7,
+      suggestions: [{ file: 'src/a.js', line_start: 1, type: 'bug', title: 'V1', description: 'd' }],
+      fileLevelSuggestions: [],
+      summary: 'Voice 1 summary'
+    },
+    {
+      voiceKey: 'voice-2',
+      provider: 'codex',
+      model: 'gpt',
+      suggestionCount: 6,
+      suggestions: [{ file: 'src/b.js', line_start: 2, type: 'bug', title: 'V2', description: 'd' }],
+      fileLevelSuggestions: [],
+      summary: 'Voice 2 summary'
+    }
+  ];
+
+  const config = { provider: 'claude', model: 'opus', tier: 'balanced', timeout: 1000 };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    analyzer = new Analyzer({}, 'sonnet', 'claude');
+  });
+
+  it('throws when the consolidation response is unparseable and voices produced suggestions', async () => {
+    mockProviderResponse({ raw: 'definitely not json' });
+
+    await expect(
+      analyzer._crossVoiceConsolidate(voiceReviews, prMetadata, null, null, config)
+    ).rejects.toThrow(/could not be parsed/);
+  });
+
+  it('does not throw for a parseable response with zero suggestions', async () => {
+    mockProviderResponse({ suggestions: [], summary: 'Nothing new to report' });
+
+    const result = await analyzer._crossVoiceConsolidate(voiceReviews, prMetadata, null, null, config);
+    expect(result.suggestions).toEqual([]);
+    expect(result.summary).toBe('Nothing new to report');
+  });
+
+  it('does not throw for an unparseable response when voices produced no suggestions', async () => {
+    mockProviderResponse({ raw: 'not json' });
+    const emptyVoices = voiceReviews.map(v => ({ ...v, suggestionCount: 0, suggestions: [] }));
+
+    const result = await analyzer._crossVoiceConsolidate(emptyVoices, prMetadata, null, null, config);
+    expect(result.suggestions).toEqual([]);
+  });
+});
+
+describe('_intraLevelConsolidate parse-failure handling (issue #560)', () => {
+  let analyzer;
+
+  const voiceGroups = [
+    {
+      voiceId: 'v1',
+      provider: 'claude',
+      model: 'opus',
+      suggestions: [{ file: 'src/a.js', line_start: 1, type: 'bug', title: 'V1', description: 'd' }],
+      summary: 's1'
+    },
+    {
+      voiceId: 'v2',
+      provider: 'codex',
+      model: 'gpt',
+      suggestions: [{ file: 'src/b.js', line_start: 2, type: 'bug', title: 'V2', description: 'd' }],
+      summary: 's2'
+    }
+  ];
+
+  const orchConfig = { provider: 'claude', model: 'opus', tier: 'balanced', timeout: 1000, reviewerCount: 2 };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    analyzer = new Analyzer({}, 'sonnet', 'claude');
+  });
+
+  it('throws when the consolidation response is unparseable and reviewers produced suggestions', async () => {
+    mockProviderResponse({ raw: 'garbage output' });
+
+    await expect(
+      analyzer._intraLevelConsolidate(1, voiceGroups, prMetadata, null, null, orchConfig)
+    ).rejects.toThrow(/could not be parsed/);
+  });
+
+  it('returns consolidated suggestions for a parseable response', async () => {
+    mockProviderResponse({
+      suggestions: [{ file: 'src/a.js', line_start: 1, line_end: 1, type: 'bug', title: 'Merged', description: 'd', confidence: 0.9 }]
+    });
+
+    const result = await analyzer._intraLevelConsolidate(1, voiceGroups, prMetadata, null, null, orchConfig);
+    expect(result).toHaveLength(1);
+    expect(result[0].title).toBe('Merged');
+  });
+});
+
+// Wiring tests: verify that consolidation parse failures propagate through the
+// full analysis flows into the persisted/returned levelOutcomes, not just the
+// parse primitives. DB access is stubbed on the instance (analysis_run repo
+// calls inside these flows are wrapped in try/catch, so a bare `{}` db is safe).
+describe('analyzeAllLevels consolidation outcome mapping (issue #560)', () => {
+  function createWiredAnalyzer() {
+    const analyzer = new Analyzer({}, 'sonnet', 'claude');
+    analyzer.loadGeneratedFilePatterns = vi.fn().mockResolvedValue([]);
+    analyzer.getChangedFilesList = vi.fn().mockResolvedValue(['src/a.js', 'src/b.js']);
+    analyzer.storeSuggestions = vi.fn().mockResolvedValue(undefined);
+    analyzer.validateAndFinalizeSuggestions = vi.fn().mockImplementation((s) => s || []);
+    // Levels succeed with suggestions; only the consolidation call reaches the provider
+    analyzer.analyzeLevel1Isolated = vi.fn().mockResolvedValue({ suggestions: inputSuggestions.level1, summary: 'L1' });
+    analyzer.analyzeLevel2Isolated = vi.fn().mockResolvedValue({ suggestions: inputSuggestions.level2, summary: 'L2' });
+    analyzer.analyzeLevel3Isolated = vi.fn().mockResolvedValue({ suggestions: [], summary: 'L3' });
+    return analyzer;
+  }
+
+  const runOptions = { runId: 'run-560', skipRunCreation: true, timeout: 1000 };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('records levelOutcomes.consolidation = failed and orchestrationFailed when the consolidation response is unparseable', async () => {
+    const analyzer = createWiredAnalyzer();
+    mockProviderResponse({ raw: 'this is prose, not our JSON schema' });
+    const progressCallback = vi.fn();
+
+    const result = await analyzer.analyzeAllLevels(
+      1, '/nonexistent-worktree', prMetadata, progressCallback, null, ['src/a.js', 'src/b.js'], runOptions
+    );
+
+    expect(result.levelOutcomes.consolidation).toBe('failed');
+    expect(result.orchestrationFailed).toBe(true);
+    // The raw union of level suggestions is preserved, not silently dropped
+    expect(result.suggestions).toHaveLength(2);
+    expect(progressCallback).toHaveBeenCalledWith(
+      expect.objectContaining({ level: 'orchestration', status: 'failed' })
+    );
+  });
+
+  it('records levelOutcomes.consolidation = success for a parseable consolidation response', async () => {
+    const analyzer = createWiredAnalyzer();
+    mockProviderResponse({
+      suggestions: [{ file: 'src/a.js', line_start: 1, line_end: 1, type: 'bug', title: 'Curated', description: 'd', confidence: 0.9 }],
+      summary: 'curated'
+    });
+
+    const result = await analyzer.analyzeAllLevels(
+      1, '/nonexistent-worktree', prMetadata, null, null, ['src/a.js', 'src/b.js'], runOptions
+    );
+
+    expect(result.levelOutcomes.consolidation).toBe('success');
+    expect(result.orchestrationFailed).toBeUndefined();
+    expect(result.suggestions).toHaveLength(1);
+  });
+});
+
+describe('runCouncilAnalysis intra-level consolidation failure (issue #560)', () => {
+  const voiceSuggestion = (title) => ({
+    file: 'src/a.js', line_start: 1, line_end: 1, type: 'bug', title, description: 'd', confidence: 0.9
+  });
+
+  function createCouncilAnalyzer() {
+    const analyzer = new Analyzer({}, 'sonnet', 'claude');
+    analyzer.loadGeneratedFilePatterns = vi.fn().mockResolvedValue([]);
+    analyzer.getChangedFilesList = vi.fn().mockResolvedValue(['src/a.js']);
+    analyzer.storeSuggestions = vi.fn().mockResolvedValue(undefined);
+    analyzer._storeCouncilSuggestions = vi.fn().mockResolvedValue(undefined);
+    analyzer.validateAndFinalizeSuggestions = vi.fn().mockImplementation((s) => s || []);
+    analyzer.buildLevel1Prompt = vi.fn().mockReturnValue('level 1 prompt');
+    return analyzer;
+  }
+
+  const reviewContext = {
+    reviewId: 1,
+    worktreePath: '/nonexistent-worktree',
+    prMetadata,
+    changedFiles: ['src/a.js'],
+    instructions: null
+  };
+
+  const councilConfig = {
+    levels: {
+      '1': {
+        enabled: true,
+        voices: [
+          { provider: 'claude', model: 'opus' },
+          { provider: 'codex', model: 'gpt' }
+        ]
+      },
+      '2': { enabled: false, voices: [] },
+      '3': { enabled: false, voices: [] }
+    },
+    consolidation: { provider: 'claude', model: 'opus', tier: 'balanced' }
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('reports consolidation failed when Pass 1 is unparseable even though Pass 2 succeeds', async () => {
+    const analyzer = createCouncilAnalyzer();
+
+    // Dispatch by the level passed to the provider: reviewer voices succeed,
+    // intra-level (Pass 1) consolidation is unparseable, cross-level (Pass 2) succeeds
+    createProvider.mockReturnValue({
+      execute: vi.fn().mockImplementation((prompt, opts) => {
+        if (opts.level === 1) {
+          return Promise.resolve({ suggestions: [voiceSuggestion('Voice finding')], summary: 'voice summary' });
+        }
+        if (opts.level === 'consolidation-L1') {
+          return Promise.resolve({ raw: 'garbage — not our JSON schema' });
+        }
+        return Promise.resolve({ suggestions: [voiceSuggestion('Merged finding')], summary: 'final summary' });
+      })
+    });
+
+    const result = await analyzer.runCouncilAnalysis(reviewContext, councilConfig, { runId: 'council-run' });
+
+    expect(result.levelOutcomes.consolidation).toBe('failed');
+    expect(result.orchestrationFailed).toBe(true);
+    // Pass 2 output is still used for the final set
+    expect(result.suggestions).toHaveLength(1);
+    expect(result.suggestions[0].title).toBe('Merged finding');
+  });
+
+  it('reports consolidation success when both passes parse', async () => {
+    const analyzer = createCouncilAnalyzer();
+
+    createProvider.mockReturnValue({
+      execute: vi.fn().mockImplementation((prompt, opts) => {
+        if (opts.level === 1) {
+          return Promise.resolve({ suggestions: [voiceSuggestion('Voice finding')], summary: 'voice summary' });
+        }
+        return Promise.resolve({ suggestions: [voiceSuggestion('Merged finding')], summary: 'final summary' });
+      })
+    });
+
+    const result = await analyzer.runCouncilAnalysis(reviewContext, councilConfig, { runId: 'council-run' });
+
+    expect(result.levelOutcomes.consolidation).toBe('success');
+    expect(result.orchestrationFailed).toBeUndefined();
+  });
+});

--- a/tests/unit/json-extractor.test.js
+++ b/tests/unit/json-extractor.test.js
@@ -1,6 +1,6 @@
 // Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect } from 'vitest';
-import { extractJSON } from '../../src/utils/json-extractor.js';
+import { extractJSON, sanitizeControlCharactersInStrings } from '../../src/utils/json-extractor.js';
 
 describe('extractJSON', () => {
   describe('empty/null input', () => {
@@ -378,6 +378,100 @@ describe('extractJSON', () => {
       const result = extractJSON('this is not json at all', 'test');
       expect(result).toHaveProperty('response');
       expect(result.response).toContain('this is not json');
+    });
+  });
+
+  // Regression tests for issue #560: consolidation responses embedding code
+  // snippets with raw (unescaped) control characters inside string literals
+  // caused every extraction strategy to fail, silently dropping all suggestions.
+  describe('unescaped control characters in string literals (issue #560)', () => {
+    it('should recover JSON with a raw newline inside a string value', () => {
+      const json = '{"suggestions": [{"file": "a.py", "line": 177, "description": "Use:\ndelete()"}], "summary": "ok"}';
+      const result = extractJSON(json, 'test');
+      expect(result.success).toBe(true);
+      expect(result.data.suggestions).toHaveLength(1);
+      expect(result.data.suggestions[0].description).toBe('Use:\ndelete()');
+      expect(result.data.summary).toBe('ok');
+    });
+
+    it('should recover JSON with raw tabs and carriage returns inside string values', () => {
+      const json = '{"suggestions": [{"title": "a\tb\rc"}]}';
+      const result = extractJSON(json, 'test');
+      expect(result.success).toBe(true);
+      expect(result.data.suggestions[0].title).toBe('a\tb\rc');
+    });
+
+    it('should recover JSON with other raw control characters inside string values', () => {
+      const json = '{"title": "a\u0000b\u001fc"}';
+      const result = extractJSON(json, 'test');
+      expect(result.success).toBe(true);
+      expect(result.data.title).toBe('a\u0000b\u001fc');
+    });
+
+    it('should recover a code-block-wrapped JSON containing a raw newline in a string', () => {
+      const response = 'Here is the result:\n```json\n{"suggestions": [{"description": "line1\nline2"}]}\n```\nDone.';
+      const result = extractJSON(response, 'test');
+      expect(result.success).toBe(true);
+      expect(result.data.suggestions[0].description).toBe('line1\nline2');
+    });
+
+    it('should recover JSON with a raw newline when preceded by prose preamble', () => {
+      const response = 'The consolidated review follows.\n{"suggestions": [{"description": "before\nafter"}], "summary": "s"}';
+      const result = extractJSON(response, 'test');
+      expect(result.success).toBe(true);
+      expect(result.data.suggestions[0].description).toBe('before\nafter');
+    });
+
+    it('should not corrupt properly escaped sequences in string values', () => {
+      // Contains a properly escaped newline AND a raw newline in the same string
+      const json = '{"description": "escaped\\nvalue\nraw"}';
+      const result = extractJSON(json, 'test');
+      expect(result.success).toBe(true);
+      expect(result.data.description).toBe('escaped\nvalue\nraw');
+    });
+
+    it('should handle escaped quotes and backslashes around raw control characters', () => {
+      const json = '{"description": "say \\"hi\\" \\\\path\nnext"}';
+      const result = extractJSON(json, 'test');
+      expect(result.success).toBe(true);
+      expect(result.data.description).toBe('say "hi" \\path\nnext');
+    });
+  });
+
+  describe('sanitizeControlCharactersInStrings', () => {
+    it('should escape control characters only inside string literals', () => {
+      const input = '{\n  "a": "x\ny"\n}';
+      const output = sanitizeControlCharactersInStrings(input);
+      // Structural newlines (outside strings) are untouched; in-string newline is escaped
+      expect(output).toBe('{\n  "a": "x\\ny"\n}');
+      expect(JSON.parse(output)).toEqual({ a: 'x\ny' });
+    });
+
+    it('should leave already-valid JSON unchanged', () => {
+      const input = '{"a": "x\\ny", "b": [1, 2]}';
+      expect(sanitizeControlCharactersInStrings(input)).toBe(input);
+    });
+
+    it('should escape uncommon control characters as unicode escapes', () => {
+      const input = '{"a": "x\u0001y"}';
+      const output = sanitizeControlCharactersInStrings(input);
+      expect(output).toBe('{"a": "x\\u0001y"}');
+      expect(JSON.parse(output)).toEqual({ a: 'x\u0001y' });
+    });
+
+    it('should not treat an escaped quote as the end of a string', () => {
+      const input = '{"a": "he said \\"hi\\"\nnext"}';
+      const output = sanitizeControlCharactersInStrings(input);
+      expect(JSON.parse(output)).toEqual({ a: 'he said "hi"\nnext' });
+    });
+
+    it('should repair a raw control character immediately following a backslash', () => {
+      // String value contains a trailing backslash followed by a raw newline:
+      // the dangling backslash must be doubled and the newline escaped.
+      const input = '{"a": "x\\\ny"}';
+      const output = sanitizeControlCharactersInStrings(input);
+      // Parsed value is backslash + newline
+      expect(JSON.parse(output)).toEqual({ a: 'x\\\ny' });
     });
   });
 

--- a/tests/unit/reviewer-centric-council.test.js
+++ b/tests/unit/reviewer-centric-council.test.js
@@ -401,6 +401,86 @@ describe('runReviewerCentricCouncil', () => {
     });
   });
 
+  describe('terminal orchestration progress events (issue #560)', () => {
+    // The aggregate levels[4] status only moves on voiceId-less orchestration
+    // events (events with a voiceId update levels[4].voices only), so the
+    // terminal events emitted around cross-voice consolidation must be
+    // voiceId-less for the live progress UI to reflect the real outcome.
+
+    function buildMultiVoiceRun(progressCallback) {
+      const { reviewContext, councilConfig } = buildTestContext({
+        extraVoices: [{ provider: 'antigravity', model: 'pro', tier: 'balanced' }]
+      });
+      let callCount = 0;
+      vi.spyOn(Analyzer.prototype, 'analyzeAllLevels').mockImplementation(async () => {
+        callCount++;
+        return { suggestions: buildMockSuggestions(callCount === 1 ? 3 : 2), summary: `Voice ${callCount}` };
+      });
+      return {
+        reviewContext,
+        councilConfig,
+        options: { analysisId: 'test-analysis-id', runId: 'parent-run-id', progressCallback }
+      };
+    }
+
+    function orchestrationEvents(progressCallback) {
+      return progressCallback.mock.calls
+        .map(([update]) => update)
+        .filter(u => u.level === 'orchestration');
+    }
+
+    it('emits a voiceId-less terminal completed event when cross-voice consolidation succeeds', async () => {
+      const progressCallback = vi.fn();
+      const { reviewContext, councilConfig, options } = buildMultiVoiceRun(progressCallback);
+
+      vi.spyOn(analyzer, '_crossVoiceConsolidate').mockResolvedValue({
+        suggestions: buildMockSuggestions(4),
+        summary: 'Consolidated'
+      });
+
+      await analyzer.runReviewerCentricCouncil(reviewContext, councilConfig, options);
+
+      const terminal = orchestrationEvents(progressCallback).find(u => u.status === 'completed');
+      expect(terminal).toBeDefined();
+      expect(terminal.voiceCentric).toBe(true);
+      expect(terminal.voiceId).toBeUndefined();
+      expect(terminal.progress).toBe('Cross-reviewer consolidation complete');
+    });
+
+    it('emits a voiceId-less terminal failed event when cross-voice consolidation fails', async () => {
+      const progressCallback = vi.fn();
+      const { reviewContext, councilConfig, options } = buildMultiVoiceRun(progressCallback);
+
+      vi.spyOn(analyzer, '_crossVoiceConsolidate').mockRejectedValue(new Error('consolidation blew up'));
+
+      const result = await analyzer.runReviewerCentricCouncil(reviewContext, councilConfig, options);
+
+      const terminal = orchestrationEvents(progressCallback).find(u => u.status === 'failed');
+      expect(terminal).toBeDefined();
+      expect(terminal.voiceCentric).toBe(true);
+      expect(terminal.voiceId).toBeUndefined();
+      expect(terminal.progress).toContain('Consolidation failed');
+
+      // The fallback result still records the failure authoritatively
+      expect(result.orchestrationFailed).toBe(true);
+      expect(result.levelOutcomes).toEqual({ consolidation: 'failed' });
+    });
+
+    it('does not emit a terminal failed event on cancellation (propagates instead)', async () => {
+      const progressCallback = vi.fn();
+      const { reviewContext, councilConfig, options } = buildMultiVoiceRun(progressCallback);
+
+      vi.spyOn(analyzer, '_crossVoiceConsolidate').mockRejectedValue(new CancellationError('cancelled'));
+
+      await expect(
+        analyzer.runReviewerCentricCouncil(reviewContext, councilConfig, options)
+      ).rejects.toThrow('cancelled');
+
+      const terminal = orchestrationEvents(progressCallback).filter(u => u.status === 'failed' || u.status === 'completed');
+      expect(terminal).toEqual([]);
+    });
+  });
+
   describe('custom_instructions column storage', () => {
     // Regression: custom_instructions was storing mergedInstructions (global + repo + request
     // concatenated with XML tags) instead of only the request-level instructions.

--- a/tests/unit/shared.test.js
+++ b/tests/unit/shared.test.js
@@ -19,7 +19,8 @@ import {
   _indexAnnouncedIds,
   parseEnabledLevels,
   getProvider,
-  resolveProviderModel
+  resolveProviderModel,
+  finalizeConsolidationLevel
 } from '../../src/routes/shared.js';
 
 /**
@@ -1710,5 +1711,49 @@ describe('resolveProviderModel', () => {
     // provider: no request, no CLI override → repo settings ('codex')
     // model: CLI override wins over repo settings ('gpt-5.5')
     expect(result).toEqual({ provider: 'codex', model: 'gpt-5.5' });
+  });
+});
+
+describe('finalizeConsolidationLevel', () => {
+  it('marks level 4 completed when the result reports no consolidation failure', () => {
+    const result = { levelOutcomes: { consolidation: 'success' } };
+    expect(finalizeConsolidationLevel(result, { status: 'running', progress: 'Consolidating...' }))
+      .toEqual({ status: 'completed', progress: 'Results finalized' });
+  });
+
+  it('marks level 4 failed when result.levelOutcomes.consolidation is failed', () => {
+    const result = { levelOutcomes: { consolidation: 'failed' } };
+    const finalized = finalizeConsolidationLevel(result, { status: 'running', progress: 'Consolidating...' });
+    expect(finalized.status).toBe('failed');
+    expect(finalized.progress).toContain('Consolidation failed');
+  });
+
+  it('marks level 4 failed when result.orchestrationFailed is true', () => {
+    const finalized = finalizeConsolidationLevel({ orchestrationFailed: true }, { status: 'running' });
+    expect(finalized.status).toBe('failed');
+  });
+
+  it('preserves a failed status reported via progress events even when the result lacks outcome fields', () => {
+    const finalized = finalizeConsolidationLevel({}, { status: 'failed', progress: 'boom' });
+    expect(finalized.status).toBe('failed');
+  });
+
+  it('preserves the steps and voices maps from the existing level-4 state', () => {
+    const level4 = {
+      status: 'running',
+      steps: { orchestration: { status: 'running', progress: 'Finalizing results...' } },
+      voices: { 'claude-opus': { status: 'completed', progress: 'Done' } }
+    };
+    const finalized = finalizeConsolidationLevel({ levelOutcomes: { consolidation: 'failed' } }, level4);
+    expect(finalized.steps).toEqual(level4.steps);
+    expect(finalized.voices).toEqual(level4.voices);
+    expect(finalized.status).toBe('failed');
+  });
+
+  it('handles an undefined level-4 state (some flows never initialize it)', () => {
+    expect(finalizeConsolidationLevel({ levelOutcomes: { consolidation: 'success' } }, undefined))
+      .toEqual({ status: 'completed', progress: 'Results finalized' });
+    expect(finalizeConsolidationLevel(undefined, undefined))
+      .toEqual({ status: 'completed', progress: 'Results finalized' });
   });
 });


### PR DESCRIPTION
Closes #560.

Cross-voice consolidation could fail to parse its model response, silently discard every child-voice suggestion (7/6/14 in the reported run), and still report `consolidation: "success"` with `count: 0` — indistinguishable from a genuinely clean PR. Two independent defects compounded: JSON extraction choked on an unescaped control character mid-response, and a parse failure degraded to "no suggestions" instead of triggering the existing fallback.

## JSON extraction hardening (`src/utils/json-extractor.js`)

- Raw control characters (literal newlines/tabs in code snippets inside string values) are now repaired and extraction retried — including the dangling-backslash-before-newline shape. The failing response from the issue would now parse outright.
- The repair pass runs at most once per `extractJSON` call (strategies stay on plain `JSON.parse`; a single sanitize-and-rerun happens only after all strategies fail), and failure logs keep the first-pass errors so `position N` offsets match the logged preview.

## Honest failure reporting (`src/ai/analyzer.js`)

- New `parseResponseWithMeta` distinguishes "no parseable response in our schema" from a legitimately empty result. A shared `hasSchemaKeys` predicate accepts `suggestions` / `fileLevelSuggestions` arrays or a summary-only zero-finding response in both acceptance branches, so dedup runs that legitimately curate everything away are still successes.
- All consolidation paths — cross-level orchestration, cross-voice council, and intra-level (Pass 1) council — treat an unparseable response with non-empty input as a failure: they fall back to the unconsolidated suggestions and record `consolidation: 'failed'` instead of success-with-zero. Intra-level failures now reach the final outcome even when Pass 2 succeeds.
- Cancellations rethrow instead of being recorded as consolidation failures; the single-surviving-reviewer fast path preserves the child's `levelOutcomes` instead of overwriting them with `'skipped'`.
- Levels 1–3 and council voices still report success on a parse failure — acknowledged as a follow-up with breadcrumb comments at the four call sites.

## Live progress parity (`src/routes/*`)

- A shared `finalizeConsolidationLevel` helper derives the terminal level-4 state from the authoritative analyzer result (`levelOutcomes` / `orchestrationFailed`) in all five completion handlers (`pr`, `local`, `analyses`, `mcp`, `stack-analysis`), so the live UI no longer shows consolidation complete when the run recorded a failure — and the existing `steps`/`voices` maps survive finalization.
- Reviewer-centric councils now emit terminal `orchestration` progress events (completed/failed) so a degraded consolidation surfaces live, not only at completion.

## Testing

- New `tests/unit/analyzer-consolidation-loss.test.js`: the parse-failure/fallback behavior of all consolidation primitives, the `analyzeAllLevels` → `levelOutcomes` wiring, the Pass-1-fails/Pass-2-succeeds council case, and the legitimate-empty shapes (summary-only, fileLevelSuggestions-only, `{summary, raw}` orderings).
- Control-character recovery tests in `tests/unit/json-extractor.test.js`; `finalizeConsolidationLevel` cases in `tests/unit/shared.test.js`; terminal-event tests in `tests/unit/reviewer-centric-council.test.js`.
- Full unit suite green (8,176 tests); integration green apart from the 3 known pre-existing local-environment `first-run.test.js` timeouts.

Changeset included (patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)