### PR TITLE
feat: refresh built-in models (GPT-6 Astra, Gemini 3.8 Flash, Muse Spark 1.3, Opus 5 default)

### DIFF
--- a/.changeset/antigravity-gemini-3-8-flash.md
+++ b/.changeset/antigravity-gemini-3-8-flash.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Antigravity: replace the retired Gemini 3.5 Flash models with Gemini 3.8 Flash (Low/High) in the fast tier. The old `gemini-3.5-flash-low`, `gemini-3.5-flash`, and `gemini-3.5-flash-high` ids are kept as aliases that resolve to the matching 3.8 Flash effort level, so saved councils and configs keep working instead of falling through to agy's default model. Gemini 3.8 Flash (High) moves to the thorough tier and becomes the provider's default model — it is now the strongest Gemini that agy exposes (DeepSWE v1.1 73.7, Terminal-Bench 2.1 89.4, on par with GPT-6 Astra and Muse 1.3), so "Flash" describes latency rather than capability. Gemini 3.1 Pro (Low/High) is demoted to the previous-generation Pro line: it keeps its balanced/thorough tiers but is no longer the default. Gemini 3.8 Flash (Low) stays the sole fast-tier model and the JSON-extraction fallback.

--- a/.changeset/claude-opus-5-default.md
+++ b/.changeset/claude-opus-5-default.md
@@ -1,0 +1,14 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Claude: make `opus-5-high` (Claude Opus 5, high effort) the provider's
+default model, replacing `opus-4.8-xhigh`. Opus 5 is priced the same as Opus
+4.8, so the default picks up the newer generation at no extra cost; `opus-5-xhigh`
+and Fable 5.1 stay explicit thorough-tier picks. `opus-5-high` now carries the
+"Recommended" badge and `opus-4.8-xhigh` reads as previous generation.
+
+All Opus 4.8 entries (`opus-4.8-xhigh`, `opus-4.8-high`) remain available and
+the bare `opus` alias still resolves to `opus-4.8-xhigh`, so existing configs,
+saved councils, and `--model opus` invocations are unchanged. Only the
+no-model-specified path and the picker's preselected entry move to Opus 5.

--- a/.changeset/codex-gpt-6-astra.md
+++ b/.changeset/codex-gpt-6-astra.md
@@ -1,0 +1,9 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Refresh the built-in Codex model list for the GPT-6 launch.
+
+- Add GPT-6 Astra as `gpt-6-astra-high` and `gpt-6-astra-xhigh` (thorough tier). Astra is OpenAI's new flagship but costs several times more than Sol, so `gpt-5.6-sol-high` remains the default.
+- Remove the retired `gpt-5.4-high`, `gpt-5.4-xhigh`, `gpt-5.4-nano`, and `gpt-5.3-codex` entries (OpenAI retired these models on Aug 31 2026; Codex now rejects them with a 400). They are intentionally not aliased onto other models, so saved councils that reference them fail with an explicit unknown-model error instead of silently running a different model. The legacy `gpt-5.4` alias is gone with them.
+- Move `gpt-5.4-mini` to the fast tier — it is now the model used for lightweight extraction steps.

--- a/.changeset/muse-spark-1-3.md
+++ b/.changeset/muse-spark-1-3.md
@@ -1,0 +1,5 @@
+---
+"@in-the-loop-labs/pair-review": patch
+---
+
+Muse: move the built-in models from Muse Spark 1.2 to Muse Spark 1.3 (`muse-spark-1.3-max`, `-xhigh`, `-high`, `-low` and their `-contributor` twins; default `muse-spark-1.3-high`). 1.3 is priced identically to 1.2 and strictly better, so every `muse-spark-1.2-*` id is kept as an alias that resolves to its 1.3 twin at the same reasoning effort — saved councils and configs upgrade in place. The top effort is now `max` (which actually runs) instead of `ultra`, which the CLI gate-closes and silently degrades to `xhigh`; the former `-ultra` ids resolve to the `-max` entries. Docs no longer list the rejected `none` effort.

--- a/.claude/skills/update-provider-models/SKILL.md
+++ b/.claude/skills/update-provider-models/SKILL.md
@@ -28,13 +28,31 @@ Each provider file has a `*_MODELS` array at the top defining models with:
 - `tier`: One of `fast`, `balanced`, `thorough` (or `free`, `premium`)
 - `tagline`, `description`, `badge`, `badgeClass`: UI metadata
 - `default: true`: Marks the default model for the provider
+- `aliases`: Optional extra ids that resolve to this entry (used to keep saved
+  councils/configs working when an id is renamed)
+
+## Ground Rules for Probing
+
+- **Never trust a CLI's own model listing over a live probe.** Installed binaries lag
+  the backend: on 2026-09-06 `agy models` (agy 1.0.16) did not list Gemini 3.8 Flash,
+  and Muse's cached catalog did not list Spark 1.3, yet both ids ran fine. Conversely,
+  ids a provider file still carries may be dead (gpt-5.4, gemini-3.5-flash). Probe every
+  id you keep AND every id you add.
+- **macOS has no `timeout`.** Wrap probes with perl instead:
+  ```
+  perl -e 'alarm 120; exec @ARGV' <cli> <args...>
+  ```
+- Run probes from the scratchpad directory (some CLIs treat cwd as a workspace) and
+  run slow batches with `run_in_background`.
+- Do not print `~/.pair-review/config.json` wholesale — it holds tokens. Grep only the
+  `command` lines you need.
 
 ## Step-by-Step Process
 
 ### 1. Check CLI Overrides
 
-Read `~/.pair-review/config.json` to see if any provider commands are overridden.
-Look at `providers.<id>.command` for each provider.
+Look at `providers.<id>.command` in `~/.pair-review/config.json` for each provider
+(grep for `"command"`; do not dump the file).
 
 ### 2. Check CLI Availability
 
@@ -43,12 +61,34 @@ For each provider, run:
 <cli> --version
 ```
 Using the command from config if overridden. Skip providers whose CLI is not installed.
+If a CLI is missing or clearly stale, tell the user which one and let them install or
+update it rather than self-updating (`agy update`, `codex update`, muse's launcher
+script auto-updates hourly).
 
 ### 3. List Available Models
 
 Each CLI has different model listing commands:
-- **Antigravity**: `agy models` — lists the available Antigravity models (e.g. `gemini-3.1-pro-low`, `gemini-3.1-pro-high`, `gemini-3.5-flash-low`, `gemini-3.5-flash-high`)
-- **Codex**: No `--list-models` flag. Check docs at developers.openai.com/codex/models/ or use web search
+- **Antigravity**: `agy models` lists what the *installed binary* knows (e.g.
+  `Gemini 3.8 Flash (High)`, `Gemini 3.1 Pro (Low)`), which can be behind the backend.
+  `agy changelog` shows the newest released CLI versions, so compare it against
+  `agy --version` to spot a stale install. Probe an id directly:
+  ```
+  agy -p 'Reply with your exact model name and nothing else' --model <id> --dangerously-skip-permissions --print-timeout 2m
+  ```
+  A valid id answers with the model name and exits 0. An unknown id exits 1 and prints
+  the available-model listing (agy no longer falls back to its default silently). The
+  provider's clean ids (`gemini-3.8-flash-low`) work as `--model` values too.
+- **Codex**: No `--list-models` flag, but the CLI caches the backend catalog at
+  `~/.codex/models_cache.json` (`models[]` with `slug`, `display_name`, `description`,
+  `visibility` (`list`/`hide`), `supported_reasoning_levels[].effort`,
+  `default_reasoning_level`, `context_window`; top-level `fetched_at`, `client_version`).
+  That file is the best local source of new slugs. Confirm with a probe:
+  ```
+  codex exec -m <slug> -c model_reasoning_effort=low --skip-git-repo-check 'Reply with the single word OK'
+  ```
+  A retired slug fails with a 400 `The '<slug>' model is not supported when using Codex
+  with a ChatGPT account`; a valid one prints OK. Pricing is not in the cache — use web
+  search (learn.chatgpt.com/docs/models, learn.chatgpt.com/docs/changelog).
 - **Copilot**: No native list command. Use `copilot -p 'list available models'` (non-interactive) or check docs.github.com/en/copilot/reference/ai-models/supported-models
 - **Cursor Agent**: `agent --list-models` — works great, comprehensive output
 - **OpenCode**: `opencode models` — lists all models in `provider/model-id` format (shows bundled + provider models)
@@ -57,26 +97,33 @@ Each CLI has different model listing commands:
 - **OMP**: `omp models` (or `omp models --json`) — lists the catalog grouped by provider with context, max-out, thinking, images columns. `omp models find <substring>` searches; `omp models refresh` forces a fresh catalog fetch.
 - **Muse**: No `models list` subcommand — and no models subcommand at all. Do not run
   `muse models`: with no matching subcommand, muse treats `models` as a prompt and tries to
-  launch the interactive TUI. Read the locally cached catalog instead, which is the
-  authoritative source (the CLI fetches it from Meta's provider API and writes it after
-  login, so it only exists once `muse login` has run):
+  launch the interactive TUI. The locally cached catalog is a starting point but is
+  **not authoritative** — it is only refreshed by the launcher on login and can lag a
+  release by weeks (it still listed only 1.2 after 1.3 shipped):
   ```
   cat ~/.local/share/muse/model-catalog/*.json
   ```
   Each file is JSON with a `rows` array; the fields that matter are `model_id` (the value for
   `--model`), `display_label`, `is_default`, `context_limit`, and `cost`. Only the underlying
-  CLI model ids appear here — as of 2026-08-07 just `muse-spark-1.2` and
-  `muse-spark-1.2-contributor` — not pair-review's reasoning-effort variants (see the note
-  below).
+  CLI model ids appear here (`muse-spark-1.3`, `muse-spark-1.3-contributor`, older
+  `muse-spark-1.2*`) — not pair-review's reasoning-effort variants (see the note below).
 
-  To confirm a specific id is still valid, pass it with the prompt as a **positional
-  argument**; an unknown id fails fast with exit 1 and ``model `X` is not in the catalog``:
+  To confirm a specific id is valid, pass it with the prompt as a **positional
+  argument** and an explicit, supported effort. An unknown id fails fast with exit 1 and
+  ``model `X` does not exist or you lack access``:
   ```
-  muse exec --model <ID> "hi"
+  muse exec --model <ID> --reasoning-effort low "Reply with the single word OK"
   ```
-  Do **not** probe with `--prompt-file /dev/null`. Muse validates the prompt file before the
-  model, so that form always dies on `--prompt-file /dev/null is not a regular file` and tells
-  you nothing about the id — a bogus id and a valid one produce the identical error.
+  Do **not** pass `--reasoning-effort none` — the meta provider rejects it with exit 2
+  and a usage dump, which looks like a bad model id but is not. Do **not** probe with
+  `--prompt-file /dev/null` either: muse validates the prompt file before the model, so
+  that form always dies on `--prompt-file /dev/null is not a regular file` and tells you
+  nothing about the id.
+
+  Also probe the effort levels you intend to ship. On 2026-09-06 `max` ran normally,
+  while `ultra` printed `reasoning effort ultra is not available (gate
+  ultra_reasoning_effort is closed); using xhigh` and silently ran at xhigh — an
+  `-ultra` built-in would be a disguised `-xhigh`.
 
 ### 4. Get Model Recommendations for Code Review
 
@@ -90,9 +137,9 @@ Recommend 1 model per tier and explain WHY for code review specifically.'
 ```
 
 Also use web search to check:
-- Latest benchmark results (SWE-bench Verified, etc.)
+- Latest benchmark results (DeepSWE v1.1 and Terminal-Bench are what vendors now publish; SWE-bench Verified is rarely reported)
 - Model release announcements
-- Pricing changes
+- Pricing changes and retirement dates (Codex's changelog lists retirements per sign-in type)
 
 ### 5. Update the Provider Files
 
@@ -101,13 +148,29 @@ For each provider, update:
 2. The constructor default parameter (should match the model with `default: true`)
 3. The `getDefaultModel()` static method return value
 4. The JSDoc comments describing the models
-5. Keep the tier structure: fast, balanced (default), thorough
+5. Keep the tier structure: fast, balanced (default), thorough — every tier must keep at
+   least one live entry after removals
+6. Retired ids: remove the entry and list it in the JSDoc "Deprecated" line. Add an
+   `aliases` entry pointing at a successor only when the successor is the same model
+   line at the same price and effort (e.g. `gemini-3.5-flash-low` → `gemini-3.8-flash-low`,
+   `muse-spark-1.2-high` → `muse-spark-1.3-high`); never alias a dead id onto a
+   different model family, an explicit unknown-model error is better than a silent swap.
+   For a same-line point release the provider decides: Claude (and other high-attention
+   providers) keeps the previous generation as explicit entries, because users hold
+   strong opinions between point releases and a saved council must keep the generation
+   it was written against; lightly used providers such as Muse may replace the entries
+   and alias the old ids onto the new generation in place
+7. Sweep every other place that lists built-in ids: `config.example.json` `_comment`
+   strings, the README provider tables, `src/main.js` `--model` help text, and the unit
+   tests (`tests/unit/<provider>-provider.test.js`, `llm-extraction.test.js`,
+   `shared.test.js`, `provider-model.test.js`, `stack-analysis-provider-model.test.js`)
+8. Add a changeset under `.changeset/` per provider touched, bump level `patch` — adding, retiring, or re-tiering built-in models has always shipped as a patch (Opus 5, GPT-5.6, Fable 5.1 all did); reserve `minor` for a new provider
 
 ### 6. Verify Changes
 
 After updating, run the test suite to ensure no regressions:
 ```
-npm test
+pnpm test
 ```
 
 Leave changes uncommitted for the user to review.
@@ -123,6 +186,10 @@ Leave changes uncommitted for the user to review.
   security review, complex multi-file changes.
   Examples: opus, pro-preview, codex-high/max variants
 
+A new flagship does not automatically become the default. If it costs several times
+the current default (GPT-6 Astra at $10/$50 vs Sol), add it to thorough and keep the
+default where it is.
+
 ## Notes
 
 - OpenCode has no built-in models. Its models are configured entirely via
@@ -131,15 +198,20 @@ Leave changes uncommitted for the user to review.
   modes (default, multi-model, review-roulette) rather than specific models
 - Copilot CLI may have limited model availability depending on subscription tier
 - Some CLIs may need authentication before they can list models or respond to queries
-- Run `agy models` to see which Antigravity models are currently available; the list can change as new models roll out
+- Antigravity only ships Gemini models in the built-in picker; agy also exposes Claude
+  and GPT-OSS models, reachable via config override only. The Pro line is still 3.1 Pro
+  (no newer Pro exists on agy as of 2026-09-06)
+- Codex retires models per sign-in type: a slug can be dead for ChatGPT accounts while
+  still documented for API keys. Probe with the account the user actually uses
 - Muse's built-in model ids are **not** raw CLI model ids. Each one pairs an underlying CLI
-  model (`muse-spark-1.2` or `muse-spark-1.2-contributor`) with a `--reasoning-effort` level
-  (`none|minimal|low|medium|high|xhigh|ultra`), so several app-level ids map onto the same CLI
+  model (`muse-spark-1.3` or `muse-spark-1.3-contributor`) with a `--reasoning-effort` level
+  (`minimal|low|medium|high|xhigh|max|ultra`; `none` is rejected by the meta provider and
+  `ultra` is gated, see step 3), so several app-level ids map onto the same CLI
   model. When updating, check whether the underlying model list changed *and* whether the effort
   levels still make sense for each tier
-- The `muse-spark-1.2-contributor` model is much cheaper because Meta may use its content for
+- The `muse-spark-*-contributor` models are much cheaper because Meta may use their content for
   product improvement. **Keep the default on a non-contributor model** so opting into data
   sharing stays an explicit user choice; do not promote a `-contributor` id to default.
-  Note that the cached catalog marks `muse-spark-1.2-contributor` with `is_default: true` —
+  Note that the cached catalog marks the `-contributor` model with `is_default: true` —
   that is muse's own default, and pair-review overrides it on purpose. Do not copy the
   catalog's `is_default` across when refreshing the model list

--- a/README.md
+++ b/README.md
@@ -638,7 +638,7 @@ pair-review integrates with AI providers via their CLI tools:
 - **Cursor**: Uses Cursor Agent CLI (streaming output with sandbox mode)
 - **Pi**: Uses Pi coding agent CLI (requires model configuration)
 - **OMP**: Uses the [Oh My Pi](https://github.com/can1357/oh-my-pi) CLI (`omp`), a fork of the Pi coding agent. Install it with `npm install -g @oh-my-pi/pi-coding-agent`. Works out of the box: the built-in `default` mode uses whatever model your OMP configuration selects, and you can add specific models via `providers.omp.models` (run `omp models` to list the catalog). OMP's advisor runtime — which passively reviews each turn and injects notes — is disabled during reviews by default for deterministic, lower-cost analysis; set `"advisor": true` in `providers.omp` to opt back in.
-- **Muse**: Uses Meta's Muse Code CLI (`muse`), a terminal coding agent released in beta in August 2026 and powered by the Muse Spark 1.2 model. Install it with the single shell command from Meta's Muse Code install instructions (macOS/Linux), then authenticate once with `muse login` (credentials are stored in `~/.config/muse/auth.json`). pair-review drives it headlessly via `muse exec --json`. Within pair-review, Muse is analysis-only: the CLI exposes no ACP server mode, so there is no Muse chat provider.
+- **Muse**: Uses Meta's Muse Code CLI (`muse`), a terminal coding agent released in beta in August 2026 and powered by the Muse Spark 1.3 model. Install it with the single shell command from Meta's Muse Code install instructions (macOS/Linux), then authenticate once with `muse login` (credentials are stored in `~/.config/muse/auth.json`). pair-review drives it headlessly via `muse exec --json`. Within pair-review, Muse is analysis-only: the CLI exposes no ACP server mode, so there is no Muse chat provider.
 
 You can select your preferred provider and model in the repository settings UI.
 
@@ -650,20 +650,22 @@ Most providers (Claude, Antigravity, Codex, Copilot, Muse) come with built-in mo
 
 Muse exposes its built-in models as reasoning-effort variants over two underlying CLI models:
 
-| Model ID | Tier | Underlying CLI model |
-|----------|------|----------------------|
-| `muse-spark-1.2-ultra` | thorough | `muse-spark-1.2` |
-| `muse-spark-1.2-contributor-ultra` | thorough | `muse-spark-1.2-contributor` |
-| `muse-spark-1.2-xhigh` | thorough | `muse-spark-1.2` |
-| `muse-spark-1.2-contributor-xhigh` | thorough | `muse-spark-1.2-contributor` |
-| `muse-spark-1.2-high` | balanced (**default**) | `muse-spark-1.2` |
-| `muse-spark-1.2-contributor-high` | balanced | `muse-spark-1.2-contributor` |
-| `muse-spark-1.2-low` | fast | `muse-spark-1.2` |
-| `muse-spark-1.2-contributor-low` | fast | `muse-spark-1.2-contributor` |
+| Model ID | Tier | CLI model |
+|----------|------|-----------|
+| `muse-spark-1.3-max` | thorough | `muse-spark-1.3` |
+| `muse-spark-1.3-contributor-max` | thorough | `muse-spark-1.3-contributor` |
+| `muse-spark-1.3-xhigh` | thorough | `muse-spark-1.3` |
+| `muse-spark-1.3-contributor-xhigh` | thorough | `muse-spark-1.3-contributor` |
+| `muse-spark-1.3-high` | balanced (**default**) | `muse-spark-1.3` |
+| `muse-spark-1.3-contributor-high` | balanced | `muse-spark-1.3-contributor` |
+| `muse-spark-1.3-low` | fast | `muse-spark-1.3` |
+| `muse-spark-1.3-contributor-low` | fast | `muse-spark-1.3-contributor` |
 
-`muse-spark-1.2` and `muse-spark` are convenience aliases for `muse-spark-1.2-high`. `muse-spark-1.2-contributor` is likewise an alias for `muse-spark-1.2-contributor-high` — worth knowing because it is the bare CLI model name, so `--model muse-spark-1.2-contributor` selects the data-sharing tier described below rather than erroring out.
+`muse-spark-1.3` and `muse-spark` are convenience aliases for `muse-spark-1.3-high`. `muse-spark-1.3-contributor` is likewise an alias for `muse-spark-1.3-contributor-high` — worth knowing because it is the bare CLI model name, so `--model muse-spark-1.3-contributor` selects the data-sharing tier described below rather than erroring out.
 
-The `-contributor` models are substantially cheaper ($0.10/M input, $0.20/M output versus $1.25/M and $4.25/M) **because Meta may use their content for product improvement**. Since a code review sends your diff and surrounding source to the model, pair-review deliberately defaults to the non-contributor `muse-spark-1.2-high` — opting into data sharing is always an explicit choice you make by selecting a `-contributor` model, whether by its full ID or by that alias.
+Muse Spark 1.3 is priced identically to 1.2 and is strictly better, so every `muse-spark-1.2-*` id (including the bare `muse-spark-1.2` and `muse-spark-1.2-contributor`) is kept as an alias of its 1.3 twin at the same reasoning effort — saved councils and configs upgrade in place. The former `-ultra` ids resolve to the `-max` entries: `--reasoning-effort ultra` is behind a closed feature gate and silently runs at `xhigh`, whereas `max` actually runs.
+
+The `-contributor` models are substantially cheaper ($0.10/M input, $0.20/M output versus $1.25/M and $4.25/M) **because Meta may use their content for product improvement**. Since a code review sends your diff and surrounding source to the model, pair-review deliberately defaults to the non-contributor `muse-spark-1.3-high` — opting into data sharing is always an explicit choice you make by selecting a `-contributor` model, whether by its full ID or by that alias.
 
 #### Configuring Custom Models
 

--- a/config.example.json
+++ b/config.example.json
@@ -147,12 +147,12 @@
     },
 
     "antigravity": {
-      "_comment": "Override Antigravity's built-in configuration. Antigravity drives the 'agy' CLI as an agentic reviewer. Built-in model IDs: gemini-3.5-flash-low, gemini-3.5-flash-high, gemini-3.1-pro-low (default), gemini-3.1-pro-high. Run 'agy models' to list everything agy exposes (Claude and GPT-OSS models included). Use 'command' for a custom path/wrapper, 'env' for environment variables, 'default_model'/'disabled_models' to shape the picker, and — on a custom model — 'cli_model' to set the exact string the 'agy --model' flag receives (agy silently uses its default for an unknown name).",
+      "_comment": "Override Antigravity's built-in configuration. Antigravity drives the 'agy' CLI as an agentic reviewer. Built-in model IDs: gemini-3.8-flash-high (default, thorough), gemini-3.1-pro-high, gemini-3.1-pro-low, gemini-3.8-flash-low. Run 'agy models' to list everything agy exposes (Claude and GPT-OSS models included). Use 'command' for a custom path/wrapper, 'env' for environment variables, 'default_model'/'disabled_models' to shape the picker, and — on a custom model — 'cli_model' to set the exact string the 'agy --model' flag receives (an unknown name makes agy exit 1 with its model listing rather than fall back to a default).",
       "command": "agy",
       "extra_args": [],
       "env": {},
       "installInstructions": "Install the Antigravity CLI: curl -fsSL https://antigravity.google/cli/install.sh | bash",
-      "default_model": "gemini-3.1-pro-low",
+      "default_model": "gemini-3.8-flash-high",
       "models": [
         {
           "_comment": "Example: define a custom model id backed by an exact 'agy --model' string. 'cli_model' is the display string printed by 'agy models' (a built-in Gemini string is shown here; agy also lists Claude and GPT-OSS models you can target the same way). The clean 'id' is what the UI and config keys use.",
@@ -174,7 +174,7 @@
     },
 
     "muse": {
-      "_comment": "Override Muse's built-in configuration. Muse drives Meta's 'muse' CLI (Muse Code) headlessly via 'muse exec --json'. Built-in model IDs: muse-spark-1.2-ultra, muse-spark-1.2-contributor-ultra, muse-spark-1.2-xhigh, muse-spark-1.2-contributor-xhigh, muse-spark-1.2-high (default; aliases 'muse-spark-1.2' and 'muse-spark'), muse-spark-1.2-contributor-high (alias 'muse-spark-1.2-contributor'), muse-spark-1.2-low, muse-spark-1.2-contributor-low. Each built-in maps to one of two real CLI models plus a --reasoning-effort level (none|minimal|low|medium|high|xhigh|ultra). NOTE: the 'contributor' models are cheaper because Meta may use their content for product improvement; pair-review defaults to the non-contributor model so that tradeoff is always an explicit opt-in. Naming the bare CLI model 'muse-spark-1.2-contributor' resolves to the contributor variant, so it opts into that data sharing too. Run 'muse login' once to authenticate.",
+      "_comment": "Override Muse's built-in configuration. Muse drives Meta's 'muse' CLI (Muse Code) headlessly via 'muse exec --json'. Built-in model IDs: muse-spark-1.3-max, muse-spark-1.3-contributor-max, muse-spark-1.3-xhigh, muse-spark-1.3-contributor-xhigh, muse-spark-1.3-high (default; aliases 'muse-spark-1.3' and 'muse-spark'), muse-spark-1.3-contributor-high (alias 'muse-spark-1.3-contributor'), muse-spark-1.3-low, muse-spark-1.3-contributor-low. Every muse-spark-1.2-* id is an alias of its 1.3 twin (same price, better model), and the former -ultra ids alias to -max because 'ultra' is gate-closed and silently runs at xhigh. Each built-in maps to one of two real CLI models plus a --reasoning-effort level (minimal|low|medium|high|xhigh|max|ultra; 'none' is rejected). NOTE: the 'contributor' models are cheaper because Meta may use their content for product improvement; pair-review defaults to the non-contributor model so that tradeoff is always an explicit opt-in. Naming the bare CLI model 'muse-spark-1.3-contributor' resolves to the contributor variant, so it opts into that data sharing too. Run 'muse login' once to authenticate.",
       "command": "muse",
       "extra_args": [],
       "env": {},

--- a/src/ai/analyzer.js
+++ b/src/ai/analyzer.js
@@ -402,7 +402,7 @@ function hasSchemaKeys(obj) {
 class Analyzer {
   /**
    * @param {Object} database - Database instance
-   * @param {string} model - Model to use (e.g., 'opus', 'gemini-3.1-pro-low')
+   * @param {string} model - Model to use (e.g., 'opus', 'gemini-3.8-flash-high')
    * @param {string} provider - Provider ID (e.g., 'claude', 'antigravity'). Defaults to 'claude'.
    * @param {Object} providerOverrides - Per-call config overrides passed to createProvider (optional)
    * @param {Object|null} providerOverridesMap - Per-provider overrides map for council mode (provider ID → overrides)

--- a/src/ai/antigravity-provider.js
+++ b/src/ai/antigravity-provider.js
@@ -91,42 +91,33 @@ const TIMEOUT_BACKSTOP_GRACE_MS = 15000;
  * which contains spaces and parentheses and must never leak into ids.
  *
  * We curate the Gemini-family models here — Antigravity is the Gemini CLI's
- * successor and its native models are Gemini. `agy` also exposes Claude and
- * GPT-OSS models; those remain reachable via a `providers.antigravity.models`
- * config override but are intentionally left out of the default picker to keep
- * the cross-provider model-mismatch guard and the UX unambiguous.
+ * successor and its native models are Gemini. Ordered thorough -> balanced ->
+ * fast, matching the other providers' pickers. Gemini 3.8 Flash at high effort
+ * is the thorough-tier default: it is the strongest Gemini agy exposes today
+ * (DeepSWE v1.1 73.7, Terminal-Bench 2.1 89.4 — on par with GPT-6 Astra and
+ * Muse 1.3), so "Flash" now describes latency, not capability. Gemini 3.1 Pro
+ * (Low/High, Feb 2026) is the previous-generation Pro line and stays on the
+ * balanced/thorough tiers for anyone who prefers it. Gemini 3.8 Flash at low
+ * effort is the sole fast-tier entry, which also makes it the JSON-extraction
+ * model (getFastTierModel() picks the first `tier: 'fast'` model — position
+ * in this array does not matter). Retired ids (3.5 Flash) are kept as aliases
+ * of their 3.8 Flash counterparts so saved selections keep working. `agy` also
+ * exposes Claude and GPT-OSS models; those remain reachable via a
+ * `providers.antigravity.models` config override but are intentionally left
+ * out of the default picker to keep the cross-provider model-mismatch guard
+ * and the UX unambiguous.
  */
 const ANTIGRAVITY_MODELS = [
   {
-    id: 'gemini-3.5-flash-low',
-    cliName: 'Gemini 3.5 Flash (Low)',
-    aliases: ['gemini-3.5-flash'],
-    name: '3.5 Flash (Low)',
-    tier: 'fast',
-    tagline: 'Rapid Sanity Check',
-    description: 'Cheapest, fastest pass — quick scans and the JSON-extraction fallback',
-    badge: 'Cheapest',
-    badgeClass: 'badge-speed'
-  },
-  {
-    id: 'gemini-3.5-flash-high',
-    cliName: 'Gemini 3.5 Flash (High)',
-    name: '3.5 Flash (High)',
-    tier: 'fast',
-    tagline: 'Quick Look',
-    description: 'Flash speed with more reasoning effort for a sharper first pass',
-    badge: 'Quick Look',
-    badgeClass: 'badge-speed'
-  },
-  {
-    id: 'gemini-3.1-pro-low',
-    cliName: 'Gemini 3.1 Pro (Low)',
-    aliases: ['gemini-3.1-pro'],
-    name: '3.1 Pro (Low)',
-    tier: 'balanced',
-    tagline: 'Standard PR Review',
-    description: 'Strong reasoning with a large context window — the reliable daily driver',
-    badge: 'Daily Driver',
+    id: 'gemini-3.8-flash-high',
+    cliName: 'Gemini 3.8 Flash (High)',
+    // Retired 3.5 Flash (High) id — see the note on gemini-3.8-flash-low.
+    aliases: ['gemini-3.5-flash-high'],
+    name: '3.8 Flash (High)',
+    tier: 'thorough',
+    tagline: 'Frontier Review',
+    description: 'Gemini 3.8 Flash at high effort is the strongest Gemini on agy — DeepSWE v1.1 73.7, Terminal-Bench 2.1 89.4, on par with GPT-6 Astra and Muse 1.3. "Flash" now means latency, not capability. Uses the thorough prompt set.',
+    badge: 'Recommended',
     badgeClass: 'badge-recommended',
     default: true
   },
@@ -136,13 +127,39 @@ const ANTIGRAVITY_MODELS = [
     name: '3.1 Pro (High)',
     tier: 'thorough',
     tagline: 'Deep Dive',
-    description: 'Maximum reasoning effort for complex, architectural reviews',
+    description: 'Previous-generation Pro (Feb 2026) at maximum reasoning effort — slower and now outscored by 3.8 Flash (High), kept for reviewers who prefer the Pro line',
     badge: 'Deep Dive',
     badgeClass: 'badge-power'
+  },
+  {
+    id: 'gemini-3.1-pro-low',
+    cliName: 'Gemini 3.1 Pro (Low)',
+    aliases: ['gemini-3.1-pro'],
+    name: '3.1 Pro (Low)',
+    tier: 'balanced',
+    tagline: 'Previous-Gen Pro',
+    description: 'Previous-generation Pro (Feb 2026) at low effort — a large-context middle ground, superseded as the default by 3.8 Flash (High)',
+    badge: 'Previous Gen',
+    badgeClass: 'badge-balanced'
+  },
+  {
+    id: 'gemini-3.8-flash-low',
+    cliName: 'Gemini 3.8 Flash (Low)',
+    // The 3.5 Flash ids no longer exist on agy (`agy --model gemini-3.5-flash-low`
+    // exits 1 with an unknown-model listing). Saved councils/configs that still
+    // name them resolve to the same effort level on 3.8 Flash; without the
+    // aliases they would hit agy's exit-1 unknown-model failure.
+    aliases: ['gemini-3.8-flash', 'gemini-3.5-flash-low', 'gemini-3.5-flash'],
+    name: '3.8 Flash (Low)',
+    tier: 'fast',
+    tagline: 'Rapid Sanity Check',
+    description: 'Cheapest, fastest pass — quick scans and the JSON-extraction fallback model',
+    badge: 'Cheapest',
+    badgeClass: 'badge-speed'
   }
 ];
 
