### PR TITLE
Derive PR host names from config instead of hardcoding them

### DIFF
--- a/.changeset/config-driven-pr-host-names.md
+++ b/.changeset/config-driven-pr-host-names.md
@@ -1,0 +1,19 @@
+---
+"@in-the-loop-labs/pair-review": minor
+---
+
+Derive the "GitHub or Graphite" copy from config instead of hardcoding it
+
+The landing-page PR input, its validation errors, and the local-review "that's a URL, not a path" error now name the hosts pair-review is actually configured for, rather than always naming GitHub and Graphite.
+
+- **Graphite is only named when `enable_graphite` is on.** It defaults to `false`, so a default install no longer advertises a feature the user has not enabled.
+- **Alt hosts are named from `repos[*].links.external.name`.** An alt host configured per `docs/alt-host.md` now appears in the copy automatically — "Enter GitHub, Graphite, or Meteorite PR URL" — with no downstream patching of shipped strings.
+- `GET /api/config` gains `pr_host_names`, `pr_host_list`, and `pr_url_hostnames`.
+
+Related fixes:
+
+- A scheme-less alt-host PR URL pasted into the local-path box (`meteorite.example/owner/repo/pull/1`) is now recognised as a URL instead of being resolved as a directory name. Previously only `github.com` and Graphite domains were detected. This also covers an alt host configured with a scheme-less `api_host` (`ghe.example.com`) or pasted with an explicit port (`ghe.example.com:8443/...`).
+- `pair-review --local <alt-host URL>` is re-checked once config is loaded, so the headless and instruction-handoff branches no longer treat a scheme-less alt-host URL as a directory name.
+- Where no configuration is available yet (CLI argument parsing, and the landing page before `/api/config` resolves), the copy is host-neutral — "Pass PR URLs as PR review inputs instead" — rather than naming GitHub alone and implying Graphite/alt-host URLs are unsupported.
+- The "that's a URL" error now carries a stable `code` (`LOCAL_PATH_IS_URL`). Callers that previously compared its message text — which now varies per installation — branch on the code instead.
+- The `enable_graphite` description in Global Settings, the README, and the config defaults now mentions that the flag also controls whether Graphite is named in the PR URL prompts and errors (Graphite URLs are accepted either way).

