### PR TITLE
feat: sync viewed files to GitHub on review submission

### DIFF
--- a/.changeset/sync-viewed-files-to-github.md
+++ b/.changeset/sync-viewed-files-to-github.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": minor
+---
+
+Sync files marked as viewed to GitHub when submitting or saving a pull request review as a draft.

--- a/public/js/components/ReviewModal.js
+++ b/public/js/components/ReviewModal.js
@@ -520,6 +520,9 @@ class ReviewModal {
       if (!pr) {
         throw new Error('No PR loaded');
       }
+
+      const viewedFiles = Array.from(window.prManager.viewedFiles || [])
+        .filter(filePath => typeof filePath === 'string' && filePath.length > 0);
       
       const response = await fetch(`/api/pr/${pr.owner}/${pr.repo}/${pr.number}/submit-review`, {
         method: 'POST',
@@ -528,7 +531,8 @@ class ReviewModal {
         },
         body: JSON.stringify({
           event: reviewEvent,
-          body: finalBody
+          body: finalBody,
+          viewedFiles
         })
       });
       

--- a/src/github/client.js
+++ b/src/github/client.js
@@ -6,6 +6,7 @@ const { GitHubApiError, isComplexityError } = require('./errors');
 const pendingReviewOps = require('./operations/pending-review');
 const reviewLifecycleOps = require('./operations/review-lifecycle');
 const pendingReviewCommentsOps = require('./operations/pending-review-comments');
+const viewedFilesOps = require('./operations/viewed-files');
 
 // Defaults used when `GitHubClient` is constructed from a bare token
 // string (i.e. without a resolved binding). These mirror the
@@ -614,6 +615,25 @@ class GitHubClient {
       comments,
       batchSize,
       prContext
+    );
+  }
+
+  /**
+   * Mark pull-request file paths as viewed on github.com.
+   *
+   * GitHub exposes this capability only through GraphQL; alternate hosts are
+   * skipped by the operation dispatcher.
+   *
+   * @param {string} prNodeId - GraphQL node ID for the pull request
+   * @param {Array} paths - File paths to mark as viewed
+   * @returns {Promise<void>}
+   */
+  async markFilesAsViewed(prNodeId, paths) {
+    return viewedFilesOps.markFilesAsViewed(
+      this.octokit,
+      this.apiHost,
+      prNodeId,
+      paths
     );
   }
 

--- a/src/github/operations/viewed-files.js
+++ b/src/github/operations/viewed-files.js
@@ -1,0 +1,42 @@
+// Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+const DEFAULT_BATCH_SIZE = 50;
+
+/**
+ * @param {Object} octokit - Octokit instance bound to the configured host
+ * @param {string|null} apiHost - null for github.com, otherwise an alt host
+ * @param {string} prNodeId - GraphQL node ID for the pull request
+ * @param {Array} paths - File paths to mark as viewed
+ * @returns {Promise<void>}
+ */
+async function markFilesAsViewed(octokit, apiHost, prNodeId, paths) {
+  if (apiHost || !prNodeId || !Array.isArray(paths) || paths.length === 0) return;
+
+  for (let offset = 0; offset < paths.length; offset += DEFAULT_BATCH_SIZE) {
+    const batch = paths.slice(offset, offset + DEFAULT_BATCH_SIZE);
+    const pathVariables = batch.map((_, index) => `$path${index}: String!`).join(', ');
+    const mutations = batch.map((_, index) => `
+      file${index}: markFileAsViewed(input: {
+        pullRequestId: $pullRequestId
+        path: $path${index}
+      }) {
+        pullRequest { id }
+      }
+    `).join('\n');
+    const variables = { pullRequestId: prNodeId };
+
+    batch.forEach((path, index) => {
+      variables[`path${index}`] = path;
+    });
+
+    await octokit.graphql(`
+      mutation MarkFilesAsViewed($pullRequestId: ID!, ${pathVariables}) {
+        ${mutations}
+      }
+    `, variables);
+  }
+}
+
+module.exports = {
+  markFilesAsViewed,
+  DEFAULT_BATCH_SIZE
+};

