### PR TITLE
feat: add OMP (Oh My Pi) chat provider

### DIFF
--- a/.changeset/add-omp-chat-provider.md
+++ b/.changeset/add-omp-chat-provider.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": minor
+---
+
+Add OMP (Oh My Pi) as a chat provider. OMP speaks Pi's RPC protocol via `omp --mode rpc`, so chat sessions (including resumption) work like Pi's, with OMP's CLI differences handled: session resumption via `--resume`, OMP's tool names (`read,bash,grep,glob`), a default `omp` command overridable via `PAIR_REVIEW_OMP_CMD` or `chat_providers.omp.command`, and no Pi-specific task extension.

--- a/README.md
+++ b/README.md
@@ -720,7 +720,7 @@ You can override provider settings and define custom models in your config file.
 | `env` | Environment variables to set when running the CLI |
 | `installInstructions` | Custom installation instructions shown in UI |
 | `availability_timeout_seconds` | Seconds to allow for the startup availability probe before the provider is reported unavailable (default `10`). Raise it for providers whose check runs a slow build/compile step. Also supported per chat provider under `chat_providers.<id>`. |
-| `availability_command` | Command run to decide availability. Executable providers default to always-available when omitted; chat providers fall back to `<command> --version` (or, for the built-in Pi, the cached AI-provider status). Pair with `availability_timeout_seconds` when the probe runs a slow build. |
+| `availability_command` | Command run to decide availability. Executable providers default to always-available when omitted; chat providers fall back to `<command> --version` (or, for the built-in Pi and OMP, the cached AI-provider status). Pair with `availability_timeout_seconds` when the probe runs a slow build. |
 | `advisor` | OMP only. Set to `true` to enable OMP's advisor runtime during analysis (`--advisor`). Defaults to `false`: pair-review disables the advisor via a bundled config overlay, even when it is enabled in your global OMP configuration. |
 | `models` | Array of model definitions (see below) |
 | `default_model` | Model `id` to use as the provider's default (in the picker and when no model is specified). Preferred over the per-model `default: true` flag. If it names an unknown or disabled model, the provider falls back to automatic selection. |
