### PR TITLE
Add host-aware repo links for main dashboard

### DIFF
--- a/.changeset/steady-links-appear.md
+++ b/.changeset/steady-links-appear.md
@@ -1,0 +1,11 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Show configured repository action links correctly for alternate-host pull requests and recent reviews.
+
+Dashboard rows now resolve their host, links, and navigation target from one server-side rule, so a row's action icon and its click always open the same system. Recent-review rows reconcile a legacy `NULL` host against the PR's recorded URL, so alternate-host reviews recorded before host stamping no longer show a GitHub-labelled link.
+
+A monorepo-style `url_pattern` claimed every `owner/repo` it could match, so a pull request that lives on github.com could be bound to — and linked to — an alternate host that has no github.com presence. Host resolution is now applied consistently across dashboard rows, PR setup, the review page, the review header links, comment sync, and stack analysis, matching the rule the URL parser already enforced. The host-filtered configuration key selects the repository's credentials together with its local path, checkout script, worktree pool, and reset script, so an exclusive alternate-host entry's local configuration is never applied to a github.com pull request.
+
+Also fixes an attribute-escaping hole in the dashboard tables: a pull request title containing a double quote could inject markup into the surrounding `title`/`data-*` attributes.

--- a/docs/alt-host.md
+++ b/docs/alt-host.md
@@ -134,6 +134,41 @@ its key (`owner/repo`) — regardless of how the URL was actually written.
 
 Invalid regexes are reported with a clear error at startup.
 
+A broad pattern is safe with respect to `github.com`. An `api_host`-bearing
+`url_pattern` never claims a canonical `github.com` or Graphite URL, and when
+pair-review knows a pull request lives on `github.com` — one listed by the
+github.com search on the dashboard, opened from a `github.com` URL, or recorded
+with a `github.com` web URL — it will not bind that pull request through an
+entry that cannot serve `github.com`.
+
+That rejection is narrow, and applies when both of these hold:
+
+- the entry is exclusive alt-host (`api_host` without `exclusive: false`), and
+- its config key differs from the pull request's own `owner/repo`, meaning the
+  entry was matched by probing its `url_pattern` rather than by name.
+
+Such an entry would otherwise claim every `owner/repo` its pattern can capture.
+Pull requests it claims wrongly resolve to their own `owner/repo` instead, use
+the standard GitHub credential chain, and render the default GitHub links.
+
+A dual-host entry (`exclusive: false`) is always kept, because it does serve
+`github.com` — including its local settings (`path`, `checkout_script`,
+`pool_size`, `reset_script`).
+
+An entry keyed **exactly** at the pull request's `owner/repo` is also kept, even
+when exclusive: there the configuration asserts that this specific repository is
+alt-host-only, and configuration wins over inference. If such a repository does
+have `github.com` pull requests, set `exclusive: false` on it. Until you do,
+pair-review refuses to bind them to `github.com` and reports it differently per
+surface:
+
+- **Web** (dashboard row, pasted URL, `?host=` on a review) — logs a warning
+  naming `exclusive: false`, ignores the `github.com` hint, and continues
+  against the alt host, so a click never fails with a server error.
+- **CLI** (`pair-review <url>` and the headless paths) — fails fast before any
+  network work with an error naming the same fix, since a command can afford a
+  loud failure and a wrong-host fetch would only 404 later.
+
 ### `git_remote_pattern`
 
 An optional escape-hatch regex for matching the git remote URL of a local
@@ -208,7 +243,7 @@ endpoint described in "Host Extensions" is used.
 
 ### `links`
 
-Customise the link buttons shown in the review header.
+Customise the link buttons pair-review renders for a repository.
 
 - **`links.external`** — declare a new link with these fields:
   - `name` (optional) — display name of the host (e.g. `"Meteorite"`). Used
@@ -216,22 +251,52 @@ Customise the link buttons shown in the review header.
     success toast, the pending-draft notice and indicator, and the
     "Save as Draft" description. It also joins the global host list described
     in "Naming Your Host in the UI" below. Defaults to `"GitHub"` when unset.
-  - `label` (required) — display text for the header link button.
+  - `label` (required) — display text for the link button.
   - `url_template` (required) — URL with `{owner}`, `{repo}`, `{number}`,
     `{branch}`, `{base_branch}`, `{head_sha}` placeholders. The resolved
-    URL must use `https://`. In addition to the header link, this template
+    URL must use `https://`. In addition to the link button, this template
     is the **authoritative source** for the URL opened after a draft submit
     and the pending-draft "Manage" / indicator links — preferred over the
     PR's API-returned `html_url`, which some hosts return on a different
     (or wrong) domain.
   - `icon` (optional) — inline SVG string for the button icon. Also shown on
     the review-submit button. Sanitised server-side (script tags, `on*`
-    handlers, and `javascript:` URLs are stripped).
+    handlers, and `javascript:` URLs are stripped) and again in the browser,
+    which keeps only inert presentation elements and attributes: shapes,
+    groups, `defs`, gradients, `clipPath`/`mask`, paint attributes, and
+    `url(#id)` references to the icon's own fragments. External references
+    (`url(https://…)`), `foreignObject`, `use`, `style`, and animation
+    elements are removed, and the browser console reports what was dropped.
 - **`links.github: false`** — hide the default "Open on GitHub" link.
 - **`links.graphite: false`** — hide the Graphite stack link.
 
 When `links` is unset, the default link set is preserved and all host-named
 text reads "GitHub".
+
+#### Surfaces that consume `links`
+
+The same resolved configuration drives four surfaces, so `links.github: false`
+and `links.graphite: false` hide those icons everywhere, not only in the
+review header:
+
+1. The **review header** icon group.
+2. The **draft/submit copy and links** — the post-submit URL, the
+   pending-draft notice, indicator, and "Manage" link.
+3. The main dashboard's **collection rows** (review requests, team reviews,
+   my PRs).
+4. The main dashboard's **recent-review rows**.
+
+The two dashboard surfaces substitute `url_template` from data recorded at
+setup or collection-refresh time, not from the live review context. A
+collection row can supply `{owner}`, `{repo}` and `{number}`; a recent-review
+row adds `{branch}`, `{base_branch}` and `{head_sha}` from its stored
+`pr_metadata`. A template that references anything a row cannot supply — or a
+`{head_sha}` that has since moved — falls back to the PR's recorded
+`html_url` for that row rather than dropping the link.
+
+Dashboard rows are also host-aware per PR: a dual-host repo shows the
+external link only for rows that live on the alt host, and the GitHub and
+Graphite links only for rows that live on github.com.
 
 Note that the host's web URL frequently cannot be derived from `api_host`
 (the API host, web host, and the host returned in PR `html_url` values may
@@ -467,8 +532,8 @@ With this configuration:
   cached per-host.
 - All GitHub operations use REST, except draft-review comments which use
   the host extension.
-- The review header shows an "Open on AltHost" link and hides the default
-  GitHub and Graphite links.
+- The review header and both dashboard row types show an "Open on AltHost"
+  link and hide the default GitHub and Graphite links.
 - Other repos in `~/.pair-review/config.json` — including any on
   `github.com` — continue to use the top-level `github_token` and the
   default GraphQL-preferred behaviour.

--- a/public/index.html
+++ b/public/index.html
@@ -1574,6 +1574,7 @@
     <script src="/js/components/VoiceCentricConfigTab.js"></script>
     <script src="/js/components/AdvancedConfigTab.js"></script>
     <script src="/js/theme.js"></script>
+    <script src="/js/repo-links.js"></script>
     <script src="/js/index.js"></script>
 </body>
 </html>

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -112,6 +112,13 @@
     return div.innerHTML;
   }
 
+  /** Escape text for insertion into a quoted HTML attribute. */
+  function escapeHtmlAttribute(text) {
+    return escapeHtml(text)
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
   // encodeBase64Utf8 / getRepoStorageKey live in public/js/utils/storage-keys.js
   // (window.encodeBase64Utf8 / window.getRepoStorageKey), shared with pr.js so the
   // per-repo keys this page writes stay byte-identical to those the PR page reads.
@@ -339,9 +346,9 @@
 
     return '' +
       '<tr data-session-id="' + session.id + '">' +
-        '<td class="col-local-name" title="' + escapeHtml(session.name || 'Untitled') + '"><a href="' + link + '">' + nameDisplay + '</a></td>' +
-        '<td class="col-local-sha" title="' + escapeHtml(session.local_head_sha || '') + '">' + escapeHtml(sha) + '</td>' +
-        '<td class="col-local-path" title="' + escapeHtml(pathDisplay) + '">' + escapeHtml(pathDisplay) + '</td>' +
+        '<td class="col-local-name" title="' + escapeHtmlAttribute(session.name || 'Untitled') + '"><a href="' + link + '">' + nameDisplay + '</a></td>' +
+        '<td class="col-local-sha" title="' + escapeHtmlAttribute(session.local_head_sha || '') + '">' + escapeHtml(sha) + '</td>' +
+        '<td class="col-local-path" title="' + escapeHtmlAttribute(pathDisplay) + '">' + escapeHtml(pathDisplay) + '</td>' +
         '<td class="col-repo">' + escapeHtml(session.repository || '') + '</td>' +
         '<td class="col-time">' + relativeTime + '</td>' +
         '<td class="col-actions">' +
@@ -349,7 +356,7 @@
           '<button' +
             ' class="btn-delete-session"' +
             ' data-session-id="' + session.id + '"' +
-            ' data-session-path="' + escapeHtml(pathDisplay) + '"' +
+            ' data-session-path="' + escapeHtmlAttribute(pathDisplay) + '"' +
             ' title="Delete session"' +
           '>' +
             '<svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">' +
@@ -470,6 +477,79 @@
     if (clearBtn) clearBtn.hidden = !value;
   }
 
+  var GITHUB_ACTION_ICON = '<svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0c4.42 0 8 3.58 8 8a8.013 8.013 0 0 1-5.45 7.59c-.4.08-.55-.17-.55-.38 0-.27.01-1.13.01-2.2 0-.75-.25-1.23-.54-1.48 1.78-.2 3.65-.88 3.65-3.95 0-.88-.31-1.59-.82-2.15.08-.2.36-1.02-.08-2.12 0 0-.67-.22-2.2.82-.64-.18-1.32-.27-2-.27-.68 0-1.36.09-2 .27-1.53-1.03-2.2-.82-2.2-.82-.44 1.1-.16 1.92-.08 2.12-.51.56-.82 1.28-.82 2.15 0 3.06 1.86 3.75 3.64 3.95-.23.2-.44.55-.51 1.07-.46.21-1.61.55-2.33-.66-.15-.24-.6-.83-1.23-.82-.67.01-.27.38.01.53.34.19.73.9.82 1.13.16.45.68 1.31 2.69.94 0 .67.01 1.3.01 1.49 0 .21-.15.45-.55.38A7.995 7.995 0 0 1 0 8c0-4.42 3.58-8 8-8Z"/></svg>';
+  var GRAPHITE_ACTION_ICON = '<svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M9.7932,1.3079L3.101,3.101l-1.7932,6.6921,4.899,4.899,6.6921-1.7931,1.7932-6.6921L9.7932,1.3079Zm1.0936,11.6921H5.1133l-2.8867-5L5.1133,3h5.7735l2.8867,5-2.8867,5Z"/><polygon points="11.3504 4.6496 6.7737 3.4232 3.4232 6.7737 4.6496 11.3504 9.2263 12.5768 12.5768 9.2263 11.3504 4.6496"/></svg>';
+  var EXTERNAL_ACTION_ICON = '<svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M3.75 2A1.75 1.75 0 0 0 2 3.75v8.5C2 13.216 2.784 14 3.75 14h8.5A1.75 1.75 0 0 0 14 12.25v-3a.75.75 0 0 0-1.5 0v3a.25.25 0 0 1-.25.25h-8.5a.25.25 0 0 1-.25-.25v-8.5a.25.25 0 0 1 .25-.25h3a.75.75 0 0 0 0-1.5h-3Zm6.97-.53a.75.75 0 0 0 0 1.06l1.72 1.72-4.97 4.97a.75.75 0 1 0 1.06 1.06l4.97-4.97 1.72 1.72a.75.75 0 0 0 1.28-.53V2.75A.75.75 0 0 0 14.75 2h-3.5a.75.75 0 0 0-.53 1.28Z"/></svg>';
+
+  /**
+   * Render the configured external-host icon, falling back to the generic
+   * "open in new tab" glyph when no icon is configured or the SVG failed
+   * sanitisation. Malformed parser output also falls back instead of breaking
+   * the entire table row.
+   */
+  function renderExternalActionIcon(icon) {
+    if (!icon || !window.RepoLinks || typeof window.RepoLinks.parseSvgIcon !== 'function') {
+      return EXTERNAL_ACTION_ICON;
+    }
+
+    var svg = window.RepoLinks.parseSvgIcon(icon);
+    if (!svg || typeof svg.outerHTML !== 'string') return EXTERNAL_ACTION_ICON;
+
+    // Match the 16px sizing of the built-in action icons.
+    if (typeof svg.getAttribute === 'function' && typeof svg.setAttribute === 'function') {
+      if (!svg.getAttribute('width')) svg.setAttribute('width', '16');
+      if (!svg.getAttribute('height')) svg.setAttribute('height', '16');
+    }
+    return svg.outerHTML;
+  }
+
+  /**
+   * Render the external, GitHub, and Graphite action links resolved by the
+   * backend for one landing-page row.
+   */
+  function renderRepoActionLinks(context) {
+    var repoLinks = context.repo_links || { external: null, github: true, graphite: true };
+    // Prefer html_url to preserve GitHub's original casing for Graphite and to
+    // keep unconfigured alternate-host rows pointing at their actual host.
+    var defaultUrl = typeof context.html_url === 'string' && context.html_url.startsWith('https://')
+      ? context.html_url
+      : 'https://github.com/' + encodeURIComponent(context.owner) + '/' + encodeURIComponent(context.repo) + '/pull/' + context.number;
+    var html = '';
+
+    if (repoLinks.external && window.RepoLinks && typeof window.RepoLinks.substituteUrlTemplate === 'function') {
+      var externalUrl = window.RepoLinks.substituteUrlTemplate(repoLinks.external.url_template, context);
+      // A template that needs row data this surface cannot supply (a stale
+      // `head_sha`, say) substitutes to nothing. Fall back to the recorded PR
+      // URL rather than dropping the button: with `links.github: false` the
+      // external link is the row's ONLY route to the PR.
+      if (!externalUrl && typeof context.html_url === 'string' && context.html_url.startsWith('https://')) {
+        externalUrl = context.html_url;
+      }
+      if (externalUrl) {
+        var label = escapeHtmlAttribute(repoLinks.external.label);
+        html += '<a href="' + escapeHtmlAttribute(externalUrl) + '" target="_blank" rel="noopener" class="btn-github-link" title="' + label + '" aria-label="' + label + '">' +
+          renderExternalActionIcon(repoLinks.external.icon) +
+          '</a>';
+      }
+    }
+
+    if (repoLinks.github !== false) {
+      html += '<a href="' + escapeHtmlAttribute(defaultUrl) + '" target="_blank" rel="noopener" class="btn-github-link" title="Open on GitHub">' +
+        GITHUB_ACTION_ICON +
+        '</a>';
+    }
+
+    if (repoLinks.graphite !== false && window.__pairReview?.enableGraphite
+        && typeof context.html_url === 'string' && /^https:\/\/github\.com\//i.test(defaultUrl)) {
+      var graphiteUrl = window.__pairReview.toGraphiteUrl(defaultUrl);
+      html += '<a href="' + escapeHtmlAttribute(graphiteUrl) + '" target="_blank" rel="noopener" class="btn-github-link" title="Open on Graphite">' +
+        GRAPHITE_ACTION_ICON +
+        '</a>';
+    }
+
+    return html;
+  }
+
   /**
    * Render a single row for a collection PR table.
    * @param {Object} pr - PR object from the API
@@ -485,39 +565,37 @@
       ? '<a href="https://github.com/' + encodeURIComponent(pr.author) + '" target="_blank" rel="noopener">' + escapeHtml(pr.author) + '</a>'
       : '';
 
-    var githubLinkHtml =
-      '<a href="' + escapeHtml(pr.html_url || prUrl) + '" target="_blank" rel="noopener" class="btn-github-link" title="Open on GitHub">' +
-        '<svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0c4.42 0 8 3.58 8 8a8.013 8.013 0 0 1-5.45 7.59c-.4.08-.55-.17-.55-.38 0-.27.01-1.13.01-2.2 0-.75-.25-1.23-.54-1.48 1.78-.2 3.65-.88 3.65-3.95 0-.88-.31-1.59-.82-2.15.08-.2.36-1.02-.08-2.12 0 0-.67-.22-2.2.82-.64-.18-1.32-.27-2-.27-.68 0-1.36.09-2 .27-1.53-1.03-2.2-.82-2.2-.82-.44 1.1-.16 1.92-.08 2.12-.51.56-.82 1.28-.82 2.15 0 3.06 1.86 3.75 3.64 3.95-.23.2-.44.55-.51 1.07-.46.21-1.61.55-2.33-.66-.15-.24-.6-.83-1.23-.82-.67.01-.27.38.01.53.34.19.73.9.82 1.13.16.45.68 1.31 2.69.94 0 .67.01 1.3.01 1.49 0 .21-.15.45-.55.38A7.995 7.995 0 0 1 0 8c0-4.42 3.58-8 8-8Z"/></svg>' +
-      '</a>';
-
-    var graphiteLinkHtml = '';
-    if (window.__pairReview?.enableGraphite && pr.html_url) {
-      // Derive from html_url to preserve GitHub's original casing (Graphite URLs are case-sensitive)
-      var graphiteUrl = window.__pairReview.toGraphiteUrl(pr.html_url);
-      graphiteLinkHtml =
-        '<a href="' + escapeHtml(graphiteUrl) + '" target="_blank" rel="noopener" class="btn-github-link" title="Open on Graphite">' +
-          '<svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M9.7932,1.3079L3.101,3.101l-1.7932,6.6921,4.899,4.899,6.6921-1.7931,1.7932-6.6921L9.7932,1.3079Zm1.0936,11.6921H5.1133l-2.8867-5L5.1133,3h5.7735l2.8867,5-2.8867,5Z"/><polygon points="11.3504 4.6496 6.7737 3.4232 3.4232 6.7737 4.6496 11.3504 9.2263 12.5768 12.5768 9.2263 11.3504 4.6496"/></svg>' +
-        '</a>';
-    }
-
     var authorTd = collection === 'my-prs'
       ? ''
       : '<td class="col-author">' + authorDisplay + '</td>';
 
-    // `data-host` carries the alt-host api_host string for PRs that live on an
-    // alternate host; github.com rows have no host and render an empty
-    // attribute. The click handler threads it into the setup call so a dual
-    // repo's alt-host PR opens against the right system without re-probing.
-    var hostAttr = pr.host ? ' data-host="' + escapeHtml(pr.host) + '"' : '';
+    // `setup_host` is resolved by the collection API (setupHostParam): an alt
+    // api_host string, the 'github' sentinel, or null to omit. Open, Analyze,
+    // and single-row navigation thread it into setup, which resolves the same
+    // row's binding key from it — so the row opens against the host its action
+    // icons point at. The browser only echoes the value; deriving it here would
+    // duplicate a config-dependent decision and let the icon and the click
+    // disagree.
+    var hostAttr = pr.setup_host
+      ? ' data-host="' + escapeHtmlAttribute(pr.setup_host) + '"'
+      : '';
+    var actionLinks = renderRepoActionLinks({
+      owner: pr.owner,
+      repo: pr.repo,
+      number: pr.number,
+      html_url: pr.html_url,
+      repo_links: pr.repo_links,
+      host: pr.host
+    });
 
     return '' +
-      '<tr class="collection-pr-row" data-pr-url="' + escapeHtml(prUrl) + '" data-owner="' + escapeHtml(pr.owner) + '" data-repo="' + escapeHtml(pr.repo) + '" data-number="' + pr.number + '"' + hostAttr + '>' +
+      '<tr class="collection-pr-row" data-pr-url="' + escapeHtmlAttribute(prUrl) + '" data-owner="' + escapeHtmlAttribute(pr.owner) + '" data-repo="' + escapeHtmlAttribute(pr.repo) + '" data-number="' + pr.number + '"' + hostAttr + '>' +
         '<td class="col-repo">' + escapeHtml(repoFull) + '</td>' +
         '<td class="col-pr"><span class="collection-pr-number">#' + pr.number + '</span></td>' +
-        '<td class="col-title" title="' + escapeHtml(pr.title || '') + '">' + escapeHtml(pr.title || '') + '</td>' +
+        '<td class="col-title" title="' + escapeHtmlAttribute(pr.title || '') + '">' + escapeHtml(pr.title || '') + '</td>' +
         authorTd +
         '<td class="col-time">' + relativeTime + '</td>' +
-        '<td class="col-actions">' + githubLinkHtml + graphiteLinkHtml + '</td>' +
+        '<td class="col-actions">' + actionLinks + '</td>' +
       '</tr>';
   }
 
@@ -1065,7 +1143,11 @@
     const parts = review.repository.split('/');
     const owner = parts[0];
     const repo = parts[1];
-    const link = '/pr/' + owner + '/' + repo + '/' + review.pr_number;
+    // Carry the API's resolved host into /pr so the row opens against the same
+    // system its action icons point at. applyHostQueryCorrection validates it
+    // and stamps a legacy NULL row on the way through.
+    const link = '/pr/' + owner + '/' + repo + '/' + review.pr_number
+      + (review.setup_host ? '?host=' + encodeURIComponent(review.setup_host) : '');
     const settingsLink = '/repo-settings.html?owner=' + encodeURIComponent(owner) + '&repo=' + encodeURIComponent(repo);
     const relativeTime = formatRelativeTime(review.last_accessed_at);
 
@@ -1074,23 +1156,27 @@
       : '';
 
     var reviewIdAttr = review.review_id ? ' data-analysis-review-id="' + review.review_id + '"' : '';
+    var actionLinks = renderRepoActionLinks({
+      owner: owner,
+      repo: repo,
+      number: review.pr_number,
+      html_url: review.html_url,
+      branch: review.head_branch,
+      base_branch: review.base_branch,
+      head_sha: review.head_sha,
+      repo_links: review.repo_links,
+      host: review.host
+    });
 
     return '' +
       '<tr data-review-id="' + review.id + '"' + reviewIdAttr + '>' +
         '<td class="col-repo">' + escapeHtml(review.repository) + '</td>' +
         '<td class="col-pr"><a href="' + link + '">#' + review.pr_number + '</a></td>' +
-        '<td class="col-title" title="' + escapeHtml(review.pr_title) + '">' + escapeHtml(review.pr_title) + '</td>' +
+        '<td class="col-title" title="' + escapeHtmlAttribute(review.pr_title) + '">' + escapeHtml(review.pr_title) + '</td>' +
         '<td class="col-author">' + authorDisplay + '</td>' +
         '<td class="col-time">' + relativeTime + '</td>' +
         '<td class="col-actions">' +
-          '<a href="https://github.com/' + escapeHtml(review.repository) + '/pull/' + review.pr_number + '" target="_blank" rel="noopener" class="btn-github-link" title="Open on GitHub">' +
-            '<svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0c4.42 0 8 3.58 8 8a8.013 8.013 0 0 1-5.45 7.59c-.4.08-.55-.17-.55-.38 0-.27.01-1.13.01-2.2 0-.75-.25-1.23-.54-1.48 1.78-.2 3.65-.88 3.65-3.95 0-.88-.31-1.59-.82-2.15.08-.2.36-1.02-.08-2.12 0 0-.67-.22-2.2.82-.64-.18-1.32-.27-2-.27-.68 0-1.36.09-2 .27-1.53-1.03-2.2-.82-2.2-.82-.44 1.1-.16 1.92-.08 2.12-.51.56-.82 1.28-.82 2.15 0 3.06 1.86 3.75 3.64 3.95-.23.2-.44.55-.51 1.07-.46.21-1.61.55-2.33-.66-.15-.24-.6-.83-1.23-.82-.67.01-.27.38.01.53.34.19.73.9.82 1.13.16.45.68 1.31 2.69.94 0 .67.01 1.3.01 1.49 0 .21-.15.45-.55.38A7.995 7.995 0 0 1 0 8c0-4.42 3.58-8 8-8Z"/></svg>' +
-          '</a>' +
-          (window.__pairReview?.enableGraphite && review.html_url
-            ? '<a href="' + escapeHtml(window.__pairReview.toGraphiteUrl(review.html_url)) + '" target="_blank" rel="noopener" class="btn-github-link" title="Open on Graphite">' +
-                '<svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M9.7932,1.3079L3.101,3.101l-1.7932,6.6921,4.899,4.899,6.6921-1.7931,1.7932-6.6921L9.7932,1.3079Zm1.0936,11.6921H5.1133l-2.8867-5L5.1133,3h5.7735l2.8867,5-2.8867,5Z"/><polygon points="11.3504 4.6496 6.7737 3.4232 3.4232 6.7737 4.6496 11.3504 9.2263 12.5768 12.5768 9.2263 11.3504 4.6496"/></svg>' +
-              '</a>'
-            : '') +
+          actionLinks +
           '<a href="' + settingsLink + '" class="btn-repo-settings" title="Repository settings">' +
             '<svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">' +
               '<path d="M8 0a8.2 8.2 0 0 1 .701.031C9.444.095 9.99.645 10.16 1.29l.288 1.107c.018.066.079.158.212.224.231.114.454.243.668.386.123.082.233.09.299.071l1.103-.303c.644-.176 1.392.021 1.82.63.27.385.506.792.704 1.218.315.675.111 1.422-.364 1.891l-.814.806c-.049.048-.098.147-.088.294.016.257.016.515 0 .772-.01.147.038.246.088.294l.814.806c.475.469.679 1.216.364 1.891a7.977 7.977 0 0 1-.704 1.217c-.428.61-1.176.807-1.82.63l-1.102-.302c-.067-.019-.177-.011-.3.071a5.909 5.909 0 0 1-.668.386c-.133.066-.194.158-.211.224l-.29 1.106c-.168.646-.715 1.196-1.458 1.26a8.006 8.006 0 0 1-1.402 0c-.743-.064-1.289-.614-1.458-1.26l-.289-1.106c-.018-.066-.079-.158-.212-.224a5.738 5.738 0 0 1-.668-.386c-.123-.082-.233-.09-.299-.071l-1.103.303c-.644.176-1.392-.021-1.82-.63a8.12 8.12 0 0 1-.704-1.218c-.315-.675-.111-1.422.363-1.891l.815-.806c.05-.048.098-.147.088-.294a6.214 6.214 0 0 1 0-.772c.01-.147-.038-.246-.088-.294l-.815-.806C.635 6.045.431 5.298.746 4.623a7.92 7.92 0 0 1 .704-1.217c.428-.61 1.176-.807 1.82-.63l1.102.302c.067.019.177.011.3-.071.214-.143.437-.272.668-.386.133-.066.194-.158.211-.224l.29-1.106C6.009.645 6.556.095 7.299.03 7.53.01 7.764 0 8 0Zm-.571 1.525c-.036.003-.108.036-.137.146l-.289 1.105c-.147.561-.549.967-.998 1.189-.173.086-.34.183-.5.29-.417.278-.97.423-1.529.27l-1.103-.303c-.109-.03-.175.016-.195.045-.22.312-.412.644-.573.99-.014.031-.021.11.059.19l.815.806c.411.406.562.957.53 1.456a4.709 4.709 0 0 0 0 .582c.032.499-.119 1.05-.53 1.456l-.815.806c-.081.08-.073.159-.059.19.162.346.353.677.573.989.02.03.085.076.195.046l1.102-.303c.56-.153 1.113-.008 1.53.27.161.107.328.204.501.29.447.222.85.629.997 1.189l.289 1.105c.029.109.101.143.137.146a6.6 6.6 0 0 0 1.142 0c.036-.003.108-.036.137-.146l.289-1.105c.147-.561.549-.967.998-1.189.173-.086.34-.183.5-.29.417-.278.97-.423 1.529-.27l1.103.303c.109.029.175-.016.195-.045.22-.313.411-.644.573-.99.014-.031.021-.11-.059-.19l-.815-.806c-.411-.406-.562-.957-.53-1.456a4.709 4.709 0 0 0 0-.582c-.032-.499.119-1.05.53-1.456l.815-.806c.081-.08.073-.159.059-.19a6.464 6.464 0 0 0-.573-.989c-.02-.03-.085-.076-.195-.046l-1.102.303c-.56.153-1.113.008-1.53-.27a4.44 4.44 0 0 0-.501-.29c-.447-.222-.85-.629-.997-1.189l-.289-1.105c-.029-.11-.101-.143-.137-.146a6.6 6.6 0 0 0-1.142 0ZM11 8a3 3 0 1 1-6 0 3 3 0 0 1 6 0ZM9.5 8a1.5 1.5 0 1 0-3.001.001A1.5 1.5 0 0 0 9.5 8Z"/>' +
@@ -1099,7 +1185,7 @@
           '<button' +
             ' class="btn-delete-review"' +
             ' data-review-id="' + review.id + '"' +
-            ' data-repository="' + escapeHtml(review.repository) + '"' +
+            ' data-repository="' + escapeHtmlAttribute(review.repository) + '"' +
             ' data-pr-number="' + review.pr_number + '"' +
             ' title="Delete review"' +
           '>' +
@@ -1370,9 +1456,9 @@
           // string = alt host, null = github.com, undefined = unknown.
           host: data.host,
           bindingRepository: data.bindingRepository,
-          // Whether the repo is dual (github + alt-host). Only dual repos probe,
-          // so only they need an explicit github pick when the URL is a github URL.
-          isDualHost: data.isDualHost
+          // Server-resolved `?host=` value for this URL (see setupHostParam).
+          // The browser echoes it rather than deciding from repo config.
+          setupHost: data.setupHost
         };
       }
 
@@ -1424,17 +1510,12 @@
     let href = '/pr/' + encodeURIComponent(parsed.owner) + '/' + encodeURIComponent(parsed.repo) + '/' + encodeURIComponent(parsed.prNumber);
     var params = new URLSearchParams();
     if (analyze) params.set('analyze', 'true');
-    // Forward the parsed host so setup binds directly instead of probing:
-    //  - alt-host URL string → the api_host (setup binds that alt host)
-    //  - github URL (host === null) on a DUAL repo → the "github" sentinel, so
-    //    setup binds github.com instead of probing alt-first (which would fail
-    //    loudly if the alt host is down for a PR we KNOW is on github)
-    //  - anything else (plain/exclusive repo, unknown host) → omit; no probe
-    //    happens for those and omitting avoids the exclusive-null throw.
-    if (typeof parsed.host === 'string' && parsed.host) {
-      params.set('host', parsed.host);
-    } else if (parsed.host === null && parsed.isDualHost) {
-      params.set('host', 'github');
+    // Forward the server-resolved host so setup binds directly instead of
+    // probing. `setupHost` is already the exact param value — an api_host
+    // string, the 'github' sentinel, or null to omit — so no configuration
+    // reasoning happens in the browser.
+    if (parsed.setupHost) {
+      params.set('host', parsed.setupHost);
     }
     var qs = params.toString();
     if (qs) href += '?' + qs;
@@ -2009,9 +2090,9 @@
           repo: tr.dataset.repo,
           number: tr.dataset.number,
           prUrl: prUrl,
-          // Alt-host rows carry a host; github.com rows leave it undefined. The
-          // single-row click path threads this the same way (see the collection
-          // row click handler) so bulk-open binds to the right system too.
+          // Known rows carry either the "github" sentinel or an alternate
+          // api_host; unknown rows leave it undefined. The single-row click
+          // path threads the same value so bulk and individual routing agree.
           host: tr.dataset.host
         });
       }
@@ -2021,9 +2102,9 @@
 
   function buildReviewUrlsFromRows(rows, query) {
     return rows.map(function (row) {
-      // Preserve any existing params (analyze / analysisConfigId) and append the
-      // alt host so setup opens the PR against the system it lives on instead of
-      // re-probing. github.com rows (no host) keep the URL unchanged.
+      // Preserve existing params and append any known host (the "github"
+      // sentinel or an alternate api_host) so setup bypasses probing. Rows
+      // whose host is unknown keep the URL unchanged.
       var qs = query || '';
       if (row.host) {
         qs += (qs ? '&' : '?') + 'host=' + encodeURIComponent(row.host);
@@ -2282,12 +2363,10 @@
         return;
       }
 
-      // Alt-host PR: we already know owner/repo/number and the host it lives
-      // on, so navigate straight to the PR route with the host as a query
-      // param (setup.html forwards it into the setup POST body). This bypasses
-      // the URL-parse round trip, which can't reliably recover the host from a
-      // pasted alt-host html_url. github.com rows (no host) keep the existing
-      // parse-and-submit flow below, byte-identical.
+      // The collection API resolved this PR's system, so navigate straight to
+      // the PR route with its host (the "github" sentinel or an alternate
+      // api_host). setup.html forwards it into the setup POST body, bypassing
+      // the host probe. Rows with no host retain the parse-and-submit fallback.
       var rowHost = collectionRow.dataset.host;
       if (rowHost) {
         var o = encodeURIComponent(collectionRow.dataset.owner);
@@ -2689,7 +2768,9 @@
       showError: showError,
       showInfo: showInfo,
       showLocalPathUrlError: showLocalPathUrlError,
-      handleLocalPathInput: handleLocalPathInput
+      handleLocalPathInput: handleLocalPathInput,
+      renderCollectionPrRow: renderCollectionPrRow,
+      renderRecentReviewRow: renderRecentReviewRow
     };
   }
 

--- a/public/js/repo-links.js
+++ b/public/js/repo-links.js
@@ -25,6 +25,24 @@
     'owner', 'repo', 'number', 'branch', 'base_branch', 'head_sha'
   ];
 
+  // Custom icons are presentation-only. Restrict the parsed tree to inert SVG
+  // shapes and paint attributes before it can enter the live document.
+  const SAFE_SVG_ELEMENTS = new Set([
+    'svg', 'g', 'path', 'circle', 'ellipse', 'line', 'polyline', 'polygon',
+    'rect', 'title', 'desc', 'defs', 'lineargradient', 'radialgradient',
+    'stop', 'clippath', 'mask'
+  ]);
+  const SAFE_SVG_ATTRIBUTES = new Set([
+    'xmlns', 'viewbox', 'preserveaspectratio', 'width', 'height',
+    'x', 'y', 'x1', 'y1', 'x2', 'y2', 'cx', 'cy', 'r', 'rx', 'ry',
+    'fx', 'fy', 'fr', 'd', 'points', 'fill', 'fill-rule', 'fill-opacity',
+    'stroke', 'stroke-width', 'stroke-linecap', 'stroke-linejoin',
+    'stroke-miterlimit', 'stroke-dasharray', 'stroke-dashoffset',
+    'stroke-opacity', 'opacity', 'transform', 'clip-path', 'clip-rule',
+    'mask', 'id', 'class', 'offset', 'stop-color', 'stop-opacity',
+    'gradientunits', 'gradienttransform', 'spreadmethod', 'role', 'focusable'
+  ]);
+
   // The most recently resolved links + substitution context for the
   // current review. Stored so other code (ReviewModal, pr.js) can read
   // the configured host name / external URL / icon instead of hardcoding
@@ -77,37 +95,68 @@
       // image/svg+xml mode returns a <parsererror> root on bad input.
       const root = doc.documentElement;
       if (!root || root.nodeName !== 'svg') return null;
-      // Belt-and-braces: strip dangerous attributes/elements even though
-      // the server already removed them.
-      stripDangerousAttributes(root);
+      // The server strips scripts/on*/javascript:, while embedded active HTML
+      // and external references are removed by this inert allowlist pass.
+      const removed = { elements: 0, attributes: 0 };
+      sanitizeSvgTree(root, removed);
+      if (removed.elements || removed.attributes) {
+        // A configured icon that renders differently than authored is otherwise
+        // silent and hard to diagnose — this parser also feeds the review header
+        // and the submit button, not just the dashboard rows.
+        console.warn(
+          '[repo-links] Sanitised configured icon: removed ' + removed.elements +
+          ' element(s) and ' + removed.attributes + ' attribute(s). Only inert SVG ' +
+          'shapes, paint attributes, and local url(#id) references are kept.'
+        );
+      }
       return root;
     } catch {
       return null;
     }
   }
 