-const DEFAULT_ANTIGRAVITY_MODEL = 'gemini-3.1-pro-low';
+const DEFAULT_ANTIGRAVITY_MODEL = 'gemini-3.8-flash-high';
 
 class AntigravityProvider extends AIProvider {
   /**
@@ -201,7 +218,9 @@ class AntigravityProvider extends AIProvider {
     // Exact `agy --model` string. Config overrides honor the shared `cli_model`
     // contract used across providers (documented in config.example.json) and
     // fall back to `cliName`; built-ins carry `cliName`. Raw id is the last
-    // resort — agy tolerates an unknown name by using its default.
+    // resort. Note: agy no longer falls back to its default for an unknown
+    // name — as of agy 1.0.16 it exits 1 and prints the model listing, and
+    // the provider's clean ids (`gemini-3.8-flash-low`) are accepted verbatim.
     const cliModel =
       configModel?.cli_model ||
       configModel?.cliName ||

--- a/src/ai/claude-provider.js
+++ b/src/ai/claude-provider.js
@@ -64,6 +64,8 @@ const CLAUDE_MODELS = [
     // The bare 'fable' alias intentionally stays pinned to Fable 5 (the same way
     // 'opus' stays on opus-4.8-xhigh) so existing configs and --model fable
     // invocations keep resolving to the generation they were written against.
+    // The provider DEFAULT is a separate knob: it moved to opus-5-high (same
+    // price as Opus 4.8) while the 'opus' alias stayed pinned to opus-4.8-xhigh.
     aliases: ['fable'],
     cli_model: 'claude-fable-5',
     env: { CLAUDE_CODE_EFFORT_LEVEL: 'xhigh' },
@@ -95,8 +97,8 @@ const CLAUDE_MODELS = [
     name: 'Opus 5 XHigh',
     tier: 'thorough',
     tagline: 'Newest Opus',
-    description: 'Opus 5 (newest) with extra-high effort',
-    badge: 'Latest',
+    description: 'Opus 5 (newest) with extra-high effort — deepest thorough reviews',
+    badge: 'Extra-High Effort',
     badgeClass: 'badge-power'
   },
   {
@@ -105,10 +107,11 @@ const CLAUDE_MODELS = [
     env: { CLAUDE_CODE_EFFORT_LEVEL: 'high' },
     name: 'Opus 5 High',
     tier: 'thorough',
-    tagline: 'Newest Opus',
-    description: 'Opus 5 with high effort — quicker than XHigh',
-    badge: 'High Effort',
-    badgeClass: 'badge-power'
+    tagline: 'Recommended Default',
+    description: 'Opus 5 (newest) with high effort — the recommended default for thorough reviews',
+    badge: 'Recommended',
+    badgeClass: 'badge-recommended',
+    default: true
   },
   {
     id: 'opus-4.8-xhigh',
@@ -117,11 +120,10 @@ const CLAUDE_MODELS = [
     env: { CLAUDE_CODE_EFFORT_LEVEL: 'xhigh' },
     name: 'Opus 4.8 XHigh',
     tier: 'thorough',
-    tagline: 'Maximum Depth',
-    description: 'Opus 4.8 with extra-high effort — deepest analysis',
-    badge: 'Most Thorough',
-    badgeClass: 'badge-power',
-    default: true
+    tagline: 'Previous Gen',
+    description: 'Opus 4.8 with extra-high effort',
+    badge: 'Previous Gen',
+    badgeClass: 'badge-power'
   },
   {
     id: 'opus-4.8-high',
@@ -1041,7 +1043,7 @@ class ClaudeProvider extends AIProvider {
   }
 
   static getDefaultModel() {
-    return 'opus-4.8-xhigh';
+    return 'opus-5-high';
   }
 
   static getInstallInstructions() {

--- a/src/ai/codex-provider.js
+++ b/src/ai/codex-provider.js
@@ -21,24 +21,58 @@ const BIN_DIR = path.join(__dirname, '..', '..', 'bin');
 /**
  * Codex model definitions with tier mappings
  *
- * Based on OpenAI's GPT-5.6 launch and Models guide
- * (openai.com/index/gpt-5-6 and developers.openai.com/api/docs/models)
- * - gpt-5.6-sol: Flagship frontier model for complex professional work
+ * Based on OpenAI's GPT-6 Astra launch (Sept 2026), the GPT-5.6 launch, and the
+ * Models guide (developers.openai.com/api/docs/models). Verified against the
+ * Codex CLI 0.144.0 model catalog.
+ * - gpt-6-astra: GPT-6 flagship, the most capable model for complex, demanding
+ *   work (272k context). Priced several times above Sol, so it is offered as an
+ *   opt-in thorough choice rather than the default.
+ * - gpt-5.6-sol: Strong frontier model for complex professional work (default)
  * - gpt-5.6-terra: Balances intelligence and cost for everyday work
  * - gpt-5.6-luna: Fast, affordable model for cost-sensitive, high-volume work
- * - gpt-5.4-nano: Cheapest model ($0.20/$1.25 per MTok), good for surface scans
- * - gpt-5.4-mini: Fast with 400k context ($0.75/$4.50 per MTok)
- * - gpt-5.3-codex: Industry-leading coding model for complex engineering tasks
- * - GPT-5.6, gpt-5.4, and gpt-5.5 models are exposed only through the requested
- *   explicit reasoning-effort variants.
+ * - gpt-5.5: Previous-generation frontier model
+ * - gpt-5.4-mini: Small, fast, cost-efficient model for simpler coding tasks
+ *   (272k context) — the sole fast-tier model
+ * - GPT-6, GPT-5.6, and GPT-5.5 models are exposed only through explicit
+ *   reasoning-effort variants.
+ *
+ * Tiers: thorough (Astra, Sol, GPT-5.5), balanced (Terra, Luna), fast (Mini).
+ * Entries are ordered thorough → balanced → fast; the first `fast` entry is the
+ * extraction model (see AIProvider.getFastTierModel).
  *
  * Reasoning-effort variants (-high / -xhigh / -max) use `cli_model` to pass the base
  * model ID to `codex exec -m` and add `-c model_reasoning_effort="..."` via
  * extra_args so Codex picks up the effort level through its config override.
  *
  * Deprecated (April 2026): gpt-5.1-codex-mini, gpt-5.1-codex-max, gpt-5.1-codex
+ * Deprecated (August 2026): gpt-5.4 (gpt-5.4-high / gpt-5.4-xhigh), gpt-5.4-nano,
+ *   gpt-5.3-codex — retired by OpenAI; Codex rejects them with a 400. They are
+ *   intentionally NOT aliased onto other models so saved councils fail loudly
+ *   instead of silently running a different model.
  */
 const CODEX_MODELS = [
+  {
+    id: 'gpt-6-astra-high',
+    cli_model: 'gpt-6-astra',
+    extra_args: ['-c', 'model_reasoning_effort="high"'],
+    name: 'GPT-6 Astra High',
+    tier: 'thorough',
+    tagline: 'Most Capable',
+    description: 'OpenAI\'s GPT-6 flagship with high reasoning effort for the hardest reviews: deep cross-file analysis, subtle regressions, and demanding architectural work. Costs several times more than Sol.',
+    badge: 'Most Capable',
+    badgeClass: 'badge-power'
+  },
+  {
+    id: 'gpt-6-astra-xhigh',
+    cli_model: 'gpt-6-astra',
+    extra_args: ['-c', 'model_reasoning_effort="xhigh"'],
+    name: 'GPT-6 Astra XHigh',
+    tier: 'thorough',
+    tagline: 'Maximum Depth',
+    description: 'GPT-6 Astra with extra-high reasoning effort for the most difficult reviews: concurrency, security-sensitive changes, and large codebase context. Premium pricing.',
+    badge: 'Extra High',
+    badgeClass: 'badge-power'
+  },
   {
     id: 'gpt-5.6-sol-high',
     cli_model: 'gpt-5.6-sol',
@@ -46,7 +80,7 @@ const CODEX_MODELS = [
     name: 'GPT-5.6 Sol High',
     tier: 'thorough',
     tagline: 'Frontier Review',
-    description: 'OpenAI flagship and best coding model yet, with high reasoning effort for demanding PR reviews, complex professional work, and cross-file analysis.',
+    description: 'Strong frontier reviewer at a fraction of Astra\'s cost, with high reasoning effort for demanding PR reviews, complex professional work, and cross-file analysis.',
     badge: 'Recommended',
     badgeClass: 'badge-recommended',
     default: true
@@ -60,6 +94,28 @@ const CODEX_MODELS = [
     tagline: 'Frontier Depth',
     description: 'GPT-5.6 Sol with extra-high reasoning effort for difficult architectural reviews, subtle regressions, and security-sensitive changes.',
     badge: 'Extra High',
+    badgeClass: 'badge-power'
+  },
+  {
+    id: 'gpt-5.5-high',
+    cli_model: 'gpt-5.5',
+    extra_args: ['-c', 'model_reasoning_effort="high"'],
+    name: 'GPT-5.5 High',
+    tier: 'thorough',
+    tagline: 'Previous Flagship',
+    description: 'Previous-generation GPT model with high reasoning effort for demanding PR reviews, strong code understanding, and careful cross-file analysis.',
+    badge: 'Previous Gen',
+    badgeClass: 'badge-power'
+  },
+  {
+    id: 'gpt-5.5-xhigh',
+    cli_model: 'gpt-5.5',
+    extra_args: ['-c', 'model_reasoning_effort="xhigh"'],
+    name: 'GPT-5.5 XHigh',
+    tier: 'thorough',
+    tagline: 'Frontier Depth',
+    description: 'GPT-5.5 with extra-high reasoning effort for the hardest reviews: architecture, concurrency, security-sensitive changes, and large codebase context.',
+    badge: 'Max Reasoning',
     badgeClass: 'badge-power'
   },
   {
@@ -85,77 +141,12 @@ const CODEX_MODELS = [
     badgeClass: 'badge-speed'
   },
   {
-    id: 'gpt-5.5-high',
-    cli_model: 'gpt-5.5',
-    extra_args: ['-c', 'model_reasoning_effort="high"'],
-    name: 'GPT-5.5 High',
-    tier: 'thorough',
-    tagline: 'Previous Flagship',
-    description: 'Previous-generation GPT model with high reasoning effort for demanding PR reviews, strong code understanding, and careful cross-file analysis.',
-    badge: 'Previous Gen',
-    badgeClass: 'badge-power'
-  },
-  {
-    id: 'gpt-5.5-xhigh',
-    cli_model: 'gpt-5.5',
-    extra_args: ['-c', 'model_reasoning_effort="xhigh"'],
-    name: 'GPT-5.5 XHigh',
-    tier: 'thorough',
-    tagline: 'Frontier Depth',
-    description: 'GPT-5.5 with extra-high reasoning effort for the hardest reviews: architecture, concurrency, security-sensitive changes, and large codebase context.',
-    badge: 'Max Reasoning',
-    badgeClass: 'badge-power'
-  },
-  {
-    id: 'gpt-5.4-high',
-    // Alias keeps results/councils saved under the previous bare `gpt-5.4`
-    // model ID resolving to the now-explicit high-effort variant.
-    aliases: ['gpt-5.4'],
-    cli_model: 'gpt-5.4',
-    extra_args: ['-c', 'model_reasoning_effort="high"'],
-    name: 'GPT-5.4 High',
-    tier: 'thorough',
-    tagline: 'Deep Review',
-    description: 'GPT-5.4 with high reasoning effort for complex multi-file reviews, architectural consistency, and subtle behavioral regressions.',
-    badge: 'Previous Gen',
-    badgeClass: 'badge-power'
-  },
-  {
-    id: 'gpt-5.4-xhigh',
-    cli_model: 'gpt-5.4',
-    extra_args: ['-c', 'model_reasoning_effort="xhigh"'],
-    name: 'GPT-5.4 XHigh',
-    tier: 'thorough',
-    tagline: 'Max Depth',
-    description: 'GPT-5.4 with extra-high reasoning effort for difficult reviews that need broad context, careful tradeoff analysis, and deeper issue validation.',
-    badge: 'Extra High',
-    badgeClass: 'badge-power'
-  },
-  {
-    id: 'gpt-5.3-codex',
-    name: 'GPT-5.3 Codex',
-    tier: 'thorough',
-    tagline: 'Deep Review',
-    description: 'Industry-leading coding model—frontier performance with strong reasoning for cross-file analysis.',
-    badge: 'Thorough',
-    badgeClass: 'badge-power'
-  },
-  {
     id: 'gpt-5.4-mini',
     name: 'GPT-5.4 Mini',
-    tier: 'balanced',
-    tagline: 'Best Balance',
-    description: 'Fast reviews with 400k context—good balance of speed and capability for everyday PR review.',
-    badge: 'Fast',
-    badgeClass: 'badge-speed'
-  },
-  {
-    id: 'gpt-5.4-nano',
-    name: 'GPT-5.4 Nano',
     tier: 'fast',
-    tagline: 'Cheapest',
-    description: 'Ultra-low-cost surface scans for style issues, obvious bugs, and lint-level feedback.',
-    badge: 'Cheapest',
+    tagline: 'Quick Scan',
+    description: 'Small, fast, cost-efficient model for surface scans: obvious bugs, style issues, and lint-level feedback.',
+    badge: 'Fastest',
     badgeClass: 'badge-speed'
   }
 ];
@@ -222,7 +213,7 @@ class CodexProvider extends AIProvider {
 
     // Resolve cli_model + extra_args + env from built-in model, provider config,
     // and per-model config. This is what lets reasoning variants like
-    // gpt-5.4-high pass `-m gpt-5.4` plus `-c model_reasoning_effort="high"`.
+    // gpt-6-astra-high pass `-m gpt-6-astra` plus `-c model_reasoning_effort="high"`.
     const { cliModel, extraArgs, env } = this._resolveModelConfig(model);
 
     // IMPORTANT: `-` (stdin marker) must come LAST, after any extra_args.
@@ -249,8 +240,8 @@ class CodexProvider extends AIProvider {
    * Produces the CLI model ID (for `-m`), merged extra_args, and merged env.
    *
    * Precedence for cli_model: config model > built-in model > modelId.
-   * `cli_model` lets reasoning-effort variants (e.g. `gpt-5.4-high`) pass the
-   * base model (`gpt-5.4`) to `codex exec -m` while adding reasoning overrides
+   * `cli_model` lets reasoning-effort variants (e.g. `gpt-6-astra-high`) pass the
+   * base model (`gpt-6-astra`) to `codex exec -m` while adding reasoning overrides
    * via extra_args.
    *
    * @param {string} modelId
@@ -261,7 +252,12 @@ class CodexProvider extends AIProvider {
     const configOverrides = this.configOverrides || {};
 
     const builtIn = CODEX_MODELS.find(m => m.id === modelId || (m.aliases && m.aliases.includes(modelId)));
-    const configModel = configOverrides.models?.find(m => m.id === modelId);
+    // A config override may target the built-in by any of its ids/aliases, or
+    // declare its own aliases; match on the union so no lookup diverges.
+    const modelKeys = new Set([modelId, builtIn?.id, ...(builtIn?.aliases || [])].filter(Boolean));
+    const configModel = configOverrides.models?.find(
+      m => modelKeys.has(m.id) || (m.aliases || []).some(a => modelKeys.has(a))
+    );
 
     const cliModel = configModel?.cli_model !== undefined
       ? configModel.cli_model

--- a/src/ai/muse-provider.js
+++ b/src/ai/muse-provider.js
@@ -153,25 +153,41 @@ function attemptIdOf(record) {
  * The provider's default model.
  *
  * DELIBERATE: this is the NON-contributor model, even though the muse CLI's own
- * default is `muse-spark-1.2-contributor`. Pair-review sends potentially
+ * default is `muse-spark-1.3-contributor`. Pair-review sends potentially
  * proprietary source code to the model, and the contributor tier is discounted
  * precisely because Meta may use that content for product improvement. Opting
  * into data sharing must be an explicit user choice, never a silent default.
  */
-const DEFAULT_MUSE_MODEL = 'muse-spark-1.2-high';
+const DEFAULT_MUSE_MODEL = 'muse-spark-1.3-high';
 
 /**
  * Muse model definitions with tier mappings.
  *
- * Muse exposes exactly two real CLI model IDs; everything below is a
- * reasoning-effort variant over those two, using the same `cli_model` +
+ * Muse exposes two real CLI model IDs per generation; everything below is a
+ * reasoning-effort variant over the current pair, using the same `cli_model` +
  * `extra_args` pattern as the Codex provider:
- * - muse-spark-1.2             — $1.25/$4.25 per MTok, ~1M context, 256k max output
- * - muse-spark-1.2-contributor — $0.10/$0.20 per MTok, discounted because
- *   submitted content may be used by Meta for product improvement
+ * - muse-spark-1.3             — $1.25/$4.25 per MTok ($0.15 cached), ~1M context
+ * - muse-spark-1.3-contributor — $0.10/$0.20 per MTok ($0.002 cached), discounted
+ *   because submitted content may be used by Meta for product improvement
  *
- * `--reasoning-effort` accepts none|minimal|low|medium|high|xhigh|ultra
- * (muse's own default is `high`).
+ * Muse Spark 1.3 (released 2026-09-02) is priced identically to 1.2 and is
+ * strictly better (Meta reports ~20% fewer tool calls and ~25% fewer tokens;
+ * DeepSWE v1.1 75.4 vs 55.0, Terminal-Bench 2.1 88.8 vs 82.9). The 1.2 ids still
+ * work on the CLI and are not deprecated, but there is no reason to offer both
+ * generations at the same price, so every `muse-spark-1.2-*` id is kept as an
+ * alias of its 1.3 twin at the same reasoning effort. Saved councils and configs
+ * upgrade in place instead of falling through to muse's own default.
+ *
+ * Do NOT treat the locally cached catalog (~/.local/share/muse/model-catalog/)
+ * as authoritative: it lags the CLI and still listed only 1.2 after 1.3 worked.
+ *
+ * `--reasoning-effort` accepts minimal|low|medium|high|xhigh|max|ultra with
+ * `--provider meta` (`none` is rejected outright; muse's own default is `high`).
+ * `ultra` is behind a closed feature gate: muse prints "reasoning effort ultra
+ * is not available (gate ultra_reasoning_effort is closed); using xhigh" and
+ * silently runs at xhigh, whereas `max` actually runs. The top built-in is
+ * therefore `max`, and the former `-ultra` ids alias onto it rather than
+ * shipping a duplicate of the xhigh entries.
  *
  * Ordering matters: each reasoning effort is listed as a non-contributor entry
  * followed by its contributor twin, so that getFastTierModel() — which picks the
@@ -180,32 +196,37 @@ const DEFAULT_MUSE_MODEL = 'muse-spark-1.2-high';
  */
 const MUSE_MODELS = [
   {
-    id: 'muse-spark-1.2-ultra',
-    cli_model: 'muse-spark-1.2',
-    extra_args: ['--reasoning-effort', 'ultra'],
-    name: 'Muse Spark 1.2 Ultra',
+    id: 'muse-spark-1.3-max',
+    // `-ultra` ids resolve here because ultra is gate-closed and degrades to
+    // xhigh; 1.2 ids resolve here because 1.3 is a same-price upgrade.
+    aliases: ['muse-spark-1.3-ultra', 'muse-spark-1.2-max', 'muse-spark-1.2-ultra'],
+    cli_model: 'muse-spark-1.3',
+    extra_args: ['--reasoning-effort', 'max'],
+    name: 'Muse Spark 1.3 Max',
     tier: 'thorough',
     tagline: 'Maximum Depth',
-    description: 'Muse Spark at the highest reasoning effort for the hardest reviews: architecture, concurrency, and security-sensitive changes.',
+    description: 'Muse Spark at the highest available reasoning effort for the hardest reviews: architecture, concurrency, and security-sensitive changes.',
     badge: 'Max Reasoning',
     badgeClass: 'badge-power'
   },
   {
-    id: 'muse-spark-1.2-contributor-ultra',
-    cli_model: 'muse-spark-1.2-contributor',
-    extra_args: ['--reasoning-effort', 'ultra'],
-    name: 'Muse Spark 1.2 Contributor Ultra',
+    id: 'muse-spark-1.3-contributor-max',
+    aliases: ['muse-spark-1.3-contributor-ultra', 'muse-spark-1.2-contributor-max', 'muse-spark-1.2-contributor-ultra'],
+    cli_model: 'muse-spark-1.3-contributor',
+    extra_args: ['--reasoning-effort', 'max'],
+    name: 'Muse Spark 1.3 Contributor Max',
     tier: 'thorough',
     tagline: 'Discounted Depth',
-    description: 'Same model and highest reasoning effort at roughly a tenth of the cost. Content you send on this tier may be used by Meta for product improvement—do not select it for proprietary code.',
+    description: 'Same model and highest available reasoning effort at roughly a tenth of the cost. Content you send on this tier may be used by Meta for product improvement—do not select it for proprietary code.',
     badge: 'Shares Data',
     badgeClass: 'badge-power'
   },
   {
-    id: 'muse-spark-1.2-xhigh',
-    cli_model: 'muse-spark-1.2',
+    id: 'muse-spark-1.3-xhigh',
+    aliases: ['muse-spark-1.2-xhigh'],
+    cli_model: 'muse-spark-1.3',
     extra_args: ['--reasoning-effort', 'xhigh'],
-    name: 'Muse Spark 1.2 XHigh',
+    name: 'Muse Spark 1.3 XHigh',
     tier: 'thorough',
     tagline: 'Frontier Depth',
     description: 'Muse Spark with extra-high reasoning effort for difficult architectural reviews and subtle behavioral regressions.',
@@ -213,10 +234,11 @@ const MUSE_MODELS = [
     badgeClass: 'badge-power'
   },
   {
-    id: 'muse-spark-1.2-contributor-xhigh',
-    cli_model: 'muse-spark-1.2-contributor',
+    id: 'muse-spark-1.3-contributor-xhigh',
+    aliases: ['muse-spark-1.2-contributor-xhigh'],
+    cli_model: 'muse-spark-1.3-contributor',
     extra_args: ['--reasoning-effort', 'xhigh'],
-    name: 'Muse Spark 1.2 Contributor XHigh',
+    name: 'Muse Spark 1.3 Contributor XHigh',
     tier: 'thorough',
     tagline: 'Discounted Frontier',
     description: 'Same model and extra-high reasoning effort at roughly a tenth of the cost. Content you send on this tier may be used by Meta for product improvement—do not select it for proprietary code.',
@@ -224,12 +246,13 @@ const MUSE_MODELS = [
     badgeClass: 'badge-power'
   },
   {
-    id: 'muse-spark-1.2-high',
-    // Aliases keep results/councils saved under a bare model ID resolving here.
-    aliases: ['muse-spark-1.2', 'muse-spark'],
-    cli_model: 'muse-spark-1.2',
+    id: 'muse-spark-1.3-high',
+    // Bare model ids (and the previous generation's) keep results/councils
+    // saved under them resolving here.
+    aliases: ['muse-spark-1.3', 'muse-spark', 'muse-spark-1.2', 'muse-spark-1.2-high'],
+    cli_model: 'muse-spark-1.3',
     extra_args: ['--reasoning-effort', 'high'],
-    name: 'Muse Spark 1.2 High',
+    name: 'Muse Spark 1.3 High',
     tier: 'balanced',
     tagline: 'Best Balance',
     description: 'Meta\'s coding model with high reasoning effort and roughly 1M tokens of context—strong everyday PR review across large diffs.',
@@ -238,11 +261,11 @@ const MUSE_MODELS = [
     default: true
   },
   {
-    id: 'muse-spark-1.2-contributor-high',
-    aliases: ['muse-spark-1.2-contributor'],
-    cli_model: 'muse-spark-1.2-contributor',
+    id: 'muse-spark-1.3-contributor-high',
+    aliases: ['muse-spark-1.3-contributor', 'muse-spark-1.2-contributor', 'muse-spark-1.2-contributor-high'],
+    cli_model: 'muse-spark-1.3-contributor',
     extra_args: ['--reasoning-effort', 'high'],
-    name: 'Muse Spark 1.2 Contributor High',
+    name: 'Muse Spark 1.3 Contributor High',
     tier: 'balanced',
     tagline: 'Discounted Tier',
     description: 'Same model and high reasoning effort at roughly a tenth of the cost. Content you send on this tier may be used by Meta for product improvement—do not select it for proprietary code.',
@@ -250,10 +273,11 @@ const MUSE_MODELS = [
     badgeClass: 'badge-balanced'
   },
   {
-    id: 'muse-spark-1.2-low',
-    cli_model: 'muse-spark-1.2',
+    id: 'muse-spark-1.3-low',
+    aliases: ['muse-spark-1.2-low'],
+    cli_model: 'muse-spark-1.3',
     extra_args: ['--reasoning-effort', 'low'],
-    name: 'Muse Spark 1.2 Low',
+    name: 'Muse Spark 1.3 Low',
     tier: 'fast',
     tagline: 'Quick Pass',
     description: 'Muse Spark with low reasoning effort for fast surface scans of small, straightforward changes.',
@@ -261,10 +285,11 @@ const MUSE_MODELS = [
     badgeClass: 'badge-speed'
   },
   {
-    id: 'muse-spark-1.2-contributor-low',
-    cli_model: 'muse-spark-1.2-contributor',
+    id: 'muse-spark-1.3-contributor-low',
+    aliases: ['muse-spark-1.2-contributor-low'],
+    cli_model: 'muse-spark-1.3-contributor',
     extra_args: ['--reasoning-effort', 'low'],
-    name: 'Muse Spark 1.2 Contributor Low',
+    name: 'Muse Spark 1.3 Contributor Low',
     tier: 'fast',
     tagline: 'Lowest Cost',
     description: 'The cheapest option: low reasoning effort on the discounted tier. Content you send on this tier may be used by Meta for product improvement—do not select it for proprietary code.',
@@ -334,8 +359,8 @@ class MuseProvider extends AIProvider {
 
     // Resolve cli_model + extra_args + env from built-in model, provider config,
     // and per-model config. This is what lets reasoning variants like
-    // muse-spark-1.2-ultra pass `--model muse-spark-1.2` plus
-    // `--reasoning-effort ultra`.
+    // muse-spark-1.3-max pass `--model muse-spark-1.3` plus
+    // `--reasoning-effort max`.
     const { cliModel, extraArgs, env } = this._resolveModelConfig(model);
 
     // A cli_model of explicitly `null` omits --model entirely, letting muse pick
@@ -368,7 +393,13 @@ class MuseProvider extends AIProvider {
     const configOverrides = this.configOverrides || {};
 
     const builtIn = MUSE_MODELS.find(m => m.id === modelId || (m.aliases && m.aliases.includes(modelId)));
-    const configModel = configOverrides.models?.find(m => m.id === modelId);
+    // A config override may target the built-in by any of its ids/aliases (e.g.
+    // keyed under a retired 1.2 id while the provider was constructed with the
+    // 1.3 id), or declare its own aliases; match on the union so no lookup diverges.
+    const modelKeys = new Set([modelId, builtIn?.id, ...(builtIn?.aliases || [])].filter(Boolean));
+    const configModel = configOverrides.models?.find(
+      m => modelKeys.has(m.id) || (m.aliases || []).some(a => modelKeys.has(a))
+    );
 
     const cliModel = configModel?.cli_model !== undefined
       ? configModel.cli_model
@@ -1078,8 +1109,8 @@ class MuseProvider extends AIProvider {
 
     if (this.isUnknownModelError(diagnostic)) {
       return new Error(
-        `${levelPrefix} Muse CLI rejected the model "${this.model}" as unknown. ` +
-        `Check the model ID (and any cli_model override) against Muse's catalog. ` +
+        `${levelPrefix} Muse CLI rejected the model "${this.model}" as unknown or inaccessible. ` +
+        `Check the model ID (and any cli_model override) against what \`muse exec --model\` accepts — the locally cached catalog can lag the CLI. ` +
         `Original error: ${diagnostic}`
       );
     }
@@ -1102,14 +1133,16 @@ class MuseProvider extends AIProvider {
   }
 
   /**
-   * Detect an unknown/hidden model rejection. Muse fails fast with
-   * "model `X` is not in the catalog".
+   * Detect an unknown/hidden/inaccessible model rejection. Muse fails fast
+   * with either "model `X` is not in the catalog" (older CLIs; also "is hidden
+   * in the catalog") or "model `X` does not exist or you lack access" (current
+   * CLI, exit 1).
    *
    * @param {string} text - Captured stderr and/or terminal reason
    * @returns {boolean}
    */
   isUnknownModelError(text) {
-    return /is (?:not in|hidden in) the catalog/i.test(text || '');
+    return /(?:is (?:not in|hidden in) the catalog|does not exist or you lack access)/i.test(text || '');
   }
 
   /**

--- a/src/ai/provider.js
+++ b/src/ai/provider.js
@@ -1097,7 +1097,7 @@ async function testProviderAvailability(providerId, timeoutMs) {
  * model IDs (e.g. `gpt-5.4` before reasoning-effort variants were introduced)
  * still resolve their tier for historical analysis runs.
  * @param {string} providerId - Provider ID (e.g., 'claude', 'antigravity')
- * @param {string} modelId - Model ID (e.g., 'sonnet', 'gemini-3.1-pro-low')
+ * @param {string} modelId - Model ID (e.g., 'sonnet', 'gemini-3.8-flash-high')
  * @returns {string|null} Tier name or null if provider or model not found
  */
 function getTierForModel(providerId, modelId) {

--- a/src/config.js
+++ b/src/config.js
@@ -68,7 +68,7 @@ const DEFAULT_CONFIG = {
   single_port: true,  // When true, reuse a single server on the configured port; new invocations delegate to the running server
   theme: "light",
   default_provider: "claude",  // AI provider: 'claude', 'antigravity', 'codex', 'copilot', 'opencode', 'cursor-agent', 'pi', 'omp', 'muse'
-  default_model: "opus",       // Model within the provider (e.g., 'opus' for Claude, 'gemini-3.1-pro-low' for Antigravity)
+  default_model: "opus",       // Model within the provider (e.g., 'opus' for Claude, 'gemini-3.8-flash-high' for Antigravity)
   tours: {
     enabled: false,            // When true, the guided-tour feature is available (toolbar button visible, etc.)
     auto_generate: true,       // When true, a tour generation job is kicked off automatically on review load

--- a/src/main.js
+++ b/src/main.js
@@ -235,7 +235,7 @@ OPTIONS:
                                   opus-4.7-xhigh, opus-4.7-high, opus-4.6-high,
                                   opus-4.6-1m, sonnet-5-xhigh, sonnet-5-high,
                                   sonnet-4.6
-                            (opus is Opus 4.8 XHigh, the default)
+                            (default is opus-5-high; opus is Opus 4.8 XHigh)
                             or use provider-specific models with Antigravity/Codex
     --provider <name>       Override the AI provider for headless modes
                             (--ai-draft / --ai-review). Defaults to the

--- a/tests/integration/routes.test.js
+++ b/tests/integration/routes.test.js
@@ -3545,8 +3545,8 @@ describe('Config Endpoints', () => {
       // rejects the foreign value and returns claude's coherent default rather than
       // publishing a model id no model-card can match — matching what the modal's
       // selectModel() guard does with 'sonnet' anyway. Claude's coherent default is
-      // the canonical 'opus-4.8-xhigh'.
-      expect(response.body.default_model).toBe('opus-4.8-xhigh');
+      // 'opus-5-high'.
+      expect(response.body.default_model).toBe('opus-5-high');
     });
 
     // The landing page, its URL-validation errors, and the local-path "that's
@@ -3640,7 +3640,7 @@ describe('Config Endpoints', () => {
 
       expect(response.body.default_provider).toBe('antigravity');
       expect(response.body.default_model).not.toBe('opus');
-      // antigravity's default model (gemini-3.1-pro-low) belongs to the provider
+      // antigravity's default model (gemini-3.8-flash-high) belongs to the provider
       expect(response.body.default_model).toMatch(/^gemini-/);
     });
 

--- a/tests/unit/analysis-config-modal-model-guard.test.js
+++ b/tests/unit/analysis-config-modal-model-guard.test.js
@@ -32,21 +32,22 @@ function makeContext(models) {
 }
 
 const ANTIGRAVITY_MODELS = [
-  { id: 'gemini-3.1-pro-low', default: true, tier: 'thorough' },
-  { id: 'gemini-3.5-flash-low', tier: 'fast' }
+  { id: 'gemini-3.8-flash-high', default: true, tier: 'thorough' },
+  { id: 'gemini-3.1-pro-low', tier: 'balanced' },
+  { id: 'gemini-3.8-flash-low', tier: 'fast' }
 ];
 
 describe('AnalysisConfigModal.selectModel guard', () => {
   it('keeps a model that belongs to the current provider', () => {
     const ctx = makeContext(ANTIGRAVITY_MODELS);
-    AnalysisConfigModal.prototype.selectModel.call(ctx, 'gemini-3.5-flash-low');
-    expect(ctx.selectedModel).toBe('gemini-3.5-flash-low');
+    AnalysisConfigModal.prototype.selectModel.call(ctx, 'gemini-3.8-flash-low');
+    expect(ctx.selectedModel).toBe('gemini-3.8-flash-low');
   });
 
   it('falls back to the provider default when given a foreign model', () => {
     const ctx = makeContext(ANTIGRAVITY_MODELS);
     AnalysisConfigModal.prototype.selectModel.call(ctx, 'opus');
-    expect(ctx.selectedModel).toBe('gemini-3.1-pro-low');
+    expect(ctx.selectedModel).toBe('gemini-3.8-flash-high');
   });
 
   it('falls back to the first model when no model is flagged default', () => {

--- a/tests/unit/antigravity-provider.test.js
+++ b/tests/unit/antigravity-provider.test.js
@@ -91,8 +91,15 @@ describe('AntigravityProvider', () => {
       expect(AntigravityProvider.getProviderId()).toBe('antigravity');
     });
 
-    it('should return gemini-3.1-pro-low as default model', () => {
-      expect(AntigravityProvider.getDefaultModel()).toBe('gemini-3.1-pro-low');
+    it('should return gemini-3.8-flash-high as default model', () => {
+      expect(AntigravityProvider.getDefaultModel()).toBe('gemini-3.8-flash-high');
+    });
+
+    it('should no longer treat gemini-3.1-pro-low as the default', () => {
+      expect(AntigravityProvider.getDefaultModel()).not.toBe('gemini-3.1-pro-low');
+      const proLow = AntigravityProvider.getModels().find(m => m.id === 'gemini-3.1-pro-low');
+      expect(proLow.default).toBeUndefined();
+      expect(proLow.tier).toBe('balanced');
     });
 
     it('should return the 4 built-in models with expected ids', () => {
@@ -101,38 +108,53 @@ describe('AntigravityProvider', () => {
       expect(models.length).toBe(4);
 
       const modelIds = models.map(m => m.id);
+      // Ordered thorough -> balanced -> fast, matching the other providers.
       expect(modelIds).toEqual([
-        'gemini-3.5-flash-low',
-        'gemini-3.5-flash-high',
+        'gemini-3.8-flash-high',
+        'gemini-3.1-pro-high',
         'gemini-3.1-pro-low',
-        'gemini-3.1-pro-high'
+        'gemini-3.8-flash-low'
       ]);
     });
 
     it('should map each model to the correct tier', () => {
       const models = AntigravityProvider.getModels();
       const tierMap = Object.fromEntries(models.map(m => [m.id, m.tier]));
-      expect(tierMap['gemini-3.5-flash-low']).toBe('fast');
-      expect(tierMap['gemini-3.5-flash-high']).toBe('fast');
+      expect(tierMap['gemini-3.8-flash-low']).toBe('fast');
+      expect(tierMap['gemini-3.8-flash-high']).toBe('thorough');
       expect(tierMap['gemini-3.1-pro-low']).toBe('balanced');
       expect(tierMap['gemini-3.1-pro-high']).toBe('thorough');
+    });
+
+    it('should keep gemini-3.8-flash-low as the only fast-tier (extraction) model', () => {
+      const fast = AntigravityProvider.getModels().filter(m => m.tier === 'fast');
+      expect(fast.map(m => m.id)).toEqual(['gemini-3.8-flash-low']);
+      expect(new AntigravityProvider().getFastTierModel()).toBe('gemini-3.8-flash-low');
     });
 
     it('should carry the exact `agy --model` cliName on each model', () => {
       const models = AntigravityProvider.getModels();
       const cliNameMap = Object.fromEntries(models.map(m => [m.id, m.cliName]));
-      expect(cliNameMap['gemini-3.5-flash-low']).toBe('Gemini 3.5 Flash (Low)');
-      expect(cliNameMap['gemini-3.5-flash-high']).toBe('Gemini 3.5 Flash (High)');
+      expect(cliNameMap['gemini-3.8-flash-low']).toBe('Gemini 3.8 Flash (Low)');
+      expect(cliNameMap['gemini-3.8-flash-high']).toBe('Gemini 3.8 Flash (High)');
       expect(cliNameMap['gemini-3.1-pro-low']).toBe('Gemini 3.1 Pro (Low)');
       expect(cliNameMap['gemini-3.1-pro-high']).toBe('Gemini 3.1 Pro (High)');
     });
 
-    it('should mark exactly one model (gemini-3.1-pro-low) as default', () => {
+    it('should mark exactly one model (gemini-3.8-flash-high) as default', () => {
       const models = AntigravityProvider.getModels();
       const defaults = models.filter(m => m.default === true);
       expect(defaults.length).toBe(1);
-      expect(defaults[0].id).toBe('gemini-3.1-pro-low');
-      expect(defaults[0].tier).toBe('balanced');
+      expect(defaults[0].id).toBe('gemini-3.8-flash-high');
+      expect(defaults[0].tier).toBe('thorough');
+      expect(defaults[0].badge).toBe('Recommended');
+      expect(defaults[0].badgeClass).toBe('badge-recommended');
+    });
+
+    it('should demote gemini-3.1-pro-low to a previous-generation badge', () => {
+      const proLow = AntigravityProvider.getModels().find(m => m.id === 'gemini-3.1-pro-low');
+      expect(proLow.badge).toBe('Previous Gen');
+      expect(proLow.badgeClass).toBe('badge-balanced');
     });
 
     it('should return install instructions with the antigravity install script', () => {
@@ -144,7 +166,8 @@ describe('AntigravityProvider', () => {
   describe('constructor: command precedence and shell mode', () => {
     it('should create instance with default model', () => {
       const provider = new AntigravityProvider();
-      expect(provider.model).toBe('gemini-3.1-pro-low');
+      expect(provider.model).toBe('gemini-3.8-flash-high');
+      expect(provider.model).toBe(AntigravityProvider.getDefaultModel());
     });
 
     it('should create instance with a specified model', () => {
@@ -222,18 +245,45 @@ describe('AntigravityProvider', () => {
     it('should translate a clean id into its exact cliName', () => {
       const provider = new AntigravityProvider();
       expect(provider._resolveCliModel('gemini-3.1-pro-low')).toBe('Gemini 3.1 Pro (Low)');
-      expect(provider._resolveCliModel('gemini-3.5-flash-high')).toBe('Gemini 3.5 Flash (High)');
+      expect(provider._resolveCliModel('gemini-3.8-flash-high')).toBe('Gemini 3.8 Flash (High)');
     });
 
     it('should resolve a built-in alias to its cliName', () => {
       const provider = new AntigravityProvider();
       // gemini-3.1-pro is an alias of gemini-3.1-pro-low
       expect(provider._resolveCliModel('gemini-3.1-pro')).toBe('Gemini 3.1 Pro (Low)');
-      // gemini-3.5-flash is an alias of gemini-3.5-flash-low
-      expect(provider._resolveCliModel('gemini-3.5-flash')).toBe('Gemini 3.5 Flash (Low)');
+      // gemini-3.8-flash is an alias of gemini-3.8-flash-low
+      expect(provider._resolveCliModel('gemini-3.8-flash')).toBe('Gemini 3.8 Flash (Low)');
     });
 
-    it('should return an unknown id unchanged (agy falls back to its default)', () => {
+    it('should resolve each retired 3.5 Flash id to its 3.8 Flash counterpart at the same effort', () => {
+      const provider = new AntigravityProvider();
+      // The 3.5 Flash ids no longer exist on agy; saved councils/configs naming
+      // them must land on 3.8 Flash instead of agy's exit-1 unknown-model failure.
+      expect(provider._resolveCliModel('gemini-3.5-flash-low')).toBe('Gemini 3.8 Flash (Low)');
+      expect(provider._resolveCliModel('gemini-3.5-flash')).toBe('Gemini 3.8 Flash (Low)');
+      expect(provider._resolveCliModel('gemini-3.5-flash-high')).toBe('Gemini 3.8 Flash (High)');
+    });
+
+    it('should declare the retired 3.5 Flash ids as aliases on the 3.8 Flash entries', () => {
+      const byId = Object.fromEntries(AntigravityProvider.getModels().map(m => [m.id, m]));
+      expect(byId['gemini-3.8-flash-low'].aliases).toEqual([
+        'gemini-3.8-flash', 'gemini-3.5-flash-low', 'gemini-3.5-flash'
+      ]);
+      expect(byId['gemini-3.8-flash-high'].aliases).toEqual(['gemini-3.5-flash-high']);
+    });
+
+    it('should keep every alias unique across the built-in models', () => {
+      const all = AntigravityProvider.getModels().flatMap(m => [m.id, ...(m.aliases || [])]);
+      expect(new Set(all).size).toBe(all.length);
+    });
+
+    it('should not expose a retired 3.5 Flash id as a canonical model', () => {
+      const ids = AntigravityProvider.getModels().map(m => m.id);
+      expect(ids.some(id => id.includes('3.5-flash'))).toBe(false);
+    });
+
+    it('should return an unknown id unchanged (agy exits 1 with its model listing)', () => {
       const provider = new AntigravityProvider();
       expect(provider._resolveCliModel('some-unknown-model')).toBe('some-unknown-model');
     });
@@ -673,7 +723,7 @@ describe('AntigravityProvider', () => {
   describe('getExtractionConfig', () => {
     it('should deliver the prompt via stdin and bake the extraction directive into -p', () => {
       const provider = new AntigravityProvider('gemini-3.1-pro-low');
-      const config = provider.getExtractionConfig('gemini-3.5-flash-low');
+      const config = provider.getExtractionConfig('gemini-3.8-flash-low');
 
       expect(config.command).toBe('agy');
       expect(config.useShell).toBe(false);
@@ -687,19 +737,19 @@ describe('AntigravityProvider', () => {
 
       // Fast-tier model resolves to its cliName.
       const modelIdx = config.args.indexOf('--model');
-      expect(config.args[modelIdx + 1]).toBe('Gemini 3.5 Flash (Low)');
+      expect(config.args[modelIdx + 1]).toBe('Gemini 3.8 Flash (Low)');
     });
 
     it('should NOT enable tools for extraction (no --dangerously-skip-permissions)', () => {
       const provider = new AntigravityProvider('gemini-3.1-pro-low');
-      const config = provider.getExtractionConfig('gemini-3.5-flash-low');
+      const config = provider.getExtractionConfig('gemini-3.8-flash-low');
       expect(config.args).not.toContain('--dangerously-skip-permissions');
     });
 
     it('should use shell mode for a multi-word command', () => {
       process.env.PAIR_REVIEW_ANTIGRAVITY_CMD = 'docker run agy';
       const provider = new AntigravityProvider('gemini-3.1-pro-low');
-      const config = provider.getExtractionConfig('gemini-3.5-flash-low');
+      const config = provider.getExtractionConfig('gemini-3.8-flash-low');
 
       expect(config.useShell).toBe(true);
       expect(config.command).toContain('docker run agy');
@@ -713,10 +763,10 @@ describe('AntigravityProvider', () => {
       const provider = new AntigravityProvider('gemini-3.1-pro-low', {
         env: { PROVIDER_VAR: 'p' },
         models: [
-          { id: 'gemini-3.5-flash-low', env: { MODEL_VAR: 'm' } }
+          { id: 'gemini-3.8-flash-low', env: { MODEL_VAR: 'm' } }
         ]
       });
-      const config = provider.getExtractionConfig('gemini-3.5-flash-low');
+      const config = provider.getExtractionConfig('gemini-3.8-flash-low');
       expect(config.env).toBeTruthy();
       expect(config.env.PROVIDER_VAR).toBe('p');
       expect(config.env.MODEL_VAR).toBe('m');
@@ -728,10 +778,10 @@ describe('AntigravityProvider', () => {
       const provider = new AntigravityProvider('gemini-3.1-pro-high', {
         models: [
           { id: 'gemini-3.1-pro-high', env: { ANALYSIS_ONLY: 'a' } },
-          { id: 'gemini-3.5-flash-low', env: { EXTRACT_ONLY: 'e' } }
+          { id: 'gemini-3.8-flash-low', env: { EXTRACT_ONLY: 'e' } }
         ]
       });
-      const config = provider.getExtractionConfig('gemini-3.5-flash-low');
+      const config = provider.getExtractionConfig('gemini-3.8-flash-low');
       expect(config.env.EXTRACT_ONLY).toBe('e');
       expect(config.env.ANALYSIS_ONLY).toBeUndefined();
     });
@@ -753,7 +803,7 @@ describe('AntigravityProvider', () => {
 
       const modelIdx = args.indexOf('--model');
       expect(modelIdx).toBeGreaterThanOrEqual(0);
-      expect(args[modelIdx + 1]).toBe('Gemini 3.1 Pro (Low)');
+      expect(args[modelIdx + 1]).toBe('Gemini 3.8 Flash (High)');
 
       // Analysis path enables the agentic tool loop.
       expect(args).toContain('--dangerously-skip-permissions');

--- a/tests/unit/build-default-analysis-config.test.js
+++ b/tests/unit/build-default-analysis-config.test.js
@@ -27,7 +27,7 @@ const { URLSearchParams: NativeURLSearchParams } = require('url');
 // shape of /api/providers (id, models, defaultModel).
 const PROVIDERS = [
   { id: 'claude', defaultModel: 'opus', models: [{ id: 'opus' }, { id: 'sonnet-4.6' }, { id: 'haiku' }] },
-  { id: 'antigravity', defaultModel: 'gemini-3.1-pro-low', models: [{ id: 'gemini-3.1-pro-low' }, { id: 'pro' }, { id: 'gemini-3.5-flash-low' }] },
+  { id: 'antigravity', defaultModel: 'gemini-3.8-flash-high', models: [{ id: 'gemini-3.8-flash-high' }, { id: 'gemini-3.1-pro-low' }, { id: 'pro' }, { id: 'gemini-3.8-flash-low' }] },
   { id: 'pi', defaultModel: 'multi-model', models: [{ id: 'multi-model' }] }
 ];
 
@@ -162,7 +162,7 @@ describe('PRManager._buildDefaultAnalysisConfig', () => {
       default_model: 'opus',
     });
     expect(config.provider).toBe('antigravity');
-    expect(config.model).toBe('gemini-3.1-pro-low');
+    expect(config.model).toBe('gemini-3.8-flash-high');
     expect(config.model).not.toBe('opus');
   });
 
@@ -367,7 +367,7 @@ describe('PRManager._buildDefaultAnalysisConfig', () => {
     const appConfig = { default_provider: 'claude', default_model: 'opus', provider_override: 'antigravity' };
     const config = await manager._buildDefaultAnalysisConfig(repoSettings, {}, appConfig, PROVIDERS);
     expect(config.provider).toBe('antigravity');
-    expect(config.model).toBe('gemini-3.1-pro-low');
+    expect(config.model).toBe('gemini-3.8-flash-high');
   });
 
   it('lets a per-invocation (delegation URL) override outrank both repo settings and the CLI flag override', async () => {
@@ -391,7 +391,7 @@ describe('PRManager._buildDefaultAnalysisConfig', () => {
     const config = await manager._buildDefaultAnalysisConfig(repoSettings, {}, appConfig, PROVIDERS);
     expect(config.isCouncil).toBeUndefined();
     expect(config.provider).toBe('antigravity');
-    expect(config.model).toBe('gemini-3.1-pro-low');
+    expect(config.model).toBe('gemini-3.8-flash-high');
     // Must NOT fetch council config when the override forces single-provider.
     expect(councilFetch).not.toHaveBeenCalled();
   });

--- a/tests/unit/claude-provider.test.js
+++ b/tests/unit/claude-provider.test.js
@@ -66,8 +66,55 @@ describe('ClaudeProvider', () => {
       expect(ClaudeProvider.getProviderId()).toBe('claude');
     });
 
-    it('should return opus-4.8-xhigh as default model', () => {
-      expect(ClaudeProvider.getDefaultModel()).toBe('opus-4.8-xhigh');
+    it('should return opus-5-high as default model', () => {
+      expect(ClaudeProvider.getDefaultModel()).toBe('opus-5-high');
+    });
+
+    it('default entry is opus-5-high: claude-opus-5 at high effort, flagged default, no aliases', () => {
+      const models = ClaudeProvider.getModels();
+      const defaults = models.filter(m => m.default === true);
+      // Exactly one entry carries default:true, and it is the one getDefaultModel() names
+      expect(defaults).toHaveLength(1);
+      expect(defaults[0].id).toBe(ClaudeProvider.getDefaultModel());
+      expect(defaults[0]).toMatchObject({
+        id: 'opus-5-high',
+        cli_model: 'claude-opus-5',
+        env: { CLAUDE_CODE_EFFORT_LEVEL: 'high' },
+        tier: 'thorough',
+        badge: 'Recommended',
+        badgeClass: 'badge-recommended',
+        default: true
+      });
+      // The default moved, but the generation alias did not: 'opus' stays on 4.8
+      expect(defaults[0].aliases).toBeUndefined();
+    });
+
+    it('keeps opus-4.8-xhigh as a non-default entry that the bare "opus" alias still resolves to', () => {
+      const models = ClaudeProvider.getModels();
+      const opus48 = models.find(m => m.id === 'opus-4.8-xhigh');
+      expect(opus48).toMatchObject({
+        id: 'opus-4.8-xhigh',
+        cli_model: 'claude-opus-4-8',
+        env: { CLAUDE_CODE_EFFORT_LEVEL: 'xhigh' },
+        tier: 'thorough',
+        badge: 'Previous Gen'
+      });
+      expect(opus48.default).toBeUndefined();
+      expect(opus48.aliases).toEqual(['opus']);
+      expect(models.filter(m => (m.aliases || []).includes('opus'))).toHaveLength(1);
+      // The alias resolves to the 4.8 entry, not the new default
+      const provider = new ClaudeProvider('opus');
+      const modelIdx = provider.args.indexOf('--model');
+      expect(provider.args[modelIdx + 1]).toBe('claude-opus-4-8');
+      expect(provider.model).not.toBe(ClaudeProvider.getDefaultModel());
+    });
+
+    it('does not make Fable 5.1 the default (higher price tier stays an explicit pick)', () => {
+      const models = ClaudeProvider.getModels();
+      for (const id of ['fable-5.1-xhigh', 'fable-5.1-high', 'fable-5-xhigh', 'fable-5-high']) {
+        expect(models.find(m => m.id === id).default).toBeUndefined();
+      }
+      expect(ClaudeProvider.getDefaultModel()).not.toMatch(/fable/);
     });
 
     it('should return array of models with expected structure', () => {
@@ -106,17 +153,18 @@ describe('ClaudeProvider', () => {
       // Fable 5.1 is a standalone generation, not an alias target
       expect(modelIds).not.toContain('fable-5.1');
 
-      // Check model structure - 'opus-4.8-xhigh' is the canonical default, aliased by 'opus'
-      const defaultModel = models.find(m => m.id === 'opus-4.8-xhigh');
-      expect(defaultModel).toMatchObject({
+      // Check model structure - 'opus-4.8-xhigh' is the canonical alias target of
+      // 'opus' but no longer the default (that moved to opus-5-high)
+      const opusAliasTarget = models.find(m => m.id === 'opus-4.8-xhigh');
+      expect(opusAliasTarget).toMatchObject({
         id: 'opus-4.8-xhigh',
         name: 'Opus 4.8 XHigh',
-        tier: 'thorough',
-        default: true
+        tier: 'thorough'
       });
-      expect(defaultModel.aliases).toContain('opus');
-      // Exactly one model is the default
-      expect(models.filter(m => m.default).length).toBe(1);
+      expect(opusAliasTarget.default).toBeUndefined();
+      expect(opusAliasTarget.aliases).toContain('opus');
+      // Exactly one model is the default, and it is opus-5-high
+      expect(models.filter(m => m.default).map(m => m.id)).toEqual(['opus-5-high']);
 
       // opus-4.6-1m is balanced
       expect(models.find(m => m.id === 'opus-4.6-1m').tier).toBe('balanced');
@@ -150,7 +198,8 @@ describe('ClaudeProvider', () => {
       expect(models.find(m => m.id === 'opus-4.8-high').env).toEqual({ CLAUDE_CODE_EFFORT_LEVEL: 'high' });
 
       // Opus 5 variants mirror the 4.8 shape: thorough tier, pinned to claude-opus-5,
-      // effort carried on the env var. They are NOT the default and hold no aliases —
+      // effort carried on the env var. opus-5-high IS the default (same price as
+      // 4.8); opus-5-xhigh is an explicit non-default pick. Neither holds aliases —
       // the bare 'opus' alias intentionally stays on opus-4.8-xhigh.
       const opus5XHigh = models.find(m => m.id === 'opus-5-xhigh');
       expect(opus5XHigh).toMatchObject({
@@ -161,6 +210,7 @@ describe('ClaudeProvider', () => {
       });
       expect(opus5XHigh.env).toEqual({ CLAUDE_CODE_EFFORT_LEVEL: 'xhigh' });
       expect(opus5XHigh.default).toBeUndefined();
+      expect(opus5XHigh.badgeClass).toBe('badge-power');
       expect(opus5XHigh.aliases).toBeUndefined();
       const opus5High = models.find(m => m.id === 'opus-5-high');
       expect(opus5High).toMatchObject({
@@ -170,7 +220,10 @@ describe('ClaudeProvider', () => {
         cli_model: 'claude-opus-5'
       });
       expect(opus5High.env).toEqual({ CLAUDE_CODE_EFFORT_LEVEL: 'high' });
-      expect(opus5High.default).toBeUndefined();
+      expect(opus5High.default).toBe(true);
+      expect(opus5High.badge).toBe('Recommended');
+      expect(opus5High.badgeClass).toBe('badge-recommended');
+      expect(opus5High.aliases).toBeUndefined();
 
       // Opus 4.8 is no longer the newest — its copy must not claim latest/newest.
       for (const id of ['opus-4.8-xhigh', 'opus-4.8-high']) {
@@ -320,7 +373,7 @@ describe('ClaudeProvider', () => {
     it('should create instance with default model', () => {
       const provider = new ClaudeProvider();
       // No-arg constructor falls back to getDefaultModel() (single source of truth)
-      expect(provider.model).toBe('opus-4.8-xhigh');
+      expect(provider.model).toBe('opus-5-high');
     });
 
     it('should create instance with specified model', () => {

--- a/tests/unit/codex-provider.test.js
+++ b/tests/unit/codex-provider.test.js
@@ -70,40 +70,63 @@ describe('CodexProvider', () => {
     it('should return array of models with expected structure', () => {
       const models = CodexProvider.getModels();
       expect(Array.isArray(models)).toBe(true);
-      expect(models.length).toBe(11);
+      expect(models.length).toBe(9);
 
-      // Check that we have the expected model IDs
+      // Check that we have the expected model IDs, ordered thorough → balanced → fast
       const modelIds = models.map(m => m.id);
-      expect(modelIds.slice(0, 4)).toEqual([
+      expect(modelIds).toEqual([
+        'gpt-6-astra-high',
+        'gpt-6-astra-xhigh',
         'gpt-5.6-sol-high',
         'gpt-5.6-sol-xhigh',
+        'gpt-5.5-high',
+        'gpt-5.5-xhigh',
         'gpt-5.6-terra-xhigh',
-        'gpt-5.6-luna-max'
+        'gpt-5.6-luna-max',
+        'gpt-5.4-mini'
       ]);
-      expect(modelIds).toContain('gpt-5.6-sol-high');
-      expect(modelIds).toContain('gpt-5.6-sol-xhigh');
-      expect(modelIds).toContain('gpt-5.6-terra-xhigh');
-      expect(modelIds).toContain('gpt-5.6-luna-max');
-      expect(modelIds).toContain('gpt-5.4-nano');
-      expect(modelIds).toContain('gpt-5.4-mini');
-      expect(modelIds).toContain('gpt-5.3-codex');
-      expect(modelIds).toContain('gpt-5.4-high');
-      expect(modelIds).toContain('gpt-5.4-xhigh');
-      expect(modelIds).toContain('gpt-5.5-high');
-      expect(modelIds).toContain('gpt-5.5-xhigh');
-      // Bare GPT-5.6 / gpt-5.4 / gpt-5.5 (unspecified reasoning effort) are not
+      // Bare GPT-6 / GPT-5.6 / gpt-5.5 (unspecified reasoning effort) are not
       // exposed as picker entries — users pick an explicit reasoning variant
-      // instead. `gpt-5.4` is kept as an alias of gpt-5.4-high so previously
-      // saved results/councils still resolve.
-      expect(modelIds).not.toContain('gpt-5.4');
+      // instead.
+      expect(modelIds).not.toContain('gpt-6-astra');
       expect(modelIds).not.toContain('gpt-5.5');
       expect(modelIds).not.toContain('gpt-5.6-sol');
       expect(modelIds).not.toContain('gpt-5.6-terra');
       expect(modelIds).not.toContain('gpt-5.6-luna');
 
-      const high54 = models.find(m => m.id === 'gpt-5.4-high');
-      expect(high54.aliases).toContain('gpt-5.4');
-      expect(high54.badge).toBe('Previous Gen');
+      // Retired by OpenAI (Aug 2026) — Codex rejects them with a 400. They must
+      // be gone from the picker AND not aliased onto any surviving model, so a
+      // saved council fails loudly instead of silently running another model.
+      for (const retired of ['gpt-5.4', 'gpt-5.4-high', 'gpt-5.4-xhigh', 'gpt-5.4-nano', 'gpt-5.3-codex']) {
+        expect(modelIds, `${retired} should be removed`).not.toContain(retired);
+        expect(models.some(m => m.aliases?.includes(retired)), `${retired} should not be aliased`).toBe(false);
+      }
+
+      // GPT-6 Astra is the new flagship but NOT the default (several times Sol's cost)
+      const astraHigh = models.find(m => m.id === 'gpt-6-astra-high');
+      expect(astraHigh).toMatchObject({
+        cli_model: 'gpt-6-astra',
+        extra_args: ['-c', 'model_reasoning_effort="high"'],
+        name: 'GPT-6 Astra High',
+        tier: 'thorough',
+        badge: 'Most Capable',
+        badgeClass: 'badge-power'
+      });
+      expect(astraHigh.default).toBeUndefined();
+      const astraXhigh = models.find(m => m.id === 'gpt-6-astra-xhigh');
+      expect(astraXhigh).toMatchObject({
+        cli_model: 'gpt-6-astra',
+        extra_args: ['-c', 'model_reasoning_effort="xhigh"'],
+        tier: 'thorough',
+        badge: 'Extra High'
+      });
+
+      // gpt-5.4-mini is the sole fast-tier model (nano was retired)
+      const fastModels = models.filter(m => m.tier === 'fast').map(m => m.id);
+      expect(fastModels).toEqual(['gpt-5.4-mini']);
+      const mini = models.find(m => m.id === 'gpt-5.4-mini');
+      expect(mini.cli_model).toBeUndefined();
+      expect(mini.description).not.toContain('400k');
 
       // Check model structure — default is GPT-5.6 Sol with explicit high reasoning
       const defaultModel = models.find(m => m.default === true);
@@ -124,8 +147,8 @@ describe('CodexProvider', () => {
         { id: 'gpt-5.6-sol-xhigh', cliModel: 'gpt-5.6-sol', effort: 'xhigh', tier: 'thorough' },
         { id: 'gpt-5.6-terra-xhigh', cliModel: 'gpt-5.6-terra', effort: 'xhigh', tier: 'balanced' },
         { id: 'gpt-5.6-luna-max', cliModel: 'gpt-5.6-luna', effort: 'max', tier: 'balanced' },
-        { id: 'gpt-5.4-high', cliModel: 'gpt-5.4', effort: 'high', tier: 'thorough' },
-        { id: 'gpt-5.4-xhigh', cliModel: 'gpt-5.4', effort: 'xhigh', tier: 'thorough' },
+        { id: 'gpt-6-astra-high', cliModel: 'gpt-6-astra', effort: 'high', tier: 'thorough' },
+        { id: 'gpt-6-astra-xhigh', cliModel: 'gpt-6-astra', effort: 'xhigh', tier: 'thorough' },
         { id: 'gpt-5.5-high', cliModel: 'gpt-5.5', effort: 'high', tier: 'thorough' },
         { id: 'gpt-5.5-xhigh', cliModel: 'gpt-5.5', effort: 'xhigh', tier: 'thorough' }
       ];
@@ -186,10 +209,10 @@ describe('CodexProvider', () => {
     });
 
     it('should configure base args correctly', () => {
-      const provider = new CodexProvider('gpt-5.4-nano');
+      const provider = new CodexProvider('gpt-5.4-mini');
       expect(provider.args).toContain('exec');
       expect(provider.args).toContain('-m');
-      expect(provider.args).toContain('gpt-5.4-nano');
+      expect(provider.args).toContain('gpt-5.4-mini');
       expect(provider.args).toContain('--json');
       expect(provider.args).toContain('--sandbox');
       expect(provider.args).toContain('workspace-write');
@@ -216,13 +239,13 @@ describe('CodexProvider', () => {
     });
 
     describe('reasoning-effort variants', () => {
-      it('should pass cli_model to -m and append -c model_reasoning_effort for gpt-5.4-high', () => {
-        const provider = new CodexProvider('gpt-5.4-high');
+      it('should pass cli_model to -m and append -c model_reasoning_effort for gpt-6-astra-high', () => {
+        const provider = new CodexProvider('gpt-6-astra-high');
         // -m should receive the base cli_model, not the variant id
         const mIdx = provider.args.indexOf('-m');
         expect(mIdx).toBeGreaterThanOrEqual(0);
-        expect(provider.args[mIdx + 1]).toBe('gpt-5.4');
-        expect(provider.args).not.toContain('gpt-5.4-high');
+        expect(provider.args[mIdx + 1]).toBe('gpt-6-astra');
+        expect(provider.args).not.toContain('gpt-6-astra-high');
 
         // -c 'model_reasoning_effort="high"' must appear as adjacent args
         const effortIdx = provider.args.indexOf('model_reasoning_effort="high"');
@@ -230,10 +253,10 @@ describe('CodexProvider', () => {
         expect(provider.args[effortIdx - 1]).toBe('-c');
       });
 
-      it('should use xhigh effort for gpt-5.4-xhigh', () => {
-        const provider = new CodexProvider('gpt-5.4-xhigh');
+      it('should use xhigh effort for gpt-6-astra-xhigh', () => {
+        const provider = new CodexProvider('gpt-6-astra-xhigh');
         const mIdx = provider.args.indexOf('-m');
-        expect(provider.args[mIdx + 1]).toBe('gpt-5.4');
+        expect(provider.args[mIdx + 1]).toBe('gpt-6-astra');
         const effortIdx = provider.args.indexOf('model_reasoning_effort="xhigh"');
         expect(effortIdx).toBeGreaterThanOrEqual(1);
         expect(provider.args[effortIdx - 1]).toBe('-c');
@@ -270,7 +293,7 @@ describe('CodexProvider', () => {
         // Regression: `-` is the positional stdin marker for `codex exec`.
         // It must appear after `-c model_reasoning_effort="..."` or the
         // reasoning override is silently ignored.
-        const provider = new CodexProvider('gpt-5.4-high');
+        const provider = new CodexProvider('gpt-6-astra-high');
         const dashIdx = provider.args.lastIndexOf('-');
         const effortIdx = provider.args.indexOf('model_reasoning_effort="high"');
         expect(dashIdx).toBe(provider.args.length - 1);
@@ -279,7 +302,7 @@ describe('CodexProvider', () => {
 
       it('should place stdin marker `-` AFTER reasoning extra_args in shell mode', () => {
         process.env.PAIR_REVIEW_CODEX_CMD = 'devx codex';
-        const provider = new CodexProvider('gpt-5.4-high');
+        const provider = new CodexProvider('gpt-6-astra-high');
         // In shell mode, args are baked into the command string
         expect(provider.useShell).toBe(true);
         const effortPos = provider.command.indexOf('model_reasoning_effort=');
@@ -289,14 +312,16 @@ describe('CodexProvider', () => {
         expect(provider.command.endsWith(' -')).toBe(true);
       });
 
-      it('should treat legacy "gpt-5.4" model ID as an alias of gpt-5.4-high', () => {
+      it('should NOT alias the retired "gpt-5.4" model ID onto another model', () => {
+        // gpt-5.4 was retired by OpenAI (Aug 2026). The former alias onto
+        // gpt-6-astra-high is gone on purpose: the id passes through verbatim so
+        // Codex returns its explicit unknown-model error rather than a
+        // saved council silently running a different model.
         const provider = new CodexProvider('gpt-5.4');
-        // this.model reflects what the caller asked for (unchanged)
         expect(provider.model).toBe('gpt-5.4');
-        // but the resolved CLI args match the gpt-5.4-high variant
         const mIdx = provider.args.indexOf('-m');
         expect(provider.args[mIdx + 1]).toBe('gpt-5.4');
-        expect(provider.args).toContain('model_reasoning_effort="high"');
+        expect(provider.args.some(a => a.startsWith('model_reasoning_effort='))).toBe(false);
       });
 
       it('getExtractionConfig should also apply cli_model + reasoning effort', () => {
@@ -332,6 +357,27 @@ describe('CodexProvider', () => {
       expect(provider.extraEnv).toEqual({ CUSTOM_VAR: 'value' });
     });
 
+    it('should honor a per-model override matched through its own declared aliases', () => {
+      // CODEX_MODELS has no built-in aliases, so the override's own `aliases`
+      // is the only way a config keyed under a different name can apply.
+      // Regression: the lookup used to be exact-id only.
+      const provider = new CodexProvider('gpt-6-astra-high', {
+        models: [
+          {
+            id: 'my-astra',
+            aliases: ['gpt-6-astra-high'],
+            cli_model: 'gpt-6-astra-custom',
+            extra_args: ['--alias-flag'],
+            env: { VIA_ALIAS: 'yes' }
+          }
+        ]
+      });
+      const mIdx = provider.args.indexOf('-m');
+      expect(provider.args[mIdx + 1]).toBe('gpt-6-astra-custom');
+      expect(provider.args).toContain('--alias-flag');
+      expect(provider.extraEnv.VIA_ALIAS).toBe('yes');
+    });
+
     it('should merge model-specific env over provider env', () => {
       const provider = new CodexProvider('gpt-5.4-mini', {
         env: { VAR1: 'provider' },
@@ -345,7 +391,7 @@ describe('CodexProvider', () => {
 
     describe('yolo mode', () => {
       it('should include sandbox restrictions by default and no dangerously-bypass flag', () => {
-        const provider = new CodexProvider('gpt-5.4-nano');
+        const provider = new CodexProvider('gpt-5.4-mini');
         expect(provider.args).toContain('--sandbox');
         expect(provider.args).toContain('workspace-write');
         expect(provider.args).not.toContain('--full-auto');
@@ -353,7 +399,7 @@ describe('CodexProvider', () => {
       });
 
       it('should use --dangerously-bypass-approvals-and-sandbox when yolo is true', () => {
-        const provider = new CodexProvider('gpt-5.4-nano', { yolo: true });
+        const provider = new CodexProvider('gpt-5.4-mini', { yolo: true });
         expect(provider.args).toContain('--dangerously-bypass-approvals-and-sandbox');
         expect(provider.args).not.toContain('--sandbox');
         expect(provider.args).not.toContain('workspace-write');
@@ -361,7 +407,7 @@ describe('CodexProvider', () => {
       });
 
       it('should include sandbox restrictions when yolo is explicitly false', () => {
-        const provider = new CodexProvider('gpt-5.4-nano', { yolo: false });
+        const provider = new CodexProvider('gpt-5.4-mini', { yolo: false });
         expect(provider.args).toContain('--sandbox');
         expect(provider.args).toContain('workspace-write');
         expect(provider.args).not.toContain('--full-auto');
@@ -744,29 +790,31 @@ describe('CodexProvider', () => {
   });
 
   describe('buildArgsForModel', () => {
-    it('should resolve cli_model for gpt-5.4-high variant', () => {
+    it('should resolve cli_model for gpt-6-astra-high variant', () => {
       // Reasoning variants pass the base model to `-m` and add effort via
       // `-c model_reasoning_effort="..."`, with the stdin marker `-` last.
       const provider = new CodexProvider('gpt-5.4-mini');
-      const args = provider.buildArgsForModel('gpt-5.4-high');
+      const args = provider.buildArgsForModel('gpt-6-astra-high');
       const mIdx = args.indexOf('-m');
       expect(mIdx).toBeGreaterThanOrEqual(0);
-      expect(args[mIdx + 1]).toBe('gpt-5.4');
+      expect(args[mIdx + 1]).toBe('gpt-6-astra');
       const effortIdx = args.indexOf('model_reasoning_effort="high"');
       expect(effortIdx).toBeGreaterThanOrEqual(1);
       expect(args[effortIdx - 1]).toBe('-c');
       expect(args[args.length - 1]).toBe('-');
     });
 
-    it('should resolve legacy `gpt-5.4` alias to the high-effort variant shape', () => {
-      // Alias keeps historical analysis runs recorded under bare `gpt-5.4`
-      // executable against the canonical gpt-5.4-high configuration.
+    it('should pass retired ids (gpt-5.4, gpt-5.4-high, gpt-5.4-nano, gpt-5.3-codex) through unaliased', () => {
+      // Retired models are deliberately not aliased: the id goes to `-m`
+      // verbatim with no reasoning-effort override, so Codex fails loudly.
       const provider = new CodexProvider('gpt-5.4-mini');
-      const args = provider.buildArgsForModel('gpt-5.4');
-      const mIdx = args.indexOf('-m');
-      expect(args[mIdx + 1]).toBe('gpt-5.4');
-      expect(args).toContain('model_reasoning_effort="high"');
-      expect(args[args.length - 1]).toBe('-');
+      for (const retired of ['gpt-5.4', 'gpt-5.4-high', 'gpt-5.4-nano', 'gpt-5.3-codex']) {
+        const args = provider.buildArgsForModel(retired);
+        const mIdx = args.indexOf('-m');
+        expect(args[mIdx + 1], retired).toBe(retired);
+        expect(args.some(a => a.startsWith('model_reasoning_effort=')), retired).toBe(false);
+        expect(args[args.length - 1]).toBe('-');
+      }
     });
 
     it('should use read-only sandbox for extraction (distinct from workspace-write)', () => {
@@ -783,17 +831,17 @@ describe('CodexProvider', () => {
     it('should respect config cli_model override (config > built-in > modelId)', () => {
       // Documents the precedence chain in _resolveModelConfig: a per-model
       // config `cli_model` beats the built-in `cli_model` (which is
-      // `gpt-5.4` for the high variant).
-      const provider = new CodexProvider('gpt-5.4-high', {
+      // `gpt-6-astra` for the high variant).
+      const provider = new CodexProvider('gpt-6-astra-high', {
         models: [
-          { id: 'gpt-5.4-high', cli_model: 'custom-model' }
+          { id: 'gpt-6-astra-high', cli_model: 'custom-model' }
         ]
       });
-      const args = provider.buildArgsForModel('gpt-5.4-high');
+      const args = provider.buildArgsForModel('gpt-6-astra-high');
       const mIdx = args.indexOf('-m');
       expect(mIdx).toBeGreaterThanOrEqual(0);
       expect(args[mIdx + 1]).toBe('custom-model');
-      expect(args).not.toContain('gpt-5.4');
+      expect(args).not.toContain('gpt-6-astra');
     });
 
     it('should NOT add reasoning effort args for bare gpt-5.5 (no alias by design)', () => {
@@ -811,12 +859,12 @@ describe('CodexProvider', () => {
   describe('getExtractionConfig', () => {
     it('should return correct config for default command', () => {
       const provider = new CodexProvider();
-      const config = provider.getExtractionConfig('gpt-5.4-nano');
+      const config = provider.getExtractionConfig('gpt-5.4-mini');
 
       expect(config.command).toBe('codex');
       expect(config.args).toContain('exec');
       expect(config.args).toContain('-m');
-      expect(config.args).toContain('gpt-5.4-nano');
+      expect(config.args).toContain('gpt-5.4-mini');
       expect(config.args).toContain('--sandbox');
       expect(config.args).toContain('read-only');
       expect(config.useShell).toBe(false);
@@ -826,7 +874,7 @@ describe('CodexProvider', () => {
     it('should use shell mode for multi-word command', () => {
       process.env.PAIR_REVIEW_CODEX_CMD = 'docker run codex';
       const provider = new CodexProvider();
-      const config = provider.getExtractionConfig('gpt-5.4-nano');
+      const config = provider.getExtractionConfig('gpt-5.4-mini');
 
       expect(config.useShell).toBe(true);
       expect(config.command).toContain('docker run codex');
@@ -840,10 +888,10 @@ describe('CodexProvider', () => {
       const provider = new CodexProvider('gpt-5.4-mini', {
         env: { PROVIDER_VAR: 'p' },
         models: [
-          { id: 'gpt-5.4-nano', env: { MODEL_VAR: 'm' } }
+          { id: 'gpt-5.4-mini', env: { MODEL_VAR: 'm' } }
         ]
       });
-      const config = provider.getExtractionConfig('gpt-5.4-nano');
+      const config = provider.getExtractionConfig('gpt-5.4-mini');
       expect(config.env).toEqual({ PROVIDER_VAR: 'p', MODEL_VAR: 'm' });
     });
 
@@ -852,7 +900,7 @@ describe('CodexProvider', () => {
       const provider = new CodexProvider('gpt-5.4-mini', {
         env: { FROM_PROVIDER: '1' }
       });
-      const config = provider.getExtractionConfig('gpt-5.4-nano');
+      const config = provider.getExtractionConfig('gpt-5.4-mini');
       expect(config.useShell).toBe(true);
       expect(config.env).toEqual({ FROM_PROVIDER: '1' });
     });

--- a/tests/unit/llm-extraction.test.js
+++ b/tests/unit/llm-extraction.test.js
@@ -55,14 +55,21 @@ describe('LLM-based JSON extraction fallback', () => {
       expect(provider.getFastTierModel()).toBe('haiku');
     });
 
-    it('should return fast-tier model for Antigravity (gemini-3.5-flash-low)', () => {
+    it('should return fast-tier model for Antigravity (gemini-3.8-flash-low)', () => {
       const provider = new AntigravityProvider('gemini-3.1-pro-low');
-      expect(provider.getFastTierModel()).toBe('gemini-3.5-flash-low');
+      expect(provider.getFastTierModel()).toBe('gemini-3.8-flash-low');
     });
 
-    it('should return fast-tier model for Codex (gpt-5.4-nano)', () => {
-      const provider = new CodexProvider('gpt-5.4-mini');
-      expect(provider.getFastTierModel()).toBe('gpt-5.4-nano');
+    it('should keep gemini-3.8-flash-low as the extraction model now that 3.8 Flash (High) is the thorough default', () => {
+      const provider = new AntigravityProvider();
+      expect(provider.model).toBe('gemini-3.8-flash-high');
+      expect(provider.getFastTierModel()).toBe('gemini-3.8-flash-low');
+      expect(provider.getFastTierModel()).not.toBe(provider.model);
+    });
+
+    it('should return fast-tier model for Codex (gpt-5.4-mini)', () => {
+      const provider = new CodexProvider('gpt-5.6-sol-high');
+      expect(provider.getFastTierModel()).toBe('gpt-5.4-mini');
     });
 
     it('should return fast-tier model for Copilot (claude-haiku-4.6)', () => {
@@ -121,7 +128,7 @@ describe('LLM-based JSON extraction fallback', () => {
     describe('AntigravityProvider', () => {
       it('should return valid config', () => {
         const provider = new AntigravityProvider();
-        const config = provider.getExtractionConfig('gemini-3.5-flash-low');
+        const config = provider.getExtractionConfig('gemini-3.8-flash-low');
 
         expect(config).toHaveProperty('command');
         expect(config).toHaveProperty('args');
@@ -130,7 +137,7 @@ describe('LLM-based JSON extraction fallback', () => {
 
       it('should deliver the extraction prompt via stdin without enabling tools', () => {
         const provider = new AntigravityProvider();
-        const config = provider.getExtractionConfig('gemini-3.5-flash-low');
+        const config = provider.getExtractionConfig('gemini-3.8-flash-low');
 
         // agy reads the prompt from stdin (plain text); extraction is a pure
         // text->JSON reformat, so it must NOT enable the agentic tool loop.
@@ -140,17 +147,17 @@ describe('LLM-based JSON extraction fallback', () => {
 
       it('should include the resolved cliName in args', () => {
         const provider = new AntigravityProvider();
-        const config = provider.getExtractionConfig('gemini-3.5-flash-low');
+        const config = provider.getExtractionConfig('gemini-3.8-flash-low');
 
         // The clean id resolves to the exact `agy --model` display string.
-        expect(config.args).toContain('Gemini 3.5 Flash (Low)');
+        expect(config.args).toContain('Gemini 3.8 Flash (Low)');
       });
     });
 
     describe('CodexProvider', () => {
       it('should return valid config', () => {
         const provider = new CodexProvider();
-        const config = provider.getExtractionConfig('gpt-5.4-nano');
+        const config = provider.getExtractionConfig('gpt-5.4-mini');
 
         expect(config).toHaveProperty('command');
         expect(config).toHaveProperty('args');
@@ -159,7 +166,7 @@ describe('LLM-based JSON extraction fallback', () => {
 
       it('should use read-only sandbox for extraction', () => {
         const provider = new CodexProvider();
-        const config = provider.getExtractionConfig('gpt-5.4-nano');
+        const config = provider.getExtractionConfig('gpt-5.4-mini');
 
         // For extraction, we don't need shell commands
         expect(config.args).toContain('read-only');
@@ -167,9 +174,9 @@ describe('LLM-based JSON extraction fallback', () => {
 
       it('should include model in args', () => {
         const provider = new CodexProvider();
-        const config = provider.getExtractionConfig('gpt-5.4-nano');
+        const config = provider.getExtractionConfig('gpt-5.4-mini');
 
-        expect(config.args).toContain('gpt-5.4-nano');
+        expect(config.args).toContain('gpt-5.4-mini');
       });
     });
 
@@ -211,8 +218,8 @@ describe('LLM-based JSON extraction fallback', () => {
     it('all providers should have fast-tier models defined', () => {
       const providers = [
         { Class: ClaudeProvider, expectedFast: 'haiku' },
-        { Class: AntigravityProvider, expectedFast: 'gemini-3.5-flash-low' },
-        { Class: CodexProvider, expectedFast: 'gpt-5.4-nano' },
+        { Class: AntigravityProvider, expectedFast: 'gemini-3.8-flash-low' },
+        { Class: CodexProvider, expectedFast: 'gpt-5.4-mini' },
         { Class: CopilotProvider, expectedFast: 'claude-haiku-4.6' },
       ];
 

--- a/tests/unit/muse-provider.test.js
+++ b/tests/unit/muse-provider.test.js
@@ -175,8 +175,8 @@ describe('MuseProvider', () => {
       expect(MuseProvider.getProviderId()).toBe('muse');
     });
 
-    it('returns muse-spark-1.2-high as the default model', () => {
-      expect(MuseProvider.getDefaultModel()).toBe('muse-spark-1.2-high');
+    it('returns muse-spark-1.3-high as the default model', () => {
+      expect(MuseProvider.getDefaultModel()).toBe('muse-spark-1.3-high');
     });
 
     it('returns models with the expected structure', () => {
@@ -194,10 +194,19 @@ describe('MuseProvider', () => {
 
     it('gives every model a real cli_model and reasoning effort', () => {
       for (const model of MuseProvider.getModels()) {
-        expect(['muse-spark-1.2', 'muse-spark-1.2-contributor']).toContain(model.cli_model);
+        expect(['muse-spark-1.3', 'muse-spark-1.3-contributor']).toContain(model.cli_model);
         expect(model.extra_args[0]).toBe('--reasoning-effort');
-        expect(['none', 'minimal', 'low', 'medium', 'high', 'xhigh', 'ultra'])
+        // `none` is rejected by `--provider meta`; `ultra` is gate-closed and
+        // silently degrades to xhigh, so neither may appear in a built-in.
+        expect(['minimal', 'low', 'medium', 'high', 'xhigh', 'max'])
           .toContain(model.extra_args[1]);
+      }
+    });
+
+    it('never ships a built-in at the rejected `none` or gate-closed `ultra` effort', () => {
+      for (const model of MuseProvider.getModels()) {
+        expect(model.extra_args[1]).not.toBe('none');
+        expect(model.extra_args[1]).not.toBe('ultra');
       }
     });
 
@@ -208,12 +217,12 @@ describe('MuseProvider', () => {
       // Reviews carry potentially proprietary source, so the data-sharing tier
       // must never be the silent default even though muse's own CLI default is
       // the contributor model.
-      expect(defaults[0].cli_model).toBe('muse-spark-1.2');
+      expect(defaults[0].cli_model).toBe('muse-spark-1.3');
     });
 
     it('warns in the description of every contributor model that Meta may use the content', () => {
       const contributors = MuseProvider.getModels()
-        .filter(m => m.cli_model === 'muse-spark-1.2-contributor');
+        .filter(m => m.cli_model === 'muse-spark-1.3-contributor');
       expect(contributors.length).toBeGreaterThan(0);
       for (const model of contributors) {
         expect(model.description).toMatch(/used by Meta for product improvement/i);
@@ -224,20 +233,20 @@ describe('MuseProvider', () => {
       // getFastTierModel() takes the FIRST fast-tier model; it must not resolve
       // to the data-sharing tier. Adding models must never disturb this order.
       const firstFast = MuseProvider.getModels().find(m => m.tier === 'fast');
-      expect(firstFast.cli_model).toBe('muse-spark-1.2');
-      expect(new MuseProvider().getFastTierModel()).toBe('muse-spark-1.2-low');
+      expect(firstFast.cli_model).toBe('muse-spark-1.3');
+      expect(new MuseProvider().getFastTierModel()).toBe('muse-spark-1.3-low');
     });
 
     it('offers a contributor counterpart at every reasoning effort it exposes', () => {
       const models = MuseProvider.getModels();
       const effortOf = (m) => m.extra_args[1];
-      const efforts = new Set(models.filter(m => m.cli_model === 'muse-spark-1.2').map(effortOf));
+      const efforts = new Set(models.filter(m => m.cli_model === 'muse-spark-1.3').map(effortOf));
       const contributorEfforts = new Set(
-        models.filter(m => m.cli_model === 'muse-spark-1.2-contributor').map(effortOf)
+        models.filter(m => m.cli_model === 'muse-spark-1.3-contributor').map(effortOf)
       );
 
-      expect([...efforts].sort()).toEqual(['high', 'low', 'ultra', 'xhigh']);
-      expect([...contributorEfforts].sort()).toEqual(['high', 'low', 'ultra', 'xhigh']);
+      expect([...efforts].sort()).toEqual(['high', 'low', 'max', 'xhigh']);
+      expect([...contributorEfforts].sort()).toEqual(['high', 'low', 'max', 'xhigh']);
       expect(models).toHaveLength(8);
     });
 
@@ -245,27 +254,27 @@ describe('MuseProvider', () => {
       // Display order, and the invariant getFastTierModel() depends on: the
       // non-data-sharing model always comes first within a pairing.
       expect(MuseProvider.getModels().map(m => m.id)).toEqual([
-        'muse-spark-1.2-ultra',
-        'muse-spark-1.2-contributor-ultra',
-        'muse-spark-1.2-xhigh',
-        'muse-spark-1.2-contributor-xhigh',
-        'muse-spark-1.2-high',
-        'muse-spark-1.2-contributor-high',
-        'muse-spark-1.2-low',
-        'muse-spark-1.2-contributor-low'
+        'muse-spark-1.3-max',
+        'muse-spark-1.3-contributor-max',
+        'muse-spark-1.3-xhigh',
+        'muse-spark-1.3-contributor-xhigh',
+        'muse-spark-1.3-high',
+        'muse-spark-1.3-contributor-high',
+        'muse-spark-1.3-low',
+        'muse-spark-1.3-contributor-low'
       ]);
     });
 
     it('gives the new thorough contributor variants the thorough tier and shares-data badge', () => {
       const byId = Object.fromEntries(MuseProvider.getModels().map(m => [m.id, m]));
 
-      for (const id of ['muse-spark-1.2-contributor-ultra', 'muse-spark-1.2-contributor-xhigh']) {
+      for (const id of ['muse-spark-1.3-contributor-max', 'muse-spark-1.3-contributor-xhigh']) {
         expect(byId[id].tier).toBe('thorough');
         expect(byId[id].badge).toBe('Shares Data');
         expect(byId[id].badgeClass).toBe('badge-power');
       }
-      expect(byId['muse-spark-1.2-contributor-ultra'].extra_args).toEqual(['--reasoning-effort', 'ultra']);
-      expect(byId['muse-spark-1.2-contributor-xhigh'].extra_args).toEqual(['--reasoning-effort', 'xhigh']);
+      expect(byId['muse-spark-1.3-contributor-max'].extra_args).toEqual(['--reasoning-effort', 'max']);
+      expect(byId['muse-spark-1.3-contributor-xhigh'].extra_args).toEqual(['--reasoning-effort', 'xhigh']);
     });
 
     it('provides real install instructions naming the launcher and muse login', () => {
@@ -283,13 +292,13 @@ describe('MuseProvider', () => {
     });
 
     it('prefers the config command over the default', () => {
-      expect(new MuseProvider('muse-spark-1.2-high', { command: '/opt/muse' }).museCmd)
+      expect(new MuseProvider('muse-spark-1.3-high', { command: '/opt/muse' }).museCmd)
         .toBe('/opt/muse');
     });
 
     it('prefers PAIR_REVIEW_MUSE_CMD over the config command', () => {
       process.env.PAIR_REVIEW_MUSE_CMD = '/env/muse';
-      expect(new MuseProvider('muse-spark-1.2-high', { command: '/opt/muse' }).museCmd)
+      expect(new MuseProvider('muse-spark-1.3-high', { command: '/opt/muse' }).museCmd)
         .toBe('/env/muse');
     });
 
@@ -302,13 +311,13 @@ describe('MuseProvider', () => {
       // configured as `muse exec` would spawn `muse exec exec --json …`, which
       // muse rejects. Normalizing in the constructor is what keeps the analysis
       // and extraction paths from disagreeing about whether it is already there.
-      const provider = new MuseProvider('muse-spark-1.2-high', { command: 'muse exec' });
+      const provider = new MuseProvider('muse-spark-1.3-high', { command: 'muse exec' });
 
       expect(provider.museCmd).toBe('muse');
       expect(provider.baseArgs.filter(a => a === 'exec')).toHaveLength(1);
-      expect(provider.buildArgsForModel('muse-spark-1.2-low').filter(a => a === 'exec')).toHaveLength(1);
+      expect(provider.buildArgsForModel('muse-spark-1.3-low').filter(a => a === 'exec')).toHaveLength(1);
 
-      const extraction = provider.getExtractionConfig('muse-spark-1.2-low');
+      const extraction = provider.getExtractionConfig('muse-spark-1.3-low');
       expect(extraction.command).toBe('muse');
       expect(extraction.args.filter(a => a === 'exec')).toHaveLength(1);
 
@@ -319,7 +328,7 @@ describe('MuseProvider', () => {
     it('stops a stripped command from needlessly going through a shell', () => {
       // `useShell` is derived AFTER stripping, so `muse exec` is single-word
       // again by the time the flag is computed.
-      expect(new MuseProvider('muse-spark-1.2-high', { command: 'muse exec' }).useShell).toBe(false);
+      expect(new MuseProvider('muse-spark-1.3-high', { command: 'muse exec' }).useShell).toBe(false);
     });
 
     it('strips a trailing exec from the environment override too', () => {
@@ -333,7 +342,7 @@ describe('MuseProvider', () => {
     ])('leaves the container-exec wrapper %s untouched', (command) => {
       // Only a bare TRAILING `exec` is removed. A container-exec invocation can
       // never end with `exec` — the container and the command to run follow it.
-      const provider = new MuseProvider('muse-spark-1.2-high', { command });
+      const provider = new MuseProvider('muse-spark-1.3-high', { command });
       expect(provider.museCmd).toBe(command);
       expect(provider.useShell).toBe(true);
     });
@@ -341,27 +350,27 @@ describe('MuseProvider', () => {
     it('does not strip an exec that sits inside a quoted path', () => {
       // A quoted trailing token ends with the quote character, so the pattern
       // cannot reach inside it.
-      const provider = new MuseProvider('muse-spark-1.2-high', { command: '"/opt/my exec"' });
+      const provider = new MuseProvider('muse-spark-1.3-high', { command: '"/opt/my exec"' });
       expect(provider.museCmd).toBe('"/opt/my exec"');
-      expect(provider.getExtractionConfig('muse-spark-1.2-low').command).toBe('/opt/my exec');
+      expect(provider.getExtractionConfig('muse-spark-1.3-low').command).toBe('/opt/my exec');
     });
 
     it('uses shell mode for a multi-word command', () => {
-      expect(new MuseProvider('muse-spark-1.2-high', { command: 'devx muse --' }).useShell)
+      expect(new MuseProvider('muse-spark-1.3-high', { command: 'devx muse --' }).useShell)
         .toBe(true);
     });
 
     it('builds baseArgs with exec, --json, --model, the safety flag and the reasoning effort', () => {
-      expect(new MuseProvider('muse-spark-1.2-high').baseArgs).toEqual([
-        'exec', '--json', '--model', 'muse-spark-1.2', '--disable-write', '--reasoning-effort', 'high'
+      expect(new MuseProvider('muse-spark-1.3-high').baseArgs).toEqual([
+        'exec', '--json', '--model', 'muse-spark-1.3', '--disable-write', '--reasoning-effort', 'high'
       ]);
     });
 
     it('maps each effort variant onto the right cli model', () => {
-      expect(new MuseProvider('muse-spark-1.2-ultra').baseArgs)
-        .toEqual(['exec', '--json', '--model', 'muse-spark-1.2', '--disable-write', '--reasoning-effort', 'ultra']);
-      expect(new MuseProvider('muse-spark-1.2-contributor-low').baseArgs)
-        .toEqual(['exec', '--json', '--model', 'muse-spark-1.2-contributor', '--disable-write', '--reasoning-effort', 'low']);
+      expect(new MuseProvider('muse-spark-1.3-max').baseArgs)
+        .toEqual(['exec', '--json', '--model', 'muse-spark-1.3', '--disable-write', '--reasoning-effort', 'max']);
+      expect(new MuseProvider('muse-spark-1.3-contributor-low').baseArgs)
+        .toEqual(['exec', '--json', '--model', 'muse-spark-1.3-contributor', '--disable-write', '--reasoning-effort', 'low']);
     });
 
     it('never bakes a --prompt-file pair into baseArgs', () => {
@@ -376,12 +385,80 @@ describe('MuseProvider', () => {
     });
 
     it.each([
+      ['muse-spark-1.3'],
+      ['muse-spark'],
       ['muse-spark-1.2'],
-      ['muse-spark']
+      ['muse-spark-1.2-high']
     ])('resolves the alias %s to the high-effort variant', (alias) => {
       expect(new MuseProvider(alias).baseArgs).toEqual([
-        'exec', '--json', '--model', 'muse-spark-1.2', '--disable-write', '--reasoning-effort', 'high'
+        'exec', '--json', '--model', 'muse-spark-1.3', '--disable-write', '--reasoning-effort', 'high'
       ]);
+    });
+
+    it.each([
+      ['muse-spark-1.3-contributor'],
+      ['muse-spark-1.2-contributor'],
+      ['muse-spark-1.2-contributor-high']
+    ])('resolves the contributor alias %s to the contributor high-effort variant', (alias) => {
+      expect(new MuseProvider(alias).baseArgs).toEqual([
+        'exec', '--json', '--model', 'muse-spark-1.3-contributor', '--disable-write', '--reasoning-effort', 'high'
+      ]);
+    });
+
+    it.each([
+      ['muse-spark-1.2-max', 'muse-spark-1.3', 'max'],
+      ['muse-spark-1.2-ultra', 'muse-spark-1.3', 'max'],
+      ['muse-spark-1.2-xhigh', 'muse-spark-1.3', 'xhigh'],
+      ['muse-spark-1.2-low', 'muse-spark-1.3', 'low'],
+      ['muse-spark-1.2-contributor-max', 'muse-spark-1.3-contributor', 'max'],
+      ['muse-spark-1.2-contributor-ultra', 'muse-spark-1.3-contributor', 'max'],
+      ['muse-spark-1.2-contributor-xhigh', 'muse-spark-1.3-contributor', 'xhigh'],
+      ['muse-spark-1.2-contributor-low', 'muse-spark-1.3-contributor', 'low']
+    ])('upgrades the 1.2 id %s in place to %s at effort %s', (legacyId, cliModel, effort) => {
+      // 1.3 is priced identically to 1.2 and strictly better, so saved councils
+      // and configs upgrade to the 1.3 twin at the same reasoning effort.
+      expect(new MuseProvider(legacyId).baseArgs).toEqual([
+        'exec', '--json', '--model', cliModel, '--disable-write', '--reasoning-effort', effort
+      ]);
+    });
+
+    it.each([
+      ['muse-spark-1.3-ultra', 'muse-spark-1.3-max'],
+      ['muse-spark-1.3-contributor-ultra', 'muse-spark-1.3-contributor-max'],
+      ['muse-spark-1.2-ultra', 'muse-spark-1.3-max'],
+      ['muse-spark-1.2-contributor-ultra', 'muse-spark-1.3-contributor-max']
+    ])('resolves the gate-closed ultra id %s to %s', (ultraId, maxId) => {
+      // `--reasoning-effort ultra` silently degrades to xhigh behind a closed
+      // feature gate; `max` actually runs, so ultra ids resolve to the max entry.
+      const resolved = MuseProvider.getModels().find(
+        m => m.id === ultraId || m.aliases?.includes(ultraId)
+      );
+      expect(resolved?.id).toBe(maxId);
+      expect(new MuseProvider(ultraId).baseArgs).toContain('max');
+      expect(new MuseProvider(ultraId).baseArgs).not.toContain('ultra');
+    });
+
+    it('resolves every 1.2 built-in id to a 1.3 twin at the same reasoning effort', () => {
+      // Every id the provider previously shipped must still resolve, and to the
+      // same effort it used to run at (ultra excepted — see above).
+      const models = MuseProvider.getModels();
+      const resolve = (id) => models.find(m => m.id === id || m.aliases?.includes(id));
+      for (const model of models) {
+        const legacyId = model.id.replace('muse-spark-1.3', 'muse-spark-1.2');
+        const twin = resolve(legacyId);
+        expect(twin?.id).toBe(model.id);
+        expect(twin.extra_args).toEqual(model.extra_args);
+      }
+    });
+
+    it('keeps every alias unique across the built-in ids and aliases', () => {
+      const seen = new Set();
+      for (const model of MuseProvider.getModels()) {
+        for (const key of [model.id, ...(model.aliases || [])]) {
+          expect(seen.has(key)).toBe(false);
+          seen.add(key);
+        }
+      }
     });
 
     it('passes --disable-write but no approval or sandbox flags outside yolo mode', () => {
@@ -390,7 +467,7 @@ describe('MuseProvider', () => {
       // (no tool runs, no terminal record emitted), so it must never appear.
       // `--disable-write` blocks the write_file tool; shell stays enabled because
       // analysis needs grep/find and the bundled git-diff-lines helper.
-      const args = new MuseProvider('muse-spark-1.2-high').baseArgs;
+      const args = new MuseProvider('muse-spark-1.3-high').baseArgs;
       expect(args).toContain('--disable-write');
       expect(args).not.toContain('--yolo');
       expect(args).not.toContain('--approval-mode');
@@ -400,9 +477,9 @@ describe('MuseProvider', () => {
     });
 
     it('passes --yolo instead of --disable-write in yolo mode', () => {
-      const args = new MuseProvider('muse-spark-1.2-high', { yolo: true }).baseArgs;
+      const args = new MuseProvider('muse-spark-1.3-high', { yolo: true }).baseArgs;
       expect(args).toEqual([
-        'exec', '--json', '--model', 'muse-spark-1.2', '--yolo', '--reasoning-effort', 'high'
+        'exec', '--json', '--model', 'muse-spark-1.3', '--yolo', '--reasoning-effort', 'high'
       ]);
       expect(args).not.toContain('--disable-write');
     });
@@ -410,7 +487,7 @@ describe('MuseProvider', () => {
     it('fully locks down the extraction path, which needs no tools', () => {
       // Unlike analysis, extraction only reformats captured text into JSON, so it
       // gets no filesystem and no shell — mirroring Codex's read-only extraction.
-      const args = new MuseProvider('muse-spark-1.2-high').buildArgsForModel('muse-spark-1.2-low');
+      const args = new MuseProvider('muse-spark-1.3-high').buildArgsForModel('muse-spark-1.3-low');
       expect(args).toContain('--disable-write');
       expect(args).toContain('--disable-shell');
     });
@@ -432,39 +509,39 @@ describe('MuseProvider', () => {
     it('appends provider-level extra_args exactly once', () => {
       // Regression: _resolveModelConfig already merges provider extra_args, so
       // splicing configOverrides.extra_args separately duplicated every flag.
-      const provider = new MuseProvider('muse-spark-1.2-high', {
+      const provider = new MuseProvider('muse-spark-1.3-high', {
         extra_args: ['--disable-web-tools']
       });
       const occurrences = provider.baseArgs.filter(a => a === '--disable-web-tools');
       expect(occurrences).toHaveLength(1);
       expect(provider.baseArgs).toEqual([
-        'exec', '--json', '--model', 'muse-spark-1.2', '--disable-write',
+        'exec', '--json', '--model', 'muse-spark-1.3', '--disable-write',
         '--reasoning-effort', 'high', '--disable-web-tools'
       ]);
     });
 
     it('merges extra_args from built-in, provider config, and per-model config in order', () => {
-      const provider = new MuseProvider('muse-spark-1.2-high', {
+      const provider = new MuseProvider('muse-spark-1.3-high', {
         extra_args: ['--provider-flag'],
-        models: [{ id: 'muse-spark-1.2-high', tier: 'balanced', extra_args: ['--model-flag'] }]
+        models: [{ id: 'muse-spark-1.3-high', tier: 'balanced', extra_args: ['--model-flag'] }]
       });
       expect(provider.baseArgs).toEqual([
-        'exec', '--json', '--model', 'muse-spark-1.2', '--disable-write',
+        'exec', '--json', '--model', 'muse-spark-1.3', '--disable-write',
         '--reasoning-effort', 'high', '--provider-flag', '--model-flag'
       ]);
     });
 
     it('lets a per-model cli_model override the built-in one', () => {
-      const provider = new MuseProvider('muse-spark-1.2-high', {
-        models: [{ id: 'muse-spark-1.2-high', tier: 'balanced', cli_model: 'muse-spark-1.2-contributor' }]
+      const provider = new MuseProvider('muse-spark-1.3-high', {
+        models: [{ id: 'muse-spark-1.3-high', tier: 'balanced', cli_model: 'muse-spark-1.3-contributor' }]
       });
-      expect(provider.baseArgs).toContain('muse-spark-1.2-contributor');
+      expect(provider.baseArgs).toContain('muse-spark-1.3-contributor');
     });
 
     it('merges env with per-model config winning over provider config', () => {
-      const provider = new MuseProvider('muse-spark-1.2-high', {
+      const provider = new MuseProvider('muse-spark-1.3-high', {
         env: { SHARED: 'provider', ONLY_PROVIDER: 'yes' },
-        models: [{ id: 'muse-spark-1.2-high', tier: 'balanced', env: { SHARED: 'model' } }]
+        models: [{ id: 'muse-spark-1.3-high', tier: 'balanced', env: { SHARED: 'model' } }]
       });
       expect(provider.extraEnv).toEqual({ SHARED: 'model', ONLY_PROVIDER: 'yes' });
     });
@@ -472,13 +549,47 @@ describe('MuseProvider', () => {
     it('defaults extraEnv to an empty object', () => {
       expect(new MuseProvider().extraEnv).toEqual({});
     });
+
+    it('applies a per-model override keyed under a retired 1.2 alias when constructed with the 1.3 id', () => {
+      // Regression: the override lookup used to be exact-id only, so a config
+      // written against muse-spark-1.2-high was silently dropped once the
+      // built-in id moved to 1.3.
+      const provider = new MuseProvider('muse-spark-1.3-high', {
+        models: [{
+          id: 'muse-spark-1.2-high',
+          tier: 'balanced',
+          cli_model: 'muse-spark-custom',
+          extra_args: ['--legacy-flag'],
+          env: { LEGACY: 'yes' }
+        }]
+      });
+      expect(provider.baseArgs).toContain('muse-spark-custom');
+      expect(provider.baseArgs).not.toContain('muse-spark-1.3');
+      expect(provider.baseArgs).toContain('--legacy-flag');
+      expect(provider.extraEnv).toEqual({ LEGACY: 'yes' });
+    });
+
+    it('applies a per-model override keyed under the 1.3 id when constructed with a retired 1.2 alias', () => {
+      const provider = new MuseProvider('muse-spark-1.2-high', {
+        models: [{
+          id: 'muse-spark-1.3-high',
+          tier: 'balanced',
+          cli_model: 'muse-spark-custom',
+          extra_args: ['--new-flag'],
+          env: { CURRENT: 'yes' }
+        }]
+      });
+      expect(provider.baseArgs).toContain('muse-spark-custom');
+      expect(provider.baseArgs).toContain('--new-flag');
+      expect(provider.extraEnv).toEqual({ CURRENT: 'yes' });
+    });
   });
 
   describe('getAnalysisSpawnConfig', () => {
     it('returns the bare command and args in non-shell mode', () => {
-      expect(new MuseProvider('muse-spark-1.2-high').getAnalysisSpawnConfig()).toEqual({
+      expect(new MuseProvider('muse-spark-1.3-high').getAnalysisSpawnConfig()).toEqual({
         command: 'muse',
-        args: ['exec', '--json', '--model', 'muse-spark-1.2', '--disable-write', '--reasoning-effort', 'high'],
+        args: ['exec', '--json', '--model', 'muse-spark-1.3', '--disable-write', '--reasoning-effort', 'high'],
         useShell: false
       });
     });
@@ -488,10 +599,10 @@ describe('MuseProvider', () => {
       // `[...baseArgs, ...trailingArgs]` trivially satisfies the invariant even
       // if merged args could land after the pair. These are the args that could
       // realistically be appended too late.
-      const provider = new MuseProvider('muse-spark-1.2-high', {
+      const provider = new MuseProvider('muse-spark-1.3-high', {
         extra_args: ['--provider-flag', 'pv'],
         models: [{
-          id: 'muse-spark-1.2-high',
+          id: 'muse-spark-1.3-high',
           tier: 'balanced',
           extra_args: ['--model-flag', 'mv']
         }]
@@ -516,25 +627,25 @@ describe('MuseProvider', () => {
     });
 
     it('folds args into the command string in shell mode', () => {
-      const result = new MuseProvider('muse-spark-1.2-high', { command: 'devx muse --' })
+      const result = new MuseProvider('muse-spark-1.3-high', { command: 'devx muse --' })
         .getAnalysisSpawnConfig(['--prompt-file', '/tmp/x/prompt.txt']);
       expect(result.useShell).toBe(true);
       expect(result.args).toEqual([]);
       // quoteShellArgs only quotes args carrying shell-special characters, so a
       // plain path stays bare; the space-bearing case is covered below.
       expect(result.command).toBe(
-        'devx muse -- exec --json --model muse-spark-1.2 --disable-write --reasoning-effort high --prompt-file /tmp/x/prompt.txt'
+        'devx muse -- exec --json --model muse-spark-1.3 --disable-write --reasoning-effort high --prompt-file /tmp/x/prompt.txt'
       );
     });
 
     it('shell-quotes paths containing spaces', () => {
-      const { command } = new MuseProvider('muse-spark-1.2-high', { command: 'devx muse --' })
+      const { command } = new MuseProvider('muse-spark-1.3-high', { command: 'devx muse --' })
         .getAnalysisSpawnConfig(['--prompt-file', '/tmp/a b/prompt.txt']);
       expect(command).toContain("'/tmp/a b/prompt.txt'");
     });
 
     it('shell-quotes a positional prompt containing an apostrophe', () => {
-      const { command } = new MuseProvider('muse-spark-1.2-high', { command: 'devx muse --' })
+      const { command } = new MuseProvider('muse-spark-1.3-high', { command: 'devx muse --' })
         .getAnalysisSpawnConfig(["it's a prompt"]);
       expect(command).toContain("'it'\\''s a prompt'");
     });
@@ -552,27 +663,27 @@ describe('MuseProvider', () => {
       // Identical model, deliberately different safety posture: analysis keeps
       // shell so the model can run grep/find and git-diff-lines, while
       // extraction only reformats captured text and so gets no tools at all.
-      const provider = new MuseProvider('muse-spark-1.2-high');
+      const provider = new MuseProvider('muse-spark-1.3-high');
       expect(provider.baseArgs).toEqual([
-        'exec', '--json', '--model', 'muse-spark-1.2', '--disable-write', '--reasoning-effort', 'high'
+        'exec', '--json', '--model', 'muse-spark-1.3', '--disable-write', '--reasoning-effort', 'high'
       ]);
-      expect(provider.buildArgsForModel('muse-spark-1.2-high')).toEqual([
-        'exec', '--json', '--model', 'muse-spark-1.2', '--disable-write', '--disable-shell', '--reasoning-effort', 'high'
+      expect(provider.buildArgsForModel('muse-spark-1.3-high')).toEqual([
+        'exec', '--json', '--model', 'muse-spark-1.3', '--disable-write', '--disable-shell', '--reasoning-effort', 'high'
       ]);
     });
 
     it('resolves a different extraction model', () => {
-      expect(new MuseProvider('muse-spark-1.2-ultra').buildArgsForModel('muse-spark-1.2-low'))
-        .toEqual(['exec', '--json', '--model', 'muse-spark-1.2', '--disable-write', '--disable-shell', '--reasoning-effort', 'low']);
+      expect(new MuseProvider('muse-spark-1.3-max').buildArgsForModel('muse-spark-1.3-low'))
+        .toEqual(['exec', '--json', '--model', 'muse-spark-1.3', '--disable-write', '--disable-shell', '--reasoning-effort', 'low']);
     });
 
     it('carries yolo through to extraction', () => {
-      expect(new MuseProvider('muse-spark-1.2-high', { yolo: true }).buildArgsForModel('muse-spark-1.2-low'))
+      expect(new MuseProvider('muse-spark-1.3-high', { yolo: true }).buildArgsForModel('muse-spark-1.3-low'))
         .toContain('--yolo');
     });
 
     it('never appends a prompt marker', () => {
-      const args = new MuseProvider().buildArgsForModel('muse-spark-1.2-low');
+      const args = new MuseProvider().buildArgsForModel('muse-spark-1.3-low');
       expect(args).not.toContain('--prompt-file');
       expect(args).not.toContain('-');
     });
@@ -584,18 +695,18 @@ describe('MuseProvider', () => {
       // one fails the spawn with E2BIG. `muse exec` never reads stdin (exits 2
       // with "missing prompt"), and the helper's promptViaFile mode appends
       // Pi's `@<path>` syntax, which muse would read as literal prompt text.
-      const config = new MuseProvider().getExtractionConfig('muse-spark-1.2-low');
+      const config = new MuseProvider().getExtractionConfig('muse-spark-1.3-low');
       expect(config.promptFileArg).toBe('--prompt-file');
       expect(config.promptViaStdin).toBe(false);
       expect(config.promptViaFile).toBeUndefined();
     });
 
     it('returns the command and args for non-shell mode', () => {
-      const config = new MuseProvider().getExtractionConfig('muse-spark-1.2-low');
+      const config = new MuseProvider().getExtractionConfig('muse-spark-1.3-low');
       expect(config.command).toBe('muse');
       expect(config.useShell).toBe(false);
       expect(config.args).toEqual([
-        'exec', '--json', '--model', 'muse-spark-1.2', '--disable-write', '--disable-shell', '--reasoning-effort', 'low'
+        'exec', '--json', '--model', 'muse-spark-1.3', '--disable-write', '--disable-shell', '--reasoning-effort', 'low'
       ]);
     });
 
@@ -606,14 +717,14 @@ describe('MuseProvider', () => {
       // re-parsed as shell syntax. The prompt now goes via --prompt-file, but
       // shell mode must STAY off: this spawn is not detached, so a cancel would
       // kill only the shell wrapper and orphan the CLI.
-      const config = new MuseProvider('muse-spark-1.2-high', { command: 'devx muse --' })
-        .getExtractionConfig('muse-spark-1.2-low');
+      const config = new MuseProvider('muse-spark-1.3-high', { command: 'devx muse --' })
+        .getExtractionConfig('muse-spark-1.3-low');
 
       expect(config.useShell).toBe(false);
       expect(config.command).toBe('devx');
       expect(config.args).toEqual([
         'muse', '--',
-        'exec', '--json', '--model', 'muse-spark-1.2', '--disable-write', '--disable-shell',
+        'exec', '--json', '--model', 'muse-spark-1.3', '--disable-write', '--disable-shell',
         '--reasoning-effort', 'low'
       ]);
       expect(config.promptViaStdin).toBe(false);
@@ -625,8 +736,8 @@ describe('MuseProvider', () => {
     });
 
     it('splits a plain multi-word command into a leading command plus argv words', () => {
-      const config = new MuseProvider('muse-spark-1.2-high', { command: 'docker exec container muse' })
-        .getExtractionConfig('muse-spark-1.2-low');
+      const config = new MuseProvider('muse-spark-1.3-high', { command: 'docker exec container muse' })
+        .getExtractionConfig('muse-spark-1.3-low');
       expect(config.useShell).toBe(false);
       expect(config.command).toBe('docker');
       expect(config.args.slice(0, 3)).toEqual(['exec', 'container', 'muse']);
@@ -638,9 +749,9 @@ describe('MuseProvider', () => {
       // installed-app path survives as one word rather than three. The trailing
       // word is deliberately NOT `exec`: the constructor strips that, which
       // would leave `args[0] === 'exec'` true no matter how the split behaved.
-      const config = new MuseProvider('muse-spark-1.2-high', {
+      const config = new MuseProvider('muse-spark-1.3-high', {
         command: '"/Applications/My Tools/muse" --workspace-trust'
-      }).getExtractionConfig('muse-spark-1.2-low');
+      }).getExtractionConfig('muse-spark-1.3-low');
       expect(config.command).toBe('/Applications/My Tools/muse');
       expect(config.args[0]).toBe('--workspace-trust');
       expect(config.args[1]).toBe('exec');
@@ -650,8 +761,8 @@ describe('MuseProvider', () => {
     it('drops empty quoted words instead of emitting them as argv elements', () => {
       // An empty argv element reaches muse as an empty positional prompt, and a
       // leading one would become spawn('').
-      const config = new MuseProvider('muse-spark-1.2-high', { command: 'devx "" muse' })
-        .getExtractionConfig('muse-spark-1.2-low');
+      const config = new MuseProvider('muse-spark-1.3-high', { command: 'devx "" muse' })
+        .getExtractionConfig('muse-spark-1.3-low');
       expect(config.command).toBe('devx');
       expect(config.args.slice(0, 2)).toEqual(['muse', 'exec']);
       expect(config.args).not.toContain('');
@@ -661,33 +772,33 @@ describe('MuseProvider', () => {
       ['devx "muse --', 'double'],
       ["devx 'muse --", 'single']
     ])('throws a named error for the unterminated %s quote rather than gluing the words together', (command, kind) => {
-      const provider = new MuseProvider('muse-spark-1.2-high', { command });
-      expect(() => provider.getExtractionConfig('muse-spark-1.2-low'))
+      const provider = new MuseProvider('muse-spark-1.3-high', { command });
+      expect(() => provider.getExtractionConfig('muse-spark-1.3-low'))
         .toThrow(new RegExp(`unterminated ${kind} quote`));
     });
 
     it('throws rather than spawning an empty command name when only quotes were configured', () => {
-      const provider = new MuseProvider('muse-spark-1.2-high', { command: '""' });
-      expect(() => provider.getExtractionConfig('muse-spark-1.2-low'))
+      const provider = new MuseProvider('muse-spark-1.3-high', { command: '""' });
+      expect(() => provider.getExtractionConfig('muse-spark-1.3-low'))
         .toThrow(/Muse command is empty/);
     });
 
     it('still spawns a single-word command directly, with no argv prefix', () => {
-      const config = new MuseProvider('muse-spark-1.2-high', { command: '/opt/muse' })
-        .getExtractionConfig('muse-spark-1.2-low');
+      const config = new MuseProvider('muse-spark-1.3-high', { command: '/opt/muse' })
+        .getExtractionConfig('muse-spark-1.3-low');
       expect(config.command).toBe('/opt/muse');
       expect(config.args[0]).toBe('exec');
     });
 
     it('surfaces the merged env for the extraction model', () => {
-      const config = new MuseProvider('muse-spark-1.2-high', { env: { TOKEN: 'x' } })
-        .getExtractionConfig('muse-spark-1.2-low');
+      const config = new MuseProvider('muse-spark-1.3-high', { env: { TOKEN: 'x' } })
+        .getExtractionConfig('muse-spark-1.3-low');
       expect(config.env).toEqual({ TOKEN: 'x' });
     });
 
     it('honours a custom command from the environment', () => {
       process.env.PAIR_REVIEW_MUSE_CMD = '/env/muse';
-      expect(new MuseProvider().getExtractionConfig('muse-spark-1.2-low').command).toBe('/env/muse');
+      expect(new MuseProvider().getExtractionConfig('muse-spark-1.3-low').command).toBe('/env/muse');
     });
 
     // End to end through the shared helper: config fields alone can't prove the
@@ -708,7 +819,7 @@ describe('MuseProvider', () => {
       // The prompt text itself never becomes an argv word — that is the E2BIG fix.
       expect(args.some(a => a.includes('Extract the JSON object'))).toBe(false);
       // Extraction runs on the fast, non-data-sharing model.
-      expect(args[args.indexOf('--model') + 1]).toBe('muse-spark-1.2');
+      expect(args[args.indexOf('--model') + 1]).toBe('muse-spark-1.3');
 
       child.stdout.emit('data', Buffer.from('{"findings": []}'));
       child.emit('close', 0);
@@ -932,7 +1043,7 @@ describe('MuseProvider', () => {
       // were the review — turning a failed run into a false success.
       const stdout = [
         record('run.lifecycle.started', { kind: 'run_started', run_id: 'r1' }),
-        record('run.model.configured', { model_id: 'muse-spark-1.2' }),
+        record('run.model.configured', { model_id: 'muse-spark-1.3' }),
         terminalRecord('failed', '', 'server_error: The model failed to generate a response.')
       ].join('\n');
 
@@ -995,6 +1106,12 @@ describe('MuseProvider', () => {
       expect(new MuseProvider().isUnknownModelError('model is hidden in the catalog')).toBe(true);
     });
 
+    it('detects the current CLI wording: does not exist or you lack access', () => {
+      expect(new MuseProvider().isUnknownModelError(
+        'model `muse-spark-9` does not exist or you lack access'
+      )).toBe(true);
+    });
+
     it('ignores unrelated errors', () => {
       expect(new MuseProvider().isUnknownModelError('some other failure')).toBe(false);
       expect(new MuseProvider().isUnknownModelError(undefined)).toBe(false);
@@ -1011,11 +1128,20 @@ describe('MuseProvider', () => {
     });
 
     it('produces an actionable message for an unknown model', () => {
-      const error = new MuseProvider('muse-spark-1.2-high').createExitError(
+      const error = new MuseProvider('muse-spark-1.3-high').createExitError(
         1, 'model `totally-not-a-model` is not in the catalog', '[Level 1]'
       );
-      expect(error.message).toContain('unknown');
-      expect(error.message).toContain('muse-spark-1.2-high');
+      expect(error.message).toContain('unknown or inaccessible');
+      expect(error.message).toContain('muse-spark-1.3-high');
+    });
+
+    it('produces the same actionable message for the current "does not exist or you lack access" wording', () => {
+      const error = new MuseProvider('muse-spark-1.3-high').createExitError(
+        1, 'model `totally-not-a-model` does not exist or you lack access', '[Level 1]'
+      );
+      expect(error.message).toContain('unknown or inaccessible');
+      expect(error.message).toContain('muse-spark-1.3-high');
+      expect(error.message).toContain('does not exist or you lack access');
     });
 
     it('surfaces the terminal reason when stderr is unhelpful', () => {
@@ -1142,10 +1268,10 @@ describe('MuseProvider', () => {
     it('logs the configured model', () => {
       logger.setStreamDebugEnabled(true);
       new MuseProvider().logStreamLine(
-        record('run.model.configured', { model_id: 'muse-spark-1.2', display_label: 'muse-spark-1.2' }),
+        record('run.model.configured', { model_id: 'muse-spark-1.3', display_label: 'muse-spark-1.3' }),
         6, '[Level 1]'
       );
-      expect(logger.streamDebug).toHaveBeenCalledWith(expect.stringContaining('muse-spark-1.2'));
+      expect(logger.streamDebug).toHaveBeenCalledWith(expect.stringContaining('muse-spark-1.3'));
     });
 
     it('logs a tool result with its outcome', () => {
@@ -1198,7 +1324,7 @@ describe('MuseProvider', () => {
       const child = makeFakeChild();
       mockSpawn.mockReturnValue(child);
 
-      const promise = new MuseProvider('muse-spark-1.2-high', { command: 'devx muse --' })
+      const promise = new MuseProvider('muse-spark-1.3-high', { command: 'devx muse --' })
         .testAvailability(10000);
 
       const [command, args, options] = mockSpawn.mock.lastCall;
@@ -1217,9 +1343,9 @@ describe('MuseProvider', () => {
       const child = makeFakeChild();
       mockSpawn.mockReturnValue(child);
 
-      const promise = new MuseProvider('muse-spark-1.2-high', {
+      const promise = new MuseProvider('muse-spark-1.3-high', {
         env: { META_API_KEY: 'provider-key' },
-        models: [{ id: 'muse-spark-1.2-high', tier: 'balanced', env: { MUSE_ENDPOINT: 'internal' } }]
+        models: [{ id: 'muse-spark-1.3-high', tier: 'balanced', env: { MUSE_ENDPOINT: 'internal' } }]
       }).testAvailability(10000);
 
       const [, , options] = mockSpawn.mock.lastCall;
@@ -1323,7 +1449,7 @@ describe('MuseProvider', () => {
       const child = makeFakeChild();
       mockSpawn.mockReturnValue(child);
 
-      const promise = new MuseProvider('muse-spark-1.2-high')
+      const promise = new MuseProvider('muse-spark-1.3-high')
         .execute('analyse this diff', { level: 1, timeout: 300000 });
 
       expect(promptDirs).toHaveLength(1);
@@ -1345,7 +1471,7 @@ describe('MuseProvider', () => {
       const child = makeFakeChild();
       mockSpawn.mockReturnValue(child);
 
-      const promise = new MuseProvider('muse-spark-1.2-high').execute('prompt', { level: 1, timeout: 300000 });
+      const promise = new MuseProvider('muse-spark-1.3-high').execute('prompt', { level: 1, timeout: 300000 });
 
       // muse's stderr only says the run failed; the reason lives in the JSONL.
       child.stderr.emit('data', 'run ended with Failed\n');
@@ -1367,7 +1493,7 @@ describe('MuseProvider', () => {
 
       vi.useFakeTimers();
       try {
-        const promise = new MuseProvider('muse-spark-1.2-high').execute('prompt', { level: 1, timeout: 1000 });
+        const promise = new MuseProvider('muse-spark-1.3-high').execute('prompt', { level: 1, timeout: 1000 });
         // Attach the rejection handler BEFORE advancing, so the rejection is
         // never momentarily unhandled.
         const failure = settledError(promise);
@@ -1387,7 +1513,7 @@ describe('MuseProvider', () => {
     it('reports install instructions and cleans up the temp file when the CLI is missing', async () => {
       const promptDirs = trackPromptDirs();
       // Deliberately a real spawn: this exercises Node's own ENOENT path.
-      const provider = new MuseProvider('muse-spark-1.2-high', {
+      const provider = new MuseProvider('muse-spark-1.3-high', {
         command: '/nonexistent/definitely-not-muse'
       });
 
@@ -1417,7 +1543,7 @@ describe('MuseProvider', () => {
       mockSpawn.mockReturnValue(child);
 
       const error = await settledError(
-        new MuseProvider('muse-spark-1.2-high').execute('prompt', {
+        new MuseProvider('muse-spark-1.3-high').execute('prompt', {
           level: 1,
           timeout: 300000,
           abortSignal: AbortSignal.abort()
@@ -1447,7 +1573,7 @@ describe('MuseProvider', () => {
       });
 
       const error = await settledError(
-        new MuseProvider('muse-spark-1.2-high').execute('prompt', { level: 1, timeout: 300000 })
+        new MuseProvider('muse-spark-1.3-high').execute('prompt', { level: 1, timeout: 300000 })
       );
 
       expect(error.message).toMatch(/Failed to write Muse prompt file/);
@@ -1460,13 +1586,13 @@ describe('MuseProvider', () => {
       const promptDirs = trackPromptDirs();
       const child = makeFakeChild();
       mockSpawn.mockReturnValue(child);
-      const provider = new MuseProvider('muse-spark-1.2-high');
+      const provider = new MuseProvider('muse-spark-1.3-high');
       const llmFallback = vi.spyOn(provider, 'extractJSONWithLLM');
 
       const promise = provider.execute('prompt', { level: 1, timeout: 300000 });
       const stdout = [
         record('run.lifecycle.started', { kind: 'run_started', run_id: 'r1' }),
-        record('run.model.configured', { model_id: 'muse-spark-1.2' }),
+        record('run.model.configured', { model_id: 'muse-spark-1.3' }),
         terminalRecord('completed', '')
       ].join('\n') + '\n';
       child.stdout.emit('data', stdout);
@@ -1501,7 +1627,7 @@ describe('MuseProvider', () => {
       const promptDirs = trackPromptDirs();
       const child = makeFakeChild();
       mockSpawn.mockReturnValue(child);
-      const provider = new MuseProvider('muse-spark-1.2-high');
+      const provider = new MuseProvider('muse-spark-1.3-high');
       const llmFallback = vi.spyOn(provider, 'extractJSONWithLLM')
         .mockResolvedValue({ success: true, data: { suggestions: [] } });
       const controller = new AbortController();
@@ -1529,7 +1655,7 @@ describe('MuseProvider', () => {
       const promptDirs = trackPromptDirs();
       const child = makeFakeChild();
       mockSpawn.mockReturnValue(child);
-      const provider = new MuseProvider('muse-spark-1.2-high');
+      const provider = new MuseProvider('muse-spark-1.3-high');
       const controller = new AbortController();
       vi.spyOn(provider, 'extractJSONWithLLM').mockImplementation(async () => {
         controller.abort();
@@ -1556,7 +1682,7 @@ describe('MuseProvider', () => {
       const promptDirs = trackPromptDirs();
       const child = makeFakeChild();
       mockSpawn.mockReturnValue(child);
-      const provider = new MuseProvider('muse-spark-1.2-high');
+      const provider = new MuseProvider('muse-spark-1.3-high');
       const controller = new AbortController();
       vi.spyOn(provider, 'extractJSONWithLLM').mockImplementation(async () => {
         controller.abort();
@@ -1581,7 +1707,7 @@ describe('MuseProvider', () => {
       const promptDirs = trackPromptDirs();
       const child = makeFakeChild();
       mockSpawn.mockReturnValue(child);
-      const provider = new MuseProvider('muse-spark-1.2-high');
+      const provider = new MuseProvider('muse-spark-1.3-high');
       vi.spyOn(provider, 'extractJSONWithLLM').mockRejectedValue(new Error('extraction CLI blew up'));
 
       const promise = provider.execute('prompt', { level: 1, timeout: 300000 });
@@ -1627,7 +1753,7 @@ describe('MuseProvider', () => {
       const child = makeFakeChild();
       mockSpawn.mockReturnValue(child);
 
-      const provider = new MuseProvider('muse-spark-1.2-high', { command: 'devx muse --' });
+      const provider = new MuseProvider('muse-spark-1.3-high', { command: 'devx muse --' });
       expect(provider.useShell).toBe(true);
 
       vi.useFakeTimers();
@@ -1666,7 +1792,7 @@ describe('MuseProvider', () => {
       // Deliberately NOT a pre-aborted signal: execute() returns before spawning
       // for that, so no kill of any kind would be dispatched.
       const controller = new AbortController();
-      const promise = new MuseProvider('muse-spark-1.2-high', { command: 'devx muse --' })
+      const promise = new MuseProvider('muse-spark-1.3-high', { command: 'devx muse --' })
         .execute('prompt', { level: 1, timeout: 300000, abortSignal: controller.signal });
       const failure = settledError(promise);
 
@@ -1693,7 +1819,7 @@ describe('MuseProvider', () => {
       mockSpawn.mockReturnValue(child);
 
       const controller = new AbortController();
-      const promise = new MuseProvider('muse-spark-1.2-high')
+      const promise = new MuseProvider('muse-spark-1.3-high')
         .execute('prompt', { level: 1, timeout: 300000, abortSignal: controller.signal });
       const failure = settledError(promise);
 

--- a/tests/unit/provider-config.test.js
+++ b/tests/unit/provider-config.test.js
@@ -259,15 +259,25 @@ describe('Provider Configuration', () => {
     });
 
     it('should resolve tier by canonical model id', () => {
-      expect(getTierForModel('codex', 'gpt-5.4-high')).toBe('thorough');
+      expect(getTierForModel('codex', 'gpt-6-astra-high')).toBe('thorough');
+      expect(getTierForModel('codex', 'gpt-5.4-mini')).toBe('fast');
     });
 
     it('should resolve tier via aliases for legacy model ids', () => {
-      // Regression: `gpt-5.4` was the pre-migration model ID stored in the
-      // analysis_runs table before reasoning-effort variants existed.
-      // It must keep resolving to 'thorough' via the alias on `gpt-5.4-high`
-      // so historical runs get their tier backfilled correctly.
-      expect(getTierForModel('codex', 'gpt-5.4')).toBe('thorough');
+      // Claude keeps `opus` as an alias of its canonical opus variant so
+      // historical analysis_runs rows get their tier backfilled correctly.
+      const models = getProviderClass('claude').getModels();
+      const aliased = models.find(m => m.aliases?.includes('opus'));
+      expect(aliased).toBeDefined();
+      expect(getTierForModel('claude', 'opus')).toBe(aliased.tier);
+    });
+
+    it('should return null for retired codex ids (no alias by design)', () => {
+      // gpt-5.4 / gpt-5.4-high / gpt-5.3-codex were retired by OpenAI (Aug
+      // 2026) and are intentionally not aliased onto surviving models.
+      expect(getTierForModel('codex', 'gpt-5.4')).toBeNull();
+      expect(getTierForModel('codex', 'gpt-5.4-high')).toBeNull();
+      expect(getTierForModel('codex', 'gpt-5.3-codex')).toBeNull();
     });
 
     it('should return null for unknown models', () => {
@@ -1522,23 +1532,23 @@ describe('Provider Configuration', () => {
     });
 
     it('moves the default off a disabled model', () => {
-      // claude's built-in default is 'opus-4.8-xhigh'; disable it and the resolver picks another
+      // claude's built-in default is 'opus-5-high'; disable it and the resolver picks another
       applyConfigOverrides({
-        providers: { claude: { disabled_models: ['opus-4.8-xhigh'] } }
+        providers: { claude: { disabled_models: ['opus-5-high'] } }
       });
       const claude = getAllProvidersInfo().find(p => p.id === 'claude');
-      expect(claude.models.find(m => m.id === 'opus-4.8-xhigh')).toBeUndefined();
-      expect(claude.defaultModel).not.toBe('opus-4.8-xhigh');
+      expect(claude.models.find(m => m.id === 'opus-5-high')).toBeUndefined();
+      expect(claude.defaultModel).not.toBe('opus-5-high');
       // The resolved default must be one of the still-available models
       expect(claude.models.find(m => m.id === claude.defaultModel)).toBeDefined();
     });
 
     it('does not pick a disabled model as the default in createProvider', () => {
       applyConfigOverrides({
-        providers: { claude: { disabled_models: ['opus-4.8-xhigh'] } }
+        providers: { claude: { disabled_models: ['opus-5-high'] } }
       });
       const provider = createProvider('claude');
-      expect(provider.model).not.toBe('opus-4.8-xhigh');
+      expect(provider.model).not.toBe('opus-5-high');
     });
 
     it('wires disabled_models and default_model onto executable provider overrides', () => {
@@ -1612,8 +1622,8 @@ describe('Provider Configuration', () => {
         providers: { claude: { default_model: 'no-such-model' } }
       });
       const claude = getAllProvidersInfo().find(p => p.id === 'claude');
-      // Falls back to the built-in default ('opus-4.8-xhigh')
-      expect(claude.defaultModel).toBe('opus-4.8-xhigh');
+      // Falls back to the built-in default ('opus-5-high')
+      expect(claude.defaultModel).toBe('opus-5-high');
     });
 
     it('falls back to automatic default when default_model is also disabled', () => {
@@ -1647,7 +1657,7 @@ describe('Provider Configuration', () => {
 
     it('normalizes per-model default flags so models.find(m => m.default) agrees with default_model', () => {
       // 'sonnet-4.6' does not carry a legacy default:true flag; the built-in
-      // default ('opus-4.8-xhigh') does. After resolving default_model, exactly one model
+      // default ('opus-5-high') does. After resolving default_model, exactly one model
       // — the targeted one — should be flagged default:true.
       applyConfigOverrides({
         providers: { claude: { default_model: 'sonnet-4.6' } }

--- a/tests/unit/provider-model.test.js
+++ b/tests/unit/provider-model.test.js
@@ -21,8 +21,8 @@ const PROVIDERS = [
   },
   {
     id: 'antigravity',
-    defaultModel: 'gemini-3.1-pro-low',
-    models: [{ id: 'gemini-3.1-pro-low' }, { id: 'gemini-3.5-flash-low' }]
+    defaultModel: 'gemini-3.8-flash-high',
+    models: [{ id: 'gemini-3.8-flash-high' }, { id: 'gemini-3.1-pro-low' }, { id: 'gemini-3.8-flash-low' }]
   }
 ];
 
@@ -34,13 +34,13 @@ describe('resolveProviderModelPair', () => {
 
   it('derives the model from the provider when the scope omits the model', () => {
     expect(resolveProviderModelPair([{ provider: 'antigravity', model: null }], PROVIDERS))
-      .toEqual({ provider: 'antigravity', model: 'gemini-3.1-pro-low' });
+      .toEqual({ provider: 'antigravity', model: 'gemini-3.8-flash-high' });
   });
 
   it('replaces a foreign model with the provider default instead of mixing halves', () => {
     // antigravity provider paired with an Anthropic model — must not be returned as-is.
     expect(resolveProviderModelPair([{ provider: 'antigravity', model: 'opus' }], PROVIDERS))
-      .toEqual({ provider: 'antigravity', model: 'gemini-3.1-pro-low' });
+      .toEqual({ provider: 'antigravity', model: 'gemini-3.8-flash-high' });
   });
 
   it('does not mix a provider from one scope with a model from another', () => {
@@ -50,12 +50,12 @@ describe('resolveProviderModelPair', () => {
       { provider: 'claude', model: 'opus' }
     ];
     expect(resolveProviderModelPair(scopes, PROVIDERS))
-      .toEqual({ provider: 'antigravity', model: 'gemini-3.1-pro-low' });
+      .toEqual({ provider: 'antigravity', model: 'gemini-3.8-flash-high' });
   });
 
   it('attributes a model-only scope to whichever provider owns the model', () => {
-    expect(resolveProviderModelPair([{ provider: null, model: 'gemini-3.5-flash-low' }], PROVIDERS))
-      .toEqual({ provider: 'antigravity', model: 'gemini-3.5-flash-low' });
+    expect(resolveProviderModelPair([{ provider: null, model: 'gemini-3.8-flash-low' }], PROVIDERS))
+      .toEqual({ provider: 'antigravity', model: 'gemini-3.8-flash-low' });
   });
 
   it('keeps a model named by an alias rather than falling back to the default', () => {

--- a/tests/unit/review-config.test.js
+++ b/tests/unit/review-config.test.js
@@ -283,10 +283,10 @@ describe('resolveReviewConfig', () => {
 
     it('falls back to claude with the provider\'s own default model when nothing is configured', async () => {
       // The provider-default rung ranks above the hardcoded 'claude'/'opus'
-      // rescue, so the zero-config case resolves Claude's canonical default id
-      // (of which 'opus' is an alias) — functionally the same model.
+      // rescue, so the zero-config case resolves Claude's built-in default id
+      // (opus-5-high), not the 'opus' alias target (opus-4.8-xhigh).
       const result = await resolveReviewConfig(db, REPOSITORY, {}, {});
-      expect(result).toEqual({ type: 'single', provider: 'claude', model: 'opus-4.8-xhigh' });
+      expect(result).toEqual({ type: 'single', provider: 'claude', model: 'opus-5-high' });
     });
   });
 
@@ -553,12 +553,12 @@ describe('resolveReviewConfig', () => {
       expect(result).toEqual({ type: 'single', provider: 'claude', model: 'sonnet-5-xhigh' });
     });
 
-    it('does not resurrect a disabled default: opus in disabled_models resolves another model', async () => {
-      applyConfigOverrides({ providers: { claude: { disabled_models: ['opus'] } } });
+    it('does not resurrect a disabled default: opus-5-high in disabled_models resolves another model', async () => {
+      applyConfigOverrides({ providers: { claude: { disabled_models: ['opus-5-high'] } } });
 
       const result = await resolveReviewConfig(db, REPOSITORY, { provider: 'claude' }, {});
-      // With the default (opus-4.8-xhigh, alias 'opus') disabled, resolution
-      // falls to the first balanced-tier model in Claude's built-in list.
+      // With the default (opus-5-high) disabled, resolution falls to the
+      // first balanced-tier model in Claude's built-in list.
       expect(result).toEqual({ type: 'single', provider: 'claude', model: 'sonnet-5-xhigh' });
     });
   });
@@ -617,7 +617,7 @@ describe('resolveReviewConfig', () => {
 
     it('defaults explicit and config args to empty objects', async () => {
       const result = await resolveReviewConfig(db, REPOSITORY);
-      expect(result).toEqual({ type: 'single', provider: 'claude', model: 'opus-4.8-xhigh' });
+      expect(result).toEqual({ type: 'single', provider: 'claude', model: 'opus-5-high' });
     });
   });
 });

--- a/tests/unit/shared.test.js
+++ b/tests/unit/shared.test.js
@@ -1664,7 +1664,7 @@ describe('resolveProviderModel', () => {
   it('request body wins over CLI override, repo settings, and config', () => {
     const req = makeReq(
       { default_provider: 'copilot', default_model: 'gpt-5' },
-      { provider: 'antigravity', model: 'gemini-3.5-flash-low' }
+      { provider: 'antigravity', model: 'gemini-3.8-flash-low' }
     );
     const repoSettings = { default_provider: 'codex', default_model: 'gpt-5.5' };
     const result = resolveProviderModel(req, {
@@ -1677,7 +1677,7 @@ describe('resolveProviderModel', () => {
 
   it('CLI flag override outranks saved repo settings (per-run intent wins)', () => {
     const req = makeReq(
-      { default_provider: 'antigravity', default_model: 'gemini-3.5-flash-low' },
+      { default_provider: 'antigravity', default_model: 'gemini-3.8-flash-low' },
       { provider: 'codex', model: 'gpt-5.5' }
     );
     const repoSettings = { default_provider: 'claude', default_model: 'opus' };
@@ -1686,16 +1686,16 @@ describe('resolveProviderModel', () => {
   });
 
   it('falls back to repo settings when there is no request body and no CLI override', () => {
-    const req = makeReq({ default_provider: 'antigravity', default_model: 'gemini-3.5-flash-low' });
+    const req = makeReq({ default_provider: 'antigravity', default_model: 'gemini-3.8-flash-low' });
     const repoSettings = { default_provider: 'claude', default_model: 'opus' };
     const result = resolveProviderModel(req, { repoSettings });
     expect(result).toEqual({ provider: 'claude', model: 'opus' });
   });
 
   it('falls back to config/legacy defaults when no request body, CLI override, or repo settings', () => {
-    const req = makeReq({ default_provider: 'antigravity', default_model: 'gemini-3.5-flash-low' });
+    const req = makeReq({ default_provider: 'antigravity', default_model: 'gemini-3.8-flash-low' });
     const result = resolveProviderModel(req, { repoSettings: null });
-    expect(result).toEqual({ provider: 'antigravity', model: 'gemini-3.5-flash-low' });
+    expect(result).toEqual({ provider: 'antigravity', model: 'gemini-3.8-flash-low' });
   });
 
   it('falls back to hard defaults (claude/opus) when nothing is configured', () => {

--- a/tests/unit/stack-analysis-provider-model.test.js
+++ b/tests/unit/stack-analysis-provider-model.test.js
@@ -17,7 +17,7 @@ describe('_resolveStackProviderModel', () => {
     const result = _resolveStackProviderModel({
       reqProvider: 'claude',
       reqModel: 'opus',
-      cliOverrides: { provider: 'antigravity', model: 'gemini-3.5-flash-low' },
+      cliOverrides: { provider: 'antigravity', model: 'gemini-3.8-flash-low' },
       repoSettings: { default_provider: 'codex', default_model: 'gpt-5.5' },
       config: { default_provider: 'copilot', default_model: 'gpt-5' }
     });
@@ -28,7 +28,7 @@ describe('_resolveStackProviderModel', () => {
     const result = _resolveStackProviderModel({
       cliOverrides: { provider: 'codex', model: 'gpt-5.5' },
       repoSettings: { default_provider: 'claude', default_model: 'opus' },
-      config: { default_provider: 'antigravity', default_model: 'gemini-3.5-flash-low' }
+      config: { default_provider: 'antigravity', default_model: 'gemini-3.8-flash-low' }
     });
     expect(result).toEqual({ provider: 'codex', model: 'gpt-5.5' });
   });
@@ -43,10 +43,10 @@ describe('_resolveStackProviderModel', () => {
 
   it('falls back to repo settings when there is no request body or CLI override', () => {
     const result = _resolveStackProviderModel({
-      repoSettings: { default_provider: 'antigravity', default_model: 'gemini-3.5-flash-low' },
+      repoSettings: { default_provider: 'antigravity', default_model: 'gemini-3.8-flash-low' },
       config: {}
     });
-    expect(result).toEqual({ provider: 'antigravity', model: 'gemini-3.5-flash-low' });
+    expect(result).toEqual({ provider: 'antigravity', model: 'gemini-3.8-flash-low' });
   });
 
   it('falls back to config default, then the legacy config key', () => {


### PR DESCRIPTION
## Summary

Refreshes the built-in model lists for four providers. Every id was probed against the installed CLI, not taken from its listing: the listings lag the backend in both directions (agy did not list Gemini 3.8 Flash, Muse's cached catalog did not list Spark 1.3, and several existing built-ins turned out to be dead).

### Antigravity
- Gemini 3.5 Flash is gone from agy (exit 1 with model listing). Replaced with **Gemini 3.8 Flash (Low/High)**.
- **3.8 Flash (High) is the new default**, in the thorough tier. It is the strongest Gemini agy exposes (DeepSWE v1.1 73.7, Terminal-Bench 2.1 89.4); 3.1 Pro dates from February and is demoted to previous-gen.
- 3.8 Flash (Low) stays the sole fast entry and JSON-extraction fallback.
- Retired 3.5 ids alias onto their 3.8 twin at the same effort so saved councils keep resolving.

### Codex
- Adds **`gpt-6-astra-high` / `-xhigh`** (thorough). Default stays `gpt-5.6-sol-high`: Astra is $10/$50 per MTok, ~5x Sol, for a small DeepSWE gain.
- Removes `gpt-5.4-high`, `gpt-5.4-xhigh`, `gpt-5.3-codex`, `gpt-5.4-nano` (retired for ChatGPT accounts Aug 31, 400 from the API). No aliases: a loud unknown-model error beats a silent model swap under a saved council.
- `gpt-5.4-mini` moves to the fast tier so it is not empty.

### Muse
- All eight entries move from **Spark 1.2 to Spark 1.3** (same price and context). 1.2 ids alias onto their 1.3 twin.
- `-ultra` entries replaced by `-max`: `ultra` is gate-closed and silently runs at xhigh; `max` actually runs.
- `none` effort is rejected by the meta provider; purged from comments and config example.
- `isUnknownModelError` now also matches the current "does not exist or you lack access" wording.

### Claude
- Default moves **`opus-4.8-xhigh` → `opus-5-high`** (same $5/$25 pricing). All 4.8 entries stay; the bare `opus` alias remains pinned to `opus-4.8-xhigh`.

### Cross-provider fix
Codex and Muse resolved per-model config overrides by exact id while the built-in lookup was alias-aware, so an override keyed under a legacy id was silently dropped. Both now use the same id+aliases key set Antigravity and Claude already use. Regression tests in both directions.

### Skill
`update-provider-models` SKILL.md rewritten with the probing facts from this run: no `timeout` on macOS, muse rejects `--reasoning-effort none`, Codex catalog in `~/.codex/models_cache.json`, listings are not authoritative, model changes ship as `patch`.

## Final defaults

| Provider | Default |
|---|---|
| Claude | `opus-5-high` |
| Codex | `gpt-5.6-sol-high` |
| Antigravity | `gemini-3.8-flash-high` |
| Muse | `muse-spark-1.3-high` |

## Test plan
- [x] `pnpm test`: 291 files, 9856 tests, all pass
- [x] Every added id probed live on the installed CLI (muse 1.0.2, codex 0.144.0, agy 1.0.16); every removed id confirmed dead
- [x] Four `patch` changesets

🤖 Generated with [Claude Code](https://claude.com/claude-code)