@@ -834,6 +834,8 @@ npm install -g @mariozechner/pi-coding-agent
 
 Configure your preferred models in `providers.pi.models` — see [AI Provider Configuration](#ai-provider-configuration) for details. Everything else in pair-review works without Pi installed.
 
+[OMP (Oh My Pi)](https://github.com/can1357/oh-my-pi), a fork of Pi, is also available as a chat provider (`omp`) — it speaks the same RPC protocol through the `omp` CLI (`npm install -g @oh-my-pi/pi-coding-agent`) and uses whatever model your OMP configuration selects (set a chat model via `chat_providers.omp.model`; values are passed to `omp --model`, which fuzzy-matches). Unlike Pi chat, OMP chat does not load pair-review's task extension for subagent delegation.
+
 **Chat provider command overrides:** To customize CLI commands for chat providers (e.g., to use a wrapper script), use the `chat_providers` config key:
 
 ```json
@@ -846,7 +848,7 @@ Configure your preferred models in `providers.pi.models` — see [AI Provider Co
 }
 ```
 
-Available chat provider IDs: `pi`, `claude`, `codex`, `copilot-acp`, `opencode-acp`, `cursor-acp`. Each supports `command`, `args` (replaces defaults), `extra_args` (appends), and `env` overrides. Codex chat also supports `sandbox`: use `workspace-write` by default, or `read-only` for discussion-only sessions. (Antigravity and Muse are analysis-only providers — neither CLI has an ACP mode, so there are no Antigravity or Muse chat providers.)
+Available chat provider IDs: `pi`, `omp`, `claude`, `codex`, `copilot-acp`, `opencode-acp`, `cursor-acp`. Each supports `command`, `args` (replaces defaults; for `pi` and `omp` there are no default args — supplied args are appended after the generated RPC flags, so use a multi-word `command` like `"devx omp"` for wrappers rather than `args`), `extra_args` (appends), and `env` overrides. Codex chat also supports `sandbox`: use `workspace-write` by default, or `read-only` for discussion-only sessions. (Antigravity and Muse are analysis-only providers — neither CLI has an ACP mode, so there are no Antigravity or Muse chat providers.)
 
 **Keyboard shortcut:** Press `p` then `c` to toggle the chat panel.
 

--- a/config.example.json
+++ b/config.example.json
@@ -317,7 +317,7 @@
   },
 
   "chat_providers": {
-    "_comment": "Chat provider command overrides. Separate from 'providers' (AI analysis). Chat providers are: pi, claude, codex, copilot-acp, opencode-acp, cursor-acp. Supports 'command', 'args' (replaces defaults), 'extra_args' (appends), 'env', 'load_skills' (Pi: false suppresses skill auto-discovery), and 'app_extensions' (Pi: false omits pair-review task extension) overrides. Codex also supports 'sandbox' ('workspace-write' or 'read-only'). 'availability_command' overrides the startup availability probe and 'availability_timeout_seconds' bounds it (default 10; raise for slow build commands).",
+    "_comment": "Chat provider command overrides. Separate from 'providers' (AI analysis). Chat providers are: pi, omp, claude, codex, copilot-acp, opencode-acp, cursor-acp. Supports 'command', 'args' (replaces defaults), 'extra_args' (appends), 'env', 'load_skills' (Pi/OMP: false suppresses skill auto-discovery), and 'app_extensions' (Pi: false omits pair-review task extension; OMP never loads it) overrides. Codex also supports 'sandbox' ('workspace-write' or 'read-only'). 'availability_command' overrides the startup availability probe and 'availability_timeout_seconds' bounds it (default 10; raise for slow build commands).",
     "claude": {
       "_comment": "Example: use a wrapper script for Claude chat",
       "command": "claude"

--- a/src/chat/chat-providers.js
+++ b/src/chat/chat-providers.js
@@ -2,8 +2,8 @@
 /**
  * Chat Provider Registry
  *
- * Defines named chat providers (Pi, Copilot, OpenCode, Claude, Codex, Cursor) with their
- * default commands/args, config overrides, and availability checks.
+ * Defines named chat providers (Pi, OMP, Copilot, OpenCode, Claude, Codex, Cursor) with
+ * their default commands/args, config overrides, and availability checks.
  */
 
 const { spawn } = require('child_process');
@@ -23,6 +23,17 @@ const CHAT_PROVIDERS = {
     id: 'pi',
     name: 'Pi (RPC)',
     type: 'pi',
+  },
+  // OMP (Oh My Pi) is a Pi fork that speaks the same RPC protocol with a
+  // slightly different CLI surface (see OmpBridge). Like the built-in Pi
+  // definition, `command` is intentionally omitted: OmpBridge resolves its own
+  // default at runtime, and the availability check delegates to the AI
+  // provider's cached probe (which honors PAIR_REVIEW_OMP_CMD and
+  // providers.omp.command).
+  omp: {
+    id: 'omp',
+    name: 'OMP (RPC)',
+    type: 'omp',
   },
   'copilot-acp': {
     id: 'copilot-acp',
@@ -206,6 +217,16 @@ function isAcpProvider(id) {
 }
 
 /**
+ * Check if a provider ID corresponds to an OMP (Oh My Pi) provider.
+ * @param {string} id
+ * @returns {boolean}
+ */
+function isOmpProvider(id) {
+  const provider = getChatProvider(id);
+  return provider?.type === 'omp';
+}
+
+/**
  * Check if a provider ID corresponds to a Claude Code provider.
  * @param {string} id
  * @returns {boolean}
@@ -262,15 +283,16 @@ async function checkChatProviderAvailability(id, _deps) {
     });
   }
 
-  // Delegate to the AI provider's cached availability only for the built-in Pi
-  // chat provider with no command override — i.e. the same binary the AI
-  // provider already probed. The built-in `pi` definition intentionally omits
-  // `command` (PiBridge resolves its own default at runtime), so `!provider.command`
-  // cleanly distinguishes it. Custom `type: 'pi'` providers and built-in Pi
-  // overridden with a different `command` point at a different binary, so they
-  // fall through to the `<command> --version` probe below (which honors `timeout`).
-  if (provider.type === 'pi' && !provider.command) {
-    const cached = getCachedAvailability('pi');
+  // Delegate to the AI provider's cached availability only for the built-in
+  // Pi/OMP chat providers with no command override — i.e. the same binary the
+  // AI provider already probed. The built-in `pi`/`omp` definitions
+  // intentionally omit `command` (PiBridge/OmpBridge resolve their own default
+  // at runtime), so `!provider.command` cleanly distinguishes them. Custom
+  // `type: 'pi'`/`type: 'omp'` providers and built-ins overridden with a
+  // different `command` point at a different binary, so they fall through to
+  // the `<command> --version` probe below (which honors `timeout`).
+  if ((provider.type === 'pi' || provider.type === 'omp') && !provider.command) {
+    const cached = getCachedAvailability(provider.type);
     return { available: cached?.available || false, error: cached?.error };
   }
 
@@ -402,6 +424,7 @@ module.exports = {
   getChatProvider,
   getAllChatProviders,
   isAcpProvider,
+  isOmpProvider,
   isClaudeCodeProvider,
   isCodexProvider,
   checkChatProviderAvailability,

--- a/src/chat/omp-bridge.js
+++ b/src/chat/omp-bridge.js
@@ -1,0 +1,111 @@
+// Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+/**
+ * OMP (Oh My Pi) RPC Bridge
+ *
+ * Manages a long-lived OMP process in RPC mode for interactive chat sessions.
+ * OMP is a fork of the Pi coding agent and speaks the same JSONL RPC protocol
+ * (`--mode rpc`, prompt/abort/get_state commands, message_update/agent_end
+ * events, and a get_state response containing `sessionFile`), so all process
+ * lifecycle and event handling is inherited from PiBridge.
+ *
+ * This subclass covers OMP's CLI surface differences:
+ * - Default command is `omp` (override via PAIR_REVIEW_OMP_CMD or config).
+ * - Session resumption uses `--resume <path>` — OMP has no `--session` flag.
+ * - Default tool set is read,grep,glob: OMP's file-listing tool is `glob`
+ *   (no find/ls), and OMP errors on unknown tool names in --tools.
+ * - No per-file `--skill` flag (OMP's `--skills` is a glob filter with
+ *   different semantics), so the skills option is not supported.
+ * - OMP's `autoResume` setting reopens the most recent session in the cwd
+ *   when no session flag is passed, so new chats must explicitly request a
+ *   fresh session via the `new_session` RPC command before session discovery.
+ */
+
+const PiBridge = require('./pi-bridge');
+const logger = require('../utils/logger');
+
+class OmpBridge extends PiBridge {
+  /**
+   * @param {Object} options - Same options as PiBridge, except:
+   * @param {string} [options.piCommand] - Override OMP command (default: 'omp')
+   * @param {string} [options.tools] - Comma-separated tool list (default: 'read,grep,glob')
+   * @param {string[]} [options.skills] - Not supported by OMP; ignored with a warning
+   */
+  constructor(options = {}) {
+    // OMP has no per-file --skill flag; drop skills so the inherited
+    // _buildArgs never emits an unsupported flag.
+    if (options.skills?.length) {
+      logger.warn('[OmpBridge] OMP does not support per-file skill loading; ignoring skills option');
+    }
+    super({ ...options, skills: [] });
+
+    // Command precedence mirrors PiBridge: explicit option > env > default.
+    // The PiBridge constructor already consulted PAIR_REVIEW_PI_CMD, so an
+    // absent option must be re-resolved against the OMP equivalents here.
+    this.piCommand = options.piCommand || process.env.PAIR_REVIEW_OMP_CMD || 'omp';
+    this.useShell = options.useShell || this.piCommand.includes(' ');
+    this.tools = options.tools || 'read,grep,glob';
+
+    this.logName = 'OmpBridge';
+    this.cliName = 'OMP';
+    this.sessionFlag = '--resume';
+  }
+
+  /**
+   * No sessionPath means this is a new chat. Launching OMP without a session
+   * flag would let its `autoResume` setting reopen the user's most recent
+   * transcript in this cwd — and pair-review would then persist that file as
+   * the chat's session, appending unrelated history. Request a fresh session
+   * explicitly before discovering the file to persist.
+   * @returns {Promise<void>}
+   */
+  async _querySessionFile() {
+    if (!this.sessionPath) {
+      await this._requestNewSession();
+    }
+    return super._querySessionFile();
+  }
+
+  /**
+   * Send the `new_session` RPC command and wait for its response.
+   * Resolves regardless of outcome — a timeout or write failure must never
+   * wedge chat startup; the worst case is falling back to OMP's default
+   * session behavior.
+   * @returns {Promise<void>}
+   */
+  _requestNewSession() {
+    if (!this.isReady()) return Promise.resolve();
+
+    return new Promise((resolve) => {
+      let timeout;
+      this._pendingCallbacks.set('new_session', (event) => {
+        clearTimeout(timeout);
+        if (event.success) {
+          logger.debug(`[${this.logName}] Started fresh session via new_session`);
+        } else {
+          logger.warn(`[${this.logName}] new_session failed: ${event.error || 'unknown error'}`);
+        }
+        resolve();
+      });
+
+      timeout = setTimeout(() => {
+        if (this._pendingCallbacks.has('new_session')) {
+          this._pendingCallbacks.delete('new_session');
+          logger.debug(`[${this.logName}] new_session timed out`);
+          resolve();
+        }
+      }, 5000);
+      if (timeout.unref) timeout.unref();
+
+      try {
+        this._write(JSON.stringify({ type: 'new_session' }));
+      } catch (err) {
+        clearTimeout(timeout);
+        this._pendingCallbacks.delete('new_session');
+        logger.debug(`[${this.logName}] Failed to send new_session: ${err.message}`);
+        resolve();
+      }
+    });
+  }
+}
+
+module.exports = OmpBridge;

--- a/src/chat/pi-bridge.js
+++ b/src/chat/pi-bridge.js
@@ -55,6 +55,14 @@ class PiBridge extends EventEmitter {
     this.sessionPath = options.sessionPath || null;
     this.loadSkills = options.loadSkills !== false;
 
+    // Subclass hooks (see OmpBridge): log prefix, human-readable CLI name for
+    // error messages, and the flag used to resume from a session file. OMP is
+    // a Pi fork that speaks the same RPC protocol but resumes via --resume
+    // (it has no --session flag).
+    this.logName = 'PiBridge';
+    this.cliName = 'Pi';
+    this.sessionFlag = '--session';
+
     this._process = null;
     this._readline = null;
     this._ready = false;
@@ -73,7 +81,7 @@ class PiBridge extends EventEmitter {
    */
   async start() {
     if (this._process) {
-      throw new Error('PiBridge already started');
+      throw new Error(`${this.logName} already started`);
     }
 
     const args = this._buildArgs();
@@ -84,7 +92,7 @@ class PiBridge extends EventEmitter {
     const spawnCmd = useShell ? `${command} ${quoteShellArgs(args).join(' ')}` : command;
     const spawnArgs = useShell ? [] : args;
 
-    logger.info(`[PiBridge] Starting Pi RPC: ${command} ${args.join(' ')}`);
+    logger.info(`[${this.logName}] Starting ${this.cliName} RPC: ${command} ${args.join(' ')}`);
 
     return new Promise((resolve, reject) => {
       const proc = spawn(spawnCmd, spawnArgs, {
@@ -100,9 +108,9 @@ class PiBridge extends EventEmitter {
       proc.on('error', (err) => {
         if (!this._ready) {
           this._ready = false;
-          reject(new Error(`Failed to start Pi RPC: ${err.message}`));
+          reject(new Error(`Failed to start ${this.cliName} RPC: ${err.message}`));
         } else {
-          logger.error(`[PiBridge] Process error: ${err.message}`);
+          logger.error(`[${this.logName}] Process error: ${err.message}`);
           this.emit('error', { error: err });
         }
       });
@@ -114,14 +122,14 @@ class PiBridge extends EventEmitter {
         this._process = null;
 
         if (!wasReady && !this._closing) {
-          reject(new Error(`Pi RPC exited before ready (code=${code}, signal=${signal})`));
+          reject(new Error(`${this.cliName} RPC exited before ready (code=${code}, signal=${signal})`));
         }
 
         if (!this._closing) {
-          logger.warn(`[PiBridge] Process exited unexpectedly (code=${code}, signal=${signal})`);
-          this.emit('error', { error: new Error(`Pi process exited (code=${code}, signal=${signal})`) });
+          logger.warn(`[${this.logName}] Process exited unexpectedly (code=${code}, signal=${signal})`);
+          this.emit('error', { error: new Error(`${this.cliName} process exited (code=${code}, signal=${signal})`) });
         } else {
-          logger.info(`[PiBridge] Process exited (code=${code}, signal=${signal})`);
+          logger.info(`[${this.logName}] Process exited (code=${code}, signal=${signal})`);
         }
 
         this.emit('close');
@@ -131,7 +139,7 @@ class PiBridge extends EventEmitter {
       proc.stderr.on('data', (data) => {
         const text = data.toString().trim();
         if (text) {
-          logger.debug(`[PiBridge] stderr: ${text}`);
+          logger.debug(`[${this.logName}] stderr: ${text}`);
         }
       });
 
@@ -147,7 +155,7 @@ class PiBridge extends EventEmitter {
 
       // Handle stdin errors (e.g., EPIPE if process dies)
       proc.stdin.on('error', (err) => {
-        logger.error(`[PiBridge] stdin error: ${err.message}`);
+        logger.error(`[${this.logName}] stdin error: ${err.message}`);
       });
 
       // Pi RPC doesn't emit a specific "ready" event, so we consider it ready
@@ -156,7 +164,7 @@ class PiBridge extends EventEmitter {
       setImmediate(() => {
         if (this._process && !this._ready) {
           this._ready = true;
-          logger.info(`[PiBridge] Ready (PID ${proc.pid})`);
+          logger.info(`[${this.logName}] Ready (PID ${proc.pid})`);
           this.emit('ready');
           resolve();
         }
@@ -171,7 +179,7 @@ class PiBridge extends EventEmitter {
    */
   async sendMessage(content) {
     if (!this.isReady()) {
-      throw new Error('PiBridge is not ready');
+      throw new Error(`${this.logName} is not ready`);
     }
 
     // Reset accumulated text for this new turn
@@ -179,9 +187,9 @@ class PiBridge extends EventEmitter {
     this._inMessage = false;
 
     const command = JSON.stringify({ type: 'prompt', message: content });
-    logger.debug(`[PiBridge] Sending prompt (${content.length} chars): ${content.substring(0, 100)}${content.length > 100 ? '...' : ''}`);
+    logger.debug(`[${this.logName}] Sending prompt (${content.length} chars): ${content.substring(0, 100)}${content.length > 100 ? '...' : ''}`);
     this._write(command);
-    logger.debug(`[PiBridge] Prompt written to stdin (${command.length} bytes)`);
+    logger.debug(`[${this.logName}] Prompt written to stdin (${command.length} bytes)`);
   }
 
   /**
@@ -190,7 +198,7 @@ class PiBridge extends EventEmitter {
   abort() {
     if (!this.isReady()) return;
     const command = JSON.stringify({ type: 'abort' });
-    logger.debug('[PiBridge] Sending abort');
+    logger.debug(`[${this.logName}] Sending abort`);
     this._write(command);
   }
 
@@ -222,7 +230,7 @@ class PiBridge extends EventEmitter {
       // Give the process a moment to exit gracefully, then force kill
       const killTimeout = setTimeout(() => {
         if (this._process) {
-          logger.warn('[PiBridge] Force killing process');
+          logger.warn(`[${this.logName}] Force killing process`);
           this._process.kill('SIGKILL');
         }
       }, 3000);
@@ -267,7 +275,7 @@ class PiBridge extends EventEmitter {
     const args = ['--mode', 'rpc', '--tools', this.tools];
 
     if (this.sessionPath) {
-      args.push('--session', this.sessionPath);
+      args.push(this.sessionFlag, this.sessionPath);
     }
 
     if (this.provider) {
@@ -326,9 +334,9 @@ class PiBridge extends EventEmitter {
         if (event.success && event.data && event.data.sessionFile) {
           this.sessionPath = event.data.sessionFile;
           this.emit('session', { sessionFile: event.data.sessionFile });
-          logger.info(`[PiBridge] Discovered session file: ${event.data.sessionFile}`);
+          logger.info(`[${this.logName}] Discovered session file: ${event.data.sessionFile}`);
         } else {
-          logger.debug('[PiBridge] get_state did not return a sessionFile');
+          logger.debug(`[${this.logName}] get_state did not return a sessionFile`);
         }
         resolve();
       });
@@ -337,7 +345,7 @@ class PiBridge extends EventEmitter {
       timeout = setTimeout(() => {
         if (this._pendingCallbacks.has('get_state')) {
           this._pendingCallbacks.delete('get_state');
-          logger.debug('[PiBridge] get_state timed out');
+          logger.debug(`[${this.logName}] get_state timed out`);
           resolve();
         }
       }, 5000);
@@ -348,7 +356,7 @@ class PiBridge extends EventEmitter {
         this._write(JSON.stringify({ type: 'get_state' }));
       } catch (err) {
         this._pendingCallbacks.delete('get_state');
-        logger.debug(`[PiBridge] Failed to send get_state: ${err.message}`);
+        logger.debug(`[${this.logName}] Failed to send get_state: ${err.message}`);
         resolve();
       }
     });
@@ -360,7 +368,7 @@ class PiBridge extends EventEmitter {
    */
   _write(jsonLine) {
     if (!this._process || !this._process.stdin.writable) {
-      throw new Error('Pi RPC process stdin is not writable');
+      throw new Error(`${this.cliName} RPC process stdin is not writable`);
     }
     this._process.stdin.write(jsonLine + '\n');
   }
@@ -376,7 +384,7 @@ class PiBridge extends EventEmitter {
     try {
       event = JSON.parse(line);
     } catch {
-      logger.debug(`[PiBridge] Ignoring unparseable line: ${line.substring(0, 100)}`);
+      logger.debug(`[${this.logName}] Ignoring unparseable line: ${line.substring(0, 100)}`);
       return;
     }
 
@@ -438,24 +446,24 @@ class PiBridge extends EventEmitter {
           this._pendingCallbacks.delete(event.command);
           callback(event);
         } else if (!event.success) {
-          logger.error(`[PiBridge] Command failed: ${event.error}`);
+          logger.error(`[${this.logName}] Command failed: ${event.error}`);
           this.emit('error', { error: new Error(event.error || 'Unknown command error') });
         } else {
-          logger.debug(`[PiBridge] Command acknowledged: ${JSON.stringify(event).substring(0, 200)}`);
+          logger.debug(`[${this.logName}] Command acknowledged: ${JSON.stringify(event).substring(0, 200)}`);
         }
         break;
 
       case 'agent_start':
       case 'turn_start':
-        logger.debug(`[PiBridge] ${type}`);
+        logger.debug(`[${this.logName}] ${type}`);
         this.emit('status', { status: 'working' });
         break;
       case 'turn_end':
-        logger.debug(`[PiBridge] ${type}`);
+        logger.debug(`[${this.logName}] ${type}`);
         this.emit('status', { status: 'turn_complete' });
         break;
       case 'session':
-        logger.debug(`[PiBridge] ${type}: ${JSON.stringify(event).substring(0, 200)}`);
+        logger.debug(`[${this.logName}] ${type}: ${JSON.stringify(event).substring(0, 200)}`);
         if (event.sessionFile) {
           this.sessionPath = event.sessionFile;
         }
@@ -463,7 +471,7 @@ class PiBridge extends EventEmitter {
         break;
 
       default:
-        logger.debug(`[PiBridge] Unhandled event type: ${type}`);
+        logger.debug(`[${this.logName}] Unhandled event type: ${type}`);
     }
   }
 
@@ -512,12 +520,12 @@ class PiBridge extends EventEmitter {
         break;
       case 'error': {
         const errorMsg = assistantEvent.error || assistantEvent.delta || 'Unknown streaming error';
-        logger.error(`[PiBridge] Streaming error: ${errorMsg}`);
+        logger.error(`[${this.logName}] Streaming error: ${errorMsg}`);
         this.emit('error', { error: new Error(errorMsg) });
         break;
       }
       default:
-        logger.debug(`[PiBridge] Unhandled assistantMessageEvent type: ${assistantEvent.type}`);
+        logger.debug(`[${this.logName}] Unhandled assistantMessageEvent type: ${assistantEvent.type}`);
     }
   }
 
@@ -531,7 +539,7 @@ class PiBridge extends EventEmitter {
     this._accumulatedText = '';
     this._inMessage = false;
 
-    logger.debug(`[PiBridge] Agent ended, accumulated ${fullText.length} chars`);
+    logger.debug(`[${this.logName}] Agent ended, accumulated ${fullText.length} chars`);
     this.emit('complete', { fullText });
   }
 
@@ -546,7 +554,7 @@ class PiBridge extends EventEmitter {
     const id = event.id;
 
     if (DIALOG_METHODS.has(method) && id) {
-      logger.debug(`[PiBridge] Auto-cancelling dialog: ${method} (${id})`);
+      logger.debug(`[${this.logName}] Auto-cancelling dialog: ${method} (${id})`);
       // Respond with cancellation
       const response = JSON.stringify({
         type: 'extension_ui_response',
@@ -559,7 +567,7 @@ class PiBridge extends EventEmitter {
         // Process may be dead
       }
     } else {
-      logger.debug(`[PiBridge] Ignoring extension_ui_request: ${method}`);
+      logger.debug(`[${this.logName}] Ignoring extension_ui_request: ${method}`);
     }
   }
 }

--- a/src/chat/session-manager.js
+++ b/src/chat/session-manager.js
@@ -10,15 +10,20 @@
 const fs = require('fs');
 const path = require('path');
 const PiBridge = require('./pi-bridge');
+const OmpBridge = require('./omp-bridge');
 const AcpBridge = require('./acp-bridge');
 const ClaudeCodeBridge = require('./claude-code-bridge');
 const CodexBridge = require('./codex-bridge');
-const { getChatProvider, isAcpProvider, isClaudeCodeProvider, isCodexProvider, applyConfigOverrides: applyChatConfigOverrides } = require('./chat-providers');
+const { getChatProvider, isAcpProvider, isOmpProvider, isClaudeCodeProvider, isCodexProvider, applyConfigOverrides: applyChatConfigOverrides } = require('./chat-providers');
 const logger = require('../utils/logger');
 
 const taskExtensionDir = path.resolve(__dirname, '../../.pi/extensions/task');
 
 const CHAT_TOOLS = 'read,bash,grep,find,ls';
+
+// OMP's tool names differ from Pi's: file listing is `glob` (no find/ls), and
+// OMP errors on unknown tool names in --tools, so the Pi list cannot be reused.
+const OMP_CHAT_TOOLS = 'read,bash,grep,glob';
 
 class ChatSessionManager {
   /**
@@ -435,7 +440,7 @@ class ChatSessionManager {
     const usesOpaqueSessionId = isAcp || isClaudeCode;
 
     if (!usesOpaqueSessionId && !isCodex) {
-      // Pi sessions require a session file on disk
+      // Pi/OMP sessions require a session file on disk
       if (!row.agent_session_id) {
         throw new Error(`Session ${sessionId} has no session file — cannot resume`);
       }
@@ -536,11 +541,13 @@ class ChatSessionManager {
 
   /**
    * Create the appropriate bridge instance for a provider.
-   * ACP providers get an AcpBridge; everything else gets a PiBridge with tools/skills.
+   * ACP providers get an AcpBridge, Claude gets a ClaudeCodeBridge, Codex gets
+   * a CodexBridge, OMP gets an OmpBridge; everything else gets a PiBridge with
+   * tools/skills.
    * @param {string} provider
    * @param {Object} options - Bridge constructor options
    * @param {Object} [providerDef] - Pre-resolved provider definition (avoids redundant getChatProvider calls)
-   * @returns {PiBridge|AcpBridge}
+   * @returns {PiBridge|OmpBridge|AcpBridge|ClaudeCodeBridge|CodexBridge}
    */
   _createBridge(provider, options, providerDef) {
     const def = providerDef || getChatProvider(provider);
@@ -572,6 +579,25 @@ class ChatSessionManager {
         env: def?.env,
         useShell: def?.useShell,
         sandbox: def?.sandbox,
+      });
+    }
+    if (isOmpProvider(provider)) {
+      // OMP — same RPC protocol as Pi, so the option mapping below mirrors the
+      // Pi branch (see its comments), with two OMP-specific differences:
+      // - Tools: OMP_CHAT_TOOLS (OMP rejects Pi's find/ls tool names).
+      // - No task extension: pair-review's bundled extension is Pi-specific
+      //   (it spawns `pi` subagents via PI_CMD), matching the AI provider,
+      //   which also omits it for OMP.
+      return new OmpBridge({
+        ...options,
+        provider: def?.provider || null,
+        model: options.model || def?.model,
+        piCommand: def?.command,
+        extraArgs: def?.args,
+        env: def?.env,
+        useShell: def?.useShell,
+        tools: OMP_CHAT_TOOLS,
+        loadSkills: options.loadSkills ?? def?.load_skills,
       });
     }
     // Pi provider — resolve config overrides (command, model, env) from provider def.

--- a/tests/unit/chat/chat-providers.test.js
+++ b/tests/unit/chat/chat-providers.test.js
@@ -25,6 +25,7 @@ const {
   getChatProvider,
   getAllChatProviders,
   isAcpProvider,
+  isOmpProvider,
   isClaudeCodeProvider,
   isCodexProvider,
   checkChatProviderAvailability,
@@ -51,6 +52,15 @@ describe('chat-providers', () => {
     it('should return pi provider', () => {
       const pi = getChatProvider('pi');
       expect(pi).toEqual({ id: 'pi', name: 'Pi (RPC)', type: 'pi' });
+    });
+
+    it('should return omp provider with no default command', () => {
+      const provider = getChatProvider('omp');
+      expect(provider).toEqual({
+        id: 'omp',
+        name: 'OMP (RPC)',
+        type: 'omp',
+      });
     });
 
     it('should return copilot-acp provider with correct defaults', () => {
@@ -291,11 +301,12 @@ describe('chat-providers', () => {
   });
 
   describe('getAllChatProviders', () => {
-    it('should return all six providers', () => {
+    it('should return all seven providers', () => {
       const providers = getAllChatProviders();
-      expect(providers).toHaveLength(6);
+      expect(providers).toHaveLength(7);
       const ids = providers.map(p => p.id);
       expect(ids).toContain('pi');
+      expect(ids).toContain('omp');
       expect(ids).toContain('copilot-acp');
       expect(ids).toContain('opencode-acp');
       expect(ids).toContain('cursor-acp');
@@ -340,6 +351,29 @@ describe('chat-providers', () => {
 
     it('should return false for codex', () => {
       expect(isAcpProvider('codex')).toBe(false);
+    });
+  });
+
+  describe('isOmpProvider', () => {
+    it('should return true for omp', () => {
+      expect(isOmpProvider('omp')).toBe(true);
+    });
+
+    it('should return false for pi', () => {
+      expect(isOmpProvider('pi')).toBe(false);
+    });
+
+    it('should return false for ACP providers', () => {
+      expect(isOmpProvider('copilot-acp')).toBe(false);
+    });
+
+    it('should return false for unknown provider', () => {
+      expect(isOmpProvider('unknown')).toBe(false);
+    });
+
+    it('should return true for a custom type:omp provider from config', () => {
+      applyConfigOverrides({ 'my-omp': { type: 'omp', command: '/opt/omp' } });
+      expect(isOmpProvider('my-omp')).toBe(true);
     });
   });
 
@@ -392,6 +426,36 @@ describe('chat-providers', () => {
       mockGetCachedAvailability.mockReturnValue(null);
       const result = await checkChatProviderAvailability('pi');
       expect(result).toEqual({ available: false, error: undefined });
+    });
+
+    it('should delegate to getCachedAvailability for omp', async () => {
+      mockGetCachedAvailability.mockReturnValue({ available: true });
+      const result = await checkChatProviderAvailability('omp');
+      expect(result).toEqual({ available: true, error: undefined });
+      expect(mockGetCachedAvailability).toHaveBeenCalledWith('omp');
+    });
+
+    it('should return unavailable for omp when getCachedAvailability returns null', async () => {
+      mockGetCachedAvailability.mockReturnValue(null);
+      const result = await checkChatProviderAvailability('omp');
+      expect(result).toEqual({ available: false, error: undefined });
+    });
+
+    it('does not consult the omp cache when built-in omp is overridden with a command', async () => {
+      applyConfigOverrides({ 'omp': { command: '/opt/omp' } });
+      mockGetCachedAvailability.mockReturnValue({ available: true });
+
+      const { EventEmitter } = require('events');
+      const fakeProc = new EventEmitter();
+      const mockSpawn = vi.fn().mockReturnValue(fakeProc);
+
+      const promise = checkChatProviderAvailability('omp', { spawn: mockSpawn });
+      fakeProc.emit('close', 0);
+
+      const result = await promise;
+      expect(result).toEqual({ available: true });
+      expect(mockGetCachedAvailability).not.toHaveBeenCalled();
+      expect(mockSpawn).toHaveBeenCalledWith('/opt/omp', ['--version'], expect.any(Object));
     });
 
     it('does not consult the pi cache for a custom type:pi provider with its own command', async () => {
@@ -766,6 +830,7 @@ describe('chat-providers', () => {
 
       const cache = getAllCachedChatAvailability();
       expect(cache.pi).toEqual({ available: true, error: undefined });
+      expect(cache.omp).toEqual({ available: true, error: undefined });
       expect(cache['copilot-acp']).toEqual({ available: true });
       expect(cache['opencode-acp']).toEqual({ available: true });
       expect(cache['cursor-acp']).toEqual({ available: true });

--- a/tests/unit/chat/omp-bridge.test.js
+++ b/tests/unit/chat/omp-bridge.test.js
@@ -1,0 +1,346 @@
+// Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest';
+import { EventEmitter } from 'events';
+import { PassThrough } from 'stream';
+
+// Mock logger to suppress output during tests
+vi.mock('../../../src/utils/logger', () => ({
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+  success: vi.fn(),
+  streamDebug: vi.fn(),
+  section: vi.fn()
+}));
+
+// Patch child_process.spawn before the bridge is loaded (PiBridge destructures spawn at import time)
+const childProcess = require('child_process');
+const realSpawn = childProcess.spawn;
+const mockSpawn = vi.fn();
+childProcess.spawn = mockSpawn;
+
+const OmpBridge = require('../../../src/chat/omp-bridge');
+const PiBridge = require('../../../src/chat/pi-bridge');
+const logger = require('../../../src/utils/logger');
+
+/**
+ * Helper to create a fake child process with real-enough streams for readline.
+ * Auto-responds to get_state and new_session RPC commands so that start()
+ * resolves quickly. Pass respondToNewSession: false to leave new_session
+ * unanswered (for exercising the timeout fallback).
+ */
+function createFakeProcess({ respondToNewSession = true } = {}) {
+  const proc = new EventEmitter();
+  proc.stdin = new PassThrough();
+  proc.stdin.writable = true;
+  const origWrite = proc.stdin.write.bind(proc.stdin);
+  proc.stdin.write = vi.fn((...args) => {
+    origWrite(...args);
+    try {
+      const parsed = JSON.parse(String(args[0]).trim());
+      if (parsed.type === 'get_state') {
+        setImmediate(() => {
+          proc.stdout.write(JSON.stringify({
+            type: 'response',
+            command: 'get_state',
+            success: true,
+            data: { sessionFile: '/tmp/auto-session.jsonl' }
+          }) + '\n');
+        });
+      } else if (parsed.type === 'new_session' && respondToNewSession) {
+        setImmediate(() => {
+          proc.stdout.write(JSON.stringify({
+            type: 'response',
+            command: 'new_session',
+            success: true,
+            data: { cancelled: false }
+          }) + '\n');
+        });
+      }
+    } catch { /* not JSON, ignore */ }
+  });
+  proc.stdout = new PassThrough();
+  proc.stderr = new PassThrough();
+  // Emit 'close' on kill so bridge.close() resolves without waiting for timers
+  proc.kill = vi.fn(() => setImmediate(() => proc.emit('close', 0, null)));
+  proc.pid = 54321;
+  return proc;
+}
+
+/** Extract the parsed RPC frames written to a fake process's stdin. */
+function writtenFrames(proc) {
+  return proc.stdin.write.mock.calls
+    .map((call) => {
+      try {
+        return JSON.parse(String(call[0]).trim());
+      } catch {
+        return null;
+      }
+    })
+    .filter(Boolean);
+}
+
+describe('OmpBridge', () => {
+  let fakeProc;
+
+  // The bridge reads PAIR_REVIEW_OMP_CMD at construction; clear it so a shell
+  // that exports it (the documented wrapper mechanism) can't flip the default
+  // command/useShell assertions below.
+  const origOmpCmd = process.env.PAIR_REVIEW_OMP_CMD;
+
+  afterAll(() => {
+    childProcess.spawn = realSpawn;
+    if (origOmpCmd === undefined) {
+      delete process.env.PAIR_REVIEW_OMP_CMD;
+    } else {
+      process.env.PAIR_REVIEW_OMP_CMD = origOmpCmd;
+    }
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.PAIR_REVIEW_OMP_CMD;
+    fakeProc = createFakeProcess();
+    mockSpawn.mockReturnValue(fakeProc);
+  });
+
+  describe('constructor', () => {
+    it('should extend PiBridge', () => {
+      const bridge = new OmpBridge();
+      expect(bridge).toBeInstanceOf(PiBridge);
+    });
+
+    it('should set OMP defaults', () => {
+      const bridge = new OmpBridge();
+      expect(bridge.piCommand).toBe('omp');
+      expect(bridge.tools).toBe('read,grep,glob');
+      expect(bridge.logName).toBe('OmpBridge');
+      expect(bridge.cliName).toBe('OMP');
+      expect(bridge.sessionFlag).toBe('--resume');
+      expect(bridge.useShell).toBe(false);
+    });
+
+    it('should accept a custom command via piCommand option', () => {
+      const bridge = new OmpBridge({ piCommand: '/usr/local/bin/omp' });
+      expect(bridge.piCommand).toBe('/usr/local/bin/omp');
+    });
+
+    it('should use PAIR_REVIEW_OMP_CMD env var when set', () => {
+      const orig = process.env.PAIR_REVIEW_OMP_CMD;
+      process.env.PAIR_REVIEW_OMP_CMD = 'devx omp';
+      try {
+        const bridge = new OmpBridge();
+        expect(bridge.piCommand).toBe('devx omp');
+        expect(bridge.useShell).toBe(true);
+      } finally {
+        if (orig === undefined) {
+          delete process.env.PAIR_REVIEW_OMP_CMD;
+        } else {
+          process.env.PAIR_REVIEW_OMP_CMD = orig;
+        }
+      }
+    });
+
+    it('should not consult PAIR_REVIEW_PI_CMD', () => {
+      const orig = process.env.PAIR_REVIEW_PI_CMD;
+      process.env.PAIR_REVIEW_PI_CMD = '/custom/pi';
+      try {
+        const bridge = new OmpBridge();
+        expect(bridge.piCommand).toBe('omp');
+      } finally {
+        if (orig === undefined) {
+          delete process.env.PAIR_REVIEW_PI_CMD;
+        } else {
+          process.env.PAIR_REVIEW_PI_CMD = orig;
+        }
+      }
+    });
+
+    it('should set useShell for multi-word commands', () => {
+      const bridge = new OmpBridge({ piCommand: 'devx omp' });
+      expect(bridge.useShell).toBe(true);
+    });
+
+    it('should honor an explicit useShell option', () => {
+      const bridge = new OmpBridge({ piCommand: 'omp', useShell: true });
+      expect(bridge.useShell).toBe(true);
+    });
+
+    it('should accept custom tools', () => {
+      const bridge = new OmpBridge({ tools: 'read,bash,grep,glob' });
+      expect(bridge.tools).toBe('read,bash,grep,glob');
+    });
+
+    it('should drop the skills option with a warning', () => {
+      const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+      try {
+        const bridge = new OmpBridge({ skills: ['/tmp/skill.md'] });
+        expect(bridge.skills).toEqual([]);
+        expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('ignoring skills option'));
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+
+    it('should not warn when no skills are passed', () => {
+      const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+      try {
+        const bridge = new OmpBridge();
+        expect(bridge.skills).toEqual([]);
+        expect(warnSpy).not.toHaveBeenCalled();
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+  });
+
+  describe('_buildArgs', () => {
+    it('should include --mode rpc and OMP default tools', () => {
+      const bridge = new OmpBridge();
+      const args = bridge._buildArgs();
+      expect(args).toContain('--mode');
+      expect(args).toContain('rpc');
+      expect(args).toContain('--tools');
+      expect(args).toContain('read,grep,glob');
+      expect(args).not.toContain('--no-session');
+    });
+
+    it('should use --resume (not --session) when sessionPath is set', () => {
+      const bridge = new OmpBridge({ sessionPath: '/tmp/session.jsonl' });
+      const args = bridge._buildArgs();
+      expect(args).toContain('--resume');
+      expect(args).toContain('/tmp/session.jsonl');
+      expect(args).not.toContain('--session');
+    });
+
+    it('should not include --resume when sessionPath is null', () => {
+      const bridge = new OmpBridge();
+      const args = bridge._buildArgs();
+      expect(args).not.toContain('--resume');
+    });
+
+    it('should never emit --skill even when skills were passed', () => {
+      const bridge = new OmpBridge({ skills: ['/tmp/skill.md'] });
+      const args = bridge._buildArgs();
+      expect(args).not.toContain('--skill');
+    });
+
+    it('should include --no-skills when loadSkills is false', () => {
+      const bridge = new OmpBridge({ loadSkills: false });
+      const args = bridge._buildArgs();
+      expect(args).toContain('--no-skills');
+    });
+
+    it('should include model and system prompt like PiBridge', () => {
+      const bridge = new OmpBridge({ model: 'opus', systemPrompt: 'You are a reviewer' });
+      const args = bridge._buildArgs();
+      expect(args).toContain('--model');
+      expect(args).toContain('opus');
+      expect(args).toContain('--append-system-prompt');
+      expect(args).toContain('You are a reviewer');
+    });
+
+    it('should append extraArgs at the end of the args list', () => {
+      const bridge = new OmpBridge({ extraArgs: ['--advisor'] });
+      const args = bridge._buildArgs();
+      expect(args.slice(-1)).toEqual(['--advisor']);
+    });
+  });
+
+  describe('start', () => {
+    it('should spawn the omp command with built args', async () => {
+      const bridge = new OmpBridge({ sessionPath: '/tmp/session.jsonl' });
+      await bridge.start();
+      expect(mockSpawn).toHaveBeenCalledTimes(1);
+      const [cmd, args] = mockSpawn.mock.calls[0];
+      expect(cmd).toBe('omp');
+      expect(args).toContain('--resume');
+      expect(args).toContain('/tmp/session.jsonl');
+      await bridge.close();
+    });
+
+    it('should discover the session file via get_state', async () => {
+      const bridge = new OmpBridge();
+      const sessionEvents = [];
+      bridge.on('session', (e) => sessionEvents.push(e));
+      await bridge.start();
+      expect(bridge.sessionPath).toBe('/tmp/auto-session.jsonl');
+      expect(sessionEvents).toEqual([{ sessionFile: '/tmp/auto-session.jsonl' }]);
+      await bridge.close();
+    });
+
+    it('should request a fresh session before get_state when no sessionPath is set', async () => {
+      const bridge = new OmpBridge();
+      await bridge.start();
+      const types = writtenFrames(fakeProc).map((f) => f.type);
+      expect(types.indexOf('new_session')).toBeGreaterThanOrEqual(0);
+      expect(types.indexOf('new_session')).toBeLessThan(types.indexOf('get_state'));
+      // The fresh session's file is still discovered and persisted
+      expect(bridge.sessionPath).toBe('/tmp/auto-session.jsonl');
+      await bridge.close();
+    });
+
+    it('should not send new_session when resuming from a sessionPath', async () => {
+      const bridge = new OmpBridge({ sessionPath: '/tmp/session.jsonl' });
+      await bridge.start();
+      const types = writtenFrames(fakeProc).map((f) => f.type);
+      expect(types).not.toContain('new_session');
+      expect(types).toContain('get_state');
+      await bridge.close();
+    });
+
+    it('should still resolve start() when new_session never gets a response', async () => {
+      fakeProc = createFakeProcess({ respondToNewSession: false });
+      mockSpawn.mockReturnValue(fakeProc);
+      const bridge = new OmpBridge();
+
+      vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+      try {
+        const startPromise = bridge.start();
+        // Let the real setImmediate ready-tick fire and new_session be written
+        await new Promise((resolve) => setImmediate(resolve));
+        await new Promise((resolve) => setImmediate(resolve));
+        expect(writtenFrames(fakeProc).map((f) => f.type)).toContain('new_session');
+        // Fire the new_session safety timeout; get_state then proceeds normally
+        await vi.advanceTimersByTimeAsync(5000);
+        await startPromise;
+      } finally {
+        vi.useRealTimers();
+      }
+
+      expect(bridge.isReady()).toBe(true);
+      expect(bridge.sessionPath).toBe('/tmp/auto-session.jsonl');
+      await bridge.close();
+    });
+
+    it('should still resolve start() when new_session responds with failure', async () => {
+      fakeProc = createFakeProcess({ respondToNewSession: false });
+      const origWrite = fakeProc.stdin.write;
+      fakeProc.stdin.write = vi.fn((...args) => {
+        const result = origWrite(...args);
+        try {
+          const parsed = JSON.parse(String(args[0]).trim());
+          if (parsed.type === 'new_session') {
+            setImmediate(() => {
+              fakeProc.stdout.write(JSON.stringify({
+                type: 'response',
+                command: 'new_session',
+                success: false,
+                error: 'nope'
+              }) + '\n');
+            });
+          }
+        } catch { /* not JSON, ignore */ }
+        return result;
+      });
+      mockSpawn.mockReturnValue(fakeProc);
+
+      const bridge = new OmpBridge();
+      await bridge.start();
+      expect(bridge.isReady()).toBe(true);
+      expect(bridge.sessionPath).toBe('/tmp/auto-session.jsonl');
+      await bridge.close();
+    });
+  });
+});

--- a/tests/unit/chat/pi-bridge.test.js
+++ b/tests/unit/chat/pi-bridge.test.js
@@ -66,12 +66,23 @@ function createFakeProcess({ autoRespondGetState = true } = {}) {
 describe('PiBridge', () => {
   let fakeProc;
 
+  // The bridge reads PAIR_REVIEW_PI_CMD at construction; clear it so a shell
+  // that exports it (the documented wrapper mechanism) can't flip the default
+  // command assertions below.
+  const origPiCmd = process.env.PAIR_REVIEW_PI_CMD;
+
   afterAll(() => {
     childProcess.spawn = realSpawn;
+    if (origPiCmd === undefined) {
+      delete process.env.PAIR_REVIEW_PI_CMD;
+    } else {
+      process.env.PAIR_REVIEW_PI_CMD = origPiCmd;
+    }
   });
 
   beforeEach(() => {
     vi.clearAllMocks();
+    delete process.env.PAIR_REVIEW_PI_CMD;
     fakeProc = createFakeProcess();
     mockSpawn.mockReturnValue(fakeProc);
   });

--- a/tests/unit/chat/session-manager.test.js
+++ b/tests/unit/chat/session-manager.test.js
@@ -17,11 +17,13 @@ vi.mock('../../../src/utils/logger', () => ({
 // session-manager.js does: const PiBridge = require('./pi-bridge')
 // We replace the cached module export before session-manager is loaded.
 const piBridgePath = require.resolve('../../../src/chat/pi-bridge');
+const ompBridgePath = require.resolve('../../../src/chat/omp-bridge');
 const acpBridgePath = require.resolve('../../../src/chat/acp-bridge');
 const claudeCodeBridgePath = require.resolve('../../../src/chat/claude-code-bridge');
 const codexBridgePath = require.resolve('../../../src/chat/codex-bridge');
 const chatProvidersPath = require.resolve('../../../src/chat/chat-providers');
 const originalPiBridgeExport = require(piBridgePath);
+const originalOmpBridgeExport = require(ompBridgePath);
 const originalAcpBridgeExport = require(acpBridgePath);
 const originalClaudeCodeBridgeExport = require(claudeCodeBridgePath);
 const originalCodexBridgeExport = require(codexBridgePath);
@@ -30,6 +32,7 @@ const originalChatProvidersExport = require(chatProvidersPath);
 // Shared state for controlling mock behavior per-test
 let _nextStartFail = false;
 const _createdBridges = [];
+const _createdOmpBridges = [];
 const _createdAcpBridges = [];
 const _createdClaudeCodeBridges = [];
 const _createdCodexBridges = [];
@@ -50,6 +53,27 @@ function MockPiBridge(options) {
   bridge.abort = vi.fn();
   bridge._bridgeType = 'pi';
   bridge._constructorOptions = options || {};
+  _createdBridges.push(bridge);
+  return bridge;
+}
+
+function MockOmpBridge(options) {
+  const bridge = new EventEmitter();
+  bridge.start = vi.fn().mockImplementation(() => {
+    if (_nextStartFail) {
+      _nextStartFail = false;
+      return Promise.reject(new Error('spawn failed'));
+    }
+    return Promise.resolve();
+  });
+  bridge.close = vi.fn().mockResolvedValue(undefined);
+  bridge.sendMessage = vi.fn().mockResolvedValue(undefined);
+  bridge.isReady = vi.fn().mockReturnValue(true);
+  bridge.isBusy = vi.fn().mockReturnValue(false);
+  bridge.abort = vi.fn();
+  bridge._bridgeType = 'omp';
+  bridge._constructorOptions = options || {};
+  _createdOmpBridges.push(bridge);
   _createdBridges.push(bridge);
   return bridge;
 }
@@ -122,6 +146,7 @@ const mockChatProviders = {
   getChatProvider: vi.fn((id) => {
     const providers = {
       pi: { id: 'pi', name: 'Pi (RPC)', type: 'pi' },
+      omp: { id: 'omp', name: 'OMP (RPC)', type: 'omp' },
       'copilot-acp': { id: 'copilot-acp', name: 'Copilot (ACP)', type: 'acp', command: 'copilot', args: ['--acp', '--stdio'], env: {} },
       'cursor-acp': { id: 'cursor-acp', name: 'Cursor (ACP)', type: 'acp', command: 'agent', args: ['acp'], env: {} },
       'opencode-acp': { id: 'opencode-acp', name: 'OpenCode (ACP)', type: 'acp', command: 'opencode', args: ['acp'], env: {} },
@@ -133,6 +158,7 @@ const mockChatProviders = {
   isAcpProvider: vi.fn((id) => {
     return ['copilot-acp', 'cursor-acp', 'opencode-acp'].includes(id);
   }),
+  isOmpProvider: vi.fn((id) => id === 'omp'),
   isClaudeCodeProvider: vi.fn((id) => id === 'claude'),
   isCodexProvider: vi.fn((id) => {
     return id === 'codex';
@@ -142,6 +168,7 @@ const mockChatProviders = {
 
 // Replace the cached exports
 require.cache[piBridgePath].exports = MockPiBridge;
+require.cache[ompBridgePath].exports = MockOmpBridge;
 require.cache[acpBridgePath].exports = MockAcpBridge;
 require.cache[claudeCodeBridgePath].exports = MockClaudeCodeBridge;
 require.cache[codexBridgePath].exports = MockCodexBridge;
@@ -157,6 +184,7 @@ describe('ChatSessionManager', () => {
   afterAll(() => {
     // Restore original modules
     require.cache[piBridgePath].exports = originalPiBridgeExport;
+    require.cache[ompBridgePath].exports = originalOmpBridgeExport;
     require.cache[acpBridgePath].exports = originalAcpBridgeExport;
     require.cache[claudeCodeBridgePath].exports = originalClaudeCodeBridgeExport;
     require.cache[codexBridgePath].exports = originalCodexBridgeExport;
@@ -166,6 +194,7 @@ describe('ChatSessionManager', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     _createdBridges.length = 0;
+    _createdOmpBridges.length = 0;
     _createdAcpBridges.length = 0;
     _createdClaudeCodeBridges.length = 0;
     _createdCodexBridges.length = 0;
@@ -728,6 +757,39 @@ describe('ChatSessionManager', () => {
       }
     });
 
+    it('should resume an omp session from its session file via OmpBridge', async () => {
+      const session = await manager.createSession({ provider: 'omp', reviewId: 1 });
+
+      const fs = require('fs');
+      const os = require('os');
+      const path = require('path');
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'omp-resume-'));
+      const sessionFilePath = path.join(tmpDir, 'session.jsonl');
+      fs.writeFileSync(sessionFilePath, '{}');
+
+      try {
+        db.prepare('UPDATE chat_sessions SET agent_session_id = ? WHERE id = ?')
+          .run(sessionFilePath, session.id);
+        await manager.closeSession(session.id);
+
+        const result = await manager.resumeSession(session.id, { systemPrompt: 'test', cwd: tmpDir });
+        expect(result).toEqual({ id: session.id, status: 'active' });
+
+        // Resume must create an OmpBridge (not a PiBridge) with sessionPath set
+        const resumedBridge = _createdOmpBridges[_createdOmpBridges.length - 1];
+        expect(resumedBridge._constructorOptions.sessionPath).toBe(sessionFilePath);
+      } finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
+    });
+
+    it('should require a session file on disk to resume an omp session', async () => {
+      const session = await manager.createSession({ provider: 'omp', reviewId: 1 });
+      await manager.closeSession(session.id);
+
+      await expect(manager.resumeSession(session.id)).rejects.toThrow('has no session file');
+    });
+
     it('should not set loadSkills when not provided on resume', async () => {
       const session = await manager.createSession({ provider: 'pi', reviewId: 1 });
       const sessionFilePath = '/tmp/test-resume-no-load-skills.json';
@@ -948,6 +1010,40 @@ describe('ChatSessionManager', () => {
       await manager.createSession({ provider: 'pi', reviewId: 1 });
       const bridge = _createdBridges[0];
       expect(bridge._bridgeType).toBe('pi');
+    });
+
+    it('should return OmpBridge for omp provider', async () => {
+      await manager.createSession({ provider: 'omp', reviewId: 1 });
+      const bridge = _createdOmpBridges[0];
+      expect(bridge).toBeDefined();
+      expect(bridge._bridgeType).toBe('omp');
+    });
+
+    it('should pass OMP tool set and no extensions to OmpBridge', async () => {
+      await manager.createSession({ provider: 'omp', reviewId: 1 });
+      const bridge = _createdOmpBridges[0];
+      // OMP rejects Pi's find/ls tool names; its file-listing tool is glob
+      expect(bridge._constructorOptions.tools).toBe('read,bash,grep,glob');
+      // The pair-review task extension is Pi-specific and must not be loaded
+      expect(bridge._constructorOptions.extensions).toBeUndefined();
+    });
+
+    it('should pass command, model, and load_skills from provider def to OmpBridge', async () => {
+      mockChatProviders.getChatProvider.mockImplementationOnce(
+        () => ({ id: 'omp', type: 'omp', command: 'devx omp', model: 'opus', useShell: true, load_skills: false })
+      );
+      await manager.createSession({ provider: 'omp', reviewId: 1 });
+      const bridge = _createdOmpBridges[0];
+      expect(bridge._constructorOptions.piCommand).toBe('devx omp');
+      expect(bridge._constructorOptions.model).toBe('opus');
+      expect(bridge._constructorOptions.useShell).toBe(true);
+      expect(bridge._constructorOptions.loadSkills).toBe(false);
+    });
+
+    it('should not pass chat provider ID as provider to OmpBridge', async () => {
+      await manager.createSession({ provider: 'omp', reviewId: 1 });
+      const bridge = _createdOmpBridges[0];
+      expect(bridge._constructorOptions.provider).toBeNull();
     });
 
     it('should pass copilot-acp command and args to AcpBridge', async () => {


### PR DESCRIPTION
## Summary

Adds OMP (Oh My Pi) as an interactive chat provider. OMP is a Pi fork that speaks the same JSONL RPC protocol (`--mode rpc`, prompt/abort/get_state, message_update/agent_end), so `OmpBridge` extends `PiBridge` and overrides only the CLI surface differences:

- Default command `omp`, overridable via `PAIR_REVIEW_OMP_CMD` or a `chat_providers` config entry
- Session resumption uses `--resume <path>` (OMP has no `--session` flag)
- Default tool set is `read,grep,glob` — OMP's file-listing tool is `glob` and it errors on unknown tool names
- The skills option is dropped with a warning (OMP's `--skills` is a glob filter with different semantics)

## autoResume protection

OMP's `autoResume` setting reopens the most recent session in the cwd when no session flag is passed — which is exactly how a brand-new pair-review chat launches. That would let unrelated history leak into the chat's context and cause pair-review to persist (and append to) a session file the user was using elsewhere. New chats now send the `new_session` RPC command before session discovery; the resume path is unaffected. Verified against the real CLI that OMP echoes `command: "new_session"` in its response frame and that `get_state` returns the fresh `sessionFile` path immediately afterward.

## Other changes

- README documents the new provider ID and clarifies that for `pi`/`omp` the `args` config is appended after the generated RPC flags rather than replacing defaults (wrapper commands should use a multi-word `command` such as `"devx omp"`)
- Bridge test suites now clear `PAIR_REVIEW_PI_CMD`/`PAIR_REVIEW_OMP_CMD` so an exported wrapper command in the shell can't flip the default-command assertions
- Changeset included (minor)

## Testing

- `pnpm vitest run tests/unit/chat` — 12 files, 1080 tests passing
- New coverage: `new_session` ordering before `get_state`, no `new_session` on resume, startup resilience when the `new_session` response never arrives or reports failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)