--- a/src/routes/pr.js
+++ b/src/routes/pr.js
@@ -1462,7 +1462,7 @@ router.get('/api/file-content-original/:fileName(*)', async (req, res) => {
 router.post('/api/pr/:owner/:repo/:number/submit-review', async (req, res) => {
   try {
     const { owner, repo, number } = req.params;
-    const { event, body } = req.body; // event: 'APPROVE' | 'REQUEST_CHANGES' | 'COMMENT' | 'DRAFT'
+    const { event, body, viewedFiles } = req.body; // event: 'APPROVE' | 'REQUEST_CHANGES' | 'COMMENT' | 'DRAFT'
     const prNumber = parseInt(number);
 
     if (isNaN(prNumber) || prNumber <= 0) {
@@ -1759,6 +1759,27 @@ router.post('/api/pr/:owner/:repo/:number/submit-review', async (req, res) => {
 
       // Commit transaction
       await run(db, 'COMMIT');
+
+      try {
+        const changedFilePaths = new Set(
+          (prData.changed_files || [])
+            .map((file) => typeof file === 'string'
+              ? file
+              : file?.filename || file?.file || file?.path)
+            .filter(Boolean)
+        );
+        const viewedFilePaths = Array.isArray(viewedFiles)
+          ? [...new Set(viewedFiles)].filter((filePath) => changedFilePaths.has(filePath))
+          : [];
+        if (prData.node_id && viewedFilePaths.length > 0) {
+          await githubClient.markFilesAsViewed(prData.node_id, viewedFilePaths);
+        }
+      } catch (error) {
+        logger.warn(
+          `Review succeeded for ${owner}/${repo}#${prNumber}, but viewed files could not be ` +
+          `synced to GitHub: ${error.message}`
+        );
+      }
 
       // Send success response after all database operations complete.
       // Use the configured remote-host display name (e.g. "Meteorite")

--- a/tests/e2e/global-setup.js
+++ b/tests/e2e/global-setup.js
@@ -291,6 +291,7 @@ async function globalSetup() {
     state: 'PENDING',
     comments_count: 0
   });
+  GitHubClient.prototype.markFilesAsViewed = async () => {};
 
   // Mock worktree manager
   GitWorktreeManager.prototype.getWorktreePath = async () => mockWorktreeResponses.getWorktreePath;

--- a/tests/e2e/test-server.js
+++ b/tests/e2e/test-server.js
@@ -290,6 +290,7 @@ async function startTestServer(port) {
     state: 'PENDING',
     comments_count: 0
   });
+  GitHubClient.prototype.markFilesAsViewed = async () => {};
 
   // Mock worktree manager
   GitWorktreeManager.prototype.getWorktreePath = async () => mockWorktreeResponses.getWorktreePath;

--- a/tests/integration/routes.test.js
+++ b/tests/integration/routes.test.js
@@ -105,6 +105,7 @@ function applyDefaultMocks() {
   resetSpy(GitHubClient.prototype, 'repositoryExists').mockResolvedValue(true);
   resetSpy(GitHubClient.prototype, 'createReviewGraphQL').mockResolvedValue(mockGitHubResponses.createReviewGraphQL);
   resetSpy(GitHubClient.prototype, 'createDraftReviewGraphQL').mockResolvedValue(mockGitHubResponses.createDraftReviewGraphQL);
+  resetSpy(GitHubClient.prototype, 'markFilesAsViewed').mockResolvedValue();
   resetSpy(GitHubClient.prototype, 'getPendingReviewForUser').mockResolvedValue(null);
   resetSpy(GitHubClient.prototype, 'getReviewById').mockResolvedValue(null);
   resetSpy(GitHubClient.prototype, 'addCommentsInBatches').mockResolvedValue({ successCount: 1, failed: false });
@@ -2874,6 +2875,49 @@ describe('Review Submission Endpoint', () => {
         // Should not be a 400 validation error
         expect(response.status).not.toBe(400);
       }
+    });
+
+    it('should sync filtered viewed files after a review succeeds', async () => {
+      const response = await request(server)
+        .post('/api/pr/owner/repo/1/submit-review')
+        .send({
+          event: 'COMMENT',
+          body: 'Test review',
+          viewedFiles: [
+            'file.js',
+            'file.js',
+            'context:file.js',
+            'not-in-this-pr.js',
+            '',
+            null
+          ]
+        });
+
+      expect(response.status).toBe(200);
+      expect(response.body.success).toBe(true);
+      expect(GitHubClient.prototype.createReviewGraphQL).toHaveBeenCalled();
+      expect(GitHubClient.prototype.markFilesAsViewed).toHaveBeenCalledWith(
+        'PR_node123',
+        ['file.js']
+      );
+    });
+
+    it('should keep review submission successful when viewed-file sync throws', async () => {
+      GitHubClient.prototype.markFilesAsViewed.mockRejectedValueOnce(
+        new Error('GraphQL unavailable')
+      );
+
+      const response = await request(server)
+        .post('/api/pr/owner/repo/1/submit-review')
+        .send({
+          event: 'COMMENT',
+          body: 'Review submitted before viewed sync',
+          viewedFiles: ['file.js']
+        });
+
+      expect(response.status).toBe(200);
+      expect(response.body.success).toBe(true);
+      expect(GitHubClient.prototype.createReviewGraphQL).toHaveBeenCalled();
     });
 
     it('should validate that comments are collected for submission', async () => {

--- a/tests/unit/github/viewed-files.test.js
+++ b/tests/unit/github/viewed-files.test.js
@@ -1,0 +1,68 @@
+// Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+import { describe, it, expect, vi } from 'vitest';
+
+const { GitHubClient } = require('../../../src/github/client');
+const { DEFAULT_BATCH_SIZE } = require('../../../src/github/operations/viewed-files');
+
+function createClient(binding = 'test-token') {
+  const client = new GitHubClient(binding);
+  client.octokit.graphql = vi.fn().mockResolvedValue({});
+  return client;
+}
+
+describe('GitHubClient.markFilesAsViewed', () => {
+  it('marks multiple files in one aliased mutation', async () => {
+    const client = createClient();
+
+    await client.markFilesAsViewed('PR_node123', [
+      'src/first.js',
+      'src/second.js'
+    ]);
+
+    expect(client.octokit.graphql).toHaveBeenCalledTimes(1);
+    const [mutation, variables] = client.octokit.graphql.mock.calls[0];
+    expect(mutation).toContain('file0: markFileAsViewed');
+    expect(mutation).toContain('file1: markFileAsViewed');
+    expect(variables).toEqual({
+      pullRequestId: 'PR_node123',
+      path0: 'src/first.js',
+      path1: 'src/second.js'
+    });
+  });
+
+  it('does not call GraphQL when there are no viewed files', async () => {
+    const client = createClient();
+
+    await client.markFilesAsViewed('PR_node123', []);
+
+    expect(client.octokit.graphql).not.toHaveBeenCalled();
+  });
+
+  it('splits large viewed-file lists into batches', async () => {
+    const client = createClient();
+    const paths = Array.from(
+      { length: DEFAULT_BATCH_SIZE + 1 },
+      (_, index) => `src/file-${index}.js`
+    );
+
+    await client.markFilesAsViewed('PR_node123', paths);
+
+    expect(client.octokit.graphql).toHaveBeenCalledTimes(2);
+    expect(client.octokit.graphql.mock.calls[0][1].path49).toBe('src/file-49.js');
+    expect(client.octokit.graphql.mock.calls[1][1]).toEqual({
+      pullRequestId: 'PR_node123',
+      path0: 'src/file-50.js'
+    });
+  });
+
+  it('skips alternate hosts that do not support GitHub GraphQL', async () => {
+    const client = createClient({
+      token: 'alt-token',
+      apiHost: 'https://example.test/api/v3'
+    });
+
+    await client.markFilesAsViewed('PR_node123', ['src/file.js']);
+
+    expect(client.octokit.graphql).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/review-modal.test.js
+++ b/tests/unit/review-modal.test.js
@@ -442,6 +442,45 @@ describe('ReviewModal', () => {
     });
   });
 
+  describe('review submission viewed-file sync', () => {
+    it('persists the current viewed-file state before submitting', async () => {
+      const { modal } = createTestReviewModal();
+      modal.hideError = vi.fn();
+      modal.updateLargeReviewWarning = vi.fn();
+      modal.setSubmittingState = vi.fn();
+      modal.hide = vi.fn();
+
+      global.window.prManager = {
+        currentPR: {
+          owner: 'owner',
+          repo: 'repo',
+          number: 7,
+          pendingDraft: null
+        },
+        viewedFiles: new Set(['src/utils.js', 'context:src/utils.js']),
+        updatePendingDraftIndicator: vi.fn()
+      };
+      global.window.toast = {
+        showSuccess: vi.fn()
+      };
+
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+        ok: true,
+        json: vi.fn().mockResolvedValue({
+          reviewUrl: 'https://github.com/owner/repo/pull/7#review-1'
+        })
+      });
+
+      await modal.submitReview();
+
+      const requestOptions = globalThis.fetch.mock.calls[0][1];
+      expect(JSON.parse(requestOptions.body)).toMatchObject({
+        event: 'COMMENT',
+        viewedFiles: ['src/utils.js', 'context:src/utils.js']
+      });
+    });
+  });
+
   describe('Cmd/Ctrl+Enter keyboard shortcut', () => {
     /**
      * Create a ReviewModal via its real constructor with document.addEventListener


### PR DESCRIPTION
## Summary

Sync Pair Review’s viewed-file state to GitHub whenever a review is commented, approved, submitted with requested changes, or saved as a draft.

- send the current viewed-file paths with review submissions
- deduplicate and validate paths against the PR’s changed files before syncing
- mark files viewed through batched GitHub GraphQL mutations
- keep review submission successful if viewed-file syncing fails
- skip alternate hosts that do not support this GitHub GraphQL operation