--- a/README.md
+++ b/README.md
@@ -516,7 +516,7 @@ For advanced configuration with custom providers and models, see [AI Provider Co
 |-----|---------|-------------|
 | `external_comments` | `false` | Opt-in: set to `true` to fetch and display GitHub PR review comments inline. Enables the **External** segment, the refresh button, and `/api/reviews/*/external-comments*` routes. |
 | `enable_chat` | `true` | Enables the chat panel feature (uses `chat_provider`). |
-| `enable_graphite` | `false` | Show Graphite links alongside GitHub links. |
+| `enable_graphite` | `false` | Show Graphite links alongside GitHub links, and name Graphite in the PR URL prompts and errors. Graphite PR URLs are accepted either way. |
 | `skip_update_notifier` | `false` | Suppress the "update available" notification on exit. |
 
 ### Configuration Files

--- a/docs/alt-host.md
+++ b/docs/alt-host.md
@@ -214,7 +214,8 @@ Customise the link buttons shown in the review header.
   - `name` (optional) — display name of the host (e.g. `"Meteorite"`). Used
     in place of the literal "GitHub" in user-facing text: the review-submit
     success toast, the pending-draft notice and indicator, and the
-    "Save as Draft" description. Defaults to `"GitHub"` when unset.
+    "Save as Draft" description. It also joins the global host list described
+    in "Naming Your Host in the UI" below. Defaults to `"GitHub"` when unset.
   - `label` (required) — display text for the header link button.
   - `url_template` (required) — URL with `{owner}`, `{repo}`, `{number}`,
     `{branch}`, `{base_branch}`, `{head_sha}` placeholders. The resolved
@@ -236,6 +237,52 @@ Note that the host's web URL frequently cannot be derived from `api_host`
 (the API host, web host, and the host returned in PR `html_url` values may
 be three different domains), which is why `url_template` exists and is used
 for every host-facing link.
+
+## Naming Your Host in the UI
+
+`links.external.name` names the host wherever pair-review has resolved a
+repository. Some copy is rendered *before* any repository is known — the
+landing-page PR input, the URL validation errors, and the local-review
+"that's a URL, not a path" error. Those surfaces use a **global host list**
+derived from the whole configuration:
+
+1. **GitHub** — always present. Repos with no entry fall back to `github.com`
+   and the top-level credentials, so github.com is always reachable.
+2. **Graphite** — only when the top-level `enable_graphite` is `true`. It
+   defaults to `false`, so a default install never advertises it. The flag
+   controls *naming* only: Graphite PR URLs are accepted either way.
+3. **Each distinct `links.external.name`** of a repo that also sets
+   `api_host`, in configuration order.
+
+With `enable_graphite: true` and one alt host named `"Meteorite"`, the
+landing-page input reads:
+
+> Enter GitHub, Graphite, or Meteorite PR URL
+
+and the parse failure reads:
+
+> Invalid PR URL. Please enter a GitHub, Graphite, or Meteorite PR URL.
+
+Two details worth knowing:
+
+- An alt-host repo with **no** `links.external.name` contributes nothing; it
+  resolves to "GitHub", which is already in the list.
+- `name` only registers as part of a *usable* external link, so it needs
+  `label` and an `https://` `url_template` alongside it — the same
+  requirement as the header link button.
+
+The list is served to the frontend by `GET /api/config` as `pr_host_names`
+(the array) and `pr_host_list` (the formatted fragment). The same endpoint
+publishes `pr_url_hostnames`, the domains derived from each alt host's
+`api_host` and `links.external.url_template`, so that a scheme-less alt-host
+URL pasted into the **local path** box is recognised as a URL rather than
+resolved as a directory name. A scheme-less `api_host` (`ghe.example.com`)
+works, and a non-default port is recorded both with and without the port so
+either shape of paste is recognised.
+
+If you have been patching these strings downstream (e.g. a packaging overlay
+rewriting the shipped copy), configure `links.external.name` instead — the
+strings are no longer stable patch targets.
 
 ## Dual-Host Repositories
 

--- a/public/index.html
+++ b/public/index.html
@@ -1394,11 +1394,14 @@
                     <div class="tab-pane active" id="pr-tab">
                         <div class="start-review-section">
                             <form class="start-review-form" id="start-review-form">
+                                <!-- The placeholder is host-neutral until /api/config
+                                     resolves; index.js rewrites it to name the configured
+                                     hosts (GitHub, Graphite when enabled, any alt hosts). -->
                                 <input
                                     type="text"
                                     class="start-review-input"
                                     id="pr-url-input"
-                                    placeholder="Enter GitHub or Graphite PR URL"
+                                    placeholder="Enter PR URL"
                                     autocomplete="off"
                                     spellcheck="false"
                                 >
@@ -1532,7 +1535,7 @@
                 <pre><code class="cmd-example" data-args="123"></code></pre>
 
                 <h3>Review a PR by URL</h3>
-                <p>From anywhere, using a full GitHub or Graphite URL:</p>
+                <p>From anywhere, using a full <span data-pr-host-list>GitHub</span> URL:</p>
                 <pre><code class="cmd-example" data-args="https://github.com/owner/repo/pull/123"></code></pre>
 
                 <h3>Review Local Changes</h3>

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -116,14 +116,94 @@
   // (window.encodeBase64Utf8 / window.getRepoStorageKey), shared with pr.js so the
   // per-repo keys this page writes stay byte-identical to those the PR page reads.
 
-  const LOCAL_REVIEW_PATH_URL_ERROR = 'Local reviews require a filesystem path, not a URL. Pass GitHub or Graphite URLs as PR review inputs instead.';
+  // Hosts named in URL copy, from /api/config's `pr_host_list`, which the
+  // SERVER formats (GitHub always; Graphite only when enable_graphite; each alt
+  // host's links.external.name). Taking the pre-joined string rather than the
+  // array keeps the Oxford-comma formatting in exactly one place —
+  // src/links/host-names.js — so this copy cannot drift from the
+  // identically-worded server-side errors.
+  //
+  // null until /api/config resolves. The copy then reads host-neutral rather
+  // than naming the built-ins, which would claim an alt host's URLs are
+  // unsupported when they are accepted (matching localReviewPathUrlError() in
+  // src/utils/local-path-input.js for its config-free callers).
+  let prHostList = null;
+
+  // Hostnames recognised as scheme-less PR URLs. Seeded with the built-ins and
+  // replaced from /api/config's `pr_url_hostnames`, which adds every
+  // configured alt host. Mirrors resolveUrlLikeHostnames() server-side.
+  let prUrlHostnames = ['github.com', 'app.graphite.dev', 'app.graphite.com'];
+
+  /** "GitHub " / "GitHub or Graphite " while the host list is known, else "". */
+  function prHostPrefix() {
+    return prHostList ? prHostList + ' ' : '';
+  }
+
+  function localReviewPathUrlError() {
+    return 'Local reviews require a filesystem path, not a URL. '
+      + 'Pass ' + (prHostList ? prHostList + ' URLs' : 'PR URLs')
+      + ' as PR review inputs instead.';
+  }
+
+  /**
+   * Adopt the server-formatted host list and refresh the copy that names it.
+   *
+   * Called once /api/config resolves. The static markup ships host-neutral
+   * ("Enter PR URL", "a GitHub URL") so nothing flashes a host list that the
+   * installation does not actually support.
+   *
+   * @param {Object} config - /api/config payload
+   */
+  function applyPrHostList(config) {
+    if (!config) return;
+    if (Array.isArray(config.pr_url_hostnames) && config.pr_url_hostnames.length > 0) {
+      prUrlHostnames = config.pr_url_hostnames;
+    }
+    if (typeof config.pr_host_list !== 'string' || !config.pr_host_list) return;
+    prHostList = config.pr_host_list;
+
+    const urlInput = document.getElementById('pr-url-input');
+    if (urlInput) urlInput.placeholder = 'Enter ' + prHostList + ' PR URL';
+
+    document.querySelectorAll('[data-pr-host-list]').forEach(el => {
+      el.textContent = prHostList;
+    });
+  }
+
+  /**
+   * Drop the "this element is showing the URL error" marker.
+   *
+   * Called from every writer that replaces or hides the message, so the flag
+   * cannot outlive the message it describes — otherwise an unrelated error
+   * (e.g. a failed directory picker) would be dismissed by the next keystroke.
+   *
+   * @param {HTMLElement} errorEl
+   */
+  function clearLocalPathUrlErrorFlag(errorEl) {
+    if (errorEl) delete errorEl.dataset.localPathUrlError;
+  }
+
+  /**
+   * Show the "that's a URL, not a path" error and mark the element so
+   * handleLocalPathInput can clear it without comparing message text.
+   */
+  function showLocalPathUrlError() {
+    // showError() clears the flag first, so setting it AFTER is what makes it
+    // describe THIS message rather than a previous one.
+    showError('local', localReviewPathUrlError());
+    const errorEl = document.getElementById('start-review-error-local');
+    if (errorEl) errorEl.dataset.localPathUrlError = 'true';
+  }
 
   function isUrlLikeLocalReviewPath(value) {
     if (!value || typeof value !== 'string') return false;
     const trimmed = value.trim();
     if (!trimmed) return false;
     if (/^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed)) return true;
-    if (/^(?:github\.com|app\.graphite\.(?:dev|com))\//i.test(trimmed)) return true;
+    // Require a path separator so a bare hostname-shaped directory name is
+    // not mistaken for a URL.
+    const lower = trimmed.toLowerCase();
+    if (prUrlHostnames.some(hostname => lower.startsWith(hostname + '/'))) return true;
     // Keep this aligned with src/utils/local-path-input.js: only a leading
     // user@host:path token is treated as an SSH-style remote.
     if (/^[^@/\\\s]+@[^:/\\\s]+:[^\s]+$/.test(trimmed)) return true;
@@ -172,6 +252,7 @@
     const elId = tab === 'pr' ? 'start-review-error-pr' : 'start-review-error-local';
     const errorEl = document.getElementById(elId);
     if (errorEl) {
+      clearLocalPathUrlErrorFlag(errorEl);
       errorEl.textContent = message;
       errorEl.classList.remove('info');
       errorEl.classList.add('visible');
@@ -188,6 +269,7 @@
     const elId = tab === 'pr' ? 'start-review-error-pr' : 'start-review-error-local';
     const errorEl = document.getElementById(elId);
     if (errorEl) {
+      clearLocalPathUrlErrorFlag(errorEl);
       errorEl.textContent = message;
       errorEl.classList.add('visible', 'info');
     }
@@ -885,7 +967,10 @@
 
     // Clear previous errors/info messages
     const errorEl = document.getElementById('start-review-error-local');
-    if (errorEl) errorEl.classList.remove('visible', 'info');
+    if (errorEl) {
+      errorEl.classList.remove('visible', 'info');
+      clearLocalPathUrlErrorFlag(errorEl);
+    }
 
     if (!pathValue) {
       showError('local', 'Please enter a directory path');
@@ -894,7 +979,7 @@
     }
 
     if (isUrlLikeLocalReviewPath(pathValue)) {
-      showError('local', LOCAL_REVIEW_PATH_URL_ERROR);
+      showLocalPathUrlError();
       input.focus();
       return;
     }
@@ -912,12 +997,16 @@
     if (!input || !errorEl) return;
 
     if (isUrlLikeLocalReviewPath(input.value)) {
-      showError('local', LOCAL_REVIEW_PATH_URL_ERROR);
+      showLocalPathUrlError();
       return;
     }
 
-    if (errorEl.textContent === LOCAL_REVIEW_PATH_URL_ERROR) {
+    // Flagged rather than text-compared: the message names the configured
+    // hosts, so it can change between being shown and being cleared (the
+    // host list arrives asynchronously from /api/config).
+    if (errorEl.dataset.localPathUrlError === 'true') {
       errorEl.classList.remove('visible', 'info');
+      clearLocalPathUrlErrorFlag(errorEl);
     }
   }
 
@@ -1313,7 +1402,7 @@
 
     // Validate input
     if (!url) {
-      showError('pr', 'Please enter a GitHub PR URL');
+      showError('pr', 'Please enter a ' + prHostPrefix() + 'PR URL');
       input.focus();
       return;
     }
@@ -1325,7 +1414,7 @@
     const parsed = await parsePRUrl(url);
     if (!parsed) {
       setFormLoading('pr', false);
-      showError('pr', 'Invalid PR URL. Please enter a GitHub or Graphite PR URL (e.g., https://github.com/owner/repo/pull/123)');
+      showError('pr', 'Invalid PR URL. Please enter a ' + prHostPrefix() + 'PR URL (e.g., https://github.com/owner/repo/pull/123)');
       input.focus();
       return;
     }
@@ -1397,6 +1486,7 @@
         window.__pairReview.modelOverride = config.model_override || null;
         window.__pairReview.hasGithubToken = Boolean(config.has_github_token);
         window.__pairReview.enableGraphite = config.enable_graphite === true;
+        applyPrHostList(config);
         window.__pairReview.chatSpinner = config.chat_spinner || 'dots';
         window.__pairReview.chatEnterToSend = config.chat_enter_to_send !== false;
 
@@ -2592,7 +2682,14 @@
   if (typeof module !== 'undefined' && module.exports) {
     module.exports = {
       buildReviewUrlsFromRows: buildReviewUrlsFromRows,
-      getSelectedCollectionRows: getSelectedCollectionRows
+      getSelectedCollectionRows: getSelectedCollectionRows,
+      applyPrHostList: applyPrHostList,
+      isUrlLikeLocalReviewPath: isUrlLikeLocalReviewPath,
+      localReviewPathUrlError: localReviewPathUrlError,
+      showError: showError,
+      showInfo: showInfo,
+      showLocalPathUrlError: showLocalPathUrlError,
+      handleLocalPathInput: handleLocalPathInput
     };
   }
 

--- a/src/config.js
+++ b/src/config.js
@@ -98,7 +98,7 @@ const DEFAULT_CONFIG = {
   repos: {},  // Repository configurations: { "owner/repo": { path: "~/path/to/clone" } }
   assisted_by_url: "https://github.com/in-the-loop-labs/pair-review",  // URL for "Review assisted by" footer link
   hooks: {},  // Hook commands per event: { "review.started": { "my_hook": { "command": "..." } } }
-  enable_graphite: false,  // When true, shows Graphite links alongside GitHub links
+  enable_graphite: false,  // When true, shows Graphite links alongside GitHub links and names Graphite in the PR URL prompts/errors (Graphite URLs are accepted either way)
   skip_update_notifier: false,  // When true, suppresses the "update available" notification on exit
   external_comments: false  // Opt-in: set to true to enable GitHub PR review-comment sync (External segment, refresh button, /api/reviews/*/external-comments routes)
 };

--- a/src/links/host-names.js
+++ b/src/links/host-names.js
@@ -1,0 +1,200 @@
+// Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+/**
+ * Known PR Host Names
+ *
+ * Derives the list of code hosts pair-review will accept a pull request from,
+ * for use in copy that is rendered BEFORE any repository has been resolved —
+ * the landing-page PR input, the URL validation errors, and the
+ * "that's a URL, not a path" local-review error.
+ *
+ * `resolveHostName()` in ./repo-links.js answers the same question for a
+ * KNOWN repo. This module answers it for the whole configuration, which is
+ * what the pre-resolution surfaces need: at the point where a user is typing
+ * a URL there is no repo to look up yet.
+ *
+ * The list is derived, never hardcoded:
+ *
+ *   - "GitHub" is always present. Unconfigured repos fall back to github.com
+ *     with the top-level credentials, so github.com is always reachable.
+ *   - "Graphite" appears only when `enable_graphite` is true. It defaults to
+ *     false, so a default install must not advertise it.
+ *   - Each distinct `repos[*].links.external.name` for a repo that also sets
+ *     `api_host` — the alt-host display name (e.g. "Meteorite").
+ *
+ * Alt-host repos with no `links.external.name` resolve to "GitHub" via
+ * `resolveHostName` and are therefore de-duplicated away rather than
+ * appearing twice.
+ */
+
+const { resolveHostName } = require('./repo-links');
+
+const DEFAULT_HOST_NAME = 'GitHub';
+const GRAPHITE_HOST_NAME = 'Graphite';
+
+// Hostnames whose PR URLs are recognised even without a scheme. Alt hosts are
+// appended from config by resolveUrlLikeHostnames().
+const BUILTIN_PR_HOSTNAMES = Object.freeze([
+  'github.com',
+  'app.graphite.dev',
+  'app.graphite.com'
+]);
+
+/**
+ * Iterate every configured repo entry.
+ *
+ * `loadConfig()` lowercases the legacy `monorepos` map, merges it into `repos`,
+ * and deletes it, so for any loaded config that branch never fires — it is here
+ * only for raw/hand-built configs, mirroring `getRepoConfig`'s equivalent
+ * fallback.
+ *
+ * @param {Object} config
+ * @returns {Array<[string, Object]>} `[repoKey, repoEntry]` pairs
+ */
+function configuredRepoEntries(config) {
+  const entries = [];
+  for (const section of [config.repos, config.monorepos]) {
+    if (!section || typeof section !== 'object') continue;
+    for (const [repoKey, repoEntry] of Object.entries(section)) {
+      if (!repoEntry || typeof repoEntry !== 'object') continue;
+      entries.push([repoKey, repoEntry]);
+    }
+  }
+  return entries;
+}
+
+/**
+ * True when a repo entry declares an alt host.
+ *
+ * @param {Object} repoEntry
+ * @returns {boolean}
+ */
+function hasApiHost(repoEntry) {
+  return typeof repoEntry.api_host === 'string' && repoEntry.api_host.length > 0;
+}
+
+/**
+ * Resolve the ordered, de-duplicated list of host display names that
+ * pair-review can accept PR URLs for.
+ *
+ * @param {Object} [config] - Configuration object from loadConfig()
+ * @returns {string[]} Non-empty list, always starting with "GitHub"
+ */
+function resolveKnownHostNames(config) {
+  const safeConfig = (config && typeof config === 'object') ? config : {};
+
+  const names = [DEFAULT_HOST_NAME];
+  if (safeConfig.enable_graphite === true) names.push(GRAPHITE_HOST_NAME);
+
+  const seen = new Set(names.map(name => name.toLowerCase()));
+
+  for (const [repoKey, repoEntry] of configuredRepoEntries(safeConfig)) {
+    if (!hasApiHost(repoEntry)) continue;
+    // Route through resolveHostName so the global list agrees with the
+    // per-repo name used in the submit toast and draft notices — including
+    // its validation (a `name` without a usable `label`/`url_template` pair
+    // does not register as an external link, and so does not appear here).
+    const name = resolveHostName(safeConfig, repoKey);
+    const dedupeKey = name.toLowerCase();
+    if (seen.has(dedupeKey)) continue;
+    seen.add(dedupeKey);
+    names.push(name);
+  }
+
+  return names;
+}
+
+/**
+ * Join host names into a user-facing fragment with an Oxford comma:
+ * "GitHub", "GitHub or Graphite", "GitHub, Graphite, or Meteorite".
+ *
+ * @param {string[]} names
+ * @returns {string}
+ */
+function formatHostList(names) {
+  const list = Array.isArray(names) ? names.filter(name => typeof name === 'string' && name) : [];
+  if (list.length === 0) return DEFAULT_HOST_NAME;
+  if (list.length === 1) return list[0];
+  if (list.length === 2) return `${list[0]} or ${list[1]}`;
+  return `${list.slice(0, -1).join(', ')}, or ${list[list.length - 1]}`;
+}
+
+/**
+ * Convenience wrapper: the formatted host fragment for a config.
+ *
+ * @param {Object} [config]
+ * @returns {string}
+ */
+function resolveHostListText(config) {
+  return formatHostList(resolveKnownHostNames(config));
+}
+
+/**
+ * Hostnames (lowercased) that belong to configured alt hosts, recorded both
+ * with and without an explicit port so either shape of paste is recognised.
+ *
+ * Derived from each alt-host repo's `api_host` and, when present, the web
+ * host in `links.external.url_template` — the API host and the web host are
+ * frequently different domains, and a user pastes the latter.
+ *
+ * @param {Object} [config]
+ * @returns {string[]}
+ */
+function resolveAltHostHostnames(config) {
+  const safeConfig = (config && typeof config === 'object') ? config : {};
+  const hostnames = new Set();
+
+  const add = (value) => {
+    if (typeof value !== 'string' || !value) return;
+    // `api_host` is only validated as a non-empty string, so a bare
+    // `ghe.example.com` is a legitimate configuration — give it a scheme so
+    // `new URL()` can parse it rather than throwing into the catch below.
+    const absolute = /^[a-z][a-z0-9+.-]*:\/\//i.test(value) ? value : `https://${value}`;
+    let url;
+    try {
+      url = new URL(absolute);
+    } catch {
+      // Not parseable even with a scheme — nothing to derive.
+      return;
+    }
+    // A template can carry a placeholder in its authority section
+    // (`https://{owner}.example/…` parses, yielding hostname `{owner}.example`);
+    // no pasted input can start with that, so drop it rather than ship junk.
+    if (!url.hostname || url.hostname.includes('{')) return;
+    // `host` keeps a non-default port — what a user actually pastes for
+    // `https://ghe.example.com:8443/…`; `hostname` drops it.
+    hostnames.add(url.host.toLowerCase());
+    hostnames.add(url.hostname.toLowerCase());
+  };
+
+  for (const [, repoEntry] of configuredRepoEntries(safeConfig)) {
+    if (!hasApiHost(repoEntry)) continue;
+    add(repoEntry.api_host);
+    add(repoEntry.links?.external?.url_template);
+  }
+
+  return Array.from(hostnames);
+}
+
+/**
+ * Every hostname whose PR URLs should be recognised without a scheme —
+ * the built-ins plus every configured alt host. De-duplicated, lowercased.
+ *
+ * @param {Object} [config]
+ * @returns {string[]}
+ */
+function resolveUrlLikeHostnames(config) {
+  const seen = new Set(BUILTIN_PR_HOSTNAMES);
+  for (const hostname of resolveAltHostHostnames(config)) seen.add(hostname);
+  return Array.from(seen);
+}
+
+module.exports = {
+  DEFAULT_HOST_NAME,
+  GRAPHITE_HOST_NAME,
+  BUILTIN_PR_HOSTNAMES,
+  resolveKnownHostNames,
+  formatHostList,
+  resolveHostListText,
+  resolveAltHostHostnames,
+  resolveUrlLikeHostnames,
+};

--- a/src/local-review.js
+++ b/src/local-review.js
@@ -1018,7 +1018,13 @@ async function handleLocalReview(targetPath, flags = {}) {
   let setupComplete = false;
 
   try {
-    rejectUrlLikeLocalReviewPath(targetPath);
+    // Loaded before path validation so the "that's a URL" error can name the
+    // configured hosts (GitHub, Graphite, alt hosts) and so scheme-less
+    // alt-host URLs are recognised. The first-run welcome still waits until
+    // the path has been validated.
+    const { config, isFirstRun } = await loadConfig();
+
+    rejectUrlLikeLocalReviewPath(targetPath, config);
 
     const resolvedPath = path.resolve(targetPath || process.cwd());
 
@@ -1031,8 +1037,6 @@ async function handleLocalReview(targetPath, flags = {}) {
     console.log(`Finding git repository root from ${resolvedPath}...`);
     const repoPath = await module.exports.findGitRoot(resolvedPath);
     console.log(`Found git repository at: ${repoPath}`);
-
-    const { config, isFirstRun } = await loadConfig();
 
     if (isFirstRun) {
       showWelcomeMessage();

--- a/src/main.js
+++ b/src/main.js
@@ -566,6 +566,12 @@ function parseArgs(args) {
       flags.local = true;
       // Next argument is optional path (if not starting with -)
       if (i + 1 < args.length && !args[i + 1].startsWith('-')) {
+        // parseArgs() is deliberately config-free — it is exported and
+        // unit-tested as a pure argv parser — so this catches only explicit
+        // `scheme://` inputs, with host-neutral copy. A scheme-less alt-host
+        // URL needs config and is caught by the re-check in main() right after
+        // loadConfig() (and again downstream by handleLocalReview /
+        // attemptDelegation / the local routes).
         rejectUrlLikeLocalReviewPath(args[i + 1]);
         flags.localPath = args[i + 1];
         i++; // Skip next argument since we consumed it
@@ -738,6 +744,17 @@ AI PROVIDERS:
     // Parse command line arguments including flags (before DB init so
     // single-port delegation can skip DB entirely)
     const { prArgs, flags } = parseArgs(args);
+
+    // parseArgs() ran config-free, so it could only reject `scheme://` inputs.
+    // Re-check now that config is loaded: a configured alt host makes
+    // `ghe.example.com/owner/repo/pull/1` a URL too, and the message can name
+    // the hosts this install actually accepts. Several branches below resolve
+    // flags.localPath directly (the instruction handoff at the delegation
+    // check, handleHeadlessDelegated, the headless local path), so the
+    // invariant has to hold here rather than only in handleLocalReview().
+    if (flags.local && flags.localPath) {
+      rejectUrlLikeLocalReviewPath(flags.localPath, config);
+    }
 
     // Headless-mode flag validation (fail fast, before any DB/server work).
     // --instructions and --instructions-file are mutually exclusive.

--- a/src/routes/config.js
+++ b/src/routes/config.js
@@ -34,6 +34,7 @@ const {
   getTourAutoGenerate
 } = require('../config');
 const { resolveRepoLinks } = require('../links/repo-links');
+const { resolveKnownHostNames, formatHostList, resolveUrlLikeHostnames } = require('../links/host-names');
 const { version } = require('../../package.json');
 const semver = require('semver');
 const { getAllChatProviders, getAllCachedChatAvailability } = require('../chat/chat-providers');
@@ -158,6 +159,8 @@ router.get('/api/config', (req, res) => {
     hasRepoGithubToken = Boolean(resolvePreflightBinding(repository, config, undefined).token);
   }
 
+  const hostNames = resolveKnownHostNames(config);
+
   // Only return safe configuration values (not secrets like github_token)
   res.json({
     version,
@@ -190,6 +193,19 @@ router.get('/api/config', (req, res) => {
     pi_available: getCachedAvailability('pi')?.available || false,
     assisted_by_url: config.assisted_by_url || 'https://github.com/in-the-loop-labs/pair-review',
     enable_graphite: config.enable_graphite === true,
+    // Code hosts pair-review accepts PR URLs from, derived from config
+    // (GitHub always; Graphite only when enabled; each alt host's
+    // `links.external.name`). Drives the landing-page placeholder, the help
+    // copy, and the client-side URL validation errors — surfaces that render
+    // before any repo is resolved and so cannot use resolveHostName().
+    // Both shapes are shipped so the Oxford-comma formatting has exactly one
+    // implementation (server-side) and cannot drift from the server's own copy.
+    pr_host_names: hostNames,
+    pr_host_list: formatHostList(hostNames),
+    // Hostnames the local-path input should recognise as scheme-less PR URLs
+    // (github.com, Graphite, and every configured alt host's API and web
+    // domains), so the client pre-flight matches the server's own check.
+    pr_url_hostnames: resolveUrlLikeHostnames(config),
     external_comments: config.external_comments !== false,
     chat_spinner: config.chat_spinner || 'dots',
     summaries: {

--- a/src/routes/local.js
+++ b/src/routes/local.js
@@ -390,7 +390,7 @@ router.post('/api/local/start', async (req, res) => {
     }
 
     try {
-      rejectUrlLikeLocalReviewPath(inputPath);
+      rejectUrlLikeLocalReviewPath(inputPath, req.app.get('config'));
     } catch (err) {
       return res.status(400).json({ error: err.message });
     }

--- a/src/routes/pr.js
+++ b/src/routes/pr.js
@@ -29,6 +29,7 @@ const path = require('path');
 const { resolveHostBinding, resolveBindingRepositoryFromPR, getWorktreeDisplayName, resolveLoadSkills, buildCouncilProviderOverrides, getSummaryEnabled, getTourEnabled } = require('../config');
 const { storedHostToOption, isDualHostRepo } = require('../utils/host-resolution');
 const { resolveHostName } = require('../links/repo-links');
+const { resolveHostListText } = require('../links/host-names');
 const { backgroundQueue } = require('../ai/background-queue');
 const logger = require('../utils/logger');
 const { buildDiffLineSet } = require('../utils/diff-annotator');
@@ -1992,7 +1993,7 @@ router.post('/api/parse-pr-url', (req, res) => {
   }
 
   return res.status(400).json({
-    error: 'Invalid PR URL. Please enter a GitHub or Graphite PR URL.',
+    error: `Invalid PR URL. Please enter a ${resolveHostListText(config)} PR URL.`,
     valid: false
   });
 });

--- a/src/routes/setup.js
+++ b/src/routes/setup.js
@@ -271,7 +271,7 @@ router.post('/api/setup/local', async (req, res) => {
     }
 
     try {
-      rejectUrlLikeLocalReviewPath(rawPath);
+      rejectUrlLikeLocalReviewPath(rawPath, req.app.get('config'));
     } catch (err) {
       return res.status(400).json({ error: err.message });
     }

--- a/src/settings/registry.js
+++ b/src/settings/registry.js
@@ -66,7 +66,7 @@ const REGISTRY = [
   {
     key: 'enable_graphite',
     label: 'Show Graphite links',
-    description: 'Show Graphite links alongside GitHub links in the PR header.',
+    description: 'Show Graphite links alongside GitHub links in the PR header, and name Graphite in the PR URL prompts and errors. Graphite PR URLs are accepted either way.',
     group: 'general',
     type: 'boolean',
     default: false,

--- a/src/setup/local-setup.js
+++ b/src/setup/local-setup.js
@@ -6,7 +6,7 @@ const { fireHooks, hasHooks } = require('../hooks/hook-runner');
 const { buildReviewStartedPayload, buildReviewLoadedPayload, getCachedUser } = require('../hooks/payloads');
 const { STOPS } = require('../local-scope');
 const logger = require('../utils/logger');
-const { LOCAL_REVIEW_PATH_URL_ERROR, rejectUrlLikeLocalReviewPath } = require('../utils/local-path-input');
+const { isLocalPathUrlError, rejectUrlLikeLocalReviewPath } = require('../utils/local-path-input');
 const path = require('path');
 const fs = require('fs').promises;
 
@@ -35,12 +35,14 @@ async function setupLocalReview({ db, targetPath, onProgress, config, flags = {}
   let resolvedPath;
   try {
     progress({ step: 'validate', status: 'running', message: 'Validating target path...' });
-    rejectUrlLikeLocalReviewPath(targetPath);
+    rejectUrlLikeLocalReviewPath(targetPath, config);
     resolvedPath = path.resolve(targetPath);
     await fs.access(resolvedPath);
     progress({ step: 'validate', status: 'completed', message: `Path resolved to ${resolvedPath}` });
   } catch (err) {
-    const message = err.message === LOCAL_REVIEW_PATH_URL_ERROR
+    // Branch on the error CODE, never the message: the URL error names the
+    // configured hosts, so its text varies per installation.
+    const message = isLocalPathUrlError(err)
       ? err.message
       : `Path does not exist: ${path.resolve(targetPath)}`;
     progress({ step: 'validate', status: 'error', message });

--- a/src/single-port.js
+++ b/src/single-port.js
@@ -327,7 +327,7 @@ async function attemptDelegation(config, flags, prArgs, _deps, options = {}) {
   // analyze=true (and analysisConfigId supersedes both when present).
   let url;
   if (flags.local) {
-    rejectUrlLikeLocalReviewPath(flags.localPath);
+    rejectUrlLikeLocalReviewPath(flags.localPath, config);
     const targetPath = path.resolve(flags.localPath || process.cwd());
     const analysisConfigId = await handoffAnalysisConfigId(options.localRepository || null);
     url = buildDelegationUrl(port, 'local', {

--- a/src/utils/local-path-input.js
+++ b/src/utils/local-path-input.js
@@ -1,23 +1,62 @@
 // Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
 
-const LOCAL_REVIEW_PATH_URL_ERROR = 'Local reviews require a filesystem path, not a URL. Pass GitHub or Graphite URLs as PR review inputs instead.';
+const { resolveHostListText, resolveUrlLikeHostnames } = require('../links/host-names');
+
+/**
+ * Error code stamped on the "you passed a URL, not a path" error.
+ *
+ * Callers MUST branch on this rather than comparing the message text — the
+ * message names the configured hosts and therefore varies per installation.
+ */
+const LOCAL_PATH_IS_URL_CODE = 'LOCAL_PATH_IS_URL';
+
+/**
+ * Build the user-facing message for a local-review path that is really a URL.
+ *
+ * Without a config the message stays host-neutral. Falling back to the
+ * built-in list would name GitHub alone, which actively misinforms: on an
+ * install with `enable_graphite` or an alt host, those URLs ARE accepted as PR
+ * review inputs.
+ *
+ * @param {Object} [config] - Configuration object from loadConfig()
+ * @returns {string}
+ */
+function localReviewPathUrlError(config) {
+  const hostClause = (config && typeof config === 'object')
+    ? `${resolveHostListText(config)} URLs`
+    : 'PR URLs';
+  return 'Local reviews require a filesystem path, not a URL. '
+    + `Pass ${hostClause} as PR review inputs instead.`;
+}
 
 /**
  * Detect inputs that are URLs or remote-style Git URLs rather than filesystem paths.
  * This intentionally checks only unambiguous URL forms so normal absolute,
  * relative, tilde, and Windows paths continue to work.
  *
+ * Scheme-less PR URLs are recognised for github.com, Graphite, and every
+ * configured alt host (both its `api_host` and its `links.external`
+ * web host, which are frequently different domains).
+ *
  * @param {unknown} input
+ * @param {Object} [config] - Configuration object; without it only the
+ *                            built-in hosts are recognised scheme-less.
  * @returns {boolean}
  */
-function isUrlLikeLocalReviewPath(input) {
+function isUrlLikeLocalReviewPath(input, config) {
   if (typeof input !== 'string') return false;
 
   const value = input.trim();
   if (!value) return false;
 
   if (/^[a-z][a-z0-9+.-]*:\/\//i.test(value)) return true;
-  if (/^(?:github\.com|app\.graphite\.(?:dev|com))\//i.test(value)) return true;
+
+  const hostnames = resolveUrlLikeHostnames(config);
+  const lower = value.toLowerCase();
+  // Require a path separator so a bare hostname-shaped directory name is not
+  // mistaken for a URL, matching the previous built-in behaviour.
+  if (hostnames.some(hostname => lower.startsWith(`${hostname}/`))) return true;
+
   // Treat only a leading user@host:path token as SSH remote syntax; if a
   // directory prefix contains @ and : it should remain a filesystem path.
   if (/^[^@/\\\s]+@[^:/\\\s]+:[^\s]+$/.test(value)) return true;
@@ -28,17 +67,34 @@ function isUrlLikeLocalReviewPath(input) {
 /**
  * Throw a user-facing error when a local review path is actually a URL.
  *
+ * The thrown error carries `code === LOCAL_PATH_IS_URL_CODE`.
+ *
  * @param {unknown} input
+ * @param {Object} [config] - Configuration object from loadConfig()
  * @throws {Error}
  */
-function rejectUrlLikeLocalReviewPath(input) {
-  if (isUrlLikeLocalReviewPath(input)) {
-    throw new Error(LOCAL_REVIEW_PATH_URL_ERROR);
+function rejectUrlLikeLocalReviewPath(input, config) {
+  if (isUrlLikeLocalReviewPath(input, config)) {
+    const error = new Error(localReviewPathUrlError(config));
+    error.code = LOCAL_PATH_IS_URL_CODE;
+    throw error;
   }
 }
 
+/**
+ * True when an error came from rejectUrlLikeLocalReviewPath().
+ *
+ * @param {unknown} error
+ * @returns {boolean}
+ */
+function isLocalPathUrlError(error) {
+  return Boolean(error) && error.code === LOCAL_PATH_IS_URL_CODE;
+}
+
 module.exports = {
-  LOCAL_REVIEW_PATH_URL_ERROR,
+  LOCAL_PATH_IS_URL_CODE,
+  localReviewPathUrlError,
   isUrlLikeLocalReviewPath,
-  rejectUrlLikeLocalReviewPath
+  rejectUrlLikeLocalReviewPath,
+  isLocalPathUrlError
 };

--- a/tests/integration/local-path-url-guard.test.js
+++ b/tests/integration/local-path-url-guard.test.js
@@ -1,0 +1,128 @@
+// Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+/**
+ * Integration test: `--local <alt-host URL>` must be rejected as a URL, with a
+ * message naming the hosts the install accepts.
+ *
+ * parseArgs() runs config-free, so it can only spot an explicit `scheme://`
+ * input. A scheme-less URL for a CONFIGURED alt host needs config, and several
+ * branches downstream (the instruction handoff, handleHeadlessDelegated, the
+ * headless local path) resolve `flags.localPath` straight to a filesystem path
+ * — so main() re-runs the guard once config is loaded. Without that re-check the
+ * user gets a git-root/path error instead.
+ *
+ * Driven through --headless --json because that failure envelope lands on stdout
+ * as parseable JSON, and the guard throws before any DB/server/git/network work
+ * (the same fast path tests/integration/headless-json-error.test.js relies on).
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { spawnSync } from 'child_process';
+import fs from 'fs/promises';
+import path from 'path';
+import os from 'os';
+
+const REPO_ROOT = path.join(__dirname, '../..');
+
+function runCli(args, homeDir) {
+  // process.execPath (not literal 'node') so the child runs under the SAME Node
+  // major as the runner — better-sqlite3 only loads under its build ABI.
+  // cwd is the temp HOME, not the repo: loadConfig() also merges any
+  // project-local `.pair-review/config.*.json` from the working directory, and
+  // this repo carries a gitignored one that would leak its hosts into the copy.
+  return spawnSync(process.execPath, [path.join(REPO_ROOT, 'bin/pair-review.js'), ...args], {
+    cwd: homeDir,
+    env: {
+      ...process.env,
+      HOME: homeDir,
+      GITHUB_TOKEN: '',
+      PAIR_REVIEW_NO_OPEN: '1'
+    },
+    timeout: 15000
+  });
+}
+
+async function writeConfig(homeDir, config) {
+  const configDir = path.join(homeDir, '.pair-review');
+  await fs.mkdir(configDir, { recursive: true });
+  await fs.writeFile(path.join(configDir, 'config.json'), JSON.stringify(config, null, 2));
+}
+
+function errorMessage(result) {
+  const stdout = (result.stdout?.toString() || '').trim();
+  return JSON.parse(stdout).error.message;
+}
+
+describe('--local URL guard (config-aware)', () => {
+  let testHomeDir;
+
+  beforeEach(async () => {
+    testHomeDir = await fs.mkdtemp(path.join(os.tmpdir(), 'pair-review-local-url-guard-'));
+  });
+
+  afterEach(async () => {
+    if (testHomeDir) {
+      await fs.rm(testHomeDir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects a scheme-less alt-host URL and names the alt host', async () => {
+    await writeConfig(testHomeDir, {
+      github_token: '',
+      port: 7247,
+      theme: 'light',
+      enable_graphite: true,
+      repos: {
+        'guardteam/guardproject': {
+          api_host: 'ghe.guard.example',
+          links: {
+            external: {
+              name: 'GuardHost',
+              label: 'Open on GuardHost',
+              url_template: 'https://ghe.guard.example/{owner}/{repo}/pull/{number}'
+            }
+          }
+        }
+      }
+    });
+
+    const result = runCli(
+      ['--local', 'ghe.guard.example/guardteam/guardproject/pull/1', '--headless', '--json'],
+      testHomeDir
+    );
+
+    expect(result.status).toBe(1);
+    // Naming GuardHost and Graphite proves the guard ran WITH config: parseArgs'
+    // config-free pre-check cannot see either, and would not have matched this
+    // scheme-less input at all.
+    expect(errorMessage(result)).toBe(
+      'Local reviews require a filesystem path, not a URL. '
+      + 'Pass GitHub, Graphite, or GuardHost URLs as PR review inputs instead.'
+    );
+  });
+
+  it('keeps the config-free pre-check for an explicit scheme, with host-neutral copy', async () => {
+    await writeConfig(testHomeDir, {
+      github_token: '',
+      port: 7247,
+      theme: 'light',
+      enable_graphite: true
+    });
+
+    // parseArgs() rejects this before config is threaded in, so the message
+    // omits the host clause rather than naming a list it cannot know.
+    const result = runCli(
+      ['--local', 'https://github.com/owner/repo/pull/1', '--headless', '--json'],
+      testHomeDir
+    );
+
+    expect(result.status).toBe(1);
+    expect(errorMessage(result)).toBe(
+      'Local reviews require a filesystem path, not a URL. '
+      + 'Pass PR URLs as PR review inputs instead.'
+    );
+  });
+});
+
+// The negative case — a filesystem path must survive the guard — is covered at
+// the unit level in tests/unit/local-path-input.test.js. Exercising it through
+// the CLI would have to run past the guard into git/server work, which is both
+// slow and prone to contacting a real dev server on the configured port.

--- a/tests/integration/routes.test.js
+++ b/tests/integration/routes.test.js
@@ -348,6 +348,48 @@ describe('PR Management Endpoints', () => {
         host: null, isDualHost: true
       });
     });
+
+    // The 400 body is the message the landing page shows on a parse failure.
+    // It names the hosts this install accepts, derived from config — pin it so a
+    // refactor cannot quietly revert the copy to a hardcoded "GitHub" literal.
+    it('names the configured hosts in the 400 message for an unparseable URL', async () => {
+      app.set('config', {
+        enable_graphite: true,
+        repos: {
+          'myteam/myproject': {
+            api_host: 'https://api.meteorite.example/api/v3',
+            links: {
+              external: {
+                name: 'Meteorite',
+                label: 'Open on Meteorite',
+                url_template: 'https://meteorite.example/{owner}/{repo}/pull/{number}'
+              }
+            }
+          }
+        }
+      });
+
+      const response = await request(server)
+        .post('/api/parse-pr-url')
+        .send({ url: 'https://example.com/not/a/pr' });
+
+      expect(response.status).toBe(400);
+      expect(response.body.valid).toBe(false);
+      expect(response.body.error)
+        .toBe('Invalid PR URL. Please enter a GitHub, Graphite, or Meteorite PR URL.');
+    });
+
+    it('names GitHub alone in the 400 message on a default install', async () => {
+      app.set('config', { enable_graphite: false, repos: {} });
+
+      const response = await request(server)
+        .post('/api/parse-pr-url')
+        .send({ url: 'https://example.com/not/a/pr' });
+
+      expect(response.status).toBe(400);
+      expect(response.body.error)
+        .toBe('Invalid PR URL. Please enter a GitHub PR URL.');
+    });
   });
 
   describe('GET /api/pr/:owner/:repo/:number', () => {
@@ -3479,6 +3521,67 @@ describe('Config Endpoints', () => {
       // selectModel() guard does with 'sonnet' anyway. Claude's coherent default is
       // the canonical 'opus-4.8-xhigh'.
       expect(response.body.default_model).toBe('opus-4.8-xhigh');
+    });
+
+    // The landing page, its URL-validation errors, and the local-path "that's
+    // a URL" error all name the hosts pair-review accepts PR URLs from. That
+    // list is derived from config here rather than hardcoded in the markup, so
+    // an alt host is named by configuring it — not by patching shipped strings.
+    describe('pr_host_names / pr_host_list / pr_url_hostnames', () => {
+      const ALT_HOST_REPO = {
+        api_host: 'https://api.meteorite.example/api/v3',
+        links: {
+          external: {
+            name: 'Meteorite',
+            label: 'Open on Meteorite',
+            url_template: 'https://meteorite.example/{owner}/{repo}/pull/{number}'
+          }
+        }
+      };
+
+      it('names GitHub alone by default (Graphite is off unless enabled)', async () => {
+        app.set('config', { ...app.get('config'), enable_graphite: false, repos: {} });
+
+        const response = await request(server).get('/api/config');
+
+        expect(response.body.pr_host_names).toEqual(['GitHub']);
+        expect(response.body.pr_host_list).toBe('GitHub');
+      });
+
+      it('adds Graphite when enable_graphite is on', async () => {
+        app.set('config', { ...app.get('config'), enable_graphite: true, repos: {} });
+
+        const response = await request(server).get('/api/config');
+
+        expect(response.body.pr_host_names).toEqual(['GitHub', 'Graphite']);
+        expect(response.body.pr_host_list).toBe('GitHub or Graphite');
+      });
+
+      it('adds an alt host from repos[*].links.external.name', async () => {
+        app.set('config', {
+          ...app.get('config'),
+          enable_graphite: true,
+          repos: { 'myteam/myproject': ALT_HOST_REPO }
+        });
+
+        const response = await request(server).get('/api/config');
+
+        expect(response.body.pr_host_names).toEqual(['GitHub', 'Graphite', 'Meteorite']);
+        expect(response.body.pr_host_list).toBe('GitHub, Graphite, or Meteorite');
+      });
+
+      it('publishes the alt host domains for scheme-less URL detection', async () => {
+        app.set('config', {
+          ...app.get('config'),
+          repos: { 'myteam/myproject': ALT_HOST_REPO }
+        });
+
+        const response = await request(server).get('/api/config');
+
+        expect(response.body.pr_url_hostnames).toEqual(expect.arrayContaining([
+          'github.com', 'meteorite.example', 'api.meteorite.example'
+        ]));
+      });
     });
 
     it('should return configured provider and model defaults', async () => {

--- a/tests/unit/host-names.test.js
+++ b/tests/unit/host-names.test.js
@@ -1,0 +1,239 @@
+// Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+import { describe, it, expect } from 'vitest';
+
+const {
+  resolveKnownHostNames,
+  formatHostList,
+  resolveHostListText,
+  resolveAltHostHostnames,
+  resolveUrlLikeHostnames
+} = require('../../src/links/host-names');
+
+function altHostRepo(overrides = {}) {
+  return {
+    api_host: 'https://api.althost.example/api/v3',
+    links: {
+      external: {
+        name: 'AltHost',
+        label: 'Open on AltHost',
+        url_template: 'https://althost.example/{owner}/{repo}/pull/{number}'
+      }
+    },
+    ...overrides
+  };
+}
+
+describe('resolveKnownHostNames', () => {
+  it('returns GitHub alone for an empty or missing config', () => {
+    expect(resolveKnownHostNames()).toEqual(['GitHub']);
+    expect(resolveKnownHostNames(null)).toEqual(['GitHub']);
+    expect(resolveKnownHostNames({})).toEqual(['GitHub']);
+  });
+
+  it('omits Graphite unless enable_graphite is exactly true', () => {
+    expect(resolveKnownHostNames({ enable_graphite: false })).toEqual(['GitHub']);
+    expect(resolveKnownHostNames({ enable_graphite: 'yes' })).toEqual(['GitHub']);
+    expect(resolveKnownHostNames({ enable_graphite: true })).toEqual(['GitHub', 'Graphite']);
+  });
+
+  it('appends the alt-host display name for api_host repos', () => {
+    const config = { repos: { 'myteam/myproject': altHostRepo() } };
+    expect(resolveKnownHostNames(config)).toEqual(['GitHub', 'AltHost']);
+  });
+
+  it('places Graphite before alt hosts when both apply', () => {
+    const config = {
+      enable_graphite: true,
+      repos: { 'myteam/myproject': altHostRepo() }
+    };
+    expect(resolveKnownHostNames(config)).toEqual(['GitHub', 'Graphite', 'AltHost']);
+  });
+
+  it('de-duplicates a name shared by several repos, preserving config order', () => {
+    const config = {
+      repos: {
+        'a/one': altHostRepo(),
+        'b/two': altHostRepo(),
+        'c/three': altHostRepo({
+          links: {
+            external: {
+              name: 'Second',
+              label: 'Open on Second',
+              url_template: 'https://second.example/{owner}/{repo}/pull/{number}'
+            }
+          }
+        })
+      }
+    };
+    expect(resolveKnownHostNames(config)).toEqual(['GitHub', 'AltHost', 'Second']);
+  });
+
+  it('ignores repos with no api_host even when they name an external link', () => {
+    const config = {
+      repos: {
+        'plain/repo': {
+          links: {
+            external: {
+              name: 'NotAHost',
+              label: 'Open elsewhere',
+              url_template: 'https://elsewhere.example/{owner}/{repo}/pull/{number}'
+            }
+          }
+        }
+      }
+    };
+    expect(resolveKnownHostNames(config)).toEqual(['GitHub']);
+  });
+
+  it('does not add a second "GitHub" for an alt-host repo with no external name', () => {
+    const config = { repos: { 'myteam/myproject': { api_host: 'https://api.althost.example' } } };
+    expect(resolveKnownHostNames(config)).toEqual(['GitHub']);
+  });
+
+  it('drops an external name whose link is not usable', () => {
+    // resolveRepoLinks requires a label and an https url_template, so a
+    // name-only entry never registers as an external link.
+    const config = {
+      repos: {
+        'myteam/myproject': { api_host: 'https://api.althost.example', links: { external: { name: 'AltHost' } } }
+      }
+    };
+    expect(resolveKnownHostNames(config)).toEqual(['GitHub']);
+  });
+
+  // loadConfig() merges `monorepos` into `repos` and deletes it, so this branch
+  // only fires for a raw/hand-built config — as does getRepoConfig's fallback.
+  it("reads a raw config's legacy monorepos section", () => {
+    const config = { monorepos: { 'myteam/myproject': altHostRepo() } };
+    expect(resolveKnownHostNames(config)).toEqual(['GitHub', 'AltHost']);
+  });
+
+  it('tolerates malformed repo entries', () => {
+    const config = { repos: { 'a/one': null, 'b/two': 'nope', 'c/three': altHostRepo() } };
+    expect(resolveKnownHostNames(config)).toEqual(['GitHub', 'AltHost']);
+  });
+});
+
+describe('formatHostList', () => {
+  it('formats zero through three names', () => {
+    expect(formatHostList([])).toBe('GitHub');
+    expect(formatHostList(['GitHub'])).toBe('GitHub');
+    expect(formatHostList(['GitHub', 'Graphite'])).toBe('GitHub or Graphite');
+    expect(formatHostList(['GitHub', 'Graphite', 'Meteorite']))
+      .toBe('GitHub, Graphite, or Meteorite');
+  });
+
+  it('uses an Oxford comma beyond three names', () => {
+    expect(formatHostList(['A', 'B', 'C', 'D'])).toBe('A, B, C, or D');
+  });
+
+  it('ignores non-string and empty entries', () => {
+    expect(formatHostList(['GitHub', '', null, 'Meteorite'])).toBe('GitHub or Meteorite');
+    expect(formatHostList(null)).toBe('GitHub');
+  });
+});
+
+describe('resolveHostListText', () => {
+  it('composes the derived list', () => {
+    expect(resolveHostListText()).toBe('GitHub');
+    expect(resolveHostListText({
+      enable_graphite: true,
+      repos: { 'myteam/myproject': altHostRepo() }
+    })).toBe('GitHub, Graphite, or AltHost');
+  });
+});
+
+describe('resolveAltHostHostnames', () => {
+  it('returns nothing without alt-host repos', () => {
+    expect(resolveAltHostHostnames()).toEqual([]);
+    expect(resolveAltHostHostnames({ repos: { 'plain/repo': { path: '~/src/repo' } } })).toEqual([]);
+  });
+
+  it('derives both the api and web hostnames', () => {
+    const config = { repos: { 'myteam/myproject': altHostRepo() } };
+    expect(resolveAltHostHostnames(config).sort())
+      .toEqual(['althost.example', 'api.althost.example']);
+  });
+
+  it('lowercases and de-duplicates', () => {
+    const config = {
+      repos: {
+        'a/one': altHostRepo({ api_host: 'https://AltHost.Example/api/v3' }),
+        'b/two': altHostRepo({ api_host: 'https://althost.example/api/v3' })
+      }
+    };
+    expect(resolveAltHostHostnames(config)).toEqual(['althost.example']);
+  });
+
+  it('skips unparseable values rather than throwing', () => {
+    const config = {
+      repos: {
+        'myteam/myproject': altHostRepo({
+          api_host: 'not a url',
+          links: { external: { name: 'X', label: 'X', url_template: 'https://web.example/{owner}' } }
+        })
+      }
+    };
+    expect(resolveAltHostHostnames(config)).toEqual(['web.example']);
+  });
+
+  // `api_host` is validated only as a non-empty string, so a bare hostname is
+  // a legitimate configuration — and one that already appears in-repo.
+  it('derives a hostname from a scheme-less api_host', () => {
+    const config = {
+      repos: { 'myteam/myproject': { api_host: 'ghe.example.com' } }
+    };
+    expect(resolveAltHostHostnames(config)).toEqual(['ghe.example.com']);
+  });
+
+  it('derives a hostname from a scheme-less api_host with a path', () => {
+    const config = {
+      repos: { 'myteam/myproject': { api_host: 'ghe.example.com/api/v3' } }
+    };
+    expect(resolveAltHostHostnames(config)).toEqual(['ghe.example.com']);
+  });
+
+  // A user pastes the host WITH its port, so both shapes must be recognised.
+  it('records a non-default port alongside the bare hostname', () => {
+    const config = {
+      repos: { 'myteam/myproject': { api_host: 'https://ghe.example.com:8443/api/v3' } }
+    };
+    expect(resolveAltHostHostnames(config).sort())
+      .toEqual(['ghe.example.com', 'ghe.example.com:8443']);
+  });
+
+  it('drops a template whose authority section is a placeholder', () => {
+    // `new URL('https://{owner}.example/...')` parses rather than throwing, so
+    // without the guard `{owner}.example` would be published to the browser.
+    const config = {
+      repos: {
+        'myteam/myproject': altHostRepo({
+          links: {
+            external: {
+              name: 'X',
+              label: 'X',
+              url_template: 'https://{owner}.example/{repo}/pull/{number}'
+            }
+          }
+        })
+      }
+    };
+    expect(resolveAltHostHostnames(config)).toEqual(['api.althost.example']);
+  });
+});
+
+describe('resolveUrlLikeHostnames', () => {
+  it('always includes the built-in hosts', () => {
+    expect(resolveUrlLikeHostnames()).toEqual([
+      'github.com', 'app.graphite.dev', 'app.graphite.com'
+    ]);
+  });
+
+  it('appends configured alt hosts', () => {
+    const config = { repos: { 'myteam/myproject': altHostRepo() } };
+    const hostnames = resolveUrlLikeHostnames(config);
+    expect(hostnames).toContain('github.com');
+    expect(hostnames).toContain('althost.example');
+    expect(hostnames).toContain('api.althost.example');
+  });
+});

--- a/tests/unit/index-open-analyze-buttons.test.js
+++ b/tests/unit/index-open-analyze-buttons.test.js
@@ -528,7 +528,10 @@ describe('Index page Open/Analyze buttons', () => {
     const browseBtn = elementsById['browse-local-btn'];
     const input = elementsById['local-path-input'];
     const errorEl = elementsById['start-review-error-local'];
-    errorEl.textContent = 'Local reviews require a filesystem path, not a URL. Pass GitHub or Graphite URLs as PR review inputs instead.';
+    // The URL error is flagged, not text-matched: it names the configured
+    // hosts and so its wording varies per installation.
+    errorEl.textContent = 'Local reviews require a filesystem path, not a URL. Pass GitHub URLs as PR review inputs instead.';
+    errorEl.dataset.localPathUrlError = 'true';
     errorEl.classList.remove.mockClear();
 
     global.fetch = vi.fn((url) => {

--- a/tests/unit/index-pr-host-list.test.js
+++ b/tests/unit/index-pr-host-list.test.js
@@ -1,0 +1,166 @@
+// @vitest-environment jsdom
+// Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+/**
+ * The landing page names the code hosts it accepts PR URLs from. That copy is
+ * derived from /api/config (`pr_host_list` / `pr_url_hostnames`), not
+ * hardcoded, so an alt host configured via `repos[*].links.external.name`
+ * appears without patching the shipped strings — and Graphite does NOT appear
+ * unless `enable_graphite` is on.
+ *
+ * Exercises the real public/js/index.js exports against a jsdom document that
+ * mirrors the relevant parts of public/index.html.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+
+const INDEX_MARKUP = `
+  <button id="help-btn"></button>
+  <div id="help-modal-overlay"><button id="help-modal-close"></button></div>
+  <form id="start-review-form">
+    <input id="pr-url-input" placeholder="Enter PR URL">
+  </form>
+  <div id="start-review-error-pr"></div>
+  <input id="local-path-input">
+  <div id="start-review-error-local"></div>
+  <p>From anywhere, using a full <span data-pr-host-list>GitHub</span> URL:</p>
+`;
+
+const path = require('path');
+const INDEX_JS = path.resolve(__dirname, '../../public/js/index.js');
+
+let indexModule;
+
+beforeEach(() => {
+  document.body.innerHTML = INDEX_MARKUP;
+  // Loaded by a preceding <script> tag in the real page.
+  window.PairReviewTheme = { setup: () => {} };
+  // The IIFE caches host state in module scope; reload it per test so each
+  // case starts from the shipped host-neutral defaults.
+  delete require.cache[INDEX_JS];
+  indexModule = require(INDEX_JS);
+});
+
+describe('landing-page host list', () => {
+  it('ships host-neutral defaults before /api/config resolves', () => {
+    expect(document.getElementById('pr-url-input').placeholder).toBe('Enter PR URL');
+    // Not "Pass GitHub URLs": naming the built-ins before the real list arrives
+    // would deny alt-host/Graphite URLs that this install does accept.
+    expect(indexModule.localReviewPathUrlError())
+      .toBe('Local reviews require a filesystem path, not a URL. '
+        + 'Pass PR URLs as PR review inputs instead.');
+  });
+
+  it('names GitHub only when Graphite is disabled and no alt host is configured', () => {
+    indexModule.applyPrHostList({ pr_host_names: ['GitHub'], pr_host_list: 'GitHub' });
+
+    expect(document.getElementById('pr-url-input').placeholder).toBe('Enter GitHub PR URL');
+    expect(document.querySelector('[data-pr-host-list]').textContent).toBe('GitHub');
+    expect(indexModule.localReviewPathUrlError())
+      .toBe('Local reviews require a filesystem path, not a URL. '
+        + 'Pass GitHub URLs as PR review inputs instead.');
+  });
+
+  it('adds Graphite when it is enabled', () => {
+    indexModule.applyPrHostList({
+      pr_host_names: ['GitHub', 'Graphite'],
+      pr_host_list: 'GitHub or Graphite'
+    });
+
+    expect(document.getElementById('pr-url-input').placeholder)
+      .toBe('Enter GitHub or Graphite PR URL');
+    expect(document.querySelector('[data-pr-host-list]').textContent)
+      .toBe('GitHub or Graphite');
+  });
+
+  it('names a configured alt host alongside the built-ins', () => {
+    indexModule.applyPrHostList({
+      pr_host_names: ['GitHub', 'Graphite', 'Meteorite'],
+      pr_host_list: 'GitHub, Graphite, or Meteorite'
+    });
+
+    expect(document.getElementById('pr-url-input').placeholder)
+      .toBe('Enter GitHub, Graphite, or Meteorite PR URL');
+    expect(document.querySelector('[data-pr-host-list]').textContent)
+      .toBe('GitHub, Graphite, or Meteorite');
+    expect(indexModule.localReviewPathUrlError())
+      .toContain('Pass GitHub, Graphite, or Meteorite URLs');
+  });
+
+  it('leaves the defaults alone for a malformed or missing payload', () => {
+    indexModule.applyPrHostList(null);
+    indexModule.applyPrHostList({});
+    indexModule.applyPrHostList({ pr_host_list: '' });
+
+    expect(document.getElementById('pr-url-input').placeholder).toBe('Enter PR URL');
+    expect(indexModule.localReviewPathUrlError()).toContain('Pass PR URLs');
+  });
+});
+
+// The "that's a URL" error is marked with a dataset flag so it can be cleared
+// without comparing message text (the text names the configured hosts). Unlike
+// the text comparison it replaced, a flag is not self-correcting: it must be
+// dropped by every writer that replaces or hides the message, or the next
+// keystroke dismisses somebody else's error.
+describe('local-path URL error flag lifetime', () => {
+  const errorEl = () => document.getElementById('start-review-error-local');
+
+  it('marks the element and clears it when a real path is typed', () => {
+    indexModule.showLocalPathUrlError();
+    expect(errorEl().dataset.localPathUrlError).toBe('true');
+    expect(errorEl().classList.contains('visible')).toBe(true);
+
+    document.getElementById('local-path-input').value = '/Users/test/repo';
+    indexModule.handleLocalPathInput();
+
+    expect(errorEl().dataset.localPathUrlError).toBeUndefined();
+    expect(errorEl().classList.contains('visible')).toBe(false);
+  });
+
+  it('does not dismiss an unrelated error shown after it', () => {
+    indexModule.showLocalPathUrlError();
+    // e.g. the directory picker failing while the URL error is on screen.
+    indexModule.showError('local', 'Failed to open directory picker');
+    expect(errorEl().dataset.localPathUrlError).toBeUndefined();
+
+    document.getElementById('local-path-input').value = '/Users/test/repo';
+    indexModule.handleLocalPathInput();
+
+    expect(errorEl().textContent).toBe('Failed to open directory picker');
+    expect(errorEl().classList.contains('visible')).toBe(true);
+  });
+
+  it('does not dismiss an unrelated info message shown after it', () => {
+    indexModule.showLocalPathUrlError();
+    indexModule.showInfo('local', 'Reusing the existing review');
+    expect(errorEl().dataset.localPathUrlError).toBeUndefined();
+
+    document.getElementById('local-path-input').value = '/Users/test/repo';
+    indexModule.handleLocalPathInput();
+
+    expect(errorEl().textContent).toBe('Reusing the existing review');
+    expect(errorEl().classList.contains('visible')).toBe(true);
+  });
+});
+
+describe('local-path URL detection', () => {
+  it('recognises the built-in hosts without any config', () => {
+    expect(indexModule.isUrlLikeLocalReviewPath('https://github.com/o/r/pull/1')).toBe(true);
+    expect(indexModule.isUrlLikeLocalReviewPath('github.com/o/r/pull/1')).toBe(true);
+    expect(indexModule.isUrlLikeLocalReviewPath('app.graphite.dev/github/o/r/pull/1')).toBe(true);
+    expect(indexModule.isUrlLikeLocalReviewPath('/Users/test/repo')).toBe(false);
+  });
+
+  it('recognises a scheme-less alt-host URL once /api/config supplies its hostname', () => {
+    expect(indexModule.isUrlLikeLocalReviewPath('meteorite.example/o/r/pull/1')).toBe(false);
+
+    indexModule.applyPrHostList({
+      pr_host_list: 'GitHub or Meteorite',
+      pr_url_hostnames: ['github.com', 'meteorite.example']
+    });
+
+    expect(indexModule.isUrlLikeLocalReviewPath('meteorite.example/o/r/pull/1')).toBe(true);
+    expect(indexModule.isUrlLikeLocalReviewPath('METEORITE.EXAMPLE/o/r/pull/1')).toBe(true);
+    // A hostname-shaped directory is still a path.
+    expect(indexModule.isUrlLikeLocalReviewPath('meteorite.example')).toBe(false);
+    expect(indexModule.isUrlLikeLocalReviewPath('/src/meteorite.example/repo')).toBe(false);
+  });
+});

--- a/tests/unit/local-path-input.test.js
+++ b/tests/unit/local-path-input.test.js
@@ -2,10 +2,28 @@
 import { describe, it, expect } from 'vitest';
 
 const {
-  LOCAL_REVIEW_PATH_URL_ERROR,
+  LOCAL_PATH_IS_URL_CODE,
+  localReviewPathUrlError,
   isUrlLikeLocalReviewPath,
-  rejectUrlLikeLocalReviewPath
+  rejectUrlLikeLocalReviewPath,
+  isLocalPathUrlError
 } = require('../../src/utils/local-path-input');
+
+const ALT_HOST_CONFIG = {
+  enable_graphite: true,
+  repos: {
+    'myteam/myproject': {
+      api_host: 'https://api.althost.example/api/v3',
+      links: {
+        external: {
+          name: 'AltHost',
+          label: 'Open on AltHost',
+          url_template: 'https://althost.example/{owner}/{repo}/pull/{number}'
+        }
+      }
+    }
+  }
+};
 
 describe('local path input validation', () => {
   it('detects URL inputs', () => {
@@ -35,6 +53,94 @@ describe('local path input validation', () => {
 
   it('throws a user-facing error for URL inputs', () => {
     expect(() => rejectUrlLikeLocalReviewPath('https://github.com/owner/repo/pull/123'))
-      .toThrow(LOCAL_REVIEW_PATH_URL_ERROR);
+      .toThrow(localReviewPathUrlError());
+  });
+
+  it('stamps a stable error code so callers need not match on message text', () => {
+    let caught = null;
+    try {
+      rejectUrlLikeLocalReviewPath('https://github.com/owner/repo/pull/123', ALT_HOST_CONFIG);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeTruthy();
+    expect(caught.code).toBe(LOCAL_PATH_IS_URL_CODE);
+    expect(isLocalPathUrlError(caught)).toBe(true);
+    expect(isLocalPathUrlError(new Error('Path does not exist: /nope'))).toBe(false);
+    expect(isLocalPathUrlError(null)).toBe(false);
+  });
+
+  describe('host-aware messaging', () => {
+    // Without a config the message must NOT name the built-ins: config-free
+    // callers (parseArgs) would then claim Graphite/alt-host URLs are
+    // unsupported on installs where they are accepted.
+    it('stays host-neutral with no config', () => {
+      expect(localReviewPathUrlError()).toBe(
+        'Local reviews require a filesystem path, not a URL. '
+        + 'Pass PR URLs as PR review inputs instead.'
+      );
+      expect(localReviewPathUrlError(null)).toBe(localReviewPathUrlError());
+    });
+
+    it('names only GitHub for a config with no extra hosts', () => {
+      expect(localReviewPathUrlError({})).toBe(
+        'Local reviews require a filesystem path, not a URL. '
+        + 'Pass GitHub URLs as PR review inputs instead.'
+      );
+    });
+
+    it('names Graphite only when it is enabled', () => {
+      expect(localReviewPathUrlError({ enable_graphite: false }))
+        .toContain('Pass GitHub URLs');
+      expect(localReviewPathUrlError({ enable_graphite: true }))
+        .toContain('Pass GitHub or Graphite URLs');
+    });
+
+    it('names configured alt hosts', () => {
+      expect(localReviewPathUrlError(ALT_HOST_CONFIG))
+        .toContain('Pass GitHub, Graphite, or AltHost URLs');
+    });
+  });
+
+  describe('alt-host URL detection', () => {
+    it('does not recognise a scheme-less alt-host URL without config', () => {
+      expect(isUrlLikeLocalReviewPath('althost.example/myteam/myproject/pull/42')).toBe(false);
+    });
+
+    it('recognises the alt host web domain from links.external.url_template', () => {
+      expect(isUrlLikeLocalReviewPath('althost.example/myteam/myproject/pull/42', ALT_HOST_CONFIG))
+        .toBe(true);
+    });
+
+    it('recognises the alt host api domain from api_host', () => {
+      expect(isUrlLikeLocalReviewPath('api.althost.example/api/v3/repos/x', ALT_HOST_CONFIG))
+        .toBe(true);
+    });
+
+    it('is case-insensitive on the hostname', () => {
+      expect(isUrlLikeLocalReviewPath('AltHost.Example/myteam/myproject/pull/42', ALT_HOST_CONFIG))
+        .toBe(true);
+    });
+
+    it('still treats a hostname-shaped directory name as a path', () => {
+      expect(isUrlLikeLocalReviewPath('althost.example', ALT_HOST_CONFIG)).toBe(false);
+      expect(isUrlLikeLocalReviewPath('/src/althost.example/repo', ALT_HOST_CONFIG)).toBe(false);
+    });
+
+    // `api_host` is only validated as a non-empty string, so a bare hostname
+    // (no scheme) is a supported configuration and must still be detected.
+    it('recognises a scheme-less api_host', () => {
+      const config = { repos: { 'owner/repo': { api_host: 'ghe.example.com' } } };
+      expect(isUrlLikeLocalReviewPath('ghe.example.com/owner/repo/pull/1', config)).toBe(true);
+    });
+
+    // A user pastes the host with its port; URL.hostname alone would drop it.
+    it('recognises an alt host pasted with its port', () => {
+      const config = {
+        repos: { 'owner/repo': { api_host: 'https://ghe.example.com:8443/api/v3' } }
+      };
+      expect(isUrlLikeLocalReviewPath('ghe.example.com:8443/owner/repo/pull/1', config)).toBe(true);
+      expect(isUrlLikeLocalReviewPath('ghe.example.com/owner/repo/pull/1', config)).toBe(true);
+    });
   });
 });


### PR DESCRIPTION
## Why

The landing-page PR input, its validation errors, and the local-review "that's a URL, not a path" error hardcoded **"GitHub or Graphite"**. That copy was wrong in two directions:

- It named Graphite even though `enable_graphite` **defaults to `false`** — so a default install advertised a feature the user had not enabled.
- It could not name an alt host configured per `docs/alt-host.md`, leaving downstream packagers to patch the shipped strings. A real example: a Nix overlay using `substituteInPlace --replace-fail` on five literals across four files, which hard-fails the build the moment any of that copy is rephrased upstream.

Notably, alt-host support already *worked* — URL parsing is server-side and honours `url_pattern`. Only the copy was lying.

## What

New `src/links/host-names.js` derives the list from config: **GitHub** always, **Graphite** only when `enable_graphite` is true, then each distinct `repos[*].links.external.name` for repos that also set `api_host`.

`GET /api/config` publishes `pr_host_names` (array), `pr_host_list` (pre-joined), and `pr_url_hostnames`. The Oxford-comma formatting lives server-side only, so client copy cannot drift from the identically-worded server errors. Static markup ships host-neutral and is upgraded once config resolves — nothing flashes a host list the install does not support.

With `enable_graphite: true` and an alt host named `Meteorite`, the input reads `Enter GitHub, Graphite, or Meteorite PR URL`. A default install reads `Enter GitHub PR URL`.

### Related fixes

- **Scheme-less alt-host URLs** are recognised in the local-path input, derived from each alt host's `api_host` and `links.external.url_template`. Covers a scheme-less `api_host` (`ghe.example.com`) and an explicit port (`ghe.example.com:8443/...`) — `URL.hostname` alone misses both.
- **`pair-review --local <alt-host URL>` is re-checked once config is loaded.** `parseArgs()` is config-free, so the instruction-handoff, headless-delegated, and headless-local branches previously resolved a scheme-less alt-host URL as a directory name and failed with a git-root error.
- **The "that's a URL" error carries a stable `code`** (`LOCAL_PATH_IS_URL`). Callers that compared its message text — which now varies per install — branch on the code instead.
- **No-config paths are host-neutral** ("Pass PR URLs as PR review inputs instead") rather than naming GitHub alone and implying alt-host URLs are unsupported.
- **The client's "showing the URL error" marker is cleared by every writer** of that element. The old text comparison was self-correcting; a flag is not, so an unrelated error (a failed directory picker) could be dismissed by the next keystroke.
- **`enable_graphite`'s description** in Global Settings, the README, and the config defaults now mentions that the flag also controls whether Graphite is *named* in the PR URL prompts. It does not gate acceptance — Graphite URLs parse either way.

## Both modes

PR mode (landing input, `/api/parse-pr-url` 400) and Local mode (local-path error, CLI `--local` guard) are both covered.

## Hazards

`rejectUrlLikeLocalReviewPath` gained a `config` parameter and has six callers: `main.js` (config-free by design), `local-review.js`, `single-port.js`, `routes/local.js`, `routes/setup.js`, `setup/local-setup.js`. All updated.

`setup/local-setup.js` compared the error by message identity; that comparison silently degrades to "Path does not exist" once the message is dynamic. Switched to the error code.

`handleLocalReview` now calls `loadConfig()` before path validation. The first-run welcome still waits until after validation.

`setFormLoading` is a sixth writer of the local error element. Verified unreachable for that tab (its clearing branch runs only when `loading` is true, and `setFormLoading('local', true)` is never called), so it is left unguarded.

## Testing

- **9,599 unit + integration pass.** New: `tests/unit/host-names.test.js`, `tests/unit/index-pr-host-list.test.js` (jsdom, loading the real IIFE), `tests/integration/local-path-url-guard.test.js` (CLI-level regression for the config-aware guard), plus extensions to `local-path-input.test.js`, `index-open-analyze-buttons.test.js`, and two `/api/parse-pr-url` 400-body assertions in `routes.test.js`.
- The 3 `tests/integration/first-run.test.js` failures are **pre-existing locally** and unrelated — a gitignored `.pair-review/config.local.json` sets `single_port: false` against a dev server on 7247. They fail identically on clean `main`.
- **E2E: 15/15** across `local-start`, `help-modal`, and `repo-links`.

## Follow-up (not in this PR)

`tests/integration/headless-json-error.test.js:25` spawns the CLI with `cwd: REPO_ROOT`, which merges this repo's gitignored `.pair-review/config.local.json` into the child. It passes today only because it asserts nothing config-derived. The new guard test works around the same trap by spawning from a temp HOME; that file deserves the same treatment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)