+  // A paint/reference attribute may point at a LOCAL fragment only. Accepts
+  // optional surrounding whitespace and optional matching quotes — `url(#a)`,
+  // `url("#paint0")`, `url('#clip0')` and ` url(#mask0) ` are all the same
+  // local reference, and the allowlist deliberately keeps `defs`, `id`,
+  // gradients, `clip-path` and `mask` so they are clearly intended. Anything
+  // else (`url(https://…)`, `url(//…)`, `url(data:…)`, mismatched quotes, or
+  // more than one reference) fails and the attribute is dropped.
+  const LOCAL_FRAGMENT_URL_RE = /^\s*url\(\s*(["']?)#[^)"'\s]+\1\s*\)\s*$/i;
+
   /**
-   * Recursively strip on* event handlers and `javascript:` URLs from an
-   * SVG element tree, and remove any `<script>` descendants. Defensive
-   * second pass after server sanitisation.
+   * Restrict a parsed SVG tree to inert presentation elements and attributes.
+   * Active HTML (`foreignObject`, iframes), scripts, event handlers, external
+   * resource references, and animation elements are removed.
+   *
+   * @param {Element} element - Subtree root to sanitise in place
+   * @param {{ elements: number, attributes: number }} removed - Accumulator so
+   *   the caller can report what changed with a single warning.
    */
-  function stripDangerousAttributes(element) {
+  function sanitizeSvgTree(element, removed) {
     if (!element || !element.attributes) return;
     const attrs = Array.from(element.attributes);
     for (const attr of attrs) {
       const name = attr.name.toLowerCase();
-      const value = String(attr.value || '').toLowerCase();
-      if (name.startsWith('on') || value.includes('javascript:')) {
+      const value = String(attr.value || '');
+      const isDataOrAria = name.startsWith('data-') || name.startsWith('aria-');
+      const hasUnsafeUrl = /javascript:/i.test(value)
+        || (/url\s*\(/i.test(value) && !LOCAL_FRAGMENT_URL_RE.test(value));
+      if ((!SAFE_SVG_ATTRIBUTES.has(name) && !isDataOrAria) || hasUnsafeUrl) {
         element.removeAttribute(attr.name);
+        removed.attributes++;
       }
     }
+
     const children = Array.from(element.children || []);
     for (const child of children) {
-      if (child.nodeName && child.nodeName.toLowerCase() === 'script') {
+      const name = String(child.localName || child.nodeName || '').toLowerCase();
+      if (!SAFE_SVG_ELEMENTS.has(name)) {
         child.remove();
+        removed.elements++;
         continue;
       }
-      stripDangerousAttributes(child);
+      sanitizeSvgTree(child, removed);
     }
   }
 

--- a/src/database.js
+++ b/src/database.js
@@ -5337,6 +5337,30 @@ class PRMetadataRepository {
   }
 
   /**
+   * Get the stored host binding for a PR together with its recorded web URL.
+   *
+   * A stored `NULL` is ambiguous on its own: it means github.com for anything
+   * stamped since schema v50, but "never stamped" for older rows. The recorded
+   * `html_url` is the evidence that settles it, so host resolution can read
+   * both in one query instead of guessing (see `resolveRecordedHost`).
+   *
+   * @param {string} repository - Repository in owner/repo format
+   * @param {number} prNumber - Pull request number
+   * @returns {Promise<{host: string|null, recordedUrl: string|null}|undefined>}
+   *   `undefined` when no pr_metadata row exists for the PR.
+   */
+  async getPRHostWithRecordedUrl(repository, prNumber) {
+    const row = await queryOne(this.db, `
+      SELECT host, json_extract(pr_data, '$.html_url') AS recorded_url
+      FROM pr_metadata
+      WHERE pr_number = ? AND repository = ? COLLATE NOCASE
+    `, [prNumber, repository]);
+
+    if (!row) return undefined;
+    return { host: row.host, recordedUrl: row.recorded_url || null };
+  }
+
+  /**
    * Update ONLY the host binding for a PR's metadata row.
    *
    * Used to persist an explicit host correction (e.g. a `?host` query param on

--- a/src/external/github-adapter.js
+++ b/src/external/github-adapter.js
@@ -19,12 +19,8 @@
  */
 
 const { GitHubClient, GitHubApiError } = require('../github/client');
-const {
-  getGitHubToken,
-  resolveHostBinding,
-  resolveBindingRepositoryFromPR
-} = require('../config');
-const { storedHostToOption } = require('../utils/host-resolution');
+const { getGitHubToken, resolveHostBinding } = require('../config');
+const { storedHostToOption, resolveBindingRepositoryForHost } = require('../utils/host-resolution');
 
 const name = 'github';
 
@@ -88,17 +84,19 @@ function resolveCredentials(config, repository, _deps, options = {}) {
     GitHubClient,
     getGitHubToken,
     resolveHostBinding,
-    resolveBindingRepositoryFromPR,
+    resolveBindingRepositoryForHost,
     ..._deps
   };
   const safeConfig = config || {};
 
   if (repository) {
     // Binding-aware path. Mirrors resolveBindingForRequest in routes/pr.js:
-    // resolve the PR identity to a binding key, then to a host binding —
-    // pinned to the PR's stored host for dual repos.
+    // resolve the PR identity to a binding key for the host it is recorded on,
+    // then to a host binding — pinned to that host for dual repos. Passing the
+    // host into the key lookup keeps an exclusive alt entry that merely
+    // `url_pattern`-claimed this owner/repo from serving a github.com PR.
     const [owner, repo] = String(repository).split('/');
-    const bindingRepository = deps.resolveBindingRepositoryFromPR(owner, repo, safeConfig);
+    const bindingRepository = deps.resolveBindingRepositoryForHost(owner, repo, safeConfig, options.storedHost);
     const hostOption = storedHostToOption(safeConfig, bindingRepository, options.storedHost);
     const binding = deps.resolveHostBinding(bindingRepository, safeConfig, hostOption || {});
     if (!binding || !binding.token) {

--- a/src/main.js
+++ b/src/main.js
@@ -3,7 +3,7 @@ const fs = require('fs');
 const path = require('path');
 const crypto = require('crypto');
 const { v4: uuidv4 } = require('uuid');
-const { loadConfig, getConfigDir, showWelcomeMessage, resolveDbName, resolveRepoOptions, resolvePoolConfig, getRepoResetScript, getRepoSkipBulkFetch, getRepoFetchTimeout, resolveLoadSkills, buildCouncilProviderOverrides } = require('./config');
+const { loadConfig, getConfigDir, showWelcomeMessage, resolveDbName, resolveRepoOptions, resolvePoolConfig, getRepoResetScript, getRepoSkipBulkFetch, getRepoFetchTimeout, resolveLoadSkills, buildCouncilProviderOverrides, resolveBindingRepositoryFromPR } = require('./config');
 const { initializeDatabase, run, queryOne, query, migrateExistingWorktrees, WorktreeRepository, ReviewRepository, RepoSettingsRepository, GitHubReviewRepository, WorktreePoolRepository, CouncilRepository, CommentRepository, AnalysisRunRepository, PRMetadataRepository } = require('./database');
 const { PRArgumentParser } = require('./github/parser');
 const { GitHubClient } = require('./github/client');
@@ -26,7 +26,7 @@ const { getChangedFiles } = require('./routes/executable-analysis');
 const { safeParseJson } = require('./utils/safe-parse-json');
 const { includesBranch, parseScopeArg, VALID_SCOPE_RANGES, EMPTY_SCOPE_MESSAGE } = require('./local-scope');
 const { storePRData, resolvePrHostBinding, registerRepositoryLocation, findRepositoryPath } = require('./setup/pr-setup');
-const { isDualHostRepo, resolvePreflightBinding, hostSetupParamValue } = require('./utils/host-resolution');
+const { resolvePreflightBinding, setupHostParam, bindingRepositoryForHost } = require('./utils/host-resolution');
 const { fireReviewStartedHook } = require('./hooks/payloads');
 const { normalizeRepository, resolveRenamedFile, resolveRenamedFileOld } = require('./utils/paths');
 const { rejectUrlLikeLocalReviewPath } = require('./utils/local-path-input');
@@ -1155,6 +1155,38 @@ AI PROVIDERS:
 }
 
 /**
+ * Resolve the `repos[...]` config-lookup key for a PR named on the CLI.
+ *
+ * Shared by every in-process PR entry point (`handlePullRequest`,
+ * `performHeadlessReview`, and the headless PR path) so they cannot drift. The
+ * key drives the token/api_host binding AND the repo's local configuration
+ * (path, checkout script, worktree pool, reset script), so both halves have to
+ * agree on it.
+ *
+ * Two corrections over the raw parse result:
+ *  - `PRArgumentParser` deliberately drops `bindingRepository` for a canonical
+ *    github.com / Graphite URL, so resolve it from owner/repo in that case.
+ *    Without this a github.com PR served by a DUAL monorepo entry would lose
+ *    that entry's local configuration, and a bare PR number on a pattern-only
+ *    alt repo would preflight against the identity instead of its entry.
+ *  - The result is filtered by the PR's known host, so an EXCLUSIVE alt entry
+ *    that only `url_pattern`-claimed this owner/repo never binds a PR that
+ *    lives on github.com (see `bindingRepositoryForHost`).
+ *
+ * @param {{owner: string, repo: string, host?: string|null, bindingRepository?: string}} prInfo
+ * @param {Object} config - Application configuration
+ * @returns {string} The `repos[...]` config-lookup key
+ */
+function resolveCliBindingRepository(prInfo, config) {
+  return bindingRepositoryForHost(
+    config,
+    normalizeRepository(prInfo.owner, prInfo.repo),
+    prInfo.bindingRepository || resolveBindingRepositoryFromPR(prInfo.owner, prInfo.repo, config),
+    prInfo.host
+  );
+}
+
+/**
  * Handle pull request processing
  * @param {Array<string>} args - Command line arguments
  * @param {Object} config - Application configuration
@@ -1174,13 +1206,9 @@ async function handlePullRequest(args, config, db, flags = {}, poolLifecycle = n
     const parser = new PRArgumentParser(config);
     const prInfo = await parser.parsePRArguments(args);
 
-    // Resolve token via repo-aware host binding so alt-host and
-    // repo-scoped credentials are respected. When a per-repo
-    // `url_pattern` matched, prefer its `bindingRepository` — that's the
-    // matched `repos[...]` config key, which may differ from the
-    // captured `${owner}/${repo}` for monorepo-style patterns.
-    const repositoryForBinding = prInfo.bindingRepository
-      || normalizeRepository(prInfo.owner, prInfo.repo);
+    // Resolve the config key via the shared helper so the token binding and the
+    // repo's local configuration agree (see resolveCliBindingRepository).
+    const repositoryForBinding = resolveCliBindingRepository(prInfo, config);
     // A pasted URL tells us the host up front (alt-host `url_pattern` match →
     // api_host string; github/graphite URL → null), so preflight the token
     // against that host. A bare number leaves host undefined → ambiguity rule,
@@ -1248,10 +1276,11 @@ async function handlePullRequest(args, config, db, flags = {}, poolLifecycle = n
     }
 
     // Thread the pasted URL's host to setup so it binds directly instead of
-    // probing (shared mapping — see hostSetupParamValue): an alt-host string
-    // forwards the api_host; a github URL on a DUAL repo forwards the 'github'
-    // sentinel; bare numbers / plain / exclusive repos omit it.
-    const hostParam = hostSetupParamValue(prInfo.host, isDualHostRepo(config, repositoryForBinding));
+    // probing (shared mapping — see setupHostParam): an alt-host string forwards
+    // the api_host; a github URL forwards the 'github' sentinel whenever an
+    // api_host entry could otherwise claim this repo; bare numbers and plain
+    // github repos omit it.
+    const hostParam = setupHostParam(config, prInfo.owner, prInfo.repo, prInfo.host);
     if (hostParam) {
       url += (url.includes('?') ? '&' : '?') + `host=${encodeURIComponent(hostParam)}`;
     }
@@ -1354,12 +1383,10 @@ async function performHeadlessReview(args, config, db, flags, options, externalP
       }
     }
 
-    // Resolve host binding for the target repo (handles alt-host).
-    // Prefer `bindingRepository` (from url_pattern match) over the raw
-    // `${owner}/${repo}` since they can differ when one config entry
-    // serves many monorepo-shaped URLs.
-    const repositoryForBinding = prInfo.bindingRepository
-      || normalizeRepository(prInfo.owner, prInfo.repo);
+    // Resolve the config key via the shared helper (see
+    // resolveCliBindingRepository): it drives the host binding below AND this
+    // PR's local path / checkout / pool / reset configuration.
+    const repositoryForBinding = resolveCliBindingRepository(prInfo, config);
     // Preflight the token so a missing credential fails fast before any network
     // work. Tolerates a dual repo with only an alt token when the host is
     // unknown (the setup probe tries the alt host first).
@@ -2010,8 +2037,10 @@ async function preparePrHeadless(db, config, flags, prArgs, externalPoolLifecycl
     }
   }
 
-  const repositoryForBinding = prInfo.bindingRepository
-    || normalizeRepository(prInfo.owner, prInfo.repo);
+  // Resolve the config key via the shared helper (see
+  // resolveCliBindingRepository): the same key drives the host binding and this
+  // PR's local path / checkout / pool / reset configuration.
+  const repositoryForBinding = resolveCliBindingRepository(prInfo, config);
   // Preflight the token so a missing credential fails fast before any network
   // work. Tolerates a dual repo with only an alt token when the host is unknown
   // (the setup probe tries the alt host first).
@@ -3005,4 +3034,4 @@ if (require.main === module) {
   main();
 }
 
-module.exports = { main, parseArgs, detectPRFromGitHubEnvironment, printCouncilList, handleHeadlessAnalysis, handleHeadlessDelegated, runHeadlessAnalysis, buildHeadlessJson, buildHeadlessErrorJson, emitHeadlessResult, resolveCliInstructions, startPoolBackgroundFetches, isPoolEntryDueForFetch, POOL_FETCH_TICK_MS, MAX_POOL_FETCH_BACKOFF_MS };
+module.exports = { main, parseArgs, detectPRFromGitHubEnvironment, printCouncilList, handleHeadlessAnalysis, handleHeadlessDelegated, runHeadlessAnalysis, buildHeadlessJson, buildHeadlessErrorJson, emitHeadlessResult, resolveCliInstructions, resolveCliBindingRepository, startPoolBackgroundFetches, isPoolEntryDueForFetch, POOL_FETCH_TICK_MS, MAX_POOL_FETCH_BACKOFF_MS };

--- a/src/routes/config.js
+++ b/src/routes/config.js
@@ -21,7 +21,11 @@ const {
   modelMatches
 } = require('../ai');
 const { normalizeRepository } = require('../utils/paths');
-const { resolvePreflightBinding } = require('../utils/host-resolution');
+const {
+  resolvePreflightBinding,
+  resolveRecordedHost,
+  resolveBindingRepositoryForHost
+} = require('../utils/host-resolution');
 const {
   isRunningViaNpx,
   getGitHubToken,
@@ -347,23 +351,33 @@ router.get('/api/repos/:owner/:repo/links', async (req, res) => {
     const repository = normalizeRepository(owner, repo);
     const config = req.app.get('config') || {};
     // Resolve via bindingRepository so monorepo-style configs (one
-    // `repos[...]` entry serving many captured owner/repo via
-    // url_pattern) surface the right link config.
-    const bindingRepository = resolveBindingRepositoryFromPR(owner, repo, config);
-
-    // Per-PR host awareness: when the caller names a PR, look up its stored
-    // host so a dual-host repo shows the correct link set (github links for a
-    // github-hosted PR, the external link for an alt-hosted one). A missing
-    // row leaves `host` undefined, which resolveRepoLinks treats as the
-    // repo-level default — so non-dual repos are unaffected regardless.
+    // `repos[...]` entry serving many captured owner/repo via url_pattern)
+    // surface the right link config.
+    //
+    // Per-PR host awareness: when the caller names a PR, resolve the host it is
+    // recorded on so a dual-host repo shows the correct link set (github links
+    // for a github-hosted PR, the external link for an alt-hosted one), and an
+    // exclusive alt entry that only pattern-claimed this owner/repo does not
+    // lend its links to a PR proven to be on github.com. A missing row leaves
+    // `host` undefined (the repo-level default), while an unprovable legacy
+    // NULL resolves to `null` (github.com) — the same value the raw column
+    // carried, so `resolveRepoLinks` sees byte-identical input to before.
     let host;
     const prNumber = parseInt(req.query.number, 10);
     if (Number.isInteger(prNumber) && prNumber > 0) {
       const prMetadataRepo = new PRMetadataRepository(req.app.get('db'));
-      const storedHost = await prMetadataRepo.getPRHost(repository, prNumber);
-      if (storedHost !== undefined) host = storedHost;
+      const recorded = await prMetadataRepo.getPRHostWithRecordedUrl(repository, prNumber);
+      if (recorded !== undefined) {
+        host = resolveRecordedHost(
+          config,
+          resolveBindingRepositoryFromPR(owner, repo, config),
+          recorded.host,
+          recorded.recordedUrl
+        );
+      }
     }
 
+    const bindingRepository = resolveBindingRepositoryForHost(owner, repo, config, host);
     const links = resolveRepoLinks(config, bindingRepository, host);
     res.json({ repository, links });
   } catch (error) {

--- a/src/routes/external-comments.js
+++ b/src/routes/external-comments.js
@@ -26,6 +26,8 @@ const {
 const { getAdapter } = require('../external');
 const { GitHubApiError } = require('../github/client');
 const logger = require('../utils/logger');
+const { resolveBindingRepositoryFromPR } = require('../config');
+const { resolveRecordedHost } = require('../utils/host-resolution');
 
 const router = express.Router();
 
@@ -136,15 +138,25 @@ async function executeSync({ db, config, review, source, _deps }) {
     );
   }
 
-  // Look up the PR's stored host so a DUAL repo's alt-hosted PR binds to the
-  // alt host (and its line-based anchoring path) rather than api.github.com.
-  // Pass the raw stored value through to the adapter, which applies the
-  // legacy-NULL convention against its resolved binding key. `undefined`
-  // (no row / unknown) preserves the two-arg ambiguity behaviour.
+  // Look up the host the PR is recorded on so a DUAL repo's alt-hosted PR binds
+  // to the alt host (and its line-based anchoring path) rather than
+  // api.github.com. `resolveRecordedHost` reads the stored host plus the recorded
+  // html_url, which is what distinguishes a pre-stamping row from a github.com
+  // one; the adapter then applies the legacy-NULL convention against the binding
+  // key it resolves for that host. `undefined` (no row) preserves the two-arg
+  // ambiguity behaviour.
   let storedHost;
   if (Number.isInteger(review.pr_number)) {
     const prMetadataRepo = new PRMetadataRepository(db);
-    storedHost = await prMetadataRepo.getPRHost(review.repository, review.pr_number);
+    const recorded = await prMetadataRepo.getPRHostWithRecordedUrl(review.repository, review.pr_number);
+    if (recorded !== undefined) {
+      storedHost = resolveRecordedHost(
+        config || {},
+        resolveBindingRepositoryFromPR(owner, repo, config || {}),
+        recorded.host,
+        recorded.recordedUrl
+      );
+    }
   }
 
   // Delegate credential resolution to the adapter so the route stays

--- a/src/routes/github-collections.js
+++ b/src/routes/github-collections.js
@@ -18,6 +18,8 @@ const { query, run, withTransaction } = require('../database');
 const { GitHubClient } = require('../github/client');
 const { getGitHubToken, resolveHostBinding } = require('../config');
 const logger = require('../utils/logger');
+const { resolveRepoLinks } = require('../links/repo-links');
+const { resolveBindingRepositoryForHost, setupHostParam } = require('../utils/host-resolution');
 
 const router = express.Router();
 
@@ -236,6 +238,30 @@ async function getCachedRows(db, collection) {
 }
 
 /**
+ * Attach the host-aware repository link configuration consumed by the landing
+ * page, plus the `?host=` value its rows navigate with. Resolution is an
+ * in-memory config lookup, so this avoids per-row HTTP requests while keeping
+ * cached and refreshed responses identical.
+ *
+ * A row's `host` is authoritative here, unlike a legacy `pr_metadata` NULL:
+ * every refresh re-derives these rows, stamping NULL from the github.com search
+ * branch and the `api_host` from the alt-host sweep. Both the links and the
+ * navigation target are therefore resolved for that known host, through the
+ * same two helpers the setup route uses — so a row's action icon and its click
+ * always reach the system the PR actually lives on.
+ */
+function attachRepoLinks(rows, config) {
+  return rows.map((row) => {
+    const bindingRepository = resolveBindingRepositoryForHost(row.owner, row.repo, config, row.host);
+    return {
+      ...row,
+      repo_links: resolveRepoLinks(config, bindingRepository, row.host),
+      setup_host: setupHostParam(config, row.owner, row.repo, row.host)
+    };
+  });
+}
+
+/**
  * Register the GET (cached) and POST (refresh) routes for a single collection.
  * @param {Object} def - Collection definition
  *   ({ name, label, buildQuery, supportsTeamFilter }).
@@ -259,8 +285,9 @@ function registerCollection(def) {
 
       const db = req.app.get('db');
       const rows = await getCachedRows(db, cacheKey(name, team));
+      const prs = attachRepoLinks(rows, req.app.get('config') || {});
       const fetchedAt = rows.length > 0 ? rows[0].fetched_at : null;
-      res.json({ success: true, prs: rows, fetched_at: fetchedAt });
+      res.json({ success: true, prs, fetched_at: fetchedAt });
     } catch (error) {
       logger.error(`Failed to fetch ${label}:`, error);
       res.status(500).json({ success: false, error: `Failed to fetch ${label}` });
@@ -344,13 +371,13 @@ function registerCollection(def) {
       });
 
       const rows = await getCachedRows(db, key);
+      const resolvedRows = attachRepoLinks(rows, config);
       const fetchedAt = rows.length > 0 ? rows[0].fetched_at : null;
       // `hosts` is additive; omit it entirely when every source is healthy (no
-      // alt-host repos and a working github token) so the github-only happy-path
-      // response shape is byte-identical to before. A skipped github source or
-      // any alt-host status makes it appear.
+      // alt-host repos and a working github token) so the happy path gains no
+      // `hosts` key. A skipped github source or any alt-host status adds it.
       const allStatuses = sourceStatuses.concat(hosts);
-      const payload = { success: true, prs: rows, fetched_at: fetchedAt };
+      const payload = { success: true, prs: resolvedRows, fetched_at: fetchedAt };
       if (allStatuses.length > 0) payload.hosts = allStatuses;
       res.json(payload);
     } catch (error) {

--- a/src/routes/pr.js
+++ b/src/routes/pr.js
@@ -26,8 +26,8 @@ const Analyzer = require('../ai/analyzer');
 const { v4: uuidv4 } = require('uuid');
 const fs = require('fs').promises;
 const path = require('path');
-const { resolveHostBinding, resolveBindingRepositoryFromPR, getWorktreeDisplayName, resolveLoadSkills, buildCouncilProviderOverrides, getSummaryEnabled, getTourEnabled } = require('../config');
-const { storedHostToOption, isDualHostRepo } = require('../utils/host-resolution');
+const { resolveHostBinding, getWorktreeDisplayName, resolveLoadSkills, buildCouncilProviderOverrides, getSummaryEnabled, getTourEnabled, resolveBindingRepositoryFromPR } = require('../config');
+const { storedHostToOption, resolveRecordedHost, resolveBindingRepositoryForHost, setupHostParam } = require('../utils/host-resolution');
 const { resolveHostName } = require('../links/repo-links');
 const { resolveHostListText } = require('../links/host-names');
 const { backgroundQueue } = require('../ai/background-queue');
@@ -140,28 +140,46 @@ module.exports._attachHunkHashes = attachHunkHashes;
  */
 async function resolveBindingForRequest(req, repository) {
   const config = req.app.get('config') || {};
-  // `repository` here is the PR-identity `${owner}/${repo}`. For
-  // monorepo-style configs the binding-key in `config.repos` can differ;
-  // resolve it via `resolveBindingRepositoryFromPR` before looking up
-  // the host binding so per-repo tokens/api_host/features apply.
+  // `repository` here is the PR-identity `${owner}/${repo}`. For monorepo-style
+  // configs the binding-key in `config.repos` can differ, so it is resolved
+  // through the shared helper before looking up the host binding — per-repo
+  // tokens/api_host/features then apply. The lookup is host-aware: an exclusive
+  // alt entry that only `url_pattern`-claimed this owner/repo cannot serve a PR
+  // proven to be on github.com, and must not bind it (same rule the dashboard
+  // rows and the setup route use).
   const [owner, repo] = String(repository).split('/');
-  const bindingRepository = resolveBindingRepositoryFromPR(owner, repo, config);
 
   // PR-aware host resolution. Every caller is an `/:owner/:repo/:number` route,
-  // so a per-PR host may already be stored. When a pr_metadata row exists, bind
-  // to its stored host (github for NULL, the api_host string for an alt host);
-  // when no row exists, fall back to the ambiguity rule (two-arg resolve). A
-  // stale stored host (config changed) makes resolveHostBinding throw — that
-  // surfaces to the route's error handler as a clear failure rather than a
-  // silent bind to a dead host.
+  // so a per-PR host may already be recorded. `resolveRecordedHost` reads the
+  // stored host plus the recorded html_url, upgrading a NULL to the alt host
+  // only where the URL proves it — an unprovable legacy NULL resolves to `null`
+  // (github.com), the same value the raw column carried, so those reviews bind
+  // exactly as before. A stale stored host (config changed) makes
+  // resolveHostBinding throw — that surfaces to the route's error handler
+  // rather than a silent bind to a dead host.
   const prNumber = parseInt(req.params && req.params.number, 10);
-  let hostOptions;
+  let recordedHost;
   if (Number.isInteger(prNumber) && prNumber > 0) {
     const prMetadataRepo = new PRMetadataRepository(req.app.get('db'));
-    const storedHost = await prMetadataRepo.getPRHost(repository, prNumber);
-    // Apply the legacy-NULL back-compat convention (see storedHostToOption).
-    hostOptions = storedHostToOption(config, bindingRepository, storedHost);
+    const recorded = await prMetadataRepo.getPRHostWithRecordedUrl(repository, prNumber);
+    if (recorded !== undefined) {
+      recordedHost = resolveRecordedHost(
+        config,
+        resolveBindingRepositoryFromPR(owner, repo, config),
+        recorded.host,
+        recorded.recordedUrl
+      );
+    }
   }
+  const bindingRepository = resolveBindingRepositoryForHost(owner, repo, config, recordedHost);
+  // Bind the host the evidence resolved to, NOT the raw column: a pre-stamping
+  // row whose recorded URL is on the alt host resolves to that host, and
+  // reapplying its NULL here would force a github.com binding while the row's
+  // links point at the alt host. `storedHostToOption` still applies the
+  // legacy-NULL convention against the entry that survived the check above.
+  const hostOptions = recordedHost === undefined
+    ? undefined
+    : storedHostToOption(config, bindingRepository, recordedHost);
   const binding = resolveHostBinding(bindingRepository, config, hostOptions || {});
   if (binding.token) {
     return { binding, token: binding.token, bindingRepository };
@@ -1770,7 +1788,11 @@ router.post('/api/pr/:owner/:repo/:number/submit-review', async (req, res) => {
       // string=alt) so a dual-host repo names the system this PR was submitted
       // to rather than its repo-level default.
       const cfg = req.app.get('config') || {};
-      const hostName = resolveHostName(cfg, resolveBindingRepositoryFromPR(owner, repo, cfg), binding.host);
+      const hostName = resolveHostName(
+        cfg,
+        resolveBindingRepositoryForHost(owner, repo, cfg, binding.host),
+        binding.host
+      );
       res.json({
         success: true,
         message: `${event === 'DRAFT' ? 'Draft review created' : 'Review submitted'} successfully ${event === 'DRAFT' ? 'on' : 'to'} ${hostName}`,
@@ -1967,15 +1989,11 @@ router.post('/api/parse-pr-url', (req, res) => {
   const result = parser.parsePRUrl(url);
 
   if (result) {
-    // Report whether the resolved repo is DUAL (github + alt-host). A github URL
-    // (host === null) for a dual repo must be forwarded to setup as an explicit
-    // github pick (the "github" sentinel) so it does not probe alt-first; for a
-    // plain or exclusive repo the client omits host (no probe / avoids the
-    // exclusive-null throw). Resolve the binding key first (url_pattern match
-    // supplies it; otherwise derive from owner/repo).
+    // `setupHost` is the resolved `?host=` value for this URL (see
+    // setupHostParam): an alt api_host string, the 'github' sentinel when any
+    // api_host entry could otherwise claim this repo, or null to omit. Computed
+    // here so the browser never has to reason about repo configuration.
     const safeConfig = config || {};
-    const bindingRepository = result.bindingRepository
-      || resolveBindingRepositoryFromPR(result.owner, result.repo, safeConfig);
     return res.json({
       valid: true,
       owner: result.owner,
@@ -1988,7 +2006,7 @@ router.post('/api/parse-pr-url', (req, res) => {
       // from owner/repo for monorepo-style url_pattern configs).
       host: result.host,
       bindingRepository: result.bindingRepository,
-      isDualHost: isDualHostRepo(safeConfig, bindingRepository)
+      setupHost: setupHostParam(safeConfig, result.owner, result.repo, result.host)
     });
   }
 

--- a/src/routes/setup.js
+++ b/src/routes/setup.js
@@ -15,8 +15,8 @@ const crypto = require('crypto');
 const { activeSetups, broadcastSetupProgress } = require('./shared');
 const { setupPRReview } = require('../setup/pr-setup');
 const { setupLocalReview } = require('../setup/local-setup');
-const { expandPath, resolveBindingRepositoryFromPR } = require('../config');
-const { resolvePreflightBinding } = require('../utils/host-resolution');
+const { expandPath } = require('../config');
+const { resolvePreflightBinding, explicitHostForBinding, resolveBindingRepositoryForHost } = require('../utils/host-resolution');
 const { queryOne, ReviewRepository } = require('../database');
 const { normalizeRepository } = require('../utils/paths');
 const { rejectUrlLikeLocalReviewPath } = require('../utils/local-path-input');
@@ -130,13 +130,20 @@ router.post('/api/setup/pr/:owner/:repo/:number', async (req, res) => {
 
     // GitHub token is required for PR setup. Resolve the binding key first so
     // monorepo-style `repos[...]` entries (matched via `url_pattern` named
-    // captures) supply their per-repo token even when the captured owner/repo
-    // differs from the config key.
-    const repositoryForToken = resolveBindingRepositoryFromPR(owner, repo, config);
+    // captures) supply their per-repo token — and their path, checkout script,
+    // pool, and reset script — even when the captured owner/repo differs from
+    // the config key. The lookup is host-aware: an explicit github.com host
+    // rejects an EXCLUSIVE alt entry that only pattern-claimed this owner/repo,
+    // matching the parser's invariant that such an entry never binds a
+    // canonical github.com PR. Dual entries are kept for either host.
+    const repositoryForToken = resolveBindingRepositoryForHost(owner, repo, config, bodyHost);
+    // Then normalise the hint against the entry that survived: a github.com hint
+    // for a repo whose own config says alt-host-only is ignored with a warning.
+    const effectiveHost = explicitHostForBinding(config, repositoryForToken, bodyHost);
     // Preflight the credential. resolvePreflightBinding gates on ANY usable
     // binding — including a dual repo's alt-only token or a token pinned by an
     // explicit body host — so an alt-host setup isn't falsely 401'd.
-    const preflightBinding = resolvePreflightBinding(repositoryForToken, config, bodyHost);
+    const preflightBinding = resolvePreflightBinding(repositoryForToken, config, effectiveHost);
     if (!preflightBinding.token) {
       return res.status(401).json({ error: 'GitHub token not configured' });
     }
@@ -226,7 +233,7 @@ router.post('/api/setup/pr/:owner/:repo/:number', async (req, res) => {
           githubToken,
           bindingRepository: repositoryForToken,
           config,
-          host: bodyHost,
+          host: effectiveHost,
           poolLifecycle: req.app.get('poolLifecycle'),
           restoreMetadata,
           onProgress: (progress) => {

--- a/src/routes/stack-analysis.js
+++ b/src/routes/stack-analysis.js
@@ -20,7 +20,7 @@ const { mergeInstructions } = require('../utils/instructions');
 const { GitWorktreeManager } = require('../git/worktree');
 const { GitHubClient } = require('../github/client');
 const { getGitHubToken, resolveHostBinding, resolveBindingRepositoryFromPR, resolveRepoOptions, resolveLoadSkills, buildCouncilProviderOverrides } = require('../config');
-const { storedHostToOption } = require('../utils/host-resolution');
+const { storedHostToOption, resolveRecordedHost, resolveBindingRepositoryForHost } = require('../utils/host-resolution');
 const { setupStackPR } = require('../setup/stack-setup');
 const Analyzer = require('../ai/analyzer');
 const { getProviderClass, createProvider } = require('../ai/provider');
@@ -255,14 +255,27 @@ async function executeStackAnalysis(params) {
     // monorepo-style `url_pattern` configs (one `repos[...]` entry serves many
     // captured owner/repo pairs). The PR identity is still used for DB rows and
     // worktree identity.
-    // Resolve the stack binding from the MAIN (trigger) PR's stored host so every
-    // sibling is fetched from — and later stamped with — the same host. Stacks
-    // don't span systems, so a dual repo's alt-hosted stack must not fall back to
-    // github via the two-arg ambiguity rule. `storedHostToOption` applies the
-    // legacy-NULL convention; `undefined` (no row) preserves the ambiguity rule.
-    const mainStoredHost = await new PRMetadataRepository(db).getPRHost(repository, triggerPRNumber);
-    const stackHostOption = storedHostToOption(config, bindingRepository, mainStoredHost);
-    const stackBinding = deps.resolveHostBinding(bindingRepository, config, stackHostOption || {});
+    // Resolve the stack binding from the MAIN (trigger) PR's recorded host so
+    // every sibling is fetched from — and later stamped with — the same host.
+    // Stacks don't span systems, so a dual repo's alt-hosted stack must not fall
+    // back to github via the two-arg ambiguity rule. `storedHostToOption` applies
+    // the legacy-NULL convention; `undefined` (no row) preserves it.
+    //
+    // The HOST key is resolved separately from `bindingRepository` above: that
+    // one is this PR's config identity (worktree options, pool, reset script) and
+    // must not move, while an exclusive alt entry that only `url_pattern`-claimed
+    // this owner/repo cannot serve a stack proven to be on github.com.
+    const mainRecorded = await new PRMetadataRepository(db).getPRHostWithRecordedUrl(repository, triggerPRNumber);
+    const mainRecordedHost = mainRecorded === undefined
+      ? undefined
+      : resolveRecordedHost(config, bindingRepository, mainRecorded.host, mainRecorded.recordedUrl);
+    const stackBindingRepository = resolveBindingRepositoryForHost(owner, repo, config, mainRecordedHost);
+    // Bind the resolved host, not the raw column: a pre-stamping trigger PR whose
+    // recorded URL is on the alt host must keep the stack on the alt host.
+    const stackHostOption = mainRecordedHost === undefined
+      ? undefined
+      : storedHostToOption(config, stackBindingRepository, mainRecordedHost);
+    const stackBinding = deps.resolveHostBinding(stackBindingRepository, config, stackHostOption || {});
     const githubToken = stackBinding.token;
     const prDataMap = new Map();
     if (githubToken) {

--- a/src/routes/worktrees.js
+++ b/src/routes/worktrees.js
@@ -17,6 +17,12 @@ const { activeAnalyses, reviewToAnalysisId, killProcesses, broadcastProgress } =
 const fs = require('fs').promises;
 const logger = require('../utils/logger');
 const { resolvePoolConfig } = require('../config');
+const { resolveRepoLinks } = require('../links/repo-links');
+const {
+  resolveRecordedHost,
+  resolveBindingRepositoryForHost,
+  setupHostParam
+} = require('../utils/host-resolution');
 
 const router = express.Router();
 
@@ -140,6 +146,7 @@ router.get('/api/worktrees/recent', async (req, res) => {
     const limit = Math.min(parseInt(req.query.limit) || 10, 50);
     const before = req.query.before || null;
     const db = req.app.get('db');
+    const config = req.app.get('config') || {};
 
     // Fetch limit + 1 to determine hasMore
     const fetchCount = limit + 1;
@@ -152,10 +159,13 @@ router.get('/api/worktrees/recent', async (req, res) => {
         pm.pr_number,
         pm.title,
         pm.author,
+        pm.base_branch,
         pm.head_branch,
         pm.last_accessed_at,
         pm.created_at,
         json_extract(pm.pr_data, '$.html_url') as html_url,
+        json_extract(pm.pr_data, '$.head_sha') as head_sha,
+        pm.host,
         w.id as worktree_id,
         w.path as worktree_path,
         w.branch,
@@ -195,6 +205,27 @@ router.get('/api/worktrees/recent', async (req, res) => {
           }
         }
       }
+      const [owner, repo] = row.repository.split('/');
+      // Host stamping (schema v50) was never backfilled, so a stored NULL can
+      // mean "github.com" OR "recorded before stamping existed".
+      // `resolveRecordedHost` upgrades a NULL to the alt host only where the
+      // recorded html_url proves it; an unprovable legacy row resolves to
+      // `null` (github.com), the stored convention, rather than to a host this
+      // row's click would not bind. Links, navigation, and the /pr binding all
+      // derive from this one value.
+      const host = resolveRecordedHost(
+        config,
+        resolveBindingRepositoryForHost(owner, repo, config, undefined),
+        row.host,
+        row.html_url
+      );
+      // With the host settled, resolve links and navigation from it through the
+      // same helpers the setup route uses, so the row's icon and its click
+      // cannot reach different systems. /pr's applyHostQueryCorrection also
+      // stamps the value on the way through, healing the legacy NULL.
+      const bindingRepository = resolveBindingRepositoryForHost(owner, repo, config, host);
+      const repoLinks = resolveRepoLinks(config, bindingRepository, host);
+      const setupHost = setupHostParam(config, owner, repo, host);
       reviews.push({
         id: row.id,
         repository: row.repository,
@@ -202,10 +233,15 @@ router.get('/api/worktrees/recent', async (req, res) => {
         pr_title: row.title,
         author: row.author || null,
         head_branch: row.head_branch || row.branch || null,
+        base_branch: row.base_branch || null,
         last_accessed_at: row.last_accessed_at,
         created_at: row.created_at,
         storage_status: storageStatus,
         html_url: row.html_url || null,
+        head_sha: row.head_sha || null,
+        host: host,
+        setup_host: setupHost,
+        repo_links: repoLinks,
         review_id: row.review_id || null
       });
     }

--- a/src/server.js
+++ b/src/server.js
@@ -1,9 +1,10 @@
 // Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
 const express = require('express');
 const path = require('path');
-const { loadConfig, getGitHubToken, resolveDbName, warnIfDevModeWithoutDbName, getRepoConfig, resolveBindingRepositoryFromPR, isExclusiveAltHost } = require('./config');
+const { loadConfig, getGitHubToken, resolveDbName, warnIfDevModeWithoutDbName, getRepoConfig, isExclusiveAltHost } = require('./config');
 const { initializeDatabase, getDatabaseStatus, queryOne, run, PRMetadataRepository } = require('./database');
 const { normalizeRepository } = require('./utils/paths');
+const { resolveBindingRepositoryForHost } = require('./utils/host-resolution');
 const { GlobalSettingsService } = require('./settings/global-settings-service');
 const { applyConfigOverrides, checkAllProviders } = require('./ai');
 const { checkAllChatProviders } = require('./chat/chat-providers');
@@ -79,8 +80,12 @@ async function applyHostQueryCorrection(db, config, owner, repo, repository, prN
   const targetHost = rawHost === 'github' ? null : rawHost;
 
   // Resolve the repo's config entry (handles monorepo-style keys matched via
-  // url_pattern) to learn its configured api_host.
-  const bindingRepo = resolveBindingRepositoryFromPR(owner, repo, config);
+  // url_pattern) to learn its configured api_host. Host-aware: an explicit
+  // github.com correction is authoritative — the dashboard row it came from was
+  // sourced from the github.com search, or the user pasted a github.com URL —
+  // so an exclusive alt entry that merely `url_pattern`-claimed this owner/repo
+  // is rejected here too, and the correction is accepted instead of dropped.
+  const bindingRepo = resolveBindingRepositoryForHost(owner, repo, config, targetHost);
   const repoConfig = getRepoConfig(config, bindingRepo);
   const configuredApiHost = (repoConfig && typeof repoConfig.api_host === 'string' && repoConfig.api_host)
     ? repoConfig.api_host

--- a/src/setup/pr-setup.js
+++ b/src/setup/pr-setup.js
@@ -18,7 +18,7 @@ const { GitHubClient } = require('../github/client');
 const { normalizeRepository } = require('../utils/paths');
 const { findMainGitRoot } = require('../local-review');
 const { getConfigDir, getRepoPath, resolveRepoOptions, resolvePoolConfig, getRepoResetScript, resolveHostBinding, resolveBindingRepositoryFromPR, getRepoConfig, DEFAULT_CHECKOUT_TIMEOUT_MS } = require('../config');
-const { storedHostToOption, isDualHostRepoConfig } = require('../utils/host-resolution');
+const { storedHostToOption, isDualHostRepoConfig, resolveRecordedHost, bindingRepositoryForHost } = require('../utils/host-resolution');
 const logger = require('../utils/logger');
 const { fireReviewStartedHook } = require('../hooks/payloads');
 const simpleGit = require('simple-git');
@@ -270,7 +270,49 @@ async function storePRData(db, prInfo, prData, diff, changedFiles, worktreePath,
 async function resolvePrHostBinding({ db, config, bindingRepository, owner, repo, prNumber, host, githubToken, deps = {} }) {
   const Client = deps.GitHubClient || GitHubClient;
   const repository = normalizeRepository(owner, repo);
-  const repoConfig = getRepoConfig(config, bindingRepository);
+
+  // Apply host precedence FIRST, because the resolved host selects which config
+  // entry may be bound through: an exclusive alt entry that only
+  // `url_pattern`-claimed this owner/repo cannot serve a PR that lives on
+  // github.com. The caller's `bindingRepository` arrives already filtered
+  // against the host known at entry (the setup route and CLI both apply this
+  // rule), and that same key selects the repo's local configuration — path,
+  // checkout script, pool, reset script — as well as credentials. The local
+  // `hostBindingRepository` below re-applies the filter with the RECORDED host,
+  // which only this function resolves.
+  let effectiveHost;
+  let hostKnown = false;
+  let recordedHost;
+  if (host !== undefined) {
+    effectiveHost = host;
+    hostKnown = true;
+    recordedHost = host;
+  } else {
+    const prMetadataRepo = new PRMetadataRepository(db);
+    const recorded = await prMetadataRepo.getPRHostWithRecordedUrl(repository, prNumber);
+    if (recorded !== undefined) {
+      // resolveRecordedHost reads the stored host against the recorded html_url,
+      // which is what separates a pre-stamping row from a github.com one.
+      recordedHost = resolveRecordedHost(config, bindingRepository, recorded.host, recorded.recordedUrl);
+      // storedHostToOption applies the legacy-NULL convention: `undefined` means
+      // "host unknown" (leave hostKnown false → ambiguity/probe path), while a
+      // returned option object pins the host. It receives the RESOLVED host, not
+      // the raw column — a pre-stamping row whose recorded URL is on the alt host
+      // must fetch from there instead of being forced to github.com.
+      const storedOption = storedHostToOption(
+        config,
+        bindingRepositoryForHost(config, repository, bindingRepository, recordedHost),
+        recordedHost
+      );
+      if (storedOption !== undefined) {
+        effectiveHost = storedOption.host;
+        hostKnown = true;
+      }
+    }
+  }
+
+  const hostBindingRepository = bindingRepositoryForHost(config, repository, bindingRepository, recordedHost);
+  const repoConfig = getRepoConfig(config, hostBindingRepository);
   const configuredApiHost = (repoConfig && typeof repoConfig.api_host === 'string' && repoConfig.api_host)
     ? repoConfig.api_host
     : null;
@@ -289,34 +331,15 @@ async function resolvePrHostBinding({ db, config, bindingRepository, owner, repo
     if (binding.token) return binding;
     if (binding.apiHost === null) return githubToken;
     throw new Error(
-      `No token configured for alt host ${binding.apiHost} (repo ${bindingRepository}). ` +
-      `Configure repos["${bindingRepository}"].token or token_command.`
+      `No token configured for alt host ${binding.apiHost} (repo ${hostBindingRepository}). ` +
+      `Configure repos["${hostBindingRepository}"].token or token_command.`
     );
   };
-
-  // Apply host precedence to decide whether we know the host up front.
-  let effectiveHost;
-  let hostKnown = false;
-  if (host !== undefined) {
-    effectiveHost = host;
-    hostKnown = true;
-  } else {
-    const prMetadataRepo = new PRMetadataRepository(db);
-    const storedHost = await prMetadataRepo.getPRHost(repository, prNumber);
-    // storedHostToOption applies the legacy-NULL convention: `undefined` means
-    // "host unknown" (leave hostKnown false → ambiguity/probe path), while a
-    // returned option object pins the host.
-    const storedOption = storedHostToOption(config, bindingRepository, storedHost);
-    if (storedOption !== undefined) {
-      effectiveHost = storedOption.host;
-      hostKnown = true;
-    }
-  }
 
   // Fixed-binding path: host is known, OR the repo can only live on one host
   // (plain github / exclusive alt) so the ambiguity rule is unambiguous.
   if (hostKnown || !isDual) {
-    const binding = resolveHostBinding(bindingRepository, config, hostKnown ? { host: effectiveHost } : {});
+    const binding = resolveHostBinding(hostBindingRepository, config, hostKnown ? { host: effectiveHost } : {});
     const client = new Client(clientArgFor(binding));
     const repoExists = await client.repositoryExists(owner, repo);
     if (!repoExists) {
@@ -329,7 +352,7 @@ async function resolvePrHostBinding({ db, config, bindingRepository, owner, repo
   // Probe path: dual repo, host unknown. Try the alt host first. `clientArgFor`
   // errors clearly if the alt binding has no token rather than silently probing
   // github.com disguised as the alt host.
-  const altBinding = resolveHostBinding(bindingRepository, config, { host: configuredApiHost });
+  const altBinding = resolveHostBinding(hostBindingRepository, config, { host: configuredApiHost });
   const altClient = new Client(clientArgFor(altBinding));
   try {
     const prData = await altClient.fetchPullRequest(owner, repo, prNumber);
@@ -338,7 +361,7 @@ async function resolvePrHostBinding({ db, config, bindingRepository, owner, repo
   } catch (altErr) {
     if (altErr && altErr.status === 404) {
       logger.info(`PR #${prNumber} (${repository}) not found on alt host ${configuredApiHost}; falling back to github.com`);
-      const githubBinding = resolveHostBinding(bindingRepository, config, { host: null });
+      const githubBinding = resolveHostBinding(hostBindingRepository, config, { host: null });
       const githubClient = new Client(clientArgFor(githubBinding));
       const prData = await githubClient.fetchPullRequest(owner, repo, prNumber);
       return { binding: githubBinding, prData, githubClient };

--- a/src/single-port.js
+++ b/src/single-port.js
@@ -6,7 +6,7 @@ const { PRArgumentParser } = require('./github/parser');
 const logger = require('./utils/logger');
 const { rejectUrlLikeLocalReviewPath } = require('./utils/local-path-input');
 const { normalizeRepository } = require('./utils/paths');
-const { isDualHostRepo, hostSetupParamValue } = require('./utils/host-resolution');
+const { setupHostParam } = require('./utils/host-resolution');
 const { buildInteractiveAnalysisConfig } = require('./interactive-analysis-config');
 const { version: packageVersion } = require('../package.json');
 
@@ -172,7 +172,7 @@ function storeAnalysisConfigRemote(port, analysisConfig, _deps) {
  *   mirroring the cold-start precedence in handlePullRequest/handleLocalReview.
  * @param {string} [context.host] - Setup `?host=` value (alt api_host string or the
  *   'github' sentinel) so a pasted alt URL binds directly instead of re-probing.
- *   Already resolved by the caller via `hostSetupParamValue`; omitted when null.
+ *   Already resolved by the caller via `setupHostParam`; omitted when null.
  * @param {string} [context.provider] - CLI provider override to carry to the running server
  * @param {string} [context.model] - CLI model override to carry to the running server
  * @param {string} [context.scope] - Local-mode only: the `--scope` range to carry
@@ -340,10 +340,10 @@ async function attemptDelegation(config, flags, prArgs, _deps, options = {}) {
     const repository = normalizeRepository(prInfo.owner, prInfo.repo);
     const analysisConfigId = await handoffAnalysisConfigId(repository);
     // Thread the parsed host so a pasted alt URL binds directly (no re-probe) —
-    // same mapping as the cold-start handlePullRequest path. bindingRepository
-    // (from a url_pattern match) is the config key that determines dual-ness.
-    const bindingRepository = prInfo.bindingRepository || repository;
-    const host = hostSetupParamValue(prInfo.host, isDualHostRepo(config, bindingRepository));
+    // same mapping as the cold-start handlePullRequest path. See setupHostParam:
+    // a github.com URL announces itself whenever an api_host entry could
+    // otherwise claim this repo, so setup never falls back to the alt host.
+    const host = setupHostParam(config, prInfo.owner, prInfo.repo, prInfo.host);
     url = buildDelegationUrl(port, 'pr', {
       ...prInfo, analyze, councilId, analysisConfigId, host,
       provider: flags.provider, model: flags.model

--- a/src/utils/host-resolution.js
+++ b/src/utils/host-resolution.js
@@ -9,7 +9,8 @@
  * here stops the copies from drifting.
  */
 
-const { getRepoConfig, isExclusiveAltHost, resolveHostBinding } = require('../config');
+const { getRepoConfig, isExclusiveAltHost, resolveHostBinding, resolveBindingRepositoryFromPR } = require('../config');
+const logger = require('./logger');
 
 /**
  * Translate a stored `pr_metadata.host` value into the `options` object for
@@ -36,6 +37,176 @@ function storedHostToOption(config, bindingRepository, storedHost) {
     return undefined;
   }
   return { host: storedHost };
+}
+
+/**
+ * Normalise an EXPLICIT host hint (a setup request body, a `?host=` sentinel, a
+ * pasted URL's parsed host) against config. The explicit-hint sibling of
+ * {@link storedHostToOption}:
+ *
+ *   - `undefined` → `undefined` (no hint; the ambiguity rule applies).
+ *   - a URL string → unchanged; `resolveHostBinding` validates it against the
+ *     repo's `api_host` and reports a mismatch.
+ *   - `null` (github.com) on a plain or dual repo → `null`.
+ *   - `null` on an EXCLUSIVE alt-host repo → `undefined` + a warning. The repo
+ *     config asserts there is no github.com presence (`exclusive` defaults to
+ *     true whenever `api_host` is set), so the hint contradicts configuration.
+ *     Ignoring it matches `applyHostQueryCorrection` in `src/server.js`, which
+ *     warns and ignores the same sentinel rather than acting on it, and keeps
+ *     `resolveHostBinding`'s exclusive-null guard unreachable from user input —
+ *     a clickable dashboard row must never 500 on a config contradiction.
+ *
+ * @param {Object} config - Application config
+ * @param {string} bindingRepository - `repos[...]` config-lookup key
+ * @param {string|null|undefined} host - The explicit hint
+ * @returns {string|null|undefined} The host to bind with
+ */
+function explicitHostForBinding(config, bindingRepository, host) {
+  if (host !== null) return host;
+  if (!isExclusiveAltHost(getRepoConfig(config, bindingRepository))) return null;
+  logger.warn(
+    `Ignoring github.com host hint for "${bindingRepository}": it is configured as an ` +
+    'exclusive alt-host repo (api_host without "exclusive": false), so it has no github.com ' +
+    'binding. Set "exclusive": false on that repo if its PRs can live on github.com too.'
+  );
+  return undefined;
+}
+
+/**
+ * Resolve the host a RECORDED PR lives on, from its stored `host` column plus
+ * its recorded `html_url`.
+ *
+ * Mirrors the convention {@link storedHostToOption} encodes, which already says
+ * which stored NULLs are ambiguous: dual-host support shipped WITH host stamping
+ * (schema v50), so a NULL on a dual or plain repo means github.com. What a NULL
+ * cannot tell us is whether an older row predates stamping — and the recorded
+ * `html_url` settles that in ONE direction, since a URL that is not on
+ * github.com cannot be a github.com PR:
+ *
+ *   - a URL string → that host (already stamped; nothing to infer).
+ *   - NULL on a repo with no `api_host` → `null`; there is no other host.
+ *   - NULL with a non-github `html_url` → the configured `api_host`. This is the
+ *     pre-stamping row (or a repo that was exclusive-alt before gaining
+ *     `exclusive: false`), so github.com would be wrong.
+ *   - NULL otherwise → `null` (github.com), per the convention above.
+ *   - `undefined` (no row) → `undefined`.
+ *
+ * One resolver serves links, navigation, AND binding on purpose: a row that
+ * renders a github.com icon must bind github.com when clicked, and the only way
+ * to guarantee that is to derive every one of them from the same value.
+ *
+ * @param {Object} config - Application config
+ * @param {string} bindingRepository - `repos[...]` config-lookup key
+ * @param {string|null|undefined} storedHost - Value from the `host` column
+ * @param {string|null|undefined} recordedUrl - The PR's stored `html_url`
+ * @returns {string|null|undefined} The host this PR is recorded on
+ */
+function resolveRecordedHost(config, bindingRepository, storedHost, recordedUrl) {
+  if (storedHost !== null) return storedHost;
+  const apiHost = getConfiguredApiHost(config, bindingRepository);
+  if (!apiHost) return null;
+  if (typeof recordedUrl !== 'string' || !recordedUrl) return null;
+  let hostname;
+  try {
+    hostname = new URL(recordedUrl).hostname.toLowerCase();
+  } catch {
+    return null;
+  }
+  return (hostname === 'github.com' || hostname.endsWith('.github.com')) ? null : apiHost;
+}
+
+/**
+ * Resolve the `repos[...]` config key for a PR whose host is KNOWN.
+ *
+ * `resolveBindingRepositoryFromPR` answers "which entry serves this
+ * owner/repo?" with no host context: its slow path probes each entry's
+ * `url_pattern` against a URL built from that entry's OWN `api_host`, so a
+ * correctly anchored monorepo-style pattern claims EVERY owner/repo — including
+ * repos that exist only on github.com.
+ *
+ * `PRArgumentParser.parsePRUrl` already refuses the same overreach in the URL
+ * dimension (see its INVARIANT: "an `api_host`-bearing `url_pattern` must NEVER
+ * bind a canonical github.com / Graphite URL"), discarding the match so a
+ * pasted github.com URL resolves to its own `owner/repo`. This applies that
+ * settled rule to the owner/repo dimension, for the one case that can be
+ * decided safely:
+ *
+ *   - `host` unknown or an alt-host string → the matched key, unchanged.
+ *   - `host === null` (github.com) and the entry was claimed by its
+ *     `url_pattern` probe (its key is not this PR's identity) and it is an
+ *     EXCLUSIVE alt-host entry → the PR's own `owner/repo`. Such an entry has
+ *     no github.com presence, so it describes neither this PR's API host nor
+ *     its checkout.
+ *   - a DUAL entry is kept for either host: `resolveHostBinding` has a
+ *     first-class github.com binding for dual repos, so the entry does serve
+ *     this PR (and its path/pool/reset config still applies).
+ *   - a directly-keyed exclusive entry is kept: there the configuration itself
+ *     asserts this exact repo is alt-host-only, and config wins over inference.
+ *
+ * Two entry points share the rule: this one resolves the key itself, while
+ * {@link bindingRepositoryForHost} filters a key a caller already holds (from a
+ * `url_pattern` parse, say) without re-deriving it.
+ *
+ * @param {string} owner
+ * @param {string} repo
+ * @param {Object} config
+ * @param {string|null|undefined} host
+ * @returns {string} The `repos[...]` config-lookup key
+ */
+function resolveBindingRepositoryForHost(owner, repo, config, host) {
+  const identity = `${String(owner || '').toLowerCase()}/${String(repo || '').toLowerCase()}`;
+  return bindingRepositoryForHost(
+    config,
+    identity,
+    resolveBindingRepositoryFromPR(owner, repo, config),
+    host
+  );
+}
+
+/**
+ * Filter form of {@link resolveBindingRepositoryForHost}: applies the same rule
+ * to a binding key the caller already resolved. Used where re-deriving the key
+ * from owner/repo could lose it — a `url_pattern` entry whose captures do not
+ * reproduce its config key, for instance.
+ *
+ * @param {Object} config
+ * @param {string} identity - The PR's own normalized `owner/repo`
+ * @param {string} bindingRepository - Key the caller resolved
+ * @param {string|null|undefined} host
+ * @returns {string} The key to bind through
+ */
+function bindingRepositoryForHost(config, identity, bindingRepository, host) {
+  if (host !== null) return bindingRepository;
+  if (String(bindingRepository).toLowerCase() === String(identity).toLowerCase()) return bindingRepository;
+  return isExclusiveAltHost(getRepoConfig(config, bindingRepository)) ? identity : bindingRepository;
+}
+
+/**
+ * The single mapping from a PR's KNOWN host to the setup `?host=` param value.
+ * Used by every entry point that can name a PR's host up front: dashboard
+ * collection rows, recent-review rows, the pasted-URL flow, the CLI cold start,
+ * and single-port delegation.
+ *
+ *   - an alt-host string → that string (setup binds it directly, no probe).
+ *   - `null` (github.com) with ANY `api_host`-bearing entry in play → the
+ *     `'github'` sentinel. Staying silent here leaves setup on the ambiguity
+ *     rule, which probes a dual repo and binds an exclusive one to its alt host;
+ *     announcing it is also what lets setup apply the host-aware key rule above.
+ *   - `null` on a plain github.com repo → `null` (omit; the ambiguity rule
+ *     already binds github.com, so there is nothing to say).
+ *   - unknown host → `null` (omit; the server derives it).
+ *
+ * @param {Object} config
+ * @param {string} owner
+ * @param {string} repo
+ * @param {string|null|undefined} host - The PR's resolved host
+ * @returns {string|null} `?host=` value, or null to omit
+ */
+function setupHostParam(config, owner, repo, host) {
+  if (typeof host === 'string' && host) return host;
+  if (host !== null) return null;
+  const matched = resolveBindingRepositoryFromPR(owner, repo, config);
+  return getConfiguredApiHost(config, matched) ? 'github' : null;
 }
 
 /**
@@ -122,36 +293,15 @@ function resolvePreflightBinding(bindingRepository, config, host) {
   return primary;
 }
 
-/**
- * Map a parser/stored host to the VALUE for the setup `?host=` query param, or
- * `null` to omit the param. Single source for the CLI cold-start, single-port
- * delegation, and (mirrored) the web paste flow — so a pasted alt URL binds the
- * alt host directly instead of re-probing at setup.
- *
- *   - alt api_host URL string → that string (setup binds the alt host)
- *   - `null` on a DUAL repo   → the `'github'` sentinel (setup binds github.com,
- *     no probe — avoids a loud failure if the alt host is down for a PR we KNOW
- *     is on github)
- *   - anything else (plain/exclusive repo, or unknown host) → `null` (omit; no
- *     probe happens for those, and omitting avoids the exclusive-null throw)
- *
- * Callers append the value as `host=${encodeURIComponent(value)}`.
- *
- * @param {string|null|undefined} host - parser/stored host
- * @param {boolean} isDual - whether the repo is dual (github + alt-host)
- * @returns {string|null} the param value, or null to omit
- */
-function hostSetupParamValue(host, isDual) {
-  if (typeof host === 'string' && host) return host;
-  if (host === null && isDual) return 'github';
-  return null;
-}
-
 module.exports = {
   storedHostToOption,
+  explicitHostForBinding,
+  resolveRecordedHost,
+  resolveBindingRepositoryForHost,
+  bindingRepositoryForHost,
+  setupHostParam,
   isDualHostRepo,
   isDualHostRepoConfig,
   getConfiguredApiHost,
   resolvePreflightBinding,
-  hostSetupParamValue,
 };

--- a/tests/e2e/dashboard-repo-links.spec.js
+++ b/tests/e2e/dashboard-repo-links.spec.js
@@ -1,0 +1,140 @@
+// Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+/**
+ * E2E Tests: host-aware repository links on the main dashboard
+ *
+ * Closes the producer/consumer loop for the dashboard row contract. The server
+ * side (field names and values) is asserted in
+ * tests/integration/github-collections.test.js and
+ * tests/integration/worktree-pagination.test.js; these tests confirm the real
+ * browser reads those exact fields and that a row's action icon and its click
+ * resolve to the SAME system.
+ *
+ * `/api/github/review-requests` and `/api/worktrees/recent` are intercepted at
+ * the Playwright network layer with the payload shape those integration tests
+ * pin, because the test server has no `repos` configuration of its own.
+ */
+
+import { test, expect } from './fixtures.js';
+
+const METEORITE_API = 'https://meteorite.example/api/v3';
+
+/** Intercept the review-requests collection (cached GET + refresh POST). */
+async function interceptReviewRequests(page, prs) {
+  await page.route('**/api/github/review-requests**', route => {
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ success: true, prs, fetched_at: new Date().toISOString() })
+    });
+  });
+}
+
+/** Open the dashboard and switch to the "My Review Requests" tab. */
+async function openReviewRequestsTab(page) {
+  await page.goto('/');
+  await page.click('#unified-tab-bar [data-tab="review-requests-tab"]');
+  return page.locator('#review-requests-tbody tr.collection-pr-row');
+}
+
+test.describe('Dashboard repository links', () => {
+  test('a dual-host github.com row opens github for both its icon and its click', async ({ page }) => {
+    await interceptReviewRequests(page, [{
+      owner: 'shop',
+      repo: 'world',
+      number: 41,
+      title: 'A github.com PR',
+      author: 'alice',
+      updated_at: new Date().toISOString(),
+      html_url: 'https://github.com/shop/world/pull/41',
+      state: 'open',
+      host: null,
+      // Server-resolved: a dual repo has a github.com binding, so the sentinel
+      // is emitted and the alt-host external link is suppressed.
+      setup_host: 'github',
+      repo_links: { external: null, github: true, graphite: true }
+    }]);
+
+    const row = await openReviewRequestsTab(page);
+    await expect(row).toHaveCount(1);
+
+    // The row echoes the server's setup host verbatim.
+    await expect(row).toHaveAttribute('data-host', 'github');
+
+    // The action icon points at github.com, matching that binding.
+    const action = row.locator('a.btn-github-link[title="Open on GitHub"]');
+    await expect(action).toHaveAttribute('href', 'https://github.com/shop/world/pull/41');
+    await expect(row.locator('a[title="Open on Meteorite"]')).toHaveCount(0);
+
+    // Clicking the row navigates to the PR route carrying the same host.
+    await row.click();
+    await expect(page).toHaveURL(/\/pr\/shop\/world\/41\?host=github/);
+  });
+
+  test('an alt-host row opens the alt host for both its icon and its click', async ({ page }) => {
+    await interceptReviewRequests(page, [{
+      owner: 'shop',
+      repo: 'world',
+      number: 42,
+      title: 'A Meteorite PR',
+      author: 'alice',
+      updated_at: new Date().toISOString(),
+      html_url: 'https://meteorite.example/shop/world/pull/42',
+      state: 'open',
+      host: METEORITE_API,
+      setup_host: METEORITE_API,
+      repo_links: {
+        external: {
+          name: 'Meteorite',
+          label: 'Open on Meteorite',
+          url_template: 'https://meteorite.example/{owner}/{repo}/pull/{number}',
+          icon: null
+        },
+        github: false,
+        graphite: false
+      }
+    }]);
+
+    const row = await openReviewRequestsTab(page);
+    await expect(row).toHaveCount(1);
+    await expect(row).toHaveAttribute('data-host', METEORITE_API);
+
+    const external = row.locator('a[title="Open on Meteorite"]');
+    await expect(external).toHaveAttribute('href', 'https://meteorite.example/shop/world/pull/42');
+    await expect(row.locator('a[title="Open on GitHub"]')).toHaveCount(0);
+
+    await row.click();
+    await expect(page).toHaveURL(
+      new RegExp('/pr/shop/world/42\\?host=' + encodeURIComponent(METEORITE_API).replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+    );
+  });
+
+  test('a hostile PR title cannot inject attributes into a dashboard row', async ({ page }) => {
+    await interceptReviewRequests(page, [{
+      owner: 'shop',
+      repo: 'world',
+      number: 43,
+      title: 'Fix " onmouseover="window.__pwned = 1" crash',
+      author: 'alice',
+      updated_at: new Date().toISOString(),
+      html_url: 'https://github.com/shop/world/pull/43',
+      state: 'open',
+      host: null,
+      setup_host: 'github',
+      repo_links: { external: null, github: true, graphite: true }
+    }]);
+
+    const row = await openReviewRequestsTab(page);
+    const titleCell = row.locator('td.col-title');
+    await expect(titleCell).toHaveCount(1);
+
+    // The whole hostile string stays inside the title attribute...
+    await expect(titleCell).toHaveAttribute(
+      'title',
+      'Fix " onmouseover="window.__pwned = 1" crash'
+    );
+    // ...and no event handler was created from it.
+    expect(await titleCell.evaluate(el => el.getAttribute('onmouseover'))).toBeNull();
+    await titleCell.hover();
+    expect(await page.evaluate(() => window.__pwned)).toBeUndefined();
+  });
+});

--- a/tests/integration/github-collections.test.js
+++ b/tests/integration/github-collections.test.js
@@ -119,6 +119,166 @@ describe('GitHub Collections Routes', () => {
       expect(res.body.fetched_at).toBeTruthy();
     });
 
+    it('should include host-aware repository links for cached PRs', async () => {
+      const apiHost = 'https://meteorite.example/api/v3';
+      app.set('config', {
+        repos: {
+          'shop/world': {
+            api_host: apiHost,
+            exclusive: false,
+            links: {
+              external: {
+                name: 'Meteorite',
+                label: 'Open on Meteorite',
+                url_template: 'https://meteorite.example/{owner}/{repo}/pull/{number}'
+              }
+            }
+          }
+        }
+      });
+      await insertCachedPR(db, {
+        owner: 'shop', repo: 'world', number: 2000042,
+        title: 'Meteorite PR', author: 'alice',
+        updated_at: '2026-08-21T18:00:00Z',
+        html_url: 'https://meteorite.example/shop/world/pull/2000042',
+        state: 'open', collection: 'review-requests'
+      });
+      await run(db, 'UPDATE github_pr_cache SET host = ? WHERE owner = ? AND repo = ? AND number = ?', [
+        apiHost,
+        'shop',
+        'world',
+        2000042
+      ]);
+
+      const res = await request(server).get('/api/github/review-requests');
+
+      expect(res.status).toBe(200);
+      expect(res.body.prs[0].repo_links).toMatchObject({
+        external: {
+          name: 'Meteorite',
+          label: 'Open on Meteorite',
+          url_template: 'https://meteorite.example/{owner}/{repo}/pull/{number}'
+        },
+        github: false,
+        graphite: false
+      });
+    });
+
+    it('does not lend an exclusive alt-host repo\'s links to an authoritative github.com row', async () => {
+      // resolveBindingRepositoryFromPR probes each alt entry's url_pattern
+      // against a URL built from that entry's own api_host, so this anchored
+      // monorepo pattern claims every owner/repo. This row came from the
+      // github.com search branch, which stamps host NULL — the PR provably
+      // lives on github.com, so the alt entry describes neither its API host
+      // nor its checkout, and must not supply its links. Mirrors the parser
+      // invariant that such an entry never binds a canonical github.com URL.
+      app.set('config', {
+        repos: {
+          'acme/platform': {
+            api_host: 'https://meteorite.example/api/v3',
+            url_pattern: '^https://meteorite\\.example/(?<owner>[^/]+)/(?<repo>[^/]+)/pull/(?<number>\\d+)',
+            links: {
+              external: {
+                name: 'Meteorite',
+                label: 'Open on Meteorite',
+                url_template: 'https://meteorite.example/{owner}/{repo}/pull/{number}'
+              },
+              github: false
+            }
+          }
+        }
+      });
+      await insertCachedPR(db, {
+        owner: 'shop', repo: 'world', number: 7,
+        title: 'A github.com PR', author: 'alice',
+        updated_at: '2026-08-21T18:00:00Z',
+        html_url: 'https://github.com/shop/world/pull/7',
+        state: 'open', collection: 'review-requests'
+      });
+
+      const res = await request(server).get('/api/github/review-requests');
+
+      expect(res.status).toBe(200);
+      expect(res.body.prs[0].host).toBeNull();
+      // Default github.com link set: the alt entry's `links` do not apply.
+      expect(res.body.prs[0].repo_links).toEqual({
+        external: null,
+        github: true,
+        graphite: true
+      });
+      // And the click must reach the same place the icon points at.
+      expect(res.body.prs[0].setup_host).toBe('github');
+    });
+
+    it('emits the github sentinel only for a dual-host repo github.com row', async () => {
+      app.set('config', {
+        repos: {
+          'shop/world': {
+            api_host: 'https://meteorite.example/api/v3',
+            exclusive: false,
+            links: {
+              external: {
+                name: 'Meteorite',
+                label: 'Open on Meteorite',
+                url_template: 'https://meteorite.example/{owner}/{repo}/pull/{number}'
+              }
+            }
+          }
+        }
+      });
+      await insertCachedPR(db, {
+        owner: 'shop', repo: 'world', number: 9,
+        title: 'A github.com PR on a dual repo', author: 'alice',
+        updated_at: '2026-08-21T18:00:00Z',
+        html_url: 'https://github.com/shop/world/pull/9',
+        state: 'open', collection: 'review-requests'
+      });
+
+      const res = await request(server).get('/api/github/review-requests');
+
+      expect(res.status).toBe(200);
+      expect(res.body.prs[0].setup_host).toBe('github');
+      // A dual repo's github.com row hides the alt-host link, so the sentinel
+      // and the rendered links agree: both mean github.com.
+      expect(res.body.prs[0].repo_links.external).toBeNull();
+      expect(res.body.prs[0].repo_links.github).toBe(true);
+    });
+
+    it('emits the api_host as setup_host for an alt-host row', async () => {
+      const apiHost = 'https://meteorite.example/api/v3';
+      app.set('config', {
+        repos: {
+          'acme/platform': {
+            api_host: apiHost,
+            url_pattern: '^https://meteorite\\.example/(?<owner>[^/]+)/(?<repo>[^/]+)/pull/(?<number>\\d+)',
+            links: {
+              external: {
+                name: 'Meteorite',
+                label: 'Open on Meteorite',
+                url_template: 'https://meteorite.example/{owner}/{repo}/pull/{number}'
+              },
+              github: false
+            }
+          }
+        }
+      });
+      await insertCachedPR(db, {
+        owner: 'shop', repo: 'world', number: 8,
+        title: 'A Meteorite PR', author: 'alice',
+        updated_at: '2026-08-21T18:00:00Z',
+        html_url: 'https://meteorite.example/shop/world/pull/8',
+        state: 'open', collection: 'review-requests'
+      });
+      await run(db, 'UPDATE github_pr_cache SET host = ? WHERE number = ?', [apiHost, 8]);
+
+      const res = await request(server).get('/api/github/review-requests');
+
+      expect(res.status).toBe(200);
+      expect(res.body.prs[0].setup_host).toBe(apiHost);
+      expect(res.body.prs[0].repo_links.external).toMatchObject({ label: 'Open on Meteorite' });
+      expect(res.body.prs[0].repo_links.github).toBe(false);
+    });
+
     it('should return data sorted by updated_at DESC', async () => {
       await insertCachedPR(db, {
         owner: 'org', repo: 'repo', number: 1,

--- a/tests/integration/pr-host-correction.test.js
+++ b/tests/integration/pr-host-correction.test.js
@@ -88,6 +88,28 @@ describe('applyHostQueryCorrection (/pr fast path ?host)', () => {
     expect(await storedHost(db)).toBe(API_HOST); // untouched
   });
 
+  it('accepts the github sentinel when only a pattern-claimed exclusive entry matched', async () => {
+    // A monorepo url_pattern probe claims every owner/repo, so this repo resolves
+    // to an exclusive alt entry that has no github.com presence. The correction
+    // is authoritative — it came from a dashboard row sourced from the github.com
+    // search — so it must be stamped, not dropped, or the review page keeps
+    // binding the alt host for a PR the dashboard labelled github.com.
+    const monorepoConfig = {
+      repos: {
+        'acme/platform': {
+          api_host: API_HOST,
+          url_pattern: '^https://althost\\.example/(?<owner>[^/]+)/(?<repo>[^/]+)/pull/(?<number>\\d+)',
+          token: 'alt-token'
+        }
+      }
+    };
+    await seedPR(db, API_HOST);
+
+    await applyHostQueryCorrection(db, monorepoConfig, 'altorg', 'altrepo', REPOSITORY, PR_NUMBER, 'github');
+
+    expect(await storedHost(db)).toBeNull();
+  });
+
   it('does nothing when no host query param is present', async () => {
     await seedPR(db, null);
     const warnSpy = vi.spyOn(logger, 'warn');

--- a/tests/integration/pr-setup-host-resolution.test.js
+++ b/tests/integration/pr-setup-host-resolution.test.js
@@ -200,4 +200,87 @@ describe('resolvePrHostBinding — precedence + probe', () => {
     expect(binding.host).toBe(ALT_HOST);
     expect(constructions).toEqual([{ apiHost: ALT_HOST }]);
   });
+
+  it('a recorded github.com PR does not bind an exclusive entry that only pattern-claimed it', async () => {
+    // The monorepo url_pattern probe claims every owner/repo, so re-running setup
+    // for this PR would otherwise fetch from the alt host. Its recorded html_url
+    // proves github.com, so the entry is rejected for this PR and the github
+    // binding is used — matching the dashboard links and the /pr binding.
+    const monorepoConfig = {
+      github_token: 'gh-tok',
+      repos: {
+        'acme/platform': {
+          api_host: ALT_HOST,
+          url_pattern: '^https://alt\\.example/(?<owner>[^/]+)/(?<repo>[^/]+)/pull/(?<number>\\d+)',
+          token: 'alt-tok'
+        }
+      }
+    };
+    await run(db,
+      'INSERT INTO pr_metadata (pr_number, repository, host, pr_data) VALUES (?, ?, NULL, ?)',
+      [42, 'acme/widgets', JSON.stringify({ html_url: 'https://github.com/acme/widgets/pull/42' })]
+    );
+    const { FakeClient, constructions } = makeFakeClient(() => ({ number: 42 }));
+
+    const { binding } = await resolvePrHostBinding({
+      db,
+      config: monorepoConfig,
+      ...base,
+      bindingRepository: 'acme/platform',
+      host: undefined,
+      deps: { GitHubClient: FakeClient }
+    });
+
+    expect(binding.host).toBe(null);
+    expect(constructions).toEqual([{ apiHost: null }]);
+  });
+
+  it('a recorded alt-host PR keeps the pattern-claimed entry', async () => {
+    const monorepoConfig = {
+      github_token: 'gh-tok',
+      repos: {
+        'acme/platform': {
+          api_host: ALT_HOST,
+          url_pattern: '^https://alt\\.example/(?<owner>[^/]+)/(?<repo>[^/]+)/pull/(?<number>\\d+)',
+          token: 'alt-tok'
+        }
+      }
+    };
+    await run(db,
+      'INSERT INTO pr_metadata (pr_number, repository, host, pr_data) VALUES (?, ?, NULL, ?)',
+      [42, 'acme/widgets', JSON.stringify({ html_url: 'https://alt.example/acme/widgets/pull/42' })]
+    );
+    const { FakeClient, constructions } = makeFakeClient(() => ({ number: 42 }));
+
+    const { binding } = await resolvePrHostBinding({
+      db,
+      config: monorepoConfig,
+      ...base,
+      bindingRepository: 'acme/platform',
+      host: undefined,
+      deps: { GitHubClient: FakeClient }
+    });
+
+    expect(binding.host).toBe(ALT_HOST);
+    expect(constructions).toEqual([{ apiHost: ALT_HOST }]);
+  });
+
+  it('a pre-stamping NULL with an alt-host recorded URL fetches from the alt host (dual repo)', async () => {
+    // Dual repo, row recorded before host stamping. The recorded URL contradicts
+    // github.com, so setup must fetch from the alt host directly — reapplying the
+    // raw NULL would force a github.com fetch for a PR that is not there.
+    await run(db,
+      'INSERT INTO pr_metadata (pr_number, repository, host, pr_data) VALUES (?, ?, NULL, ?)',
+      [42, 'acme/widgets', JSON.stringify({ html_url: 'https://alt.example/acme/widgets/pull/42' })]
+    );
+    const { FakeClient, constructions } = makeFakeClient(() => ({ number: 42 }));
+
+    const { binding } = await resolvePrHostBinding({
+      db, config: dualConfig, ...base, host: undefined, deps: { GitHubClient: FakeClient }
+    });
+
+    expect(binding.host).toBe(ALT_HOST);
+    // Bound directly: no github-first attempt and no probe.
+    expect(constructions).toEqual([{ apiHost: ALT_HOST }]);
+  });
 });

--- a/tests/integration/resolve-binding-for-request.test.js
+++ b/tests/integration/resolve-binding-for-request.test.js
@@ -27,6 +27,30 @@ const exclusiveConfig = {
   github_token: 'gh-tok',
   repos: { 'acme/widgets': { api_host: ALT_HOST, token: 'alt-tok' } }
 };
+// Monorepo-style entry: its url_pattern probe claims EVERY owner/repo, so an
+// existing review of a github.com PR resolves through it unless the lookup is
+// host-aware.
+const MONOREPO_PATTERN = '^https://alt\\.example/(?<owner>[^/]+)/(?<repo>[^/]+)/pull/(?<number>\\d+)';
+const exclusiveMonorepoConfig = {
+  github_token: 'gh-tok',
+  repos: {
+    'acme/platform': { api_host: ALT_HOST, url_pattern: MONOREPO_PATTERN, token: 'alt-tok' }
+  }
+};
+const dualMonorepoConfig = {
+  github_token: 'gh-tok',
+  repos: {
+    'acme/platform': { api_host: ALT_HOST, exclusive: false, url_pattern: MONOREPO_PATTERN, token: 'alt-tok' }
+  }
+};
+
+/** Seed a pr_metadata row with a recorded html_url in pr_data. */
+async function seedReview(db, { repository, number, host, htmlUrl }) {
+  await run(db,
+    'INSERT INTO pr_metadata (pr_number, repository, host, pr_data) VALUES (?, ?, ?, ?)',
+    [number, repository, host, htmlUrl ? JSON.stringify({ html_url: htmlUrl }) : null]
+  );
+}
 
 describe('resolveBindingForRequest — per-PR host', () => {
   let db;
@@ -76,5 +100,107 @@ describe('resolveBindingForRequest — per-PR host', () => {
     await expect(
       resolveBindingForRequest(makeReq(db, dualConfig, 42), 'acme/widgets')
     ).rejects.toThrow(/stored host no longer matches config/);
+  });
+
+  it('an existing github.com review does not bind an exclusive entry that only pattern-claimed it', async () => {
+    // The dashboard renders github.com links for this row; the review page must
+    // reach the same host rather than the monorepo entry's alt host.
+    await seedReview(db, {
+      repository: 'acme/widgets',
+      number: 42,
+      host: null,
+      htmlUrl: 'https://github.com/acme/widgets/pull/42'
+    });
+
+    const resolved = await resolveBindingForRequest(
+      makeReq(db, exclusiveMonorepoConfig, 42), 'acme/widgets'
+    );
+
+    expect(resolved.bindingRepository).toBe('acme/widgets');
+    expect(resolved.binding.apiHost).toBe(null);
+    expect(resolved.token).toBe('gh-tok');
+  });
+
+  it('an existing alt-host review keeps the monorepo entry', async () => {
+    await seedReview(db, {
+      repository: 'acme/widgets',
+      number: 43,
+      host: ALT_HOST,
+      htmlUrl: 'https://alt.example/acme/widgets/pull/43'
+    });
+
+    const resolved = await resolveBindingForRequest(
+      makeReq(db, exclusiveMonorepoConfig, 43), 'acme/widgets'
+    );
+
+    expect(resolved.bindingRepository).toBe('acme/platform');
+    expect(resolved.binding.apiHost).toBe(ALT_HOST);
+    expect(resolved.token).toBe('alt-tok');
+  });
+
+  it('a pre-stamping NULL with an alt-host recorded URL still binds the alt host', async () => {
+    // No regression for reviews recorded before host stamping existed: the
+    // recorded URL contradicts github.com, so the monorepo entry is kept.
+    await seedReview(db, {
+      repository: 'acme/widgets',
+      number: 44,
+      host: null,
+      htmlUrl: 'https://alt.example/acme/widgets/pull/44'
+    });
+
+    const resolved = await resolveBindingForRequest(
+      makeReq(db, exclusiveMonorepoConfig, 44), 'acme/widgets'
+    );
+
+    expect(resolved.bindingRepository).toBe('acme/platform');
+    expect(resolved.binding.apiHost).toBe(ALT_HOST);
+  });
+
+  it('a DUAL monorepo entry is kept for a github.com review, preserving its config', async () => {
+    await seedReview(db, {
+      repository: 'acme/widgets',
+      number: 45,
+      host: null,
+      htmlUrl: 'https://github.com/acme/widgets/pull/45'
+    });
+
+    const resolved = await resolveBindingForRequest(
+      makeReq(db, dualMonorepoConfig, 45), 'acme/widgets'
+    );
+
+    expect(resolved.bindingRepository).toBe('acme/platform');
+    expect(resolved.binding.apiHost).toBe(null);
+    expect(resolved.token).toBe('gh-tok');
+  });
+
+  it('a pre-stamping NULL with an alt-host URL binds the alt host on a DUAL repo', async () => {
+    // The row's links resolve to the alt host from the same evidence, so the
+    // binding must too — reapplying the raw NULL here would force github.com and
+    // put the review page on a different system than its own links.
+    await seedReview(db, {
+      repository: 'acme/widgets',
+      number: 46,
+      host: null,
+      htmlUrl: 'https://alt.example/acme/widgets/pull/46'
+    });
+
+    const resolved = await resolveBindingForRequest(makeReq(db, dualConfig, 46), 'acme/widgets');
+
+    expect(resolved.binding.apiHost).toBe(ALT_HOST);
+    expect(resolved.token).toBe('alt-tok');
+  });
+
+  it('a stamped NULL with a github URL still binds github on a DUAL repo', async () => {
+    await seedReview(db, {
+      repository: 'acme/widgets',
+      number: 47,
+      host: null,
+      htmlUrl: 'https://github.com/acme/widgets/pull/47'
+    });
+
+    const resolved = await resolveBindingForRequest(makeReq(db, dualConfig, 47), 'acme/widgets');
+
+    expect(resolved.binding.apiHost).toBe(null);
+    expect(resolved.token).toBe('gh-tok');
   });
 });

--- a/tests/integration/routes.test.js
+++ b/tests/integration/routes.test.js
@@ -289,7 +289,7 @@ describe('PR Management Endpoints', () => {
   });
 
   describe('POST /api/parse-pr-url', () => {
-    it('returns host: null for a github.com URL', async () => {
+    it('returns host: null and no setup host for a plain github.com URL', async () => {
       const response = await request(server)
         .post('/api/parse-pr-url')
         .send({ url: 'https://github.com/owner/repo/pull/123' });
@@ -297,11 +297,13 @@ describe('PR Management Endpoints', () => {
       expect(response.status).toBe(200);
       expect(response.body).toMatchObject({
         valid: true, owner: 'owner', repo: 'repo', prNumber: 123, host: null,
-        isDualHost: false
+        // No api_host entry is in play, so the ambiguity rule already binds
+        // github.com and there is nothing to announce.
+        setupHost: null
       });
     });
 
-    it('returns the matched api_host and bindingRepository for a url_pattern match (exclusive → not dual)', async () => {
+    it('returns the matched api_host as the setup host for a url_pattern match', async () => {
       app.set('config', {
         repos: {
           'acme/widgets': {
@@ -319,12 +321,11 @@ describe('PR Management Endpoints', () => {
       expect(response.body).toMatchObject({
         valid: true, owner: 'acme', repo: 'widgets', prNumber: 42,
         host: 'https://althost.example/api/v3', bindingRepository: 'acme/widgets',
-        // api_host with no `exclusive` key → exclusive:true → NOT dual.
-        isDualHost: false
+        setupHost: 'https://althost.example/api/v3'
       });
     });
 
-    it('flags isDualHost:true for a github URL that resolves to a DUAL repo', async () => {
+    it('announces the github sentinel for a github URL on a DUAL repo', async () => {
       app.set('config', {
         github_token: 'gh-tok',
         repos: {
@@ -343,9 +344,34 @@ describe('PR Management Endpoints', () => {
       expect(response.status).toBe(200);
       expect(response.body).toMatchObject({
         valid: true, owner: 'acme', repo: 'widgets', prNumber: 42,
-        // github URL → host null, but the repo is dual so the client sends the
-        // "github" sentinel to avoid an alt-first probe.
-        host: null, isDualHost: true
+        host: null, setupHost: 'github'
+      });
+    });
+
+    it('announces the github sentinel when a monorepo pattern could claim the repo', async () => {
+      // The parser discards an api_host `url_pattern` match for a canonical
+      // github.com URL, so `host` is null and `bindingRepository` is absent. Setup
+      // would still re-resolve the alt entry from owner/repo, so the sentinel has
+      // to be announced or the PR gets fetched from the alt host.
+      app.set('config', {
+        github_token: 'gh-tok',
+        repos: {
+          'acme/platform': {
+            api_host: 'https://althost.example/api/v3',
+            url_pattern: '^https://althost\\.example/(?<owner>[^/]+)/(?<repo>[^/]+)/pull/(?<number>[0-9]+)',
+            token: 'alt-tok'
+          }
+        }
+      });
+
+      const response = await request(server)
+        .post('/api/parse-pr-url')
+        .send({ url: 'https://github.com/acme/widgets/pull/42' });
+
+      expect(response.status).toBe(200);
+      expect(response.body).toMatchObject({
+        valid: true, owner: 'acme', repo: 'widgets', prNumber: 42,
+        host: null, setupHost: 'github'
       });
     });
 
@@ -4452,6 +4478,69 @@ describe('Repo Links Endpoint', () => {
       expect(res.body.links.external).not.toBeNull();
       expect(res.body.links.github).toBe(true);
       expect(res.body.links.graphite).toBe(true);
+    });
+
+    it('a github.com PR does not get the links of an exclusive entry that pattern-claimed it', async () => {
+      // The url_pattern probe claims every owner/repo, so this PR resolves to an
+      // exclusive alt entry. Its recorded html_url proves it is on github.com,
+      // so the review header must show github links — matching what the review
+      // page binds and what the dashboard row already renders.
+      app.set('config', {
+        ...app.get('config'),
+        repos: {
+          'acme/platform': {
+            api_host: ALT_HOST,
+            url_pattern: '^https://alt\\.example/(?<owner>[^/]+)/(?<repo>[^/]+)/pull/(?<number>\\d+)',
+            links: {
+              external: {
+                name: 'Meteorite',
+                label: 'Open on Meteorite',
+                url_template: 'https://meteorite.example/{owner}/{repo}/pull/{number}'
+              },
+              github: false
+            }
+          }
+        }
+      });
+      await run(db, `
+        INSERT INTO pr_metadata (pr_number, repository, title, host, pr_data)
+        VALUES (?, 'gh/repo', 'A github.com PR', NULL, ?)
+      `, [11, JSON.stringify({ html_url: 'https://github.com/gh/repo/pull/11' })]);
+
+      const res = await request(server).get('/api/repos/gh/repo/links?number=11');
+
+      expect(res.status).toBe(200);
+      expect(res.body.links).toEqual({ external: null, github: true, graphite: true });
+    });
+
+    it('a pre-stamping alt-host PR keeps the pattern-claimed entry links', async () => {
+      app.set('config', {
+        ...app.get('config'),
+        repos: {
+          'acme/platform': {
+            api_host: ALT_HOST,
+            url_pattern: '^https://alt\\.example/(?<owner>[^/]+)/(?<repo>[^/]+)/pull/(?<number>\\d+)',
+            links: {
+              external: {
+                name: 'Meteorite',
+                label: 'Open on Meteorite',
+                url_template: 'https://meteorite.example/{owner}/{repo}/pull/{number}'
+              },
+              github: false
+            }
+          }
+        }
+      });
+      await run(db, `
+        INSERT INTO pr_metadata (pr_number, repository, title, host, pr_data)
+        VALUES (?, 'alt/repo', 'An alt-host PR', NULL, ?)
+      `, [12, JSON.stringify({ html_url: 'https://alt.example/alt/repo/pull/12' })]);
+
+      const res = await request(server).get('/api/repos/alt/repo/links?number=12');
+
+      expect(res.status).toBe(200);
+      expect(res.body.links.external).not.toBeNull();
+      expect(res.body.links.github).toBe(false);
     });
   });
 });

--- a/tests/integration/setup-routes.test.js
+++ b/tests/integration/setup-routes.test.js
@@ -19,6 +19,7 @@ const request = require('supertest');
 const setupRoutes = require('../../src/routes/setup');
 const { WorktreePoolRepository } = require('../../src/database');
 const { activeSetups } = require('../../src/routes/shared');
+const logger = require('../../src/utils/logger');
 
 function createApp(db, config = { github_token: 'test-token' }, { withPool = false } = {}) {
   const app = express();
@@ -242,6 +243,94 @@ describe('POST /api/setup/pr/:owner/:repo/:number', () => {
     expect(res.status).toBe(200);
     expect(prSetupModule.setupPRReview).toHaveBeenCalledOnce();
     expect(prSetupModule.setupPRReview.mock.calls[0][0].host).toBe('https://althost.example/api/v3');
+  });
+
+  it('ignores a github.com body host for a directly-keyed exclusive alt-host repo', async () => {
+    // A dashboard collection row stamps host NULL for every github.com search
+    // result and sends the 'github' sentinel, which setup.html forwards as
+    // `{ host: null }`. When config declares this repo exclusive alt-host the
+    // hint contradicts configuration: warn and fall back to the ambiguity rule
+    // instead of surfacing resolveHostBinding's exclusive-null throw as a 500.
+    const app = createApp(db, {
+      repos: { 'owner/repo': { api_host: 'https://althost.example/api/v3', token: 'alt-tok' } }
+    });
+    const warnSpy = vi.spyOn(logger, 'warn');
+    server = await listenOnLoopback(app);
+    const res = await request(server)
+      .post('/api/setup/pr/owner/repo/42')
+      .send({ host: null });
+
+    expect(res.status).toBe(200);
+    expect(res.body.setupId).toBeTruthy();
+    expect(prSetupModule.setupPRReview).toHaveBeenCalledOnce();
+    const callArgs = prSetupModule.setupPRReview.mock.calls[0][0];
+    expect(callArgs.host).toBeUndefined();
+    expect(callArgs.bindingRepository).toBe('owner/repo');
+    // The user is told why, and what to change, rather than silently getting
+    // the alt host for a PR the dashboard sourced from github.com.
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringMatching(/exclusive alt-host repo.*"exclusive": false/s)
+    );
+  });
+
+  it('rejects an exclusive monorepo entry that only pattern-claimed a github.com PR', async () => {
+    // resolveBindingRepositoryFromPR probes each alt entry's url_pattern against
+    // a URL built from that entry's own api_host, so an anchored monorepo pattern
+    // claims every owner/repo. An exclusive alt entry has no github.com presence,
+    // so for a PR we KNOW is on github.com it describes neither the API host nor
+    // the checkout — the same call PRArgumentParser.parsePRUrl already makes for
+    // a pasted github.com URL. Bind the PR's own identity instead.
+    const app = createApp(db, {
+      github_token: 'gh-tok',
+      repos: {
+        'acme/platform': {
+          api_host: 'https://althost.example/api/v3',
+          url_pattern: '^https://althost\\.example/(?<owner>[^/]+)/(?<repo>[^/]+)/pull/(?<number>\\d+)',
+          token: 'alt-tok'
+        }
+      }
+    });
+    server = await listenOnLoopback(app);
+    const res = await request(server)
+      .post('/api/setup/pr/owner/repo/42')
+      .send({ host: null });
+
+    expect(res.status).toBe(200);
+    expect(prSetupModule.setupPRReview).toHaveBeenCalledOnce();
+    const callArgs = prSetupModule.setupPRReview.mock.calls[0][0];
+    expect(callArgs.bindingRepository).toBe('owner/repo');
+    // The github.com host survives, so the PR is fetched from where it lives.
+    expect(callArgs.host).toBeNull();
+    expect(callArgs.githubToken).toBe('gh-tok');
+  });
+
+  it('keeps a DUAL monorepo config key for a github.com body host', async () => {
+    // A dual entry does serve github.com (resolveHostBinding has a first-class
+    // dual-github binding), so its key must be preserved — setupPRReview reads
+    // the repo's local path, checkout script, pool size, and reset script from it
+    // (pr-setup.js findRepositoryPath / resolvePoolConfig / getRepoResetScript).
+    // Dropping it here would silently discard the monorepo's local configuration.
+    const app = createApp(db, {
+      github_token: 'gh-tok',
+      repos: {
+        'acme/platform': {
+          api_host: 'https://althost.example/api/v3',
+          exclusive: false,
+          url_pattern: '^https://althost\\.example/(?<owner>[^/]+)/(?<repo>[^/]+)/pull/(?<number>\\d+)',
+          token: 'alt-tok'
+        }
+      }
+    });
+    server = await listenOnLoopback(app);
+    const res = await request(server)
+      .post('/api/setup/pr/owner/repo/42')
+      .send({ host: null });
+
+    expect(res.status).toBe(200);
+    expect(prSetupModule.setupPRReview).toHaveBeenCalledOnce();
+    const callArgs = prSetupModule.setupPRReview.mock.calls[0][0];
+    expect(callArgs.bindingRepository).toBe('acme/platform');
+    expect(callArgs.host).toBeNull();
   });
 
   it('passes an explicit body host of null through to setupPRReview', async () => {

--- a/tests/integration/worktree-pagination.test.js
+++ b/tests/integration/worktree-pagination.test.js
@@ -436,6 +436,134 @@ describe('GET /api/worktrees/recent — pagination', () => {
     expect(res.body.reviews[0].html_url).toBe(htmlUrl);
   });
 
+  it('should include host-aware repository links for recent reviews', async () => {
+    const apiHost = 'https://meteorite.example/api/v3';
+    app.set('config', {
+      repos: {
+        'shop/world': {
+          api_host: apiHost,
+          exclusive: false,
+          links: {
+            external: {
+              name: 'Meteorite',
+              label: 'Open on Meteorite',
+              url_template: 'https://meteorite.example/{owner}/{repo}/pull/{number}'
+            }
+          }
+        }
+      }
+    });
+    await insertWorktree(db, {
+      id: 'wt-meteorite',
+      prNumber: 2000042,
+      repository: 'shop/world',
+      title: 'Meteorite PR',
+      author: 'user',
+      accessedAt: new Date().toISOString(),
+      prData: { html_url: 'https://meteorite.example/shop/world/pull/2000042' }
+    });
+    await run(db, 'UPDATE pr_metadata SET host = ? WHERE repository = ? AND pr_number = ?', [
+      apiHost,
+      'shop/world',
+      2000042
+    ]);
+
+    const res = await request(server).get('/api/worktrees/recent?limit=10');
+
+    expect(res.status).toBe(200);
+    expect(res.body.reviews[0].host).toBe(apiHost);
+    expect(res.body.reviews[0].repo_links).toMatchObject({
+      external: {
+        name: 'Meteorite',
+        label: 'Open on Meteorite',
+        url_template: 'https://meteorite.example/{owner}/{repo}/pull/{number}'
+      },
+      github: false,
+      graphite: false
+    });
+  });
+
+  it('reconciles a legacy NULL host against a non-github recorded URL', async () => {
+    // Host stamping was added without a backfill, so rows recorded before it
+    // carry NULL regardless of where the PR lives. Reading NULL as github.com
+    // would hide the configured external link and label the alt-host URL
+    // "Open on GitHub"; the recorded html_url settles it.
+    const apiHost = 'https://meteorite.example/api/v3';
+    app.set('config', {
+      repos: {
+        'shop/world': {
+          api_host: apiHost,
+          exclusive: false,
+          links: {
+            external: {
+              name: 'Meteorite',
+              label: 'Open on Meteorite',
+              url_template: 'https://meteorite.example/{owner}/{repo}/pull/{number}'
+            }
+          }
+        }
+      }
+    });
+    await insertWorktree(db, {
+      id: 'wt-legacy-null',
+      prNumber: 2000043,
+      repository: 'shop/world',
+      title: 'Unstamped Meteorite PR',
+      author: 'user',
+      accessedAt: new Date().toISOString(),
+      prData: { html_url: 'https://meteorite.example/shop/world/pull/2000043' }
+    });
+    // Left NULL on purpose: this is the pre-stamping shape.
+
+    const res = await request(server).get('/api/worktrees/recent?limit=10');
+
+    expect(res.status).toBe(200);
+    expect(res.body.reviews[0].host).toBe(apiHost);
+    // Navigation must reach the same system the external link points at.
+    expect(res.body.reviews[0].setup_host).toBe(apiHost);
+    expect(res.body.reviews[0].repo_links).toMatchObject({
+      external: { label: 'Open on Meteorite' },
+      github: false,
+      graphite: false
+    });
+  });
+
+  it('leaves a legacy NULL host as github.com when the recorded URL is github.com', async () => {
+    const apiHost = 'https://meteorite.example/api/v3';
+    app.set('config', {
+      repos: {
+        'shop/world': {
+          api_host: apiHost,
+          exclusive: false,
+          links: {
+            external: {
+              name: 'Meteorite',
+              label: 'Open on Meteorite',
+              url_template: 'https://meteorite.example/{owner}/{repo}/pull/{number}'
+            }
+          }
+        }
+      }
+    });
+    await insertWorktree(db, {
+      id: 'wt-legacy-github',
+      prNumber: 2000044,
+      repository: 'shop/world',
+      title: 'Unstamped github.com PR',
+      author: 'user',
+      accessedAt: new Date().toISOString(),
+      prData: { html_url: 'https://github.com/shop/world/pull/2000044' }
+    });
+
+    const res = await request(server).get('/api/worktrees/recent?limit=10');
+
+    expect(res.status).toBe(200);
+    expect(res.body.reviews[0].host).toBeNull();
+    expect(res.body.reviews[0].setup_host).toBe('github');
+    expect(res.body.reviews[0].repo_links.external).toBeNull();
+    expect(res.body.reviews[0].repo_links.github).toBe(true);
+  });
+
   it('should return html_url as null when pr_data has no html_url', async () => {
     await insertWorktree(db, {
       id: 'wt-no-url',

--- a/tests/unit/external/github-adapter.test.js
+++ b/tests/unit/external/github-adapter.test.js
@@ -179,22 +179,83 @@ describe('github-adapter', () => {
       expect(result.isAltHost).toBe(true);
     });
 
-    it('binding-aware: resolves the binding key via resolveBindingRepositoryFromPR before resolveHostBinding', () => {
+    it('a github.com PR does not sync through an exclusive entry that pattern-claimed it', () => {
+      // A monorepo url_pattern probe claims every owner/repo, so comment sync for
+      // a github.com PR would otherwise authenticate against the alt host with
+      // the alt token. `storedHost: null` says this PR is on github.com.
+      const FakeGitHubClient = vi.fn(function (binding) { this.binding = binding; });
+
+      const config = {
+        github_token: 'github-com-top-level-token',
+        repos: {
+          'acme/platform': {
+            api_host: 'https://git.example.com/api/v3',
+            url_pattern: '^https://git\\.example\\.com/(?<owner>[^/]+)/(?<repo>[^/]+)/pull/(?<number>\\d+)',
+            token: 'alt-host-repo-token'
+          }
+        }
+      };
+
+      const result = githubAdapter.resolveCredentials(
+        config,
+        'shop/world',
+        { GitHubClient: FakeGitHubClient },
+        { storedHost: null }
+      );
+
+      const binding = FakeGitHubClient.mock.calls[0][0];
+      expect(binding.apiHost).toBe(null);
+      expect(binding.token).toBe('github-com-top-level-token');
+      expect(result.isAltHost).toBe(false);
+    });
+
+    it('an alt-host PR still syncs through the pattern-claimed entry', () => {
+      const FakeGitHubClient = vi.fn(function (binding) { this.binding = binding; });
+      const ALT = 'https://git.example.com/api/v3';
+
+      const config = {
+        github_token: 'github-com-top-level-token',
+        repos: {
+          'acme/platform': {
+            api_host: ALT,
+            url_pattern: '^https://git\\.example\\.com/(?<owner>[^/]+)/(?<repo>[^/]+)/pull/(?<number>\\d+)',
+            token: 'alt-host-repo-token'
+          }
+        }
+      };
+
+      const result = githubAdapter.resolveCredentials(
+        config,
+        'shop/world',
+        { GitHubClient: FakeGitHubClient },
+        { storedHost: ALT }
+      );
+
+      const binding = FakeGitHubClient.mock.calls[0][0];
+      expect(binding.apiHost).toBe(ALT);
+      expect(binding.token).toBe('alt-host-repo-token');
+      expect(result.isAltHost).toBe(true);
+    });
+
+    it('binding-aware: resolves the binding key via resolveBindingRepositoryForHost before resolveHostBinding', () => {
       // Verify the helper chain wiring using injected fakes: the binding key
-      // returned by resolveBindingRepositoryFromPR is what gets passed to
-      // resolveHostBinding (mirrors resolveBindingForRequest in routes/pr.js).
+      // returned by the key resolver is what gets passed to resolveHostBinding
+      // (mirrors resolveBindingForRequest in routes/pr.js). The key lookup is
+      // host-aware, so the PR's recorded host is threaded into it as well.
       const FakeGitHubClient = vi.fn(function (binding) { this.binding = binding; });
       const fakeBinding = { apiHost: 'https://ghe.internal/api/v3', token: 'tok', features: {}, source: 'repo:token' };
-      const resolveBindingRepositoryFromPR = vi.fn(() => 'monorepo/key');
+      const resolveBindingRepositoryForHost = vi.fn(() => 'monorepo/key');
       const resolveHostBinding = vi.fn(() => fakeBinding);
 
       const result = githubAdapter.resolveCredentials(
         { repos: {} },
         'OctoCat/Hello-World',
-        { GitHubClient: FakeGitHubClient, resolveBindingRepositoryFromPR, resolveHostBinding }
+        { GitHubClient: FakeGitHubClient, resolveBindingRepositoryForHost, resolveHostBinding }
       );
 
-      expect(resolveBindingRepositoryFromPR).toHaveBeenCalledWith('OctoCat', 'Hello-World', { repos: {} });
+      expect(resolveBindingRepositoryForHost).toHaveBeenCalledWith(
+        'OctoCat', 'Hello-World', { repos: {} }, undefined
+      );
       // Third arg is the resolved host option; with no storedHost it is {} (ambiguity).
       expect(resolveHostBinding).toHaveBeenCalledWith('monorepo/key', { repos: {} }, {});
       expect(FakeGitHubClient).toHaveBeenCalledWith(fakeBinding);

--- a/tests/unit/host-resolution.test.js
+++ b/tests/unit/host-resolution.test.js
@@ -4,12 +4,33 @@
  */
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 
-const { storedHostToOption, isDualHostRepo, getConfiguredApiHost, resolvePreflightBinding, hostSetupParamValue } = require('../../src/utils/host-resolution');
+const {
+  storedHostToOption,
+  explicitHostForBinding,
+  resolveRecordedHost,
+  resolveBindingRepositoryForHost,
+  setupHostParam,
+  isDualHostRepo,
+  getConfiguredApiHost,
+  resolvePreflightBinding
+} = require('../../src/utils/host-resolution');
+const logger = require('../../src/utils/logger');
 
 const ALT = 'https://alt.example/api/v3';
 const dualConfig = { repos: { 'acme/widgets': { api_host: ALT, exclusive: false, token: 't' } } };
 const exclusiveConfig = { repos: { 'acme/widgets': { api_host: ALT, token: 't' } } };
 const plainConfig = { repos: {} };
+
+// Monorepo-style entries: one config key serves many captured owner/repo pairs,
+// so resolveBindingRepositoryFromPR's url_pattern probe claims EVERY owner/repo
+// — including repos that exist only on github.com.
+const MONOREPO_PATTERN = '^https://alt\\.example/(?<owner>[^/]+)/(?<repo>[^/]+)/pull/(?<number>\\d+)';
+const exclusiveMonorepoConfig = {
+  repos: { 'acme/platform': { api_host: ALT, url_pattern: MONOREPO_PATTERN, token: 't' } }
+};
+const dualMonorepoConfig = {
+  repos: { 'acme/platform': { api_host: ALT, exclusive: false, url_pattern: MONOREPO_PATTERN, token: 't' } }
+};
 
 describe('storedHostToOption', () => {
   it('undefined (no row) → undefined (ambiguity)', () => {
@@ -30,6 +51,62 @@ describe('storedHostToOption', () => {
 
   it('null on an EXCLUSIVE alt-host repo → undefined (legacy NULL derives alt)', () => {
     expect(storedHostToOption(exclusiveConfig, 'acme/widgets', null)).toBeUndefined();
+  });
+});
+
+describe('resolveBindingRepositoryForHost', () => {
+  it('an unknown host resolves exactly as before', () => {
+    expect(resolveBindingRepositoryForHost('acme', 'widgets', exclusiveMonorepoConfig, undefined))
+      .toBe('acme/platform');
+  });
+
+  it('an alt-host PR stays bound to the entry that serves it', () => {
+    expect(resolveBindingRepositoryForHost('acme', 'widgets', exclusiveMonorepoConfig, ALT))
+      .toBe('acme/platform');
+  });
+
+  it('a known github.com PR rejects an EXCLUSIVE entry that only pattern-claimed it', () => {
+    expect(resolveBindingRepositoryForHost('acme', 'widgets', exclusiveMonorepoConfig, null))
+      .toBe('acme/widgets');
+  });
+
+  it('a known github.com PR keeps a DUAL entry, which does serve github.com', () => {
+    expect(resolveBindingRepositoryForHost('acme', 'widgets', dualMonorepoConfig, null))
+      .toBe('acme/platform');
+  });
+
+  it('keeps a directly-keyed exclusive entry: config asserts this exact repo', () => {
+    expect(resolveBindingRepositoryForHost('acme', 'widgets', exclusiveConfig, null))
+      .toBe('acme/widgets');
+  });
+
+  it('plain github repos are unaffected', () => {
+    expect(resolveBindingRepositoryForHost('acme', 'widgets', plainConfig, null)).toBe('acme/widgets');
+  });
+});
+
+describe('setupHostParam', () => {
+  it('an alt-host PR navigates with its api_host', () => {
+    expect(setupHostParam(dualConfig, 'acme', 'widgets', ALT)).toBe(ALT);
+  });
+
+  it('an unknown host omits the param', () => {
+    expect(setupHostParam(dualConfig, 'acme', 'widgets', undefined)).toBe(null);
+  });
+
+  it('a plain github repo omits the param (the ambiguity rule already binds github)', () => {
+    expect(setupHostParam(plainConfig, 'acme', 'widgets', null)).toBe(null);
+  });
+
+  it('announces github.com whenever an api_host entry would otherwise be consulted', () => {
+    // Dual: skips the alt-host probe. Exclusive: overrides the ambiguity rule,
+    // which would bind the alt host for a PR that lives on github.com. This is
+    // what a pasted canonical github.com URL needs too — without it, setup's
+    // key lookup reclaims a pattern-claiming alt entry.
+    expect(setupHostParam(dualConfig, 'acme', 'widgets', null)).toBe('github');
+    expect(setupHostParam(exclusiveMonorepoConfig, 'acme', 'widgets', null)).toBe('github');
+    expect(setupHostParam(dualMonorepoConfig, 'acme', 'widgets', null)).toBe('github');
+    expect(setupHostParam(exclusiveConfig, 'acme', 'widgets', null)).toBe('github');
   });
 });
 
@@ -59,20 +136,75 @@ describe('getConfiguredApiHost', () => {
   });
 });
 
-describe('hostSetupParamValue (FINDING C)', () => {
-  it('alt api_host string → that string', () => {
-    expect(hostSetupParamValue(ALT, false)).toBe(ALT);
-    expect(hostSetupParamValue(ALT, true)).toBe(ALT);
+describe('resolveRecordedHost', () => {
+  it('passes a stamped alt host through untouched', () => {
+    expect(resolveRecordedHost(dualConfig, 'acme/widgets', ALT, 'https://alt.example/acme/widgets/pull/1'))
+      .toBe(ALT);
   });
-  it('null on a dual repo → github sentinel', () => {
-    expect(hostSetupParamValue(null, true)).toBe('github');
+
+  it('a pre-stamping NULL with a non-github recorded URL resolves to the api_host', () => {
+    expect(resolveRecordedHost(dualConfig, 'acme/widgets', null, 'https://alt.example/acme/widgets/pull/1'))
+      .toBe(ALT);
   });
-  it('null on a non-dual repo → null (omit)', () => {
-    expect(hostSetupParamValue(null, false)).toBe(null);
+
+  it('NULL with a github.com recorded URL stays github.com', () => {
+    expect(resolveRecordedHost(dualConfig, 'acme/widgets', null, 'https://github.com/acme/widgets/pull/1'))
+      .toBe(null);
   });
-  it('undefined (unknown) → null (omit)', () => {
-    expect(hostSetupParamValue(undefined, true)).toBe(null);
-    expect(hostSetupParamValue(undefined, false)).toBe(null);
+
+  it('NULL on a repo with no api_host stays github.com', () => {
+    expect(resolveRecordedHost(plainConfig, 'acme/widgets', null, 'https://alt.example/acme/widgets/pull/1'))
+      .toBe(null);
+  });
+
+  it('keeps the stored convention when the URL cannot contradict it', () => {
+    // Dual-host support shipped with stamping, so NULL means github.com unless
+    // a recorded URL proves otherwise. No URL proves nothing.
+    expect(resolveRecordedHost(dualConfig, 'acme/widgets', null, null)).toBe(null);
+    expect(resolveRecordedHost(dualConfig, 'acme/widgets', null, '')).toBe(null);
+    expect(resolveRecordedHost(dualConfig, 'acme/widgets', null, 'not a url')).toBe(null);
+  });
+
+  it('reports an absent row as unknown', () => {
+    expect(resolveRecordedHost(dualConfig, 'acme/widgets', undefined, null)).toBeUndefined();
+  });
+});
+
+describe('explicitHostForBinding', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('passes an undefined hint through (ambiguity rule)', () => {
+    expect(explicitHostForBinding(exclusiveConfig, 'acme/widgets', undefined)).toBeUndefined();
+  });
+
+  it('passes an alt-host hint through for validation downstream', () => {
+    expect(explicitHostForBinding(exclusiveConfig, 'acme/widgets', ALT)).toBe(ALT);
+  });
+
+  it('keeps a github.com hint for dual and plain repos', () => {
+    expect(explicitHostForBinding(dualConfig, 'acme/widgets', null)).toBe(null);
+    expect(explicitHostForBinding(plainConfig, 'acme/widgets', null)).toBe(null);
+  });
+
+  it('warns and ignores a github.com hint for an exclusive alt-host repo', () => {
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+
+    expect(explicitHostForBinding(exclusiveConfig, 'acme/widgets', null)).toBeUndefined();
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toMatch(/exclusive alt-host repo/);
+  });
+
+  it('does not warn for hints it accepts', () => {
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+
+    explicitHostForBinding(dualConfig, 'acme/widgets', null);
+    explicitHostForBinding(exclusiveConfig, 'acme/widgets', ALT);
+    explicitHostForBinding(exclusiveConfig, 'acme/widgets', undefined);
+
+    expect(warn).not.toHaveBeenCalled();
   });
 });
 

--- a/tests/unit/index-open-analyze-buttons.test.js
+++ b/tests/unit/index-open-analyze-buttons.test.js
@@ -45,8 +45,7 @@ function createMockElement(overrides = {}) {
       this.innerHTML = String(val)
         .replace(/&/g, '&amp;')
         .replace(/</g, '&lt;')
-        .replace(/>/g, '&gt;')
-        .replace(/"/g, '&quot;');
+        .replace(/>/g, '&gt;');
     },
     classList: {
       add: vi.fn((...cls) => cls.forEach(c => classes.add(c))),
@@ -200,6 +199,7 @@ function setupGlobals() {
   // helper (loaded against these stubbed globals) rather than a hand-rolled
   // stub — its setup() is null-safe when no #theme-toggle button is present.
   global.window.PairReviewTheme = require('../../public/js/theme.js');
+  global.window.RepoLinks = require('../../public/js/repo-links.js');
 
   global.fetch = vi.fn(() => Promise.resolve({ ok: false }));
   global.Event = class Event {
@@ -301,7 +301,7 @@ describe('Index page Open/Analyze buttons', () => {
     expect(global.window.location.href).toBe('/pr/testowner/testrepo/42');
   });
 
-  // Helper: mock parse-pr-url with custom host / isDualHost fields.
+  // Helper: mock parse-pr-url with custom host / setupHost fields.
   function mockFetchParsePR(extra) {
     global.fetch = vi.fn((url) => {
       if (typeof url === 'string' && url.includes('/api/parse-pr-url')) {
@@ -316,12 +316,17 @@ describe('Index page Open/Analyze buttons', () => {
     });
   }
 
-  // ─── FIX 2: host sentinel forwarding on the paste flow ───────────────────
+  // ─── Host sentinel forwarding on the paste flow ───────────────────────────
+  // The server resolves `setupHost` (setupHostParam); the browser echoes it, so
+  // these assert the echo, not a config decision made in the browser.
 
   it('paste of an alt-host URL forwards the api_host as ?host=', async () => {
     const form = elementsById['start-review-form'];
     elementsById['pr-url-input'].value = 'https://althost.example/testowner/testrepo/pull/42';
-    mockFetchParsePR({ host: 'https://althost.example/api/v3', isDualHost: false });
+    mockFetchParsePR({
+      host: 'https://althost.example/api/v3',
+      setupHost: 'https://althost.example/api/v3'
+    });
 
     await form._listeners.submit[0]({ preventDefault: vi.fn() });
 
@@ -330,20 +335,20 @@ describe('Index page Open/Analyze buttons', () => {
     );
   });
 
-  it('paste of a github URL for a DUAL repo forwards the "github" sentinel', async () => {
+  it('paste of a github URL forwards a resolved "github" sentinel', async () => {
     const form = elementsById['start-review-form'];
     elementsById['pr-url-input'].value = 'https://github.com/testowner/testrepo/pull/42';
-    mockFetchParsePR({ host: null, isDualHost: true });
+    mockFetchParsePR({ host: null, setupHost: 'github' });
 
     await form._listeners.submit[0]({ preventDefault: vi.fn() });
 
     expect(global.window.location.href).toBe('/pr/testowner/testrepo/42?host=github');
   });
 
-  it('paste of a github URL for a plain repo omits the host param', async () => {
+  it('paste omits the host param when the server resolved none', async () => {
     const form = elementsById['start-review-form'];
     elementsById['pr-url-input'].value = 'https://github.com/testowner/testrepo/pull/42';
-    mockFetchParsePR({ host: null, isDualHost: false });
+    mockFetchParsePR({ host: null, setupHost: null });
 
     await form._listeners.submit[0]({ preventDefault: vi.fn() });
 
@@ -458,9 +463,55 @@ describe('Index page Open/Analyze buttons', () => {
     ]);
   });
 
-  it('buildReviewUrlsFromRows adds no host param for github.com rows', () => {
+  it('renders the API-resolved setup host for bulk Open and Analyze', () => {
+    // The server maps host → setup_host (setupHostParam): the 'github' sentinel
+    // only where a github.com binding exists, so the browser never decides this.
+    const rowHtml = indexModule.renderCollectionPrRow({
+      owner: 'dual-org',
+      repo: 'dual-repo',
+      number: 5,
+      title: 'GitHub PR',
+      author: 'alice',
+      updated_at: new Date().toISOString(),
+      html_url: 'https://github.com/dual-org/dual-repo/pull/5',
+      host: null,
+      setup_host: 'github',
+      repo_links: { external: null, github: true, graphite: false }
+    }, 'my-prs');
+
+    expect(rowHtml).toContain('data-host="github"');
+    expect(indexModule.buildReviewUrlsFromRows(
+      [{ owner: 'dual-org', repo: 'dual-repo', number: '5', host: 'github' }],
+      ''
+    )).toEqual(['/pr/dual-org/dual-repo/5?host=github']);
+    expect(indexModule.buildReviewUrlsFromRows(
+      [{ owner: 'dual-org', repo: 'dual-repo', number: '5', host: 'github' }],
+      '?analyze=true'
+    )).toEqual(['/pr/dual-org/dual-repo/5?analyze=true&host=github']);
+  });
+
+  it('omits data-host when the API resolved no usable setup host', () => {
+    // An exclusive alt-host repo has no github.com binding, so the API returns
+    // setup_host null for a github.com row and the row must not claim one.
+    const rowHtml = indexModule.renderCollectionPrRow({
+      owner: 'alt-org',
+      repo: 'alt-repo',
+      number: 9,
+      title: 'Row with no usable host',
+      author: 'alice',
+      updated_at: new Date().toISOString(),
+      html_url: 'https://github.com/alt-org/alt-repo/pull/9',
+      host: null,
+      setup_host: null,
+      repo_links: { external: null, github: true, graphite: true }
+    }, 'my-prs');
+
+    expect(rowHtml).not.toContain('data-host=');
+  });
+
+  it('buildReviewUrlsFromRows adds no host param for host-unknown rows', () => {
     const urls = indexModule.buildReviewUrlsFromRows(
-      [{ owner: 'gh-org', repo: 'gh-repo', number: '5' }], // no host
+      [{ owner: 'gh-org', repo: 'gh-repo', number: '5' }], // host unknown
       '?analyze=true'
     );
     expect(urls).toEqual(['/pr/gh-org/gh-repo/5?analyze=true']);
@@ -638,5 +689,238 @@ describe('Index page Open/Analyze buttons', () => {
     await submitHandler({ preventDefault: vi.fn() });
 
     expect(startBtn.textContent).toBe('Open');
+  });
+
+  it('renders a configured external host action for collection rows', () => {
+    vi.spyOn(window.RepoLinks, 'parseSvgIcon').mockReturnValue({
+      outerHTML: '<svg data-host="meteorite"></svg>'
+    });
+    const html = indexModule.renderCollectionPrRow({
+      owner: 'shop',
+      repo: 'world',
+      number: 2000042,
+      title: 'Meteorite PR',
+      author: 'alice',
+      updated_at: new Date().toISOString(),
+      html_url: 'https://meteorite.example/shop/world/pull/2000042',
+      host: 'https://meteorite.example/api/v3',
+      repo_links: {
+        external: {
+          name: 'Meteorite',
+          label: 'Open on Meteorite',
+          url_template: 'https://meteorite.example/{owner}/{repo}/pull/{number}',
+          icon: '<svg></svg>'
+        },
+        github: false,
+        graphite: false
+      }
+    }, 'review-requests');
+
+    expect(html).toContain('href="https://meteorite.example/shop/world/pull/2000042"');
+    expect(html).toContain('title="Open on Meteorite"');
+    expect(html).toContain('aria-label="Open on Meteorite"');
+    expect(html).toContain('<svg data-host="meteorite"></svg>');
+    expect(html).not.toContain('title="Open on GitHub"');
+  });
+
+  it('falls back to the host URL when an external template needs unavailable collection data', () => {
+    const html = indexModule.renderCollectionPrRow({
+      owner: 'shop',
+      repo: 'world',
+      number: 2000042,
+      title: 'Meteorite PR',
+      author: 'alice',
+      updated_at: new Date().toISOString(),
+      html_url: 'https://meteorite.example/shop/world/pull/2000042',
+      host: 'https://meteorite.example/api/v3',
+      repo_links: {
+        external: {
+          label: 'Open on Meteorite',
+          url_template: 'https://meteorite.example/branches/{branch}',
+          icon: null
+        },
+        github: false,
+        graphite: false
+      }
+    }, 'review-requests');
+
+    expect(html).toContain('href="https://meteorite.example/shop/world/pull/2000042"');
+    expect(html).toContain('title="Open on Meteorite"');
+  });
+
+  it('escapes configured external link values in HTML attributes', () => {
+    const html = indexModule.renderCollectionPrRow({
+      owner: 'shop',
+      repo: 'world',
+      number: 2000042,
+      title: 'Meteorite PR',
+      author: 'alice',
+      updated_at: new Date().toISOString(),
+      host: 'https://meteorite.example/api/v3',
+      // Config-derived, so still attacker-influenced if a config is shared.
+      setup_host: 'https://meteorite.example/api/v3" onmouseenter="alert(1)',
+      repo_links: {
+        external: {
+          label: 'Open" onmouseover="alert(1)',
+          url_template: 'https://meteorite.example/{owner}/{repo}/pull/{number}?next=" onfocus="alert(1)',
+          icon: null
+        },
+        github: false,
+        graphite: false
+      }
+    }, 'review-requests');
+
+    expect(html).not.toContain('title="Open" onmouseover="alert(1)"');
+    expect(html).not.toContain('?next=" onfocus="alert(1)"');
+    expect(html).toContain('title="Open&quot; onmouseover=&quot;alert(1)"');
+    expect(html).toContain('?next=&quot; onfocus=&quot;alert(1)');
+    expect(html).not.toContain('data-host="https://meteorite.example/api/v3" onmouseenter="alert(1)"');
+    expect(html).toContain('data-host="https://meteorite.example/api/v3&quot; onmouseenter=&quot;alert(1)"');
+  });
+
+  // Reduce a row to its attribute-name skeleton: keep tag markup only (quotes
+  // in text nodes are harmless), then blank out every quoted value. A correctly
+  // escaped hostile value collapses into one `""`; a regressed one leaves its
+  // injected `onmouseover=` behind as an attribute NAME, which is the failure.
+  function attributeSkeleton(html) {
+    return (html.match(/<[^>]*>/g) || [])
+      .join('\n')
+      .replace(/"[^"]*"/g, '""');
+  }
+
+  it('escapes GitHub-supplied collection values in HTML attributes', () => {
+    // Titles, owners and repos come straight from the GitHub search API, so they
+    // are remote input. escapeHtml() is text-node escaping and leaves quotes
+    // intact, which let a crafted title close `title="` and open a new
+    // attribute — an event handler, i.e. script execution on the dashboard.
+    const html = indexModule.renderCollectionPrRow({
+      owner: 'sh"op',
+      repo: 'wo"rld',
+      number: 2000042,
+      title: 'Fix " onmouseover="alert(1)" crash',
+      author: 'alice',
+      updated_at: new Date().toISOString(),
+      html_url: 'https://github.com/shop/world/pull/2000042?x=" onload="alert(1)',
+      host: null
+    }, 'review-requests');
+
+    // No attribute anywhere in the row may start with `on`.
+    expect(attributeSkeleton(html)).not.toMatch(/\son[a-z]+\s*=/i);
+    expect(html).toContain('title="Fix &quot; onmouseover=&quot;alert(1)&quot; crash"');
+    expect(html).toContain('data-owner="sh&quot;op"');
+    expect(html).toContain('data-repo="wo&quot;rld"');
+    expect(html).toContain('?x=&quot; onload=&quot;alert(1)');
+  });
+
+  it('escapes GitHub-supplied recent-review values in HTML attributes', () => {
+    const html = indexModule.renderRecentReviewRow({
+      id: 7,
+      repository: 'shop/world',
+      pr_number: 42,
+      pr_title: 'Fix " onmouseover="alert(1)" crash',
+      last_accessed_at: new Date().toISOString(),
+      html_url: 'https://github.com/shop/world/pull/42',
+      host: null
+    });
+
+    expect(attributeSkeleton(html)).not.toMatch(/\son[a-z]+\s*=/i);
+    expect(html).toContain('title="Fix &quot; onmouseover=&quot;alert(1)&quot; crash"');
+  });
+
+  it('preserves GitHub URL casing for GitHub and Graphite actions', () => {
+    window.__pairReview.enableGraphite = true;
+    window.__pairReview.toGraphiteUrl = (githubUrl) => githubUrl.replace(
+      /^https:\/\/github\.com\/([^/]+)\/([^/]+)\/pull\/(\d+)/,
+      'https://app.graphite.com/github/pr/$1/$2/$3'
+    );
+    const html = indexModule.renderCollectionPrRow({
+      owner: 'mixedowner',
+      repo: 'mixedrepo',
+      number: 42,
+      title: 'GitHub PR',
+      author: 'alice',
+      updated_at: new Date().toISOString(),
+      html_url: 'https://github.com/MixedOwner/MixedRepo/pull/42',
+      repo_links: { external: null, github: true, graphite: true }
+    }, 'review-requests');
+
+    expect(html).toContain('href="https://github.com/MixedOwner/MixedRepo/pull/42"');
+    expect(html).toContain('href="https://app.graphite.com/github/pr/MixedOwner/MixedRepo/42"');
+  });
+
+  it('preserves the host URL when repository link config is absent', () => {
+    window.__pairReview.enableGraphite = true;
+    window.__pairReview.toGraphiteUrl = vi.fn();
+    const html = indexModule.renderCollectionPrRow({
+      owner: 'shop',
+      repo: 'world',
+      number: 2000042,
+      title: 'Meteorite PR',
+      author: 'alice',
+      updated_at: new Date().toISOString(),
+      html_url: 'https://meteorite.example/shop/world/pull/2000042'
+    }, 'review-requests');
+
+    expect(html).toContain('href="https://meteorite.example/shop/world/pull/2000042"');
+    expect(html).not.toContain('href="https://github.com/shop/world/pull/2000042"');
+    expect(window.__pairReview.toGraphiteUrl).not.toHaveBeenCalled();
+    expect(html).not.toContain('title="Open on Graphite"');
+  });
+
+  it('falls back to the host URL for recent rows with unavailable template data', () => {
+    const html = indexModule.renderRecentReviewRow({
+      id: 1,
+      repository: 'shop/world',
+      pr_number: 2000042,
+      pr_title: 'Meteorite PR',
+      author: 'alice',
+      last_accessed_at: new Date().toISOString(),
+      html_url: 'https://meteorite.example/shop/world/pull/2000042',
+      host: 'https://meteorite.example/api/v3',
+      repo_links: {
+        external: {
+          label: 'Open on Meteorite',
+          url_template: 'https://meteorite.example/commits/{head_sha}',
+          icon: null
+        },
+        github: false,
+        graphite: false
+      }
+    });
+
+    expect(html).toContain('href="https://meteorite.example/shop/world/pull/2000042"');
+    expect(html).toContain('title="Open on Meteorite"');
+  });
+
+  it('does not construct a Graphite action without a canonical GitHub URL', () => {
+    window.__pairReview.enableGraphite = true;
+    window.__pairReview.toGraphiteUrl = vi.fn();
+    const html = indexModule.renderRecentReviewRow({
+      id: 1,
+      repository: 'mixedowner/mixedrepo',
+      pr_number: 42,
+      pr_title: 'Legacy GitHub PR',
+      author: 'alice',
+      last_accessed_at: new Date().toISOString()
+    });
+
+    expect(html).toContain('title="Open on GitHub"');
+    expect(html).not.toContain('title="Open on Graphite"');
+    expect(window.__pairReview.toGraphiteUrl).not.toHaveBeenCalled();
+  });
+
+  it('keeps the GitHub action fallback for recent review rows', () => {
+    const html = indexModule.renderRecentReviewRow({
+      id: 1,
+      repository: 'shop/world',
+      pr_number: 42,
+      pr_title: 'GitHub PR',
+      author: 'alice',
+      last_accessed_at: new Date().toISOString()
+    });
+
+    expect(html).toContain('href="https://github.com/shop/world/pull/42"');
+    expect(html).toContain('title="Open on GitHub"');
+    expect(html).not.toContain('Open on Meteorite');
   });
 });

--- a/tests/unit/main-token-resolution.test.js
+++ b/tests/unit/main-token-resolution.test.js
@@ -19,6 +19,8 @@ import { describe, it, expect } from 'vitest';
 const fs = require('fs');
 const path = require('path');
 const { resolveHostBinding } = require('../../src/config');
+const { setupHostParam, resolvePreflightBinding } = require('../../src/utils/host-resolution');
+const { resolveCliBindingRepository } = require('../../src/main');
 
 function readMainSource() {
   return fs.readFileSync(path.join(__dirname, '../../src/main.js'), 'utf-8');
@@ -167,5 +169,96 @@ describe('main.js — performHeadlessReview / submit feature-gating', () => {
     // for the default github.com (all-GraphQL) configuration.
     expect(src).toMatch(/GraphQL PR node id required for/);
     expect(src).toMatch(/refresh the PR data and try again/);
+  });
+});
+
+describe('main.js — CLI binding key is host-aware at every PR entry point', () => {
+  const ALT = 'https://alt.example/api/v3';
+  const MONOREPO_PATTERN = '^https://alt\\.example/(?<owner>[^/]+)/(?<repo>[^/]+)/pull/(?<number>\\d+)';
+
+  const dualMonorepo = {
+    github_token: 'gh-tok',
+    repos: {
+      'acme/platform': { api_host: ALT, exclusive: false, url_pattern: MONOREPO_PATTERN, token: 'alt-tok' }
+    }
+  };
+  const exclusiveMonorepo = {
+    github_token: 'gh-tok',
+    repos: {
+      'acme/platform': { api_host: ALT, url_pattern: MONOREPO_PATTERN, token: 'alt-tok' }
+    }
+  };
+
+  it('every in-process PR entry point resolves the key through the shared helper', () => {
+    const src = readMainSource();
+    // handlePullRequest, performHeadlessReview, and the headless PR path. Match
+    // assignments only, so the function declaration itself is not counted.
+    const calls = src.match(/=\s*resolveCliBindingRepository\(prInfo, config\)/g);
+    expect(calls).toHaveLength(3);
+    // The bare fallback that skipped the config probe must be gone.
+    expect(src).not.toMatch(/prInfo\.bindingRepository\s*\n?\s*\|\|\s*normalizeRepository\(/);
+  });
+
+  it('a canonical github.com URL KEEPS a dual monorepo entry (its local config still applies)', () => {
+    // Parser dropped its key (canonical github URL) and reports host null. The
+    // dual entry does serve github.com, so it — and its path/pool/reset
+    // configuration — must be retained.
+    expect(resolveCliBindingRepository(
+      { owner: 'acme', repo: 'widgets', host: null },
+      dualMonorepo
+    )).toBe('acme/platform');
+  });
+
+  it('a canonical github.com URL rejects an EXCLUSIVE monorepo entry', () => {
+    expect(resolveCliBindingRepository(
+      { owner: 'acme', repo: 'widgets', host: null },
+      exclusiveMonorepo
+    )).toBe('acme/widgets');
+  });
+
+  it('a bare PR number preflights against the configured monorepo entry', () => {
+    // Host unknown: the entry serving this owner/repo must still be found, or the
+    // preflight resolves the identity and misses the repo-scoped token.
+    const key = resolveCliBindingRepository(
+      { owner: 'acme', repo: 'widgets', host: undefined },
+      exclusiveMonorepo
+    );
+    expect(key).toBe('acme/platform');
+    expect(resolveHostBinding(key, exclusiveMonorepo, { host: ALT }).token).toBe('alt-tok');
+  });
+
+  it('an alt-host URL keeps the key the parser matched', () => {
+    expect(resolveCliBindingRepository(
+      { owner: 'acme', repo: 'widgets', host: ALT, bindingRepository: 'acme/platform' },
+      exclusiveMonorepo
+    )).toBe('acme/platform');
+  });
+
+  it('a directly keyed exclusive repo fails fast, naming the config fix', () => {
+    // The CLI passes the parsed host straight into the preflight, so a canonical
+    // github.com URL for a repo its own entry declares alt-host-only fails before
+    // any network work. Documented in docs/alt-host.md alongside the web
+    // surface's warn-and-continue behaviour — the two differ deliberately.
+    const directlyKeyedExclusive = {
+      github_token: 'gh-tok',
+      repos: { 'acme/widgets': { api_host: ALT, token: 'alt-tok' } }
+    };
+    const key = resolveCliBindingRepository(
+      { owner: 'acme', repo: 'widgets', host: null },
+      directlyKeyedExclusive
+    );
+    // Config wins over inference: the entry is kept, not escaped.
+    expect(key).toBe('acme/widgets');
+    expect(() => resolvePreflightBinding(key, directlyKeyedExclusive, null))
+      .toThrow(/exclusive alt-host repo.*"exclusive": false/s);
+  });
+
+  it('announces the github sentinel for a canonical URL an alt entry could claim', () => {
+    const src = readMainSource();
+    // main.js must build the ?host= param through the shared mapping.
+    expect(src).toMatch(/setupHostParam\(config, prInfo\.owner, prInfo\.repo, prInfo\.host\)/);
+
+    // Without the sentinel, setup re-resolves the alt entry and fetches from it.
+    expect(setupHostParam(exclusiveMonorepo, 'acme', 'widgets', null)).toBe('github');
   });
 });

--- a/tests/unit/pr-setup-binding-repo.test.js
+++ b/tests/unit/pr-setup-binding-repo.test.js
@@ -11,8 +11,8 @@
  * pool_size, reset_script) and resolved the wrong token, causing 401s.
  *
  * These tests assert:
- *   1. routes/setup.js — token preflight calls resolveBindingRepositoryFromPR
- *      and feeds the result to getGitHubToken.
+ *   1. routes/setup.js — token preflight resolves the `repos[...]` binding key
+ *      through the shared helper and feeds the result to the preflight.
  *   2. pr-setup.js findRepositoryPath — config helpers (getRepoPath,
  *      resolveRepoOptions) receive the binding key.
  *   3. pr-setup.js setupPRReview — resolvePoolConfig and getRepoResetScript
@@ -35,17 +35,21 @@ function readSource(relativePath) {
 // ---------------------------------------------------------------------------
 
 describe('src/routes/setup.js — token preflight uses binding key', () => {
-  it('imports resolveBindingRepositoryFromPR from config', () => {
+  it('resolves the binding key through the shared host-aware helper', () => {
     const src = readSource('src/routes/setup.js');
-    expect(src).toMatch(/resolveBindingRepositoryFromPR/);
+    // resolveBindingRepositoryForHost wraps resolveBindingRepositoryFromPR and
+    // additionally rejects an exclusive alt entry that only pattern-claimed a
+    // known-github.com PR (see src/utils/host-resolution.js).
+    expect(src).toMatch(/resolveBindingRepositoryForHost/);
   });
 
   it('resolves the binding key before resolving the preflight token', () => {
     const src = readSource('src/routes/setup.js');
-    const bindingPos = src.indexOf('resolveBindingRepositoryFromPR(owner, repo, config)');
-    // Token resolution now goes through resolvePreflightBinding (which tolerates
-    // a dual repo's alt-only token) keyed on the resolved binding repository.
-    const tokenPos = src.indexOf('resolvePreflightBinding(repositoryForToken, config, bodyHost)');
+    const bindingPos = src.indexOf('resolveBindingRepositoryForHost(owner, repo, config,');
+    // Token resolution goes through resolvePreflightBinding (which tolerates a
+    // dual repo's alt-only token) keyed on the resolved binding repository. Both
+    // literals stop before the host argument: this test is about ordering.
+    const tokenPos = src.indexOf('resolvePreflightBinding(repositoryForToken, config,');
     expect(bindingPos).toBeGreaterThan(-1);
     expect(tokenPos).toBeGreaterThan(-1);
     expect(bindingPos).toBeLessThan(tokenPos);

--- a/tests/unit/repo-links-frontend.test.js
+++ b/tests/unit/repo-links-frontend.test.js
@@ -1,12 +1,11 @@
 // Copyright 2026 Tim Perkins (tjwp) | SPDX-License-Identifier: Apache-2.0
+// @vitest-environment jsdom
 /**
  * Unit tests for the frontend repo-links helper
  * (public/js/repo-links.js).
  *
- * Only the pure URL-template substitution logic is exercised here.
- * DOM-touching code paths (parseSvgIcon, buildExternalLink,
- * applyRepoLinks) require a browser context and are covered by the
- * Playwright E2E suite.
+ * URL-template substitution, SVG sanitisation, and host accessors are exercised
+ * against the production helper. DOM-backed tests use Vitest's jsdom runtime.
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
@@ -79,6 +78,94 @@ describe('frontend substituteUrlTemplate', () => {
       { owner: 'acme', some_unknown: 'x' }
     );
     expect(url).toBe('https://h/acme/{some_unknown}');
+  });
+});
+
+describe('frontend SVG parsing', () => {
+  it('removes active HTML embedded through foreignObject', () => {
+    const svg = RepoLinks.parseSvgIcon(
+      '<svg xmlns="http://www.w3.org/2000/svg">' +
+        '<foreignObject width="1" height="1">' +
+          '<iframe xmlns="http://www.w3.org/1999/xhtml" srcdoc="&lt;script&gt;parent.document.body.dataset.pwned=1&lt;/script&gt;"></iframe>' +
+        '</foreignObject>' +
+        '<path d="M1 1h14v14H1z"/>' +
+      '</svg>'
+    );
+
+    expect(svg).not.toBeNull();
+    expect(svg.querySelector('foreignObject')).toBeNull();
+    expect(svg.querySelector('iframe')).toBeNull();
+    expect(svg.querySelector('path')).not.toBeNull();
+  });
+
+  it('keeps local fragment references in every equivalent url() form', () => {
+    const svg = RepoLinks.parseSvgIcon(
+      '<svg xmlns="http://www.w3.org/2000/svg">' +
+        '<defs><linearGradient id="paint0"><stop offset="0" stop-color="#fff"/></linearGradient></defs>' +
+        '<path id="bare" d="M1 1h1v1H1z" fill="url(#paint0)"/>' +
+        '<path id="dquote" d="M2 2h1v1H2z" fill="url(&quot;#paint0&quot;)"/>' +
+        "<path id='squote' d='M3 3h1v1H3z' fill=\"url('#paint0')\"/>" +
+        '<path id="spaced" d="M4 4h1v1H4z" fill=" url(#paint0) "/>' +
+      '</svg>'
+    );
+
+    expect(svg).not.toBeNull();
+    for (const id of ['bare', 'dquote', 'squote', 'spaced']) {
+      expect(svg.querySelector('#' + id).getAttribute('fill')).toContain('#paint0');
+    }
+  });
+
+  it('strips url() references that leave the document', () => {
+    const svg = RepoLinks.parseSvgIcon(
+      '<svg xmlns="http://www.w3.org/2000/svg">' +
+        '<path id="remote" d="M1 1h1v1H1z" fill="url(https://evil.example/x)"/>' +
+        '<path id="scheme" d="M2 2h1v1H2z" fill="url(//evil.example/x)"/>' +
+        '<path id="data" d="M3 3h1v1H3z" fill="url(data:image/svg+xml,%3Csvg/%3E)"/>' +
+        '<path id="mixedquotes" d="M4 4h1v1H4z" fill="url(&quot;#a\')"/>' +
+      '</svg>'
+    );
+
+    expect(svg).not.toBeNull();
+    for (const id of ['remote', 'scheme', 'data', 'mixedquotes']) {
+      expect(svg.querySelector('#' + id).hasAttribute('fill')).toBe(false);
+    }
+  });
+
+  it('still strips scripts and event handlers', () => {
+    const svg = RepoLinks.parseSvgIcon(
+      '<svg xmlns="http://www.w3.org/2000/svg" onload="window.pwned=1">' +
+        '<script>window.pwned = 1</script>' +
+        '<path d="M1 1h14v14H1z" onmouseover="window.pwned=1"/>' +
+      '</svg>'
+    );
+
+    expect(svg).not.toBeNull();
+    expect(svg.hasAttribute('onload')).toBe(false);
+    expect(svg.querySelector('script')).toBeNull();
+    expect(svg.querySelector('path').hasAttribute('onmouseover')).toBe(false);
+  });
+
+  it('warns once when sanitisation changes the icon, and stays silent otherwise', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      RepoLinks.parseSvgIcon(
+        '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">' +
+          '<path d="M1 1h14v14H1z" fill="url(#paint0)"/>' +
+        '</svg>'
+      );
+      expect(warn).not.toHaveBeenCalled();
+
+      RepoLinks.parseSvgIcon(
+        '<svg xmlns="http://www.w3.org/2000/svg" onload="window.pwned=1">' +
+          '<script>window.pwned = 1</script>' +
+          '<path d="M1 1h14v14H1z" fill="url(https://evil.example/x)"/>' +
+        '</svg>'
+      );
+      expect(warn).toHaveBeenCalledTimes(1);
+      expect(warn.mock.calls[0][0]).toContain('[repo-links] Sanitised configured icon');
+    } finally {
+      warn.mockRestore();
+    }
   });
 });
 

--- a/tests/unit/route-bindings.test.js
+++ b/tests/unit/route-bindings.test.js
@@ -81,11 +81,14 @@ describe('PR-mode route call sites use host bindings (alt-host safety)', () => {
   it('src/routes/stack-analysis.js — resolves the binding for the stack repo', () => {
     const src = readSource('src/routes/stack-analysis.js');
     // Must resolve the config-binding key first (handles monorepo url_pattern
-    // configs where the config key differs from `${owner}/${repo}`), then
-    // pass that key into `resolveHostBinding`.
+    // configs where the config key differs from `${owner}/${repo}`), then pass
+    // a host-aware key into `resolveHostBinding`. The two are deliberately
+    // separate: `bindingRepository` stays the PR's config identity (worktree
+    // options, reset script), while `stackBindingRepository` is the entry that
+    // can serve the host the trigger PR is recorded on.
     expect(src).toMatch(/resolveBindingRepositoryFromPR\(owner, repo, config\)/);
-    // Now host-aware: the third arg pins the main PR's stored host for the stack.
-    expect(src).toMatch(/resolveHostBinding\(bindingRepository, config, stackHostOption \|\| \{\}\)/);
+    expect(src).toMatch(/resolveBindingRepositoryForHost\(owner, repo, config, mainRecordedHost\)/);
+    expect(src).toMatch(/resolveHostBinding\(stackBindingRepository, config, stackHostOption \|\| \{\}\)/);
     expect(src).toMatch(/new deps\.GitHubClient\(stackBinding\)/);
   });
 

--- a/tests/unit/single-port.test.js
+++ b/tests/unit/single-port.test.js
@@ -555,6 +555,29 @@ describe('attemptDelegation', () => {
     expect(deps.open).toHaveBeenCalledWith(expect.stringContaining('host=github'));
   });
 
+  it('threads the github sentinel when a monorepo pattern could claim the repo', async () => {
+    // The parser discards an api_host url_pattern match for a canonical github.com
+    // URL, so it reports host null with no bindingRepository. Setup would still
+    // re-resolve the alt entry from owner/repo, so the sentinel must be sent.
+    class GithubParser {
+      async parsePRArguments() { return { owner: 'acme', repo: 'widgets', number: 42, host: null }; }
+    }
+    const deps = createMockDeps({ PRArgumentParser: GithubParser });
+    const config = {
+      port: 7247,
+      single_port: true,
+      repos: {
+        'acme/platform': {
+          api_host: 'https://alt.example/api/v3',
+          url_pattern: '^https://alt\\.example/(?<owner>[^/]+)/(?<repo>[^/]+)/pull/(?<number>\\d+)',
+          token: 't'
+        }
+      }
+    };
+    await attemptDelegation(config, {}, ['https://github.com/acme/widgets/pull/42'], deps);
+    expect(deps.open).toHaveBeenCalledWith(expect.stringContaining('host=github'));
+  });
+
   it('omits the host param for a plain github repo', async () => {
     class PlainParser {
       async parsePRArguments() { return { owner: 'a', repo: 'b', number: 1, host: null }; }

--- a/tests/unit/stack-analysis-binding-repo.test.js
+++ b/tests/unit/stack-analysis-binding-repo.test.js
@@ -63,7 +63,10 @@ vi.spyOn(databaseModule.PRMetadataRepository.prototype, 'getByPR').mockResolvedV
   description: ''
 });
 vi.spyOn(databaseModule.PRMetadataRepository.prototype, 'updateLastAiRunId').mockResolvedValue(undefined);
-  vi.spyOn(databaseModule.PRMetadataRepository.prototype, 'getPRHost').mockResolvedValue(undefined);
+vi.spyOn(databaseModule.PRMetadataRepository.prototype, 'getPRHost').mockResolvedValue(undefined);
+// Host resolution reads the stored host together with the recorded html_url, so
+// the stack binding can tell a github.com PR from a pre-stamping alt-host one.
+vi.spyOn(databaseModule.PRMetadataRepository.prototype, 'getPRHostWithRecordedUrl').mockResolvedValue(undefined);
 vi.spyOn(databaseModule.ReviewRepository.prototype, 'getOrCreate').mockResolvedValue({ review: { id: 1 } });
 vi.spyOn(databaseModule.ReviewRepository.prototype, 'upsertSummary').mockResolvedValue(undefined);
 vi.spyOn(databaseModule.RepoSettingsRepository.prototype, 'getRepoSettings').mockResolvedValue(null);
@@ -330,9 +333,12 @@ describe('executeStackAnalysis — bindingRepository resolution', () => {
         'acme/widget-a': { api_host: 'https://alt.example/api/v3', exclusive: false, token: 'alt-tok' }
       }
     };
-    // Trigger PR (#10) is stored on the alt host.
-    vi.spyOn(databaseModule.PRMetadataRepository.prototype, 'getPRHost')
-      .mockResolvedValue('https://alt.example/api/v3');
+    // Trigger PR (#10) is stored on the alt host, with a matching recorded URL.
+    vi.spyOn(databaseModule.PRMetadataRepository.prototype, 'getPRHostWithRecordedUrl')
+      .mockResolvedValue({
+        host: 'https://alt.example/api/v3',
+        recordedUrl: 'https://alt.example/acme/widget-a/pull/10'
+      });
 
     const resolveHostBinding = vi.fn().mockReturnValue({
       apiHost: 'https://alt.example/api/v3', host: 'https://alt.example/api/v3',

--- a/tests/unit/stack-orchestrator.test.js
+++ b/tests/unit/stack-orchestrator.test.js
@@ -56,7 +56,8 @@ vi.spyOn(databaseModule.PRMetadataRepository.prototype, 'getByPR').mockResolvedV
   description: ''
 });
 vi.spyOn(databaseModule.PRMetadataRepository.prototype, 'updateLastAiRunId').mockResolvedValue(undefined);
-  vi.spyOn(databaseModule.PRMetadataRepository.prototype, 'getPRHost').mockResolvedValue(undefined);
+vi.spyOn(databaseModule.PRMetadataRepository.prototype, 'getPRHost').mockResolvedValue(undefined);
+vi.spyOn(databaseModule.PRMetadataRepository.prototype, 'getPRHostWithRecordedUrl').mockResolvedValue(undefined);
 vi.spyOn(databaseModule.ReviewRepository.prototype, 'getOrCreate').mockResolvedValue({ review: { id: 1 } });
 vi.spyOn(databaseModule.ReviewRepository.prototype, 'upsertSummary').mockResolvedValue(undefined);
 vi.spyOn(databaseModule.RepoSettingsRepository.prototype, 'getRepoSettings').mockResolvedValue(null);
@@ -198,6 +199,7 @@ describe('executeStackAnalysis', () => {
     });
     vi.spyOn(databaseModule.PRMetadataRepository.prototype, 'updateLastAiRunId').mockResolvedValue(undefined);
   vi.spyOn(databaseModule.PRMetadataRepository.prototype, 'getPRHost').mockResolvedValue(undefined);
+    vi.spyOn(databaseModule.PRMetadataRepository.prototype, 'getPRHostWithRecordedUrl').mockResolvedValue(undefined);
     vi.spyOn(databaseModule.ReviewRepository.prototype, 'getOrCreate').mockResolvedValue({ review: { id: 1 } });
     vi.spyOn(databaseModule.RepoSettingsRepository.prototype, 'getRepoSettings').mockResolvedValue(null);
     vi.spyOn(databaseModule.AnalysisRunRepository.prototype, 'create').mockResolvedValue(undefined);


### PR DESCRIPTION
The dashboard always rendered GitHub, even when a pull request belonged to a configured alternate host such as Meteorite. This made collection and recent-review rows open the wrong system.

## Change

- Adds host-aware repository links to cached collections, refreshed collections, and recent reviews.
- Renders the configured external-host action alongside GitHub and Graphite when applicable.
- Preserves known GitHub and alternate-host identities through single-row, bulk Open, and bulk Analyze navigation.
- Uses the recorded PR URL when a configured template needs unavailable row data.
- Preserves URL casing when creating Graphite links.
- Escapes configuration-derived attributes and restricts custom SVG icons to inert presentation elements.
- Adds a patch changeset.

## Testing

- 108 targeted unit and integration tests passed.
- 4 repository-link Playwright tests passed.
- Verified bulk Open and Analyze navigation for GitHub and alternate-host rows.
- Verified configured external links on collection and recent-review rows.

<img width="2606" height="946" alt="image" src="https://github.com/user-attachments/assets/fc458f73-27de-412f-9151-2726b2fff758" />
