### PR TITLE
docs(pair-loop): forbid running review rounds in a subagent

### DIFF
--- a/.changeset/pair-loop-no-subagent-guidance.md
+++ b/.changeset/pair-loop-no-subagent-guidance.md
@@ -1,0 +1,13 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+pair-loop skill: forbid running review rounds inside a subagent
+
+A council round is a 15–40 minute background process owned by the session
+that spawned it, so a round launched from a subagent is killed the moment
+that agent returns — the council work is discarded and the JSON result never
+arrives. The skill now carries this as a hard rule, repeats it at the point
+where the round command is launched, and clarifies that delegating the
+implementation and fix steps is still safe because that work completes inside
+the agent.

--- a/README.md
+++ b/README.md
@@ -988,6 +988,8 @@ An implement→review→fix loop with pair-review as the review oracle. The agen
 |-------|-------------|
 | `/pair-loop:loop` | Implement, review with pair-review councils, triage, fix, and repeat until clean |
 
+**Run the loop in your agent's main session — do not delegate it to a subagent.** Each council round is a 15–40 minute external process owned by the session that started it, so a subagent's exit kills the round mid-flight and the work is discarded. Delegating the implementation or fix work *within* a round is fine; delegating the loop itself is not.
+
 ### code-critic — Standalone Analysis
 
 AI-powered code review analysis that works without any server or MCP dependency. Install this plugin for three-level AI analysis directly in your coding agent.

--- a/plugin-pair-loop/skills/loop/SKILL.md
+++ b/plugin-pair-loop/skills/loop/SKILL.md
@@ -49,11 +49,19 @@ These are not judgment calls:
 3. **Sequence strictly: fix → write triage back → then run the next round.**
 4. **One review at a time.** Never run two reviews concurrently for the same
    repo.
-5. **Do not commit or push.** Leave changes in the working tree. New
+5. **Drive the loop from the session that owns it — never delegate a review
+   round to a subagent.** A round is a 15–40 minute external process, and a
+   background process is killed when the session that spawned it ends. A
+   subagent's session ends the moment it returns, so a round launched inside
+   one dies mid-flight and the run is lost. If you are reading this from
+   inside a subagent, do not start a round — hand the loop back to the main
+   session. (Subagents are still fine for work that *finishes inside the
+   agent*: implementing the objective, applying a batch of fixes.)
+6. **Do not commit or push.** Leave changes in the working tree. New
    (untracked) files are included automatically whenever the review scope ends
    at `untracked` — which the default scope (`unstaged..untracked`) does — so
    no `git add -N` (intent-to-add) is needed.
-6. **Report failures faithfully.** A failed run (`"ok": false`, non-zero
+7. **Report failures faithfully.** A failed run (`"ok": false`, non-zero
    exit) is reported as what it is — never papered over as "no findings".
 
 ## Phase: Setup
@@ -69,8 +77,10 @@ These are not judgment calls:
    call. An unknown handle → show the available names and ask the user.
 4. If an objective was given and the working tree has no relevant changes
    yet, implement the objective first (directly or via a Task agent — your
-   call based on size). Verify with `git status --short` that changes exist
-   before the first review round; if none, tell the user and stop.
+   call based on size; delegation is safe here because the agent's work
+   finishes before it returns, unlike a review round — hard rule 5). Verify
+   with `git status --short` that changes exist before the first review
+   round; if none, tell the user and stop.
 
 ## Running a review round
 
@@ -94,6 +104,10 @@ pair-review --local --headless --json --council <handle> [--scope <range>] --ins
   Run the command in the background (or with a timeout of at least 45
   minutes) and wait for it to exit. Do not abandon or kill it early; do not
   start a second review while one is running (hard rule 4).
+- **Launch it from the loop's own session, not from a subagent.** The
+  background process belongs to the session that spawned it, so a round
+  started inside a subagent is killed the moment that agent returns — the
+  council work is thrown away and the JSON never arrives (hard rule 5).
 - stdout is exactly one JSON document (logs go to stderr):
   - success: `{"ok": true, "mode": "local", "run": {...}, "suggestions":
     [...], "count": N}` — exit code 0. **Zero suggestions is still
@@ -141,8 +155,9 @@ fresh.
 ## Fix
 
 Apply the fixes (directly or via a Task agent for large batches — your
-call). Run the project's relevant tests for the changed code. A fix that
-breaks tests is not a fix.
+call; delegation is safe here for the same reason as in Setup — the agent's
+edits and test runs complete before it returns). Run the project's relevant
+tests for the changed code. A fix that breaks tests is not a fix.
 
 ## Write triage back (optional, needs the server)
 


### PR DESCRIPTION
## Problem

A pair-loop council round is a 15–40 minute external process, and the skill told the agent to background it without saying *whose* background. A background process is owned by the session that spawned it, so a round launched from inside a subagent is killed the moment that agent returns — the council work is discarded and the JSON result never arrives. Observed in practice; the loop silently loses the round.

## Change

Documentation and skill-prompt guidance only. No executable code.

**`plugin-pair-loop/skills/loop/SKILL.md`**

- New **hard rule 5**: drive the loop from the session that owns it, never delegate a round to a subagent. States the mechanism, the consequence, and — since an agent may be reading the skill from inside a subagent — the instruction to hand the loop back rather than start a round. Inserted at position 5, so the existing cross-references to hard rules 1 and 4 are unaffected; nothing referenced the two that shifted to 6 and 7.
- New bullet under **Running a review round**, at the point where the command is actually launched.
- **Setup step 4** and the **Fix** section already invited a Task agent; both now note *why* delegation is safe there (the work completes before the agent returns), so a reader does not over-apply hard rule 5 and stop delegating anything at all.

**`README.md`** — one paragraph in the pair-loop plugin section, since the likelier human error is a user asking their agent to "run the loop in the background".

## Note on verification

The guidance asserts a mechanism: a background process is killed when its spawning session ends. That rests on the observed outcome (round dies, run lost), not on an isolated experiment separating process reaping at agent teardown from subtler causes. The outcome is what the documentation is protecting against either way.

## Testing

Nothing executable changed, so there is nothing to run. `scripts/generate-skill-prompts.js` does not reference this plugin, so no prompt regeneration is required. Changeset included (`patch`) because the skill ships in the npm package and governs agent